### PR TITLE
Add technical writers as codeowners to md files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,3 +6,6 @@
 
 # These are the default owners for the whole content of the `kyma` repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
 * @clebs @a-thaler @suleymanakbas91 @lilitgh
+
+# All .md files
+*.md @kazydek @klaudiagrz @tomekpapiernik @dpolitesap


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add technical writers as codeowners to md files