### PR TITLE
Setup allow cancellation flag

### DIFF
--- a/prow-configurations/config.yaml.tpl
+++ b/prow-configurations/config.yaml.tpl
@@ -12,3 +12,6 @@ presubmits: # runs on PRs
       containers:
       - image: alpine
         command: ["/bin/printenv"]
+
+plank:
+  allow_cancellations: true # AllowCancellations enables aborting presubmit jobs for commits that have been superseded by newer commits in Github pull requests.


### PR DESCRIPTION
To test it, you can change command for "ui-api-layer" presubmit job to:
```
command: ["sleep","120"]
```
and then add such comment many times:
```/test all```
After changes proposed in this PR, old job will be terminated and new one created; previously we ends up with many the same jobs running for the same PR. 