### PR TITLE
Run kyma-integration selectively

### DIFF
--- a/prow-configurations/config.yaml.tpl
+++ b/prow-configurations/config.yaml.tpl
@@ -44,7 +44,6 @@ postsubmits:
     branches:
     - master
     context: kyma-integration
-    skip_report: false # from documentation: SkipReport skips commenting and setting status on GitHub.
     max_concurrency: 10
     labels:
       preset-compute-service-account: "true"

--- a/prow-configurations/config.yaml.tpl
+++ b/prow-configurations/config.yaml.tpl
@@ -26,7 +26,7 @@ presubmits: # runs on PRs
         command: ["/bin/printenv"]
   - name: kyma-integration
     optional: true
-    run_if_changed: "^(resources|installation|cluster)"
+    run_if_changed: "^(resources|installation)"
     trigger: "(?m)^/test kyma-integration"
     rerun_command: "/test kyma-integration"
     context: kyma-integration

--- a/prow-configurations/config.yaml.tpl
+++ b/prow-configurations/config.yaml.tpl
@@ -25,11 +25,8 @@ presubmits: # runs on PRs
       - image: alpine
         command: ["/bin/printenv"]
   - name: kyma-integration
-<<<<<<< HEAD
     optional: true
-=======
     run_if_changed: "^(resources|installation|cluster)"
->>>>>>> Added initial config
     trigger: "(?m)^/test kyma-integration"
     rerun_command: "/test kyma-integration"
     context: kyma-integration

--- a/prow-configurations/config.yaml.tpl
+++ b/prow-configurations/config.yaml.tpl
@@ -40,10 +40,9 @@ presubmits: # runs on PRs
             
 postsubmits:
   {{ .OrganizationOrUser }}/kyma:
-  - name: kyma-integration
+  - name: kyma-integration-master
     branches:
     - master
-    context: kyma-integration
     max_concurrency: 10
     labels:
       preset-compute-service-account: "true"

--- a/prow-configurations/config.yaml.tpl
+++ b/prow-configurations/config.yaml.tpl
@@ -25,11 +25,29 @@ presubmits: # runs on PRs
       - image: alpine
         command: ["/bin/printenv"]
   - name: kyma-integration
+<<<<<<< HEAD
     optional: true
+=======
+    run_if_changed: "^(resources|installation|cluster)"
+>>>>>>> Added initial config
     trigger: "(?m)^/test kyma-integration"
     rerun_command: "/test kyma-integration"
     context: kyma-integration
     skip_report: true # from documentation: SkipReport skips commenting and setting status on GitHub.
+    max_concurrency: 10
+    labels:
+      preset-compute-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/kyma-project/snapshot/test/integration:0.0.1 # created by running `docker build -t <image> .` in the integration-job directory.
+            
+postsubmits:
+  {{ .OrganizationOrUser }}/kyma:
+  - name: kyma-integration
+    branches:
+    - master
+    context: kyma-integration
+    skip_report: false # from documentation: SkipReport skips commenting and setting status on GitHub.
     max_concurrency: 10
     labels:
       preset-compute-service-account: "true"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -44,7 +44,6 @@ postsubmits:
     branches:
     - master
     context: kyma-integration
-    skip_report: false # from documentation: SkipReport skips commenting and setting status on GitHub.
     max_concurrency: 10
     labels:
       preset-compute-service-account: "true"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -26,7 +26,7 @@ presubmits: # runs on PRs
         command: ["/bin/printenv"]
   - name: kyma-integration
     optional: true
-    run_if_changed: "^(resources|installation|cluster)"
+    run_if_changed: "^(resources|installation)"
     trigger: "(?m)^/test kyma-integration"
     rerun_command: "/test kyma-integration"
     context: kyma-integration

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -40,10 +40,9 @@ presubmits: # runs on PRs
 
 postsubmits:
   kyma-project/kyma:
-  - name: kyma-integration
+  - name: kyma-integration-master
     branches:
     - master
-    context: kyma-integration
     max_concurrency: 10
     labels:
       preset-compute-service-account: "true"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -26,10 +26,25 @@ presubmits: # runs on PRs
         command: ["/bin/printenv"]
   - name: kyma-integration
     optional: true
+    run_if_changed: "^(resources|installation|cluster)"
     trigger: "(?m)^/test kyma-integration"
     rerun_command: "/test kyma-integration"
     context: kyma-integration
     skip_report: true # from documentation: SkipReport skips commenting and setting status on GitHub.
+    max_concurrency: 10
+    labels:
+      preset-compute-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/kyma-project/snapshot/test/integration:0.0.1 # created by running `docker build -t <image> .` in the integration-job directory.
+
+postsubmits:
+  kyma-project/kyma:
+  - name: kyma-integration
+    branches:
+    - master
+    context: kyma-integration
+    skip_report: false # from documentation: SkipReport skips commenting and setting status on GitHub.
     max_concurrency: 10
     labels:
       preset-compute-service-account: "true"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- kyma-integration job runs on PR only if there were some changes to `resources` or `installation` directories
- kyma-integration runs on master branch after commit

As for now with job per component approach, it is not possible to run kyma-integration job only in case all components jobs succeeded.

**Related issue(s)**
#46 
