### PR TITLE
Fix error on running integration tests: Login profile size exceeds 32 KiB

### DIFF
--- a/prow/images/cleaner/Dockerfile
+++ b/prow/images/cleaner/Dockerfile
@@ -1,0 +1,4 @@
+FROM eu.gcr.io/kyma-project/prow/bootstrap:0.0.1
+
+COPY cleaner.sh cleaner.sh
+ENTRYPOINT ["./cleaner.sh"]

--- a/prow/images/cleaner/README.md
+++ b/prow/images/cleaner/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 This image contains the script which performs a cleanup of the service account profile in the `kyma-project` project. 
-The Script requires following environment variables:
+The script requires the following environment variables:
 - **GOOGLE_APPLICATION_CREDENTIALS** which is a path to the service account key.
 - **CLOUDSDK_CORE_PROJECT** which is a Gcloud project name.
 
@@ -11,7 +11,7 @@ The Script requires following environment variables:
 To build the Docker image, run this command:
 
 ```bash
-docker build -t cleaner:<version> .
+docker build -t cleaner:{version} .
 ```
 
 

--- a/prow/images/cleaner/README.md
+++ b/prow/images/cleaner/README.md
@@ -2,7 +2,9 @@
 
 ## Overview
 This image contains the script which performs a cleanup of the service account profile in the `kyma-project` project. 
-Script requires environment variable `GOOGLE_APPLICATION_CREDENTIALS` which is a path to service account key.
+The Script requires following environment variables:
+- **GOOGLE_APPLICATION_CREDENTIALS** which is a path to the service account key.
+- **CLOUDSDK_CORE_PROJECT** which is a Gcloud project name.
 
 ## Installation
 

--- a/prow/images/cleaner/README.md
+++ b/prow/images/cleaner/README.md
@@ -1,7 +1,7 @@
 # Cleaner Docker Image
 
 ## Overview
-This image contains script which perform cleanup of service account profile in the `kyma-project` project. 
+This image contains the script which performs a cleanup of the service account profile in the `kyma-project` project. 
 Script requires environment variable `GOOGLE_APPLICATION_CREDENTIALS` which is a path to service account key.
 
 ## Installation

--- a/prow/images/cleaner/README.md
+++ b/prow/images/cleaner/README.md
@@ -4,7 +4,7 @@
 This image contains script which perform cleanup of service account profile in the `kyma-project` project. 
 Script requires environment variable `GOOGLE_APPLICATION_CREDENTIALS` which is a path to service account key.
 
-## Build
+## Installation
 
 To build Docker image, run this command:
 

--- a/prow/images/cleaner/README.md
+++ b/prow/images/cleaner/README.md
@@ -8,7 +8,7 @@ The Script requires following environment variables:
 
 ## Installation
 
-To build Docker image, run this command:
+To build the Docker image, run this command:
 
 ```bash
 docker build -t cleaner:<version> .

--- a/prow/images/cleaner/README.md
+++ b/prow/images/cleaner/README.md
@@ -1,0 +1,15 @@
+# Cleaner Docker Image
+
+## Overview
+This image contains script which perform cleanup of service account profile in the `kyma-project` project. 
+Script requires environment variable `GOOGLE_APPLICATION_CREDENTIALS` which is a path to service account key.
+
+## Build
+
+To build Docker image, run this command:
+
+```bash
+docker build -t cleaner:<version> .
+```
+
+

--- a/prow/images/cleaner/cleaner.sh
+++ b/prow/images/cleaner/cleaner.sh
@@ -3,9 +3,7 @@ set -e
 set -o pipefail
 
 echo "Authenticating to Google Cloud..."
-export CLOUDSDK_COMPUTE_ZONE="europe-west3-a"
-export CLOUDSDK_COMPUTE_REGION="europe-west3"
-gcloud config set project kyma-project
+gcloud config set project ${CLOUDSDK_CORE_PROJECT}
 gcloud auth activate-service-account --key-file "${GOOGLE_APPLICATION_CREDENTIALS}"
 
 # Get list of ssh-keys, remove header line and print only first column which is key

--- a/prow/images/cleaner/cleaner.sh
+++ b/prow/images/cleaner/cleaner.sh
@@ -12,16 +12,6 @@ if [ -z "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
     exit 1
 fi
 
-if [ -z "$CLOUDSDK_COMPUTE_ZONE" ]; then
-    echo "Environment variable CLOUDSDK_COMPUTE_ZONE is empty"
-    exit 1
-fi
-
-if [ -z "$CLOUDSDK_COMPUTE_REGION" ]; then
-    echo "Environment variable CLOUDSDK_COMPUTE_REGION is empty"
-    exit 1
-fi
-
 echo "Authenticating to Google Cloud..."
 gcloud config set project ${CLOUDSDK_CORE_PROJECT}
 gcloud auth activate-service-account --key-file "${GOOGLE_APPLICATION_CREDENTIALS}"

--- a/prow/images/cleaner/cleaner.sh
+++ b/prow/images/cleaner/cleaner.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+echo "Authenticating to Google Cloud..."
+export CLOUDSDK_COMPUTE_ZONE="europe-west3-a"
+export CLOUDSDK_COMPUTE_REGION="europe-west3"
+gcloud config set project kyma-project
+gcloud auth activate-service-account --key-file "${GOOGLE_APPLICATION_CREDENTIALS}"
+
+# Get list of ssh-keys, remove header line and print only first column which is key
+out=$(gcloud compute os-login ssh-keys list | sed '1 d' | awk -F "\t" '{print $1}')
+
+for id in ${out}; do
+    echo "Removing key ${id} ..."
+    gcloud compute os-login ssh-keys remove --key ${id}
+done;
+
+echo "DONE"

--- a/prow/images/cleaner/cleaner.sh
+++ b/prow/images/cleaner/cleaner.sh
@@ -2,6 +2,26 @@
 set -e
 set -o pipefail
 
+if [ -z "$CLOUDSDK_CORE_PROJECT" ]; then
+    echo "Environment variable CLOUDSDK_CORE_PROJECT is empty"
+    exit 1
+fi
+
+if [ -z "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
+    echo "Environment variable GOOGLE_APPLICATION_CREDENTIALS is empty"
+    exit 1
+fi
+
+if [ -z "$CLOUDSDK_COMPUTE_ZONE" ]; then
+    echo "Environment variable CLOUDSDK_COMPUTE_ZONE is empty"
+    exit 1
+fi
+
+if [ -z "$CLOUDSDK_COMPUTE_REGION" ]; then
+    echo "Environment variable CLOUDSDK_COMPUTE_REGION is empty"
+    exit 1
+fi
+
 echo "Authenticating to Google Cloud..."
 gcloud config set project ${CLOUDSDK_CORE_PROJECT}
 gcloud auth activate-service-account --key-file "${GOOGLE_APPLICATION_CREDENTIALS}"

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -22,7 +22,7 @@ presubmits: # runs on PRs
       spec:
         containers:
           - image: eu.gcr.io/kyma-project/prow/bootstrap:0.0.1
-            command: 
+            command:
               - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-and-start-kyma.sh"
     - name: prow/kyma/kyma-gke-integration
       run_if_changed: "^(resources|installation)"
@@ -64,5 +64,16 @@ postsubmits:
       spec:
         containers:
           - image: eu.gcr.io/kyma-project/prow/bootstrap:0.0.1
-            command: 
+            command:
               - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-and-start-kyma.sh"
+
+periodics:
+# kyma-integration-cleaner removes all sshPublic keys stored for service account "sa-vm-kyma-integration". Those keys refers to machines that in most cases were already removed.
+# Purpose of this job is to avoid error: "Login profile size exceeds 32 KiB" when running kyma-integration tests
+- name: prow/utilities/kyma/kyma-integration-cleaner
+  cron: "0 7 * * 1-5" # “At 07:00 on every day-of-week from Monday through Friday.”
+  labels:
+    preset-sa-vm-kyma-integration: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/kyma-project/prow/cleaner:0.0.1 # see test-infra/prow/images/cleaner

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -75,7 +75,6 @@ periodics:
   labels:
     preset-sa-vm-kyma-integration: "true"
     preset-gc-project-env: "true"
-    preset-gc-compute-envs: "true"
   spec:
     containers:
     - image: eu.gcr.io/kyma-project/prow/cleaner:0.0.1 # see test-infra/prow/images/cleaner

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -74,6 +74,8 @@ periodics:
   cron: "0 7 * * 1-5" # “At 07:00 on every day-of-week from Monday through Friday.”
   labels:
     preset-sa-vm-kyma-integration: "true"
+    preset-gc-project-env: "true"
+    preset-gc-compute-envs: "true"
   spec:
     containers:
     - image: eu.gcr.io/kyma-project/prow/cleaner:0.0.1 # see test-infra/prow/images/cleaner


### PR DESCRIPTION
Problem is described here: https://stackoverflow.com/questions/53180624/gcloud-cannot-provision-many-vm-using-one-service-account

Proposed solution: run periodic jobs that perform cleanups once a day