### PR TITLE
Restructure documentation in test-infra

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ The purpose of the `test-infra` repository is to store configuration and scripts
 The `test-infra` repository has the following structure:
 
 ```
-  ├── .github                     # Pull request and issue templates.             
-  ├── development                 # Scripts used for the development of the "test-infra" repository.
-  ├── docs                        # Documentation for the test infrastructure, such as Prow installation guides.
-  └── prow                        # Installation scripts for Prow on the production cluster.    
+  ├── .github                     # Pull request and issue templates             
+  ├── development                 # Scripts used for the development of the "test-infra" repository
+  ├── docs                        # Documentation for the test infrastructure, such as Prow installation guides
+  └── prow                        # Installation scripts for Prow on the production cluster    
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ The `test-infra` repository has the following structure:
   ├── .github                     # Pull request and issue templates.             
   ├── development                 # Scripts used for the development of the "test-infra" repository.
   ├── docs                        # Documentation for the test infrastructure, such as Prow installation guides.
-  └── prow                        # Installation scripts for the production Prow.    
+  └── prow                        # Installation scripts for Prow on the production cluster.    
 
 ```
 
 ### Prow
 
-The `test-infra` repository contains the whole configuration of Prow, the purpose of which is to replace the internal Continuous Integration (CI) tool in the `kyma-project` organization.
+The `test-infra` repository contains the whole configuration of Prow. Its purpose is to replace the internal Continuous Integration (CI) tool in the `kyma-project` organization.
 
 If you want to find out what Prow is, how you can test it, or contribute to it, read the main [`README.md`](./prow/README.md) document in the `prow` folder.
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,27 @@
-# test-infra
+# Test Infra
 
 ## Overview
 
-Test infrastructure for the Kyma project.
+The purpose of the `test-infra` repository is to store configuration and scripts for the test infrastructure used in the `kyma-project` organization.
 
-## Prerequisites
+### Project structure
 
-No prerequisites at the moment.
+<!-- Update the repository structure each time you modify it. -->
 
-## Installation
+The `test-infra` repository has the following structure:
 
-No installation instructions at the moment.
+```
+  ├── .github                     # Pull request and issue templates.             
+  ├── development                 # Scripts used for the development of the "test-infra" repository.
+  ├── docs                        # Documentation for the test infrastructure, such as Prow installation guides.
+  └── prow                        # Installation scripts for the production Prow.    
 
-## Usage
+```
 
-No usage instructions at the moment.
+### Prow
 
-## Development
-- You cannot test Prow configuration locally on Minikube. Perform all the tests on the cluster. 
-- Avoid provisioning long-running clusters.
-- Test Prow configuration against your `kyma` fork repository.
-- Disable builds on the internal CI only after all CI functionalities are provided by Prow. This applies not only for the `master` branch but also for release branches.
+The `test-infra` repository contains the whole configuration of Prow, the purpose of which is to replace the internal Continuous Integration (CI) tool in the `kyma-project` organization.
+
+If you want to find out what Prow is, how you can test it, or contribute to it, read the main [`README.md`](./prow/README.md) document in the `prow` folder.
+
+For more detailed documentation, such as installation guides, see the [`docs/prow`](./docs/prow) subfolder.

--- a/development/README.md
+++ b/development/README.md
@@ -10,8 +10,8 @@ The `development` folder has the following structure:
 <!-- Update the project structure each time you modify it. -->
 
 ```
-  ├── checker                  # The folder that contains code sources of a simple Go application that verifies the configuration of the "config.yaml" and "plugins.yaml" files.          
-  ├── check.sh                 # The script that runs the "Checker" application. application                                             
+  ├── checker                  # Code sources of a simple Go application that verifies the configuration of the "config.yaml" and "plugins.yaml" files.          
+  ├── check.sh                 # The script that runs the "Checker" application.                                              
   ├── create-gcp-secrets.sh    # The script that downloads the Secrets from the GSP storage bucket to your Prow installation.
   ├── install-prow.sh          # The script that installs Prow on your cluster.
   ├── provision-cluster.sh     # The script that creates a Kubernetes cluster.

--- a/development/README.md
+++ b/development/README.md
@@ -10,14 +10,14 @@ The `development` folder has the following structure:
 <!-- Update the project structure each time you modify it. -->
 
 ```
-  ├── checker                  # Code sources of a simple Go application that verifies the configuration of the "config.yaml" and "plugins.yaml" files.          
-  ├── check.sh                 # The script that runs the "Checker" application.                                              
-  ├── create-gcp-secrets.sh    # The script that downloads Secrets from the GCP storage bucket to your Prow installation.
-  ├── install-prow.sh          # The script that installs Prow on your cluster.
-  ├── provision-cluster.sh     # The script that creates a Kubernetes cluster.
-  ├── remove-prow.sh           # The script that removes Prow from your Kubernetes cluster.
-  ├── update-config.sh         # The script that updates the new configuration of the "config.yaml" file on a cluster.
-  ├── update-plugins.sh        # The script that updates the new configuration of the "plugins.yaml" file on a cluster.
-  └── validate-scripts.sh      # The script that performs a static analysis of bash scripts in the "test-infra" repository.
+  ├── checker                  # This folder contains code sources of a simple Go application that verifies the configuration of the "config.yaml" and "plugins.yaml" files          
+  ├── check.sh                 # This script runs the "Checker" application.  .                                            
+  ├── create-gcp-secrets.sh    # This script downloads Secrets from the GCP storage bucket to your Prow installation.
+  ├── install-prow.sh          # This script installs Prow on your cluster.
+  ├── provision-cluster.sh     # This script creates a Kubernetes cluster.
+  ├── remove-prow.sh           # This script removes Prow from your Kubernetes cluster.
+  ├── update-config.sh         # This script updates the new configuration of the "config.yaml" file on a cluster.
+  ├── update-plugins.sh        # This script updates the new configuration of the "plugins.yaml" file on a cluster.
+  └── validate-scripts.sh      # This script performs a static analysis of bash scripts in the "test-infra" repository.
 
 ```

--- a/development/README.md
+++ b/development/README.md
@@ -1,127 +1,22 @@
-# Prow Installation
+# Development
 
 ## Overview
 
-This folder contains the installation script and the set of configurations for Prow.
+The purpose of the folder is to store scripts used for the development of the `test-infra` repository.
 
-> **NOTE:** The following instructions assume that you are signed in to the Google Cloud project with administrative rights.
+### Project structure
 
-## Prerequisites
-
-Install the following tools:
-
-- Kubernetes 1.10+ on GKE
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-- [gcloud](https://cloud.google.com/sdk/gcloud/)
-- OpenSSL
-
-### Provision a cluster
-
-Use the `provision-cluster.sh` script or follow [these](https://github.com/kubernetes/test-infra/blob/master/prow/getting_started.md#create-the-cluster) instructions to provision a new cluster on GKE. Ensure that kubectl points to the correct cluster. For GKE, execute the following command:
+The `development` folder has the following structure:
+<!-- Update the project structure each time you modify it. -->
 
 ```
-gcloud container clusters get-credentials {CLUSTER_NAME} --zone={ZONE_NAME} --project={PROJECT_NAME}
-```
+  ├── checker                  # The folder that contains code sources of a simple Go application that verifies the configuration of the "config.yaml" and "plugins.yaml" files.          
+  ├── check.sh                 # The script that runs the "Checker" application. application                                             
+  ├── create-gcp-secrets.sh    # The script that downloads the Secrets from the GSP storage bucket to your Prow installation.
+  ├── install-prow.sh          # The script that installs Prow on your cluster.
+  ├── provision-cluster.sh     # The script that creates a Kubernetes cluster.
+  ├── remove-prow.sh           # The script that removes Prow from your Kubernetes cluster.
+  ├── update-config.sh         # The script that updates the new configuration of the "config.yaml" file on a cluster.
+  └── update-plugins.sh        # The script that updates the new configuration of the "plugins.yaml" file on a cluster.
 
-## Installation
-
-1. Set an OAuth2 token that has the read and write access to the bot account. You can set it either as an environment variable named `OAUTH` or interactively during the installation.
-   To generate a new token, go to the **Settings** tab of a given GitHub account and click **Developer Settings**. Choose **Personal Access Token** and **Generate New Token**.
-   In the new window, select all scopes and click **Generate token**.
-
-   > **NOTE:** Create a separate bot account instead of using your personal one. If the Prow bot account is the same as the account that creates a job-triggering comment, the job is not triggered.
-
-2. Export the environment variables:
-
-- **BUCKET_NAME** is a GCS bucket in the Google Cloud project that is used to store Prow Secrets.
-- **KEYRING_NAME** is the KMS key ring.
-- **ENCRYPTION_KEY_NAME** is the key name in the key ring that is used for data encryption.
-
-> **NOTE:** For more details on setting up Google Cloud Project refer to [Prow Secrets management](https://github.com/kyma-project/test-infra/blob/master/docs/prow-secrets-management.md)
-
-The Prow installation script assumes that the following service accounts exist:
-
-- **sa-gke-kyma-integration** with a role that allows the account to create Kubernetes clusters.
-- **sa-vm-kyma-integration** with roles that allow the account to provision virtual machines.
-- **sa-gcs-plank** with roles that allow the account to store objects in a Bucket.
-- **sa-gcr-push** with roles that allow the account to push images to Google Container Repository.
-
-The account files are encrypted with the **ENCRYPTION_KEY_NAME** key from **KEYRING_NAME** and are stored in **BUCKET_NAME**.
-
-3. Run the following script to start the installation process:
-
-```bash
-./install-prow.sh
-```
-
-The installation script performs the following steps to install Prow:
-
-- Deploy the NGINX Ingress Controller.
-- Create a ClusterRoleBinding.
-- Create a HMAC token to be used for GitHub Webhooks.
-- Create secrets for HMAC and OAuth2 to be used by Prow.
-- Deploy Prow components using the `starter.yaml` file from the `prow/cluster` directory.
-- Add annotations for the Prow Ingress to make it work with the NGINX Ingress Controller.
-
-To check if the installation is successful, perform the following steps:
-
-1. Check if all Pods are up and running:
-   `kubeclt get pods`
-2. Check if the Deck is accessible from outside of the cluster:
-   `kubectl get ingress ing`
-   Copy the address of the ingress `ing` and open it in a browser to display the Prow status on the dashboard.
-
-## Development
-
-[Configure Webhook](https://github.com/kubernetes/test-infra/blob/master/prow/getting_started.md#add-the-webhook-to-github) to enable sending Events from a GitHub repository to Prow.
-When you use our script `install-prow.sh` to install Prow on your cluster the list of plugins and configuration is empty. You can configure Prow by specifying the `plugins.yaml` and `config.yaml` files.
-
-To check if the `plugins.yaml` and `config.yaml` configuration files are correct, run the `check.sh` script.
-In case of changes in the plugins configuration, use the `update-plugins.sh` to apply changes on a cluster.
-In case of changes in the jobs configuration, use the `update-config.sh` to apply changes on a cluster.
-
-### Strategy for organising jobs
-
-The `test-infra` repository has defined configurations for the Prow cluster in the `prow` subdirectory. This directory has the following structure:
-
-- `cluster` directory, which contains all `yaml` files for Prow cluster provisioning
-- `jobs/{repository_name}` directory, which contains all files with jobs definitions. Each file must have a unique name.
-- `config.yaml` file, which contains Prow configuration without job definitions
-- `plugins.yaml` file, which contains Prow plugins configuration
-
-`jobs/{repository_name}` directories have subdirectories which represent each component and contain job definitions. Job definitions not connected to a particular component, like integration jobs, are defined directly under the `jobs/{repository_name}` directory.
-
-For example:
-
-```
-...
-prow
-|- cluster
-| |- starter.yaml
-|- jobs
-| |- kyma
-| | |- components
-| | | |- environments
-| | | | |- environments.jobs.yaml
-| | |- kyma.integration.yaml
-|- config.yaml
-|- plugins.yaml
-...
-```
-
-### Convention for naming jobs
-
-When you define jobs for Prow, both **name** and **context** of the job must follow one of these patterns:
-
-- `prow/{repository_name}/{component_name}/{job_name}` for components
-- `prow/{repository_name}/{job_name}` for jobs not connected to a particular component
-
-In both cases, `{job_name}` must reflect the job's responsibility.
-
-### Cleanup
-
-To clean up everything created by the installation script, run the removal script:
-
-```bash
-./remove-prow.sh
 ```

--- a/development/README.md
+++ b/development/README.md
@@ -12,11 +12,12 @@ The `development` folder has the following structure:
 ```
   ├── checker                  # Code sources of a simple Go application that verifies the configuration of the "config.yaml" and "plugins.yaml" files.          
   ├── check.sh                 # The script that runs the "Checker" application.                                              
-  ├── create-gcp-secrets.sh    # The script that downloads the Secrets from the GSP storage bucket to your Prow installation.
+  ├── create-gcp-secrets.sh    # The script that downloads the Secrets from the GCP storage bucket to your Prow installation.
   ├── install-prow.sh          # The script that installs Prow on your cluster.
   ├── provision-cluster.sh     # The script that creates a Kubernetes cluster.
   ├── remove-prow.sh           # The script that removes Prow from your Kubernetes cluster.
   ├── update-config.sh         # The script that updates the new configuration of the "config.yaml" file on a cluster.
-  └── update-plugins.sh        # The script that updates the new configuration of the "plugins.yaml" file on a cluster.
+  ├── update-plugins.sh        # The script that updates the new configuration of the "plugins.yaml" file on a cluster.
+  └── validate-scripts.sh      # The script that performs a static analysis of bash scripts in the "test-infra" repository.
 
 ```

--- a/development/README.md
+++ b/development/README.md
@@ -12,7 +12,7 @@ The `development` folder has the following structure:
 ```
   ├── checker                  # Code sources of a simple Go application that verifies the configuration of the "config.yaml" and "plugins.yaml" files.          
   ├── check.sh                 # The script that runs the "Checker" application.                                              
-  ├── create-gcp-secrets.sh    # The script that downloads the Secrets from the GCP storage bucket to your Prow installation.
+  ├── create-gcp-secrets.sh    # The script that downloads Secrets from the GCP storage bucket to your Prow installation.
   ├── install-prow.sh          # The script that installs Prow on your cluster.
   ├── provision-cluster.sh     # The script that creates a Kubernetes cluster.
   ├── remove-prow.sh           # The script that removes Prow from your Kubernetes cluster.

--- a/docs/prow/README.md
+++ b/docs/prow/README.md
@@ -4,12 +4,12 @@
 
 The folder contains documents that provide an insight into Prow configuration, development, and testing.
 
-Read the documents to learn how you to:
+<!-- Update the list each time you modify the document structure in this folder. -->
+
+Read the documents to learn how to:
 
 - [Configure a production Prow](./production-cluster-configuration.md) based on the preconfigured Google Cloud Storage (GCS) resources.
 - [Install and configure Prow](./prow-installation-on-forks.md) on a forked repository to test and develop it on your own.
 - [Create a service account](./prow-secrets-management.md) and store its encrypted key in a GCS bucket.
-
-<!-- Update the list each time you modify the document structure in this folder. -->
 
  Read also the proposal for the new [release process](./kyma-release-process.md) in Kyma that uses Prow, and see how it differs from the release process with the internal CI.

--- a/docs/prow/README.md
+++ b/docs/prow/README.md
@@ -12,4 +12,4 @@ Read the documents to learn how you to:
 
 <!-- Update the list each time you modify the document structure in this folder. -->
 
- Read also the proposal for the new [release process](./kyma-release-process.md) in Kyma that uses Prow, and how it differs from the release process with the internal CI.
+ Read also the proposal for the new [release process](./kyma-release-process.md) in Kyma that uses Prow, and see how it differs from the release process with the internal CI.

--- a/docs/prow/README.md
+++ b/docs/prow/README.md
@@ -1,0 +1,13 @@
+# Docs
+
+## Overview
+
+The folder contains documents that provide an insight into Prow configuration, development, and testing.
+
+Read the documents to learn how you to:
+
+- [Configure a production Prow](./production-cluster-configuration.md) based on the preconfigured Google Cloud Storage (GCS) resources.
+- [Install and configure Prow](./prow-installation-on-forks.md) on a forked repository to test and develop it on your own.
+- [Create a service account](./prow-secrets-management.md) and store its encrypted key in a GCS bucket.
+
+<!-- Update the list each time you modify a document in this folder. -->

--- a/docs/prow/README.md
+++ b/docs/prow/README.md
@@ -10,4 +10,6 @@ Read the documents to learn how you to:
 - [Install and configure Prow](./prow-installation-on-forks.md) on a forked repository to test and develop it on your own.
 - [Create a service account](./prow-secrets-management.md) and store its encrypted key in a GCS bucket.
 
-<!-- Update the list each time you modify a document in this folder. -->
+<!-- Update the list each time you modify the document structure in this folder. -->
+
+ Read also the proposal for the new [release process](./kyma-release-process.md) in Kyma that uses Prow, and how it differs from the release process with the internal CI.

--- a/docs/prow/README.md
+++ b/docs/prow/README.md
@@ -8,7 +8,7 @@ The folder contains documents that provide an insight into Prow configuration, d
 
 Read the documents to learn how to:
 
-- [Configure a production Prow](./production-cluster-configuration.md) based on the preconfigured Google Cloud Storage (GCS) resources.
+- [Configure Prow on a production cluster](./production-cluster-configuration.md) based on the preconfigured Google Cloud Storage (GCS) resources.
 - [Install and configure Prow](./prow-installation-on-forks.md) on a forked repository to test and develop it on your own.
 - [Create a service account](./prow-secrets-management.md) and store its encrypted key in a GCS bucket.
 

--- a/docs/prow/production-cluster-configuration.md
+++ b/docs/prow/production-cluster-configuration.md
@@ -8,16 +8,16 @@ This instruction provides the steps required to deploy a production cluster for 
 
 Use the following tools and configuration:
 
-- Kubernetes 1.10+ on GKE
+- Kubernetes 1.10+ on Google Kubernetes Engine (GKE)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) to communicate with Kubernetes
-- [gcloud](https://cloud.google.com/sdk/gcloud/) to communicate with Google Cloud Platform
+- [gcloud](https://cloud.google.com/sdk/gcloud/) to communicate with Google Cloud Platform (GCP)
 - The `kyma-bot` GitHub account
 - [Kubernetes cluster](./prow-installation-on-forks.md/#provision-a-cluster)
 - Two Secrets in the Kubernetes cluster:
-    - `hmac-token` which is a Prow HMAC token used for validating GitHub webhooks
+    - `hmac-token` which is a Prow HMAC token used to validate GitHub webhooks
     - `oauth-token` which is a GitHub token with read and write access to the `kyma-bot` account
-- Two buckets on GCS, one for storing Secrets and the second for storing logs
-- Google Cloud Platform configuration that includes:
+- Two buckets on Google Cloud Storage (GCS), one for storing Secrets and the second for storing logs
+- GCP configuration that includes:
     - A [global static IP address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address) with the `prow-production` name
     - A [DNS registry](https://cloud.google.com/dns/docs/quickstart#create_a_managed_public_zone) for the `status.build.kyma-project.io` domain that points to the `prow-production` address
 
@@ -25,13 +25,13 @@ Use the following tools and configuration:
 
 1. When you communicate for the first time with Google Cloud, set the context to your Google Cloud project.
 
-Export the **PROJECT** variable and execute this command:
+Export the **PROJECT** variable and run this command:
 
 ```
 gcloud config set project $PROJECT
 ```
 
-2. Ensure that kubectl points to the correct cluster.
+2. Make sure that kubectl points to the correct cluster.
 
 Export these variables:  
 
@@ -41,13 +41,13 @@ export ZONE=europe-west3-b
 export PROJECT=kyma-project
 ```
 
-For GKE, execute the following command:
+For GKE, run the following command:
 
 ```
 gcloud container clusters get-credentials $CLUSTER_NAME --zone=$ZONE --project=$PROJECT
 ```
 3. Export these environment variables, where:
-  - **BUCKET_NAME** is a GCS bucket in the Google Cloud project that is used to store Prow Secrets.
+  - **BUCKET_NAME** is a GCS bucket in the Google Cloud project that stores Prow Secrets.
   - **KEYRING_NAME** is the KMS key ring.
   - **ENCRYPTION_KEY_NAME** is the key name in the key ring that is used for data encryption.
 
@@ -68,9 +68,9 @@ The installation script performs the following steps to install Prow:
 - Deploy the NGINX Ingress Controller.
 - Create a ClusterRoleBinding.
 - Deploy Prow components with the `a202e595a33ac92ab503f913f2d710efabd3de21`revision.
-- Deploy Cert Manager.
-- Deploy Secure Ingress.
-- Remove Insecure Ingress.
+- Deploy the Cert Manager.
+- Deploy secure Ingress.
+- Remove insecure Ingress.
 
 5. Verify the installation.
 
@@ -80,4 +80,4 @@ To check if the installation is successful, perform the following steps:
    `kubeclt get pods`
 - Check if the Deck is accessible from outside of the cluster:
    `kubectl get ingress tls-ing`
-   Copy the address of the `tls-ing` Ingress and open it in a browser to display the Prow status on the dashboard.
+- Copy the address of the `tls-ing` Ingress and open it in a browser to display the Prow status on the dashboard.

--- a/docs/prow/production-cluster-configuration.md
+++ b/docs/prow/production-cluster-configuration.md
@@ -1,0 +1,59 @@
+# Production Cluster Configuration
+
+## Overview
+
+This instruction provides the steps required to deploy the production cluster for Prow.
+
+## Prerequisites
+
+Use the following tools and configuration:
+
+- Kubernetes 1.10+ on GKE
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) to communicate with Kubernetes.
+- [gcloud](https://cloud.google.com/sdk/gcloud/) to communicate with Google Cloud Platform.
+- The `kyma-bot` GitHub account
+- [Kubernetes cluster](./prow-installation-on-forks.md/#provision-a-cluster)
+- Two Secrets in the Kubernetes cluster:
+    - `hmac-token` which is a Prow HMAC token used for validating GitHub webhooks.
+    - `oauth-token` which is a GitHub token with read and write access to the `kyma-bot` account.
+- Google Cloud Platform configuration that includes:
+    - A [global static IP address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address) with the `prow-production` name.
+    - A [DNS registry](https://cloud.google.com/dns/docs/quickstart#create_a_managed_public_zone) for the `status.build.kyma-project.io` domain that points to the `prow-production` address.
+
+## Installation
+
+1. Export these environment variables, where:
+      - **BUCKET_NAME** is a GCS bucket in the Google Cloud project that is used to store Prow Secrets.
+      - **KEYRING_NAME** is the KMS key ring.
+      - **ENCRYPTION_KEY_NAME** is the key name in the key ring that is used for data encryption.
+
+      ```
+      export BUCKET_NAME=kyma-prow
+      export KEYRING_NAME=kyma-prow
+      export ENCRYPTION_KEY_NAME=kyma-prow-encryption
+      ```
+
+2. Run the following script to start the installation process:
+
+```bash
+./install-prow.sh
+```
+
+The installation script performs the following steps to install Prow:
+
+- Deploy the NGINX Ingress Controller.
+- Create a ClusterRoleBinding.
+- Deploy Prow components with the `a202e595a33ac92ab503f913f2d710efabd3de21`revision.
+- Deploy Cert Manager.
+- Deploy Secure Ingress.
+- Removes Insecure Ingress.
+
+3. Verify the installation.
+
+To check if the installation is successful, perform the following steps:
+
+- Check if all Pods are up and running:
+   `kubeclt get pods`
+- Check if the Deck is accessible from outside of the cluster:
+   `kubectl get ingress tls-ing`
+   Copy the address of the `tls-ing` Ingress and open it in a browser to display the Prow status on the dashboard.

--- a/docs/prow/production-cluster-configuration.md
+++ b/docs/prow/production-cluster-configuration.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This instruction provides the steps required to deploy the production cluster for Prow.
+This instruction provides the steps required to deploy a production cluster for Prow.
 
 ## Prerequisites
 

--- a/docs/prow/production-cluster-configuration.md
+++ b/docs/prow/production-cluster-configuration.md
@@ -16,24 +16,49 @@ Use the following tools and configuration:
 - Two Secrets in the Kubernetes cluster:
     - `hmac-token` which is a Prow HMAC token used for validating GitHub webhooks.
     - `oauth-token` which is a GitHub token with read and write access to the `kyma-bot` account.
+- Two buckets on GCS, one for storing Secrets and the second for storing logs.
 - Google Cloud Platform configuration that includes:
     - A [global static IP address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address) with the `prow-production` name.
     - A [DNS registry](https://cloud.google.com/dns/docs/quickstart#create_a_managed_public_zone) for the `status.build.kyma-project.io` domain that points to the `prow-production` address.
 
 ## Installation
 
+1. When you communicate for the first time with the Google Cloud, set the context to your Google Cloud project.
+
+Export the **PROJECT** variable and execute this command:
+
+```
+gcloud config set project $PROJECT
+```
+
+2. Ensure that kubectl points to the correct cluster.
+
+Export these variables:  
+
+```
+export CLUSTER_NAME=prow-production
+export ZONE=europe-west3-b
+export PROJECT=kyma-project
+```
+
+For GKE, execute the following command:
+
+```
+gcloud container clusters get-credentials $CLUSTER_NAME --zone=$ZONE --project=$PROJECT
+```
 1. Export these environment variables, where:
-      - **BUCKET_NAME** is a GCS bucket in the Google Cloud project that is used to store Prow Secrets.
-      - **KEYRING_NAME** is the KMS key ring.
-      - **ENCRYPTION_KEY_NAME** is the key name in the key ring that is used for data encryption.
+  - **BUCKET_NAME** is a GCS bucket in the Google Cloud project that is used to store Prow Secrets.
+  - **KEYRING_NAME** is the KMS key ring.
+  - **ENCRYPTION_KEY_NAME** is the key name in the key ring that is used for data encryption.
 
-      ```
-      export BUCKET_NAME=kyma-prow
-      export KEYRING_NAME=kyma-prow
-      export ENCRYPTION_KEY_NAME=kyma-prow-encryption
-      ```
+```
+export BUCKET_NAME=kyma-prow
+export KEYRING_NAME=kyma-prow
+export ENCRYPTION_KEY_NAME=kyma-prow-encryption
+```
 
-2. Run the following script to start the installation process:
+
+3. Run the following script to start the installation process:
 
 ```bash
 ./install-prow.sh

--- a/docs/prow/production-cluster-configuration.md
+++ b/docs/prow/production-cluster-configuration.md
@@ -9,17 +9,17 @@ This instruction provides the steps required to deploy a production cluster for 
 Use the following tools and configuration:
 
 - Kubernetes 1.10+ on GKE
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) to communicate with Kubernetes.
-- [gcloud](https://cloud.google.com/sdk/gcloud/) to communicate with Google Cloud Platform.
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) to communicate with Kubernetes
+- [gcloud](https://cloud.google.com/sdk/gcloud/) to communicate with Google Cloud Platform
 - The `kyma-bot` GitHub account
 - [Kubernetes cluster](./prow-installation-on-forks.md/#provision-a-cluster)
 - Two Secrets in the Kubernetes cluster:
-    - `hmac-token` which is a Prow HMAC token used for validating GitHub webhooks.
-    - `oauth-token` which is a GitHub token with read and write access to the `kyma-bot` account.
-- Two buckets on GCS, one for storing Secrets and the second for storing logs.
+    - `hmac-token` which is a Prow HMAC token used for validating GitHub webhooks
+    - `oauth-token` which is a GitHub token with read and write access to the `kyma-bot` account
+- Two buckets on GCS, one for storing Secrets and the second for storing logs
 - Google Cloud Platform configuration that includes:
-    - A [global static IP address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address) with the `prow-production` name.
-    - A [DNS registry](https://cloud.google.com/dns/docs/quickstart#create_a_managed_public_zone) for the `status.build.kyma-project.io` domain that points to the `prow-production` address.
+    - A [global static IP address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address) with the `prow-production` name
+    - A [DNS registry](https://cloud.google.com/dns/docs/quickstart#create_a_managed_public_zone) for the `status.build.kyma-project.io` domain that points to the `prow-production` address
 
 ## Installation
 

--- a/docs/prow/production-cluster-configuration.md
+++ b/docs/prow/production-cluster-configuration.md
@@ -23,7 +23,7 @@ Use the following tools and configuration:
 
 ## Installation
 
-1. When you communicate for the first time with the Google Cloud, set the context to your Google Cloud project.
+1. When you communicate for the first time with Google Cloud, set the context to your Google Cloud project.
 
 Export the **PROJECT** variable and execute this command:
 
@@ -46,7 +46,7 @@ For GKE, execute the following command:
 ```
 gcloud container clusters get-credentials $CLUSTER_NAME --zone=$ZONE --project=$PROJECT
 ```
-1. Export these environment variables, where:
+3. Export these environment variables, where:
   - **BUCKET_NAME** is a GCS bucket in the Google Cloud project that is used to store Prow Secrets.
   - **KEYRING_NAME** is the KMS key ring.
   - **ENCRYPTION_KEY_NAME** is the key name in the key ring that is used for data encryption.
@@ -57,8 +57,7 @@ export KEYRING_NAME=kyma-prow
 export ENCRYPTION_KEY_NAME=kyma-prow-encryption
 ```
 
-
-3. Run the following script to start the installation process:
+4. Run the following script to start the installation process:
 
 ```bash
 ./install-prow.sh
@@ -71,9 +70,9 @@ The installation script performs the following steps to install Prow:
 - Deploy Prow components with the `a202e595a33ac92ab503f913f2d710efabd3de21`revision.
 - Deploy Cert Manager.
 - Deploy Secure Ingress.
-- Removes Insecure Ingress.
+- Remove Insecure Ingress.
 
-3. Verify the installation.
+5. Verify the installation.
 
 To check if the installation is successful, perform the following steps:
 

--- a/docs/prow/prow-installation-on-forks.md
+++ b/docs/prow/prow-installation-on-forks.md
@@ -1,0 +1,191 @@
+# Prow Installation
+
+This instruction provides the steps required to deploy your own Prow on a forked repository for test and development purposes.
+
+> **NOTE:** The following instructions assume that you are signed in to the Google Cloud project with administrative rights and that you have the $GOPATH already set.
+
+## Prerequisites
+
+Install the following tools:
+
+- Kubernetes 1.10+ on GKE
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) to communicate with Kubernetes.
+- [gcloud](https://cloud.google.com/sdk/gcloud/) to communicate with Google Cloud Platform.
+- OpenSSL
+
+## Provision a cluster
+
+1. Export these variables:
+
+```
+
+export PROJECT={project-name}
+export CLUSTER_NAME={cluster-name}
+export ZONE={zone-name}
+
+```
+
+2. When you communicate for the first time with the Google Cloud, set the context to your Google Cloud project. Execute this command:
+
+```
+gcloud config set project $PROJECT
+```
+
+3. Run the [`provision-cluster.sh`](../../development/provision-cluster.sh) script or follow [this](https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md#create-the-cluster) instruction to provision a new cluster on GKE. Ensure that kubectl points to the correct cluster. For GKE, execute the following command:
+
+```
+gcloud container clusters get-credentials $CLUSTER_NAME --zone=$ZONE --project=$PROJECT
+```
+
+## Create a bot account
+
+Create a separate GitHub account which serves as a bot account that triggers the Prow comments that you enter in the pull request. If the Prow bot account is the same as the account that creates a job-triggering comment, the job is not triggered.
+
+Add the bot account to the [collaborators](https://help.github.com/articles/adding-outside-collaborators-to-repositories-in-your-organization/) on your personal GitHub account.
+
+## Set an access token
+
+Set an OAuth2 token that has the read and write access to the bot account.
+
+To generate a new token, go to the **Settings** tab of a given GitHub account and click **Developer Settings**. Choose **Personal Access Token** and **Generate New Token**.
+In the new window, select all scopes and click **Generate token**.
+
+You can set the token either as an environment variable named `OAUTH` or provide it during the installation process when prompted.
+
+## Create Secrets
+
+For the purpose of the installation, you require to have a set of service accounts and secret files created on Google Cloud Storage (GCS).
+
+> **NOTE:** For details, see the [prow-secrets-management.md](./prow-secrets-management.md) document that explains step by step how to create all required GSC resources.
+
+1. Create two buckets on GCS, one for storing secrets and the second for storing logs.
+
+>**NOTE:** The bucket for storing logs is used in Prow by the Plank component. This reference is defined in the `config.yaml` file.
+
+2. Create the following service accounts, role bindings, and private keys, encrypt them using Key Management Service (KMS), and upload them to your Secret storage bucket:
+
+- **sa-gke-kyma-integration** with roles that allow the account to create Kubernetes clusters:
+    - Kubernetes Engine Cluster Admin (`roles/container.clusterAdmin`)
+    - Service Account User (`roles/iam.serviceAccountUser`)
+- **sa-vm-kyma-integration** with roles that allow the account to provision virtual machines:
+    - Compute Instance Admin (beta) (`roles/compute.instanceAdmin`)
+    - Compute OS Admin Login (`roles/compute.osAdminLogin`)
+    - Service Account User (`roles/iam.serviceAccountUser`)
+- **sa-gcs-plank** with the role that allows the account to store objects in a Bucket:
+    - Storage Object Admin (`roles/storage.objectAdmin`)
+- **sa-gcr-push** with the role that allows the account to push images to Google Container Repository:
+    - Storage Admin `roles/storage.admin`
+
+See an example of variables you need to export for each account:
+
+```
+export SA_NAME=sa-gcs-plank
+export SA_DISPLAY_NAME=sa-gcs-plank
+export SECRET_FILE=sa-gcs-plank
+export ROLE=roles/storage.objectAdmin
+
+```
+
+## Install Prow
+
+Follow these steps:
+
+1. Export these environment variables:
+
+- **BUCKET_NAME** is a GCS bucket in the Google Cloud project that is used to store Prow Secrets.
+- **KEYRING_NAME** is the KMS key ring.
+- **ENCRYPTION_KEY_NAME** is the key name in the key ring that is used for data encryption.
+
+The account files are encrypted with the **ENCRYPTION_KEY_NAME** key from **KEYRING_NAME** and are stored in **BUCKET_NAME**.
+
+2. Go to the `development` folder and run the following script to start the installation process:
+
+```bash
+./install-prow.sh
+```
+
+> **NOTE:** The scripts prompts you to enter your OAuth2 token.
+
+This script performs the following steps to install Prow:
+
+- Deploy the NGINX Ingress Controller.
+- Create a ClusterRoleBinding.
+- Create a HMAC token to be used for GitHub Webhooks.
+- Create secrets for HMAC and OAuth2 to be used by Prow.
+- Deploy Prow components using the `starter.yaml` file from the `prow/cluster` directory.
+- Add annotations for the Prow Ingress to make it work with the NGINX Ingress Controller.
+
+## Verify the Installation
+
+Verify if Prow installed successfully.
+
+1. Check if all Pods are up and running:
+
+   ```
+   kubectl get pods
+   ```
+
+2. Check if the Deck is accessible from outside of the cluster:
+
+   ```
+   kubectl get ingress ing
+   ```
+
+   Copy the address of the ingress `ing` and open it in a browser to display the Prow status on the dashboard.
+
+## Configure the webhook
+
+After Prow installs successfully, you need to:
+
+1. [Configure a webhook](https://support.hockeyapp.net/kb/third-party-bug-trackers-services-and-webhooks/how-to-set-up-a-webhook-in-github) to enable sending Events from a GitHub repository to Prow.
+2. Add the bot account to [collaborators](https://help.github.com/articles/adding-outside-collaborators-to-repositories-in-your-organization/) on your forked repository and set it with push access rights. The bot account needs to accept your invitation.
+
+## Configure Prow
+
+When you use the [`install-prow.sh`](../../development/provision-cluster.sh) script to install Prow on your cluster, the list of plugins and configuration is empty. You can configure Prow by specifying the `config.yaml` and `plugins.yaml` files.
+
+### The config.yaml file
+
+The `config.yaml` file contains the basic Prow configuration. When you create a particular Prow job, it uses the Pod Preset definitions from this file. See the example of such a file [here](../../development/config.yaml).
+
+For more details, see the [Kubernetes documentation](https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md#add-more-jobs-by-modifying-configyaml).
+
+### The plugins.yaml file
+
+ The `plugins.yaml` file contains the list of [plugins](https://prow.k8s.io/plugins) you enable on a given repository. See the example of such a file [here](../../development/plugins.yaml).
+
+For more details, see the [Kubernetes documentation](https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md#enable-some-plugins-by-modifying-pluginsyaml).
+
+### Verify the configuration
+
+To check if the `plugins.yaml` and `config.yaml` configuration files are correct, run the `check.sh {file_path}` script. For example, run:
+
+```
+./check.sh ../prow/plugins.yaml ../prow/config.yaml
+```
+
+### Upload the configuration on a cluster
+
+If the files are configured correctly, upload the files on a cluster.
+
+1. Use the `update-plugins.sh {file_path}` script to apply plugin changes on a cluster.
+
+```
+./update-plugins.sh ../prow/plugins.yaml
+```
+
+2. Use the `update-config.sh {file_path}` script to apply jobs configuration on a cluster.
+
+```
+./update-config.sh ../prow/config.yaml
+```
+
+After you complete the required configuration, you can already start testing the uploaded plugins and configuration. You can also create your own job pipeline and test it against the forked repository.
+
+### Cleanup
+
+To clean up everything created by the installation script, run the removal script:
+
+```bash
+./remove-prow.sh
+```

--- a/docs/prow/prow-installation-on-forks.md
+++ b/docs/prow/prow-installation-on-forks.md
@@ -41,7 +41,7 @@ gcloud container clusters get-credentials $CLUSTER_NAME --zone=$ZONE --project=$
 
 Create a separate GitHub account which serves as a bot account that triggers the Prow comments that you enter in the pull request. If the Prow bot account is the same as the account that creates a job-triggering comment, the job is not triggered.
 
-Add the bot account to the [collaborators](https://help.github.com/articles/adding-outside-collaborators-to-repositories-in-your-organization/) on your personal GitHub account.
+Add the bot account to the [collaborators](https://help.github.com/articles/adding-outside-collaborators-to-repositories-in-your-organization/) on your forked repository and set it with push access rights. The bot account needs to accept your invitation.
 
 ## Set an access token
 
@@ -58,7 +58,7 @@ For the purpose of the installation, you require to have a set of service accoun
 
 > **NOTE:** For details, see the [prow-secrets-management.md](./prow-secrets-management.md) document that explains step by step how to create all required GSC resources.
 
-1. Create two buckets on GCS, one for storing secrets and the second for storing logs.
+1. Create two buckets on GCS, one for storing Secrets and the second for storing logs.
 
 >**NOTE:** The bucket for storing logs is used in Prow by the Plank component. This reference is defined in the `config.yaml` file.
 
@@ -75,16 +75,6 @@ For the purpose of the installation, you require to have a set of service accoun
     - Storage Object Admin (`roles/storage.objectAdmin`)
 - **sa-gcr-push** with the role that allows the account to push images to Google Container Repository:
     - Storage Admin `roles/storage.admin`
-
-See an example of variables you need to export for each account:
-
-```
-export SA_NAME=sa-gcs-plank
-export SA_DISPLAY_NAME=sa-gcs-plank
-export SECRET_FILE=sa-gcs-plank
-export ROLE=roles/storage.objectAdmin
-
-```
 
 ## Install Prow
 
@@ -135,10 +125,8 @@ Verify if Prow installed successfully.
 
 ## Configure the webhook
 
-After Prow installs successfully, you need to:
+After Prow installs successfully, you need to [Configure a webhook](https://support.hockeyapp.net/kb/third-party-bug-trackers-services-and-webhooks/how-to-set-up-a-webhook-in-github) to enable sending Events from a GitHub repository to Prow.
 
-1. [Configure a webhook](https://support.hockeyapp.net/kb/third-party-bug-trackers-services-and-webhooks/how-to-set-up-a-webhook-in-github) to enable sending Events from a GitHub repository to Prow.
-2. Add the bot account to [collaborators](https://help.github.com/articles/adding-outside-collaborators-to-repositories-in-your-organization/) on your forked repository and set it with push access rights. The bot account needs to accept your invitation.
 
 ## Configure Prow
 
@@ -146,19 +134,19 @@ When you use the [`install-prow.sh`](../../development/provision-cluster.sh) scr
 
 ### The config.yaml file
 
-The `config.yaml` file contains the basic Prow configuration. When you create a particular Prow job, it uses the Pod Preset definitions from this file. See the example of such a file [here](../../development/config.yaml).
+The `config.yaml` file contains the basic Prow configuration. When you create a particular Prow job, it uses the Pod Preset definitions from this file. See the example of such a file [here](../../prow/config.yaml).
 
 For more details, see the [Kubernetes documentation](https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md#add-more-jobs-by-modifying-configyaml).
 
 ### The plugins.yaml file
 
- The `plugins.yaml` file contains the list of [plugins](https://prow.k8s.io/plugins) you enable on a given repository. See the example of such a file [here](../../development/plugins.yaml).
+ The `plugins.yaml` file contains the list of [plugins](https://status.build.kyma-project.io/plugins) you enable on a given repository. See the example of such a file [here](../../prow/plugins.yaml).
 
 For more details, see the [Kubernetes documentation](https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md#enable-some-plugins-by-modifying-pluginsyaml).
 
 ### Verify the configuration
 
-To check if the `plugins.yaml` and `config.yaml` configuration files are correct, run the `check.sh {file_path}` script. For example, run:
+To check if the `plugins.yaml` and `config.yaml` configuration files are correct, run the `check.sh {plugins_file_path} {config_file_path}` script. For example, run:
 
 ```
 ./check.sh ../prow/plugins.yaml ../prow/config.yaml

--- a/docs/prow/prow-installation-on-forks.md
+++ b/docs/prow/prow-installation-on-forks.md
@@ -9,8 +9,8 @@ This instruction provides the steps required to deploy your own Prow on a forked
 Install the following tools:
 
 - Kubernetes 1.10+ on GKE
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) to communicate with Kubernetes.
-- [gcloud](https://cloud.google.com/sdk/gcloud/) to communicate with Google Cloud Platform.
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) to communicate with Kubernetes
+- [gcloud](https://cloud.google.com/sdk/gcloud/) to communicate with Google Cloud Platform
 - OpenSSL
 
 ## Provision a cluster
@@ -25,13 +25,13 @@ export ZONE={zone-name}
 
 ```
 
-2. When you communicate for the first time with the Google Cloud, set the context to your Google Cloud project. Execute this command:
+2. When you communicate for the first time with Google Cloud, set the context to your Google Cloud project. Execute this command:
 
 ```
 gcloud config set project $PROJECT
 ```
 
-3. Run the [`provision-cluster.sh`](../../development/provision-cluster.sh) script or follow [this](https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md#create-the-cluster) instruction to provision a new cluster on GKE. Ensure that kubectl points to the correct cluster. For GKE, execute the following command:
+3. Run the [`provision-cluster.sh`](../../development/provision-cluster.sh) script or follow [this](https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md#create-the-cluster) instruction to provision a new cluster on Google Kubernetes Engine (GKE). Ensure that kubectl points to the correct cluster. For GKE, execute the following command:
 
 ```
 gcloud container clusters get-credentials $CLUSTER_NAME --zone=$ZONE --project=$PROJECT
@@ -56,7 +56,7 @@ You can set the token either as an environment variable named `OAUTH` or provide
 
 For the purpose of the installation, you require to have a set of service accounts and secret files created on Google Cloud Storage (GCS).
 
-> **NOTE:** For details, see the [prow-secrets-management.md](./prow-secrets-management.md) document that explains step by step how to create all required GSC resources.
+> **NOTE:** For details, see the [prow-secrets-management.md](./prow-secrets-management.md) document that explains step by step how to create all required GCS resources.
 
 1. Create two buckets on GCS, one for storing Secrets and the second for storing logs.
 
@@ -71,14 +71,14 @@ For the purpose of the installation, you require to have a set of service accoun
     - Compute Instance Admin (beta) (`roles/compute.instanceAdmin`)
     - Compute OS Admin Login (`roles/compute.osAdminLogin`)
     - Service Account User (`roles/iam.serviceAccountUser`)
-- **sa-gcs-plank** with the role that allows the account to store objects in a Bucket:
+- **sa-gcs-plank** with the role that allows the account to store objects in a bucket:
     - Storage Object Admin (`roles/storage.objectAdmin`)
 - **sa-gcr-push** with the role that allows the account to push images to Google Container Repository:
     - Storage Admin `roles/storage.admin`
 
 ## Install Prow
 
-Follow these steps:
+Follow these steps to install Prow:
 
 1. Export these environment variables:
 
@@ -125,7 +125,7 @@ Verify if Prow installed successfully.
 
 ## Configure the webhook
 
-After Prow installs successfully, you need to [Configure a webhook](https://support.hockeyapp.net/kb/third-party-bug-trackers-services-and-webhooks/how-to-set-up-a-webhook-in-github) to enable sending Events from a GitHub repository to Prow.
+After Prow installs successfully, you need to [configure the webhook](https://support.hockeyapp.net/kb/third-party-bug-trackers-services-and-webhooks/how-to-set-up-a-webhook-in-github) to enable the GitHub repository to send Events to Prow.
 
 
 ## Configure Prow
@@ -174,6 +174,6 @@ After you complete the required configuration, you can already start testing the
 
 To clean up everything created by the installation script, run the removal script:
 
-```bash
+```
 ./remove-prow.sh
 ```

--- a/docs/prow/prow-installation-on-forks.md
+++ b/docs/prow/prow-installation-on-forks.md
@@ -1,4 +1,4 @@
-# Prow Installation
+# Prow Installation on Forks
 
 This instruction provides the steps required to deploy your own Prow on a forked repository for test and development purposes.
 
@@ -8,9 +8,9 @@ This instruction provides the steps required to deploy your own Prow on a forked
 
 Install the following tools:
 
-- Kubernetes 1.10+ on GKE
+- Kubernetes 1.10+ on Google Kubernetes Engine (GKE)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) to communicate with Kubernetes
-- [gcloud](https://cloud.google.com/sdk/gcloud/) to communicate with Google Cloud Platform
+- [gcloud](https://cloud.google.com/sdk/gcloud/) to communicate with Google Cloud Platform (GCP)
 - OpenSSL
 
 ## Provision a cluster
@@ -25,13 +25,13 @@ export ZONE={zone-name}
 
 ```
 
-2. When you communicate for the first time with Google Cloud, set the context to your Google Cloud project. Execute this command:
+2. When you communicate for the first time with Google Cloud, set the context to your Google Cloud project. Run this command:
 
 ```
 gcloud config set project $PROJECT
 ```
 
-3. Run the [`provision-cluster.sh`](../../development/provision-cluster.sh) script or follow [this](https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md#create-the-cluster) instruction to provision a new cluster on Google Kubernetes Engine (GKE). Ensure that kubectl points to the correct cluster. For GKE, execute the following command:
+3. Run the [`provision-cluster.sh`](../../development/provision-cluster.sh) script or follow [this](https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md#create-the-cluster) instruction to provision a new cluster on GKE. Make sure that kubectl points to the correct cluster. For GKE, run the following command:
 
 ```
 gcloud container clusters get-credentials $CLUSTER_NAME --zone=$ZONE --project=$PROJECT
@@ -41,7 +41,7 @@ gcloud container clusters get-credentials $CLUSTER_NAME --zone=$ZONE --project=$
 
 Create a separate GitHub account which serves as a bot account that triggers the Prow comments that you enter in the pull request. If the Prow bot account is the same as the account that creates a job-triggering comment, the job is not triggered.
 
-Add the bot account to the [collaborators](https://help.github.com/articles/adding-outside-collaborators-to-repositories-in-your-organization/) on your forked repository and set it with push access rights. The bot account needs to accept your invitation.
+Add the bot account to the [collaborators](https://help.github.com/articles/adding-outside-collaborators-to-repositories-in-your-organization/) on your forked repository and set it with push access rights. The bot account must accept your invitation.
 
 ## Set an access token
 
@@ -54,15 +54,15 @@ You can set the token either as an environment variable named `OAUTH` or provide
 
 ## Create Secrets
 
-For the purpose of the installation, you require to have a set of service accounts and secret files created on Google Cloud Storage (GCS).
+For the purpose of the installation, you must have a set of service accounts and secret files created on Google Cloud Storage (GCS).
 
-> **NOTE:** For details, see the [prow-secrets-management.md](./prow-secrets-management.md) document that explains step by step how to create all required GCS resources.
+> **NOTE:** For details, see the [Prow Secrets Management](./prow-secrets-management.md) document that explains step by step how to create all required GCS resources.
 
 1. Create two buckets on GCS, one for storing Secrets and the second for storing logs.
 
 >**NOTE:** The bucket for storing logs is used in Prow by the Plank component. This reference is defined in the `config.yaml` file.
 
-2. Create the following service accounts, role bindings, and private keys, encrypt them using Key Management Service (KMS), and upload them to your Secret storage bucket:
+2. Create the following service accounts, role bindings, and private keys. Encrypt them using Key Management Service (KMS), and upload them to your Secret storage bucket:
 
 - **sa-gke-kyma-integration** with roles that allow the account to create Kubernetes clusters:
     - Kubernetes Engine Cluster Admin (`roles/container.clusterAdmin`)
@@ -82,7 +82,7 @@ Follow these steps to install Prow:
 
 1. Export these environment variables:
 
-- **BUCKET_NAME** is a GCS bucket in the Google Cloud project that is used to store Prow Secrets.
+- **BUCKET_NAME** is a GCS bucket in the Google Cloud project that stores Prow Secrets.
 - **KEYRING_NAME** is the KMS key ring.
 - **ENCRYPTION_KEY_NAME** is the key name in the key ring that is used for data encryption.
 
@@ -100,14 +100,14 @@ This script performs the following steps to install Prow:
 
 - Deploy the NGINX Ingress Controller.
 - Create a ClusterRoleBinding.
-- Create a HMAC token to be used for GitHub Webhooks.
-- Create secrets for HMAC and OAuth2 to be used by Prow.
+- Create a HMAC token used for GitHub webhooks.
+- Create Secrets for HMAC and OAuth2 used by Prow.
 - Deploy Prow components using the `starter.yaml` file from the `prow/cluster` directory.
 - Add annotations for the Prow Ingress to make it work with the NGINX Ingress Controller.
 
 ## Verify the Installation
 
-Verify if Prow installed successfully.
+Verify if the Prow installation was successful.
 
 1. Check if all Pods are up and running:
 
@@ -125,7 +125,7 @@ Verify if Prow installed successfully.
 
 ## Configure the webhook
 
-After Prow installs successfully, you need to [configure the webhook](https://support.hockeyapp.net/kb/third-party-bug-trackers-services-and-webhooks/how-to-set-up-a-webhook-in-github) to enable the GitHub repository to send Events to Prow.
+After Prow installs successfully, you must [configure the webhook](https://support.hockeyapp.net/kb/third-party-bug-trackers-services-and-webhooks/how-to-set-up-a-webhook-in-github) to enable the GitHub repository to send Events to Prow.
 
 
 ## Configure Prow
@@ -134,7 +134,7 @@ When you use the [`install-prow.sh`](../../development/provision-cluster.sh) scr
 
 ### The config.yaml file
 
-The `config.yaml` file contains the basic Prow configuration. When you create a particular Prow job, it uses the Pod Preset definitions from this file. See the example of such a file [here](../../prow/config.yaml).
+The `config.yaml` file contains the basic Prow configuration. When you create a particular Prow job, it uses the Preset definitions from this file. See the example of such a file [here](../../prow/config.yaml).
 
 For more details, see the [Kubernetes documentation](https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md#add-more-jobs-by-modifying-configyaml).
 
@@ -168,7 +168,7 @@ If the files are configured correctly, upload the files on a cluster.
 ./update-config.sh ../prow/config.yaml
 ```
 
-After you complete the required configuration, you can already start testing the uploaded plugins and configuration. You can also create your own job pipeline and test it against the forked repository.
+After you complete the required configuration, you can test the uploaded plugins and configuration. You can also create your own job pipeline and test it against the forked repository.
 
 ### Cleanup
 

--- a/docs/prow/prow-secrets-management.md
+++ b/docs/prow/prow-secrets-management.md
@@ -43,6 +43,14 @@ Use this command to create a keyring for the private keys:
 ```
 gcloud kms keyrings create $KEYRING_NAME --location $LOCATION
 ```
+### Create a key in the keyring
+
+Create a key for encrypting your private key.
+
+```
+gcloud kms keys create $ENCRYPTION_KEY_NAME --location $LOCATION \
+  --keyring $KEYRING_NAME --purpose encryption
+  ```
 
 ### Create a Google service account
 

--- a/docs/prow/prow-secrets-management.md
+++ b/docs/prow/prow-secrets-management.md
@@ -2,19 +2,19 @@
 
 ## Overview
 
-Some jobs require using sensitive data. You need to encrypt data using Key Management Service (KMS) and store them in Google Cloud Storage (GCS).
+Some jobs require using sensitive data. Encrypt the data using Key Management Service (KMS) and store it in Google Cloud Storage (GCS).
 This document shows the commands necessary to create a service account and store its encrypted key in a GCS bucket.
 
 >**NOTE:** This document assumes that you are logged in to the Google Cloud project with administrative rights.
 
 ## Prerequisites
 
- - [gcloud](https://cloud.google.com/sdk/gcloud/) to communicate with Google Cloud Platform
+ - [gcloud](https://cloud.google.com/sdk/gcloud/) to communicate with Google Cloud Platform (GCP)
  - Basic knowledge of [GCP key rings and keys](https://cloud.google.com/kms/docs/creating-keys)
 
 Use the `export {VARIABLE}={value}` command to set up these variables, where:
  - **PROJECT** is a Google Cloud project.
- - **BUCKET_NAME** is a GCS bucket in the Google Cloud project that is used to store Prow Secrets
+ - **BUCKET_NAME** is a GCS bucket in the Google Cloud project that stores Prow Secrets
  - **KEYRING_NAME** is the KMS key ring.
  - **ENCRYPTION_KEY_NAME** is the key name in the key ring that is used for data encryption.
  - **LOCATION** is the geographical location of the data center that handles requests for Cloud KMS regarding a given resource and stores the corresponding cryptographic keys. When set to `global`, your Cloud KMS resources are available from multiple data centres.
@@ -23,7 +23,7 @@ Use the `export {VARIABLE}={value}` command to set up these variables, where:
 
 >**NOTE:** Before you follow this guide, check Prow Secrets setup for the Google Cloud project.
 
-When you communicate for the first time with the Google Cloud, set the context to your Google Cloud project. Execute this command:
+When you communicate for the first time with Google Cloud, set the context to your Google Cloud project. Run this command:
 ```
 gcloud config set project $PROJECT
 ```
@@ -45,7 +45,7 @@ gcloud kms keyrings create $KEYRING_NAME --location $LOCATION
 ```
 ### Create a key in the key ring
 
-Create a key for encrypting your private key.
+Create a key to encrypt your private key.
 
 ```
 gcloud kms keys create $ENCRYPTION_KEY_NAME --location $LOCATION \
@@ -59,10 +59,10 @@ Follow these steps:
 1. Export the variables, where:
  - **SA_NAME** is the name of the service account.
  - **SA_DISPLAY_NAME** is the display name of the service account.
- - **SECRET_FILE** is the path for the private key.
+ - **SECRET_FILE** is the path to the private key.
  - **ROLE** is the role bound to the service account.
 
- See an example of variables you need to export for such an account:
+ See an example of variables you must export for such an account:
 
  ```
  export SA_NAME=sa-gcs-plank
@@ -89,7 +89,7 @@ gcloud projects add-iam-policy-binding $PROJECT --member=serviceAccount:$SA_NAME
 
 ### Encrypt the Secret
 
-1. Export the **SECRET_FILE** variable which is the path to the file containing the Secret.
+1. Export the **SECRET_FILE** variable which is the path to the file which contains the Secret.
 
 2. Encrypt the Secret:
 ```

--- a/docs/prow/prow-secrets-management.md
+++ b/docs/prow/prow-secrets-management.md
@@ -54,6 +54,16 @@ Follow these steps:
  - **SECRET_FILE** is the path for the private key.
  - **ROLE** is the role bound to the service account.
 
+ See an example of variables you need to export for each account:
+
+ ```
+ export SA_NAME=sa-gcs-plank
+ export SA_DISPLAY_NAME=sa-gcs-plank
+ export SECRET_FILE=sa-gcs-plank
+ export ROLE=roles/storage.objectAdmin
+
+ ```
+
 2. Create a service account:
 ```
 gcloud iam service-accounts create $SA_NAME --display-name $SA_DISPLAY_NAME

--- a/docs/prow/prow-secrets-management.md
+++ b/docs/prow/prow-secrets-management.md
@@ -9,15 +9,15 @@ This document shows the commands necessary to create a service account and store
 
 ## Prerequisites
 
- - [gcloud](https://cloud.google.com/sdk/gcloud/) to communicate with Google Cloud Platform.
- - Basic knowledge of [GCP key rings and keys](https://cloud.google.com/kms/docs/creating-keys).
+ - [gcloud](https://cloud.google.com/sdk/gcloud/) to communicate with Google Cloud Platform
+ - Basic knowledge of [GCP key rings and keys](https://cloud.google.com/kms/docs/creating-keys)
 
 Use the `export {VARIABLE}={value}` command to set up these variables, where:
  - **PROJECT** is a Google Cloud project.
- - **BUCKET_NAME** is a GCS bucket in the Google Cloud project that is used to store Prow Secrets.
+ - **BUCKET_NAME** is a GCS bucket in the Google Cloud project that is used to store Prow Secrets
  - **KEYRING_NAME** is the KMS key ring.
  - **ENCRYPTION_KEY_NAME** is the key name in the key ring that is used for data encryption.
- - **LOCATION** is the geographical data center location where requests to Cloud KMS regarding a given resource are handled, and where the corresponding cryptographic keys are stored. When set to `global`, your Cloud KMS resources are available from multiple data centres.
+ - **LOCATION** is the geographical location of the data center that handles requests for Cloud KMS regarding a given resource and stores the corresponding cryptographic keys. When set to `global`, your Cloud KMS resources are available from multiple data centres.
 
 ## Secrets management
 
@@ -36,14 +36,14 @@ Run this command to create a bucket:
 gsutil mb -p $PROJECT gs://$BUCKET_NAME/
 ```
 
-### Create a keyring
+### Create a key ring
 
-Use this command to create a keyring for the private keys:
+Use this command to create a key ring for the private keys:
 
 ```
 gcloud kms keyrings create $KEYRING_NAME --location $LOCATION
 ```
-### Create a key in the keyring
+### Create a key in the key ring
 
 Create a key for encrypting your private key.
 
@@ -62,7 +62,7 @@ Follow these steps:
  - **SECRET_FILE** is the path for the private key.
  - **ROLE** is the role bound to the service account.
 
- See an example of variables you need to export for each account:
+ See an example of variables you need to export for such an account:
 
  ```
  export SA_NAME=sa-gcs-plank

--- a/prow/README.md
+++ b/prow/README.md
@@ -4,7 +4,7 @@
 
 Prow is a Kubernetes-developed system that you can use as a Continuous Integration (CI) tool for validating your GitHub repositories and components, managing automatic validation of PRs, applying and removing labels, or opening and closing issues.
 
-You interact with Prow using slash (/) commands, such as `/test all`. You add them on pull requests or issues to trigger the predefined automation [plugins](https://prow.k8s.io/plugins) that perform certain actions in respond to GitHub events. Upon proper configuration, GitHub events trigger jobs that are single-container Pods, created in dedicated builds and Kubernetes clusters by a microservice called Plank that is running in GCP. Each Prow component is a small Go service that has its own function in the management of these one-off single-pod ProwJobs.
+You interact with Prow using slash (/) commands, such as `/test all`. You add them on pull requests or issues to trigger the predefined automation [plugins](https://prow.k8s.io/plugins) that perform certain actions in respond to GitHub events. Upon proper configuration, GitHub events trigger jobs that are single-container Pods, created in dedicated builds and Kubernetes clusters by a microservice called Plank that is running in GCP. Each Prow component is a small Go service that has its own function in the management of these one-off single-pod Prow jobs.
 
 In the content of the `kyma-project` organization, the main purpose of Prow is to serve as an external CI test tool that replaces the internal CI system.
 
@@ -40,7 +40,7 @@ Its structure looks as follows:
 ```
 
   ├── cluster               # All "yaml" files for Prow cluster provisioning.           
-  ├── images                # Images for component jobs that you can also use for generic builds.                                             
+  ├── images                # Images for Prow jobs that you can also use for generic builds.                                             
   ├── jobs                  # All files with jobs definitions.
   ├── scripts               # Scripts used by the test jobs.
   ├── config.yaml           # The main Prow configuration, without job definitions. For example, it contains Plank configuration and Preset definitions.

--- a/prow/README.md
+++ b/prow/README.md
@@ -4,7 +4,7 @@
 
 Prow is a Kubernetes-developed system that you can use as a Continuous Integration (CI) tool for validating your GitHub repositories and components, managing automatic validation of PRs, applying and removing labels, or opening and closing issues.
 
-You interact with Prow using slash (/) commands, such as `/test all`. You add them on pull requests or issues to trigger the predefined automation [plugins](https://prow.k8s.io/plugins) that perform certain actions in respond to GitHub events. Upon proper configuration, GitHub events trigger jobs that are single-container Pods, created in dedicated builds and Kubernetes clusters by a microservice called Plank that is running in the GCP. Each Prow component is a small Go service that has its own function in the management of these one-off single-pod ProwJobs.
+You interact with Prow using slash (/) commands, such as `/test all`. You add them on pull requests or issues to trigger the predefined automation [plugins](https://prow.k8s.io/plugins) that perform certain actions in respond to GitHub events. Upon proper configuration, GitHub events trigger jobs that are single-container Pods, created in dedicated builds and Kubernetes clusters by a microservice called Plank that is running in GCP. Each Prow component is a small Go service that has its own function in the management of these one-off single-pod ProwJobs.
 
 In the content of the `kyma-project` organization, the main purpose of Prow is to serve as an external CI test tool that replaces the internal CI system.
 

--- a/prow/README.md
+++ b/prow/README.md
@@ -9,13 +9,13 @@ You interact with Prow using slash (/) commands, such as `/test all`. You add th
 In the content of the `kyma-project` organization, the main purpose of Prow is to serve as an external CI test tool that replaces the internal CI system.
 
 Prow configuration replies on this basic set of configurations:
-- Kubernetes cluster deployed in Google Container Engine (GKE)
-- GitHub bot account
+- Kubernetes cluster deployed in Google Container Engine (GKE).
+- GitHub bot account.
 - GitHub tokens:
-    - `hmac-token` as a Prow HMAC token used for validating GitHub webhooks.
-    - `oauth-token` as a GitHub token with read and write access to the bot account.
-- Service accounts and their Secret files for sensitive jobs that are encrypted using Key Management Service (KMS) and stored in Google Cloud Storage (GCS)
-- The `starter.yaml` file with a basic configuration of Prow components
+    - `hmac-token` which is a Prow HMAC token used for validating GitHub webhooks.
+    - `oauth-token` which is a GitHub token with read and write access to the bot account.
+- Service accounts and their Secret files for sensitive jobs that are encrypted using Key Management Service (KMS) and stored in Google Cloud Storage (GCS).
+- The `starter.yaml` file with a basic configuration of Prow components.
 - Webhooks configured for the GitHub repository to enable sending Events from a GitHub repository to Prow.
 - Plugins enabled by creating and modifying the `plugins.yaml` file.
 - Jobs enabled by creating and configuring the basic `config.yaml` file and additional `yaml` files for specific Kyma components.
@@ -39,11 +39,11 @@ Its structure looks as follows:
 
 ```
 
-  ├── cluster               # The folder with all "yaml" files for Prow cluster provisioning.           
-  ├── images                # The folder with images for component jobs that you can also use for generic builds.                                             
-  ├── jobs                  # The folder with all files with jobs definitions.
-  ├── scripts               # The folder with scripts used by the test jobs.
-  ├── config.yaml           # The file with the main Prow configuration, without job definitions. For example, it contains Plank configuration and Preset definitions.
+  ├── cluster               # All "yaml" files for Prow cluster provisioning.           
+  ├── images                # Images for component jobs that you can also use for generic builds.                                             
+  ├── jobs                  # All files with jobs definitions.
+  ├── scripts               # Scripts used by the test jobs.
+  ├── config.yaml           # The main Prow configuration, without job definitions. For example, it contains Plank configuration and Preset definitions.
   ├── install-prow.sh       # The script for the production cluster installation.
   └── plugins.yaml          # The file with Prow plugins configuration.
 ```

--- a/prow/README.md
+++ b/prow/README.md
@@ -39,13 +39,13 @@ Its structure looks as follows:
 
 ```
 
-  ├── cluster               # All "yaml" files for Prow cluster provisioning.           
-  ├── images                # Images for Prow jobs.                                             
-  ├── jobs                  # All files with jobs definitions.
-  ├── scripts               # Scripts used by the test jobs.
+  ├── cluster               # Files for Prow cluster provisioning           
+  ├── images                # Images for Prow jobs                                             
+  ├── jobs                  # Files with job definitions
+  ├── scripts               # Scripts used by the test jobs
   ├── config.yaml           # The main Prow configuration, without job definitions. For example, it contains Plank configuration and Preset definitions.
-  ├── install-prow.sh       # The script for the production cluster installation.
-  └── plugins.yaml          # The file with Prow plugins configuration.
+  ├── install-prow.sh       # The script for the production cluster installation
+  └── plugins.yaml          # The file with Prow plugins configuration
 ```
 
 ## Installation

--- a/prow/README.md
+++ b/prow/README.md
@@ -6,28 +6,28 @@ Prow is a Kubernetes-developed system that you can use as a Continuous Integrati
 
 You interact with Prow using slash (/) commands, such as `/test all`. You add them on pull requests or issues to trigger the predefined automation [plugins](https://status.build.kyma-project.io/plugins) that perform certain actions in respond to GitHub events. Upon proper configuration, GitHub events trigger jobs that are single-container Pods, created in dedicated builds and Kubernetes clusters by a microservice called Plank that is running in GCP. Each Prow component is a small Go service that has its own function in the management of these one-off single-pod Prow jobs.
 
-In the content of the `kyma-project` organization, the main purpose of Prow is to serve as an external CI test tool that replaces the internal CI system.
+In the context of the `kyma-project` organization, the main purpose of Prow is to serve as an external CI test tool that replaces the internal CI system.
 
-Prow configuration replies on this basic set of configurations:
-- Kubernetes cluster deployed in Google Kubernetes Engine (GKE).
-- GitHub bot account.
+Prow replies on this basic set of configurations:
+- Kubernetes cluster deployed in Google Kubernetes Engine (GKE)
+- GitHub bot account
 - GitHub tokens:
-    - `hmac-token` which is a Prow HMAC token used for validating GitHub webhooks.
-    - `oauth-token` which is a GitHub token with read and write access to the bot account.
-- Service accounts and their Secret files for sensitive jobs that are encrypted using Key Management Service (KMS) and stored in Google Cloud Storage (GCS).
-- The `starter.yaml` file with a basic configuration of Prow components.
+    - `hmac-token` which is a Prow HMAC token used for validating GitHub webhooks
+    - `oauth-token` which is a GitHub token with read and write access to the bot account
+- Service accounts and their Secret files for sensitive jobs that are encrypted using Key Management Service (KMS) and stored in Google Cloud Storage (GCS)
+- The `starter.yaml` file with a basic configuration of Prow components
 - Webhooks configured for the GitHub repository to enable sending Events from a GitHub repository to Prow.
-- Plugins enabled by creating and modifying the `plugins.yaml` file.
-- Jobs enabled by creating and configuring the basic `config.yaml` file and additional `yaml` files for specific Kyma components.
+- Plugins enabled by creating and modifying the `plugins.yaml` file
+- Jobs enabled by creating and configuring the basic `config.yaml` file and an additional `Makefile` for a specific Kyma component
 
 ### Basic rules
 
 Follow these basic rules when working with Prow in the `kyma-project` organization:
 
-- You cannot test Prow configuration locally on Minikube. Perform all the tests on the cluster.
+- You cannot test Prow configuration locally on Minikube. Perform all tests on the cluster.
 - Avoid provisioning long-running clusters.
 - Test Prow configuration against your `kyma` fork repository.
-- Disable builds on the internal CI only after all CI functionalities are provided by Prow. This applies not only for the `master` branch but also for release branches.
+- Disable builds on the internal CI only after all CI functionalities are provided by Prow. This applies not only to the `master` branch but also to release branches.
 
 ### Project structure
 
@@ -72,7 +72,7 @@ For example:
    | |- kyma
    | | |- components
    | | | |- environments
-   | | | | |- environments.jobs.yaml
+   | | | | |- environments.yaml
    | | |- kyma.integration.yaml
    |- scripts
    |- config.yaml

--- a/prow/README.md
+++ b/prow/README.md
@@ -1,67 +1,90 @@
-# Prow Production Configuration
+# Prow
+
 ## Overview
-This project contains a set of configuration files for the Prow production cluster.
-## Prerequisites
 
+Prow is a Kubernetes-developed system that you can use as a Continuous Integration (CI) tool for validating your GitHub repositories and components, managing automatic validation of PRs, applying and removing labels, or opening and closing issues.
 
-Install the following tools:
+You interact with Prow using slash (/) commands, such as `/test all`. You add them on pull requests or issues to trigger the predefined automation [plugins](https://prow.k8s.io/plugins) and perform a certain action in respond to GitHub events. Upon proper configuration, GitHub events trigger jobs that are single-container Pods, created in dedicated builds and Kubernetes clusters by a microservice called Plank that is running in the GSP. Each Prow component is a small Go service that has its own function in the management of these one-off single-pod ProwJobs.
 
-- Kubernetes 1.10+ on GKE
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-- [gcloud](https://cloud.google.com/sdk/gcloud/)
+In the content of the `kyma-project` organization, the main purpose of Prow is to serve as an external CI test tool that replaces the internal CI system.
 
-### Google Cloud Platform configuration
+Prow configuration replies on this basic set of configurations:
+- Kubernetes cluster deployed in Google Container Engine (GKE)
+- GitHub bot account
+- GitHub tokens:
+    - `hmac-token` as a Prow HMAC token used for validating GitHub webhooks.
+    - `oauth-token` as a GitHub token with read and write access to the bot account.
+- Service accounts and their Secret files for sensitive jobs that are encrypted using Key Management Service (KMS) and stored in Google Cloud Storage (GCS)
+- The `starter.yaml` file with a basic configuration of Prow components
+- Webhooks configured for the GitHub repository to enable sending Events from a GitHub repository to Prow.
+- Plugins enabled by creating and modifying the `plugins.yaml` file.
+- Jobs enabled by creating and configuring the basic `config.yaml` file and additional `yaml` files for specific Kyma components.
 
-- A global static IP address with the `prow-production` name.
-- A DNS registry for the `status.build.kyma-project.io` domain that points to the `prow-production` address.
+### Basic rules
 
-### Secrets
-The obligatory Secrets include:
-- `hmac-token` which is a Prow HMAC token used for GitHub Webhooks.
-- `oauth-token` which is a GitHub token with read and write access to the `kyma-bot` account.
-- `compute-service-account` which is a Google Cloud service account with the following roles:
-  - Service Account User
-  - Compute Admin
-  - Compute OS Admin Login
+Follow these basic rules when working with Prow in the `kyma-project` organization:
+
+- You cannot test Prow configuration locally on Minikube. Perform all the tests on the cluster.
+- Avoid provisioning long-running clusters.
+- Test Prow configuration against your `kyma` fork repository.
+- Disable builds on the internal CI only after all CI functionalities are provided by Prow. This applies not only for the `master` branch but also for release branches.
+
+### Project structure
+
+The `prow` folder contains a set of configuration files for the Prow production cluster.
+
+<!-- Update the folder structure each time you modify it. -->
+
+Its structure looks as follows:
+
+```
+
+  ├── cluster               # The folder with all "yaml" files for Prow cluster provisioning.           
+  ├── images                # The folder with images for component jobs that you can also use for generic builds.                                             
+  ├── jobs                  # The folder with all files with jobs definitions.
+  ├── scripts               # The folder with scripts used by the test jobs.
+  ├── config.yaml           # The file with the main Prow configuration, without job definitions. For example, it contains Plank configuration and Preset definitions.
+  ├── install-prow.sh       # The script for the production cluster installation.
+  └── plugins.yaml          # The file with Prow plugins configuration.
+```
 
 ## Installation
 
-1. Ensure that `kubectl` points to the correct cluster. For GKE, execute the following command:
+Read the [`docs`](../docs/prow/README.md) to lean how to configure the production Prow or install it on your forked repository for development and testing.
 
-```
-gcloud container clusters get-credentials {CLUSTER_NAME} --zone={ZONE_NAME} --project={PROJECT_NAME}
-```
+## Development
 
-2. Export the environment variables:
- - **BUCKET_NAME** is a GCS bucket in the Google Cloud project that is used to store Prow Secrets.
- - **KEYRING_NAME** is the KMS key ring.
- - **ENCRYPTION_KEY_NAME** is the key name in the key ring that is used for data encryption.
+Read about the conventions for organizing and naming jobs in the `prow` subdirectories.
 
- ```
- export BUCKET_NAME=kyma-prow
- export KEYRING_NAME=kyma-prow
- export ENCRYPTION_KEY_NAME=kyma-prow-encryption
- ```
- 
-3. Run the following script to start the installation process:
+### Strategy for organising jobs
 
-```bash
-./install-prow.sh
-```
+The `jobs/{repository_name}` directories have subdirectories which represent each component and contain job definitions. Each file must have a unique name. Job definitions not connected to a particular component, like integration jobs, are defined directly under the `jobs/{repository_name}` directory.
 
-The installation script performs the following steps to install Prow:
+For example:
 
-- Deploy the NGINX Ingress Controller.
-- Create a ClusterRoleBinding.
-- Deploy Prow components with the `a202e595a33ac92ab503f913f2d710efabd3de21`revision.
-- Deploy Cert Manager.
-- Deploy Secure Ingress.
-- Removes Insecure Ingress.
+   ```
+   ...
+   prow
+   |- cluster
+   | |- starter.yaml
+   |- images
+   |- jobs
+   | |- kyma
+   | | |- components
+   | | | |- environments
+   | | | | |- environments.jobs.yaml
+   | | |- kyma.integration.yaml
+   |- scripts
+   |- config.yaml
+   |- plugins.yaml
+   ...
+   ```
 
-To check if the installation is successful, perform the following steps:
+### Convention for naming jobs
 
-1. Check if all Pods are up and running:
-   `kubeclt get pods`
-2. Check if the Deck is accessible from outside of the cluster:
-   `kubectl get ingress tls-ing`
-   Copy the address of the `tls-ing` Ingress and open it in a browser to display the Prow status on the dashboard.
+When you define jobs for Prow, both **name** and **context** of the job must follow one of these patterns:
+
+- `prow/{repository_name}/{component_name}/{job_name}` for components
+- `prow/{repository_name}/{job_name}` for jobs not connected to a particular component
+
+In both cases, `{job_name}` must reflect the job's responsibility.

--- a/prow/README.md
+++ b/prow/README.md
@@ -4,7 +4,7 @@
 
 Prow is a Kubernetes-developed system that you can use as a Continuous Integration (CI) tool for validating your GitHub repositories and components, managing automatic validation of PRs, applying and removing labels, or opening and closing issues.
 
-You interact with Prow using slash (/) commands, such as `/test all`. You add them on pull requests or issues to trigger the predefined automation [plugins](https://prow.k8s.io/plugins) and perform a certain action in respond to GitHub events. Upon proper configuration, GitHub events trigger jobs that are single-container Pods, created in dedicated builds and Kubernetes clusters by a microservice called Plank that is running in the GSP. Each Prow component is a small Go service that has its own function in the management of these one-off single-pod ProwJobs.
+You interact with Prow using slash (/) commands, such as `/test all`. You add them on pull requests or issues to trigger the predefined automation [plugins](https://prow.k8s.io/plugins) that perform certain actions in respond to GitHub events. Upon proper configuration, GitHub events trigger jobs that are single-container Pods, created in dedicated builds and Kubernetes clusters by a microservice called Plank that is running in the GCP. Each Prow component is a small Go service that has its own function in the management of these one-off single-pod ProwJobs.
 
 In the content of the `kyma-project` organization, the main purpose of Prow is to serve as an external CI test tool that replaces the internal CI system.
 

--- a/prow/README.md
+++ b/prow/README.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-Prow is a Kubernetes-developed system that you can use as a Continuous Integration (CI) tool for validating your GitHub repositories and components, managing automatic validation of PRs, applying and removing labels, or opening and closing issues.
+Prow is a Kubernetes-developed system that you can use as a Continuous Integration (CI) tool for validating your GitHub repositories and components, managing automatic validation of pull requests, applying and removing labels, or opening and closing issues.
 
-You interact with Prow using slash (/) commands, such as `/test all`. You add them on pull requests or issues to trigger the predefined automation [plugins](https://status.build.kyma-project.io/plugins) that perform certain actions in respond to GitHub events. Upon proper configuration, GitHub events trigger jobs that are single-container Pods, created in dedicated builds and Kubernetes clusters by a microservice called Plank that is running in GCP. Each Prow component is a small Go service that has its own function in the management of these one-off single-pod Prow jobs.
+You interact with Prow using slash (/) commands, such as `/test all`. You add them on pull requests or issues to trigger the predefined automation [plugins](https://status.build.kyma-project.io/plugins) that perform certain actions in respond to GitHub events. Upon proper configuration, GitHub events trigger jobs that are single-container Pods, created in dedicated builds and Kubernetes clusters by a microservice called Plank that is running in Google Cloud Platform (GCP). Each Prow component is a small Go service that has its own function in the management of these one-off single-pod Prow jobs.
 
 In the context of the `kyma-project` organization, the main purpose of Prow is to serve as an external CI test tool that replaces the internal CI system.
 
@@ -12,7 +12,7 @@ Prow replies on this basic set of configurations:
 - Kubernetes cluster deployed in Google Kubernetes Engine (GKE)
 - GitHub bot account
 - GitHub tokens:
-    - `hmac-token` which is a Prow HMAC token used for validating GitHub webhooks
+    - `hmac-token` which is a Prow HMAC token used to validate GitHub webhooks
     - `oauth-token` which is a GitHub token with read and write access to the bot account
 - Service accounts and their Secret files for sensitive jobs that are encrypted using Key Management Service (KMS) and stored in Google Cloud Storage (GCS)
 - The `starter.yaml` file with a basic configuration of Prow components

--- a/prow/README.md
+++ b/prow/README.md
@@ -4,12 +4,12 @@
 
 Prow is a Kubernetes-developed system that you can use as a Continuous Integration (CI) tool for validating your GitHub repositories and components, managing automatic validation of PRs, applying and removing labels, or opening and closing issues.
 
-You interact with Prow using slash (/) commands, such as `/test all`. You add them on pull requests or issues to trigger the predefined automation [plugins](https://prow.k8s.io/plugins) that perform certain actions in respond to GitHub events. Upon proper configuration, GitHub events trigger jobs that are single-container Pods, created in dedicated builds and Kubernetes clusters by a microservice called Plank that is running in GCP. Each Prow component is a small Go service that has its own function in the management of these one-off single-pod Prow jobs.
+You interact with Prow using slash (/) commands, such as `/test all`. You add them on pull requests or issues to trigger the predefined automation [plugins](https://status.build.kyma-project.io/plugins) that perform certain actions in respond to GitHub events. Upon proper configuration, GitHub events trigger jobs that are single-container Pods, created in dedicated builds and Kubernetes clusters by a microservice called Plank that is running in GCP. Each Prow component is a small Go service that has its own function in the management of these one-off single-pod Prow jobs.
 
 In the content of the `kyma-project` organization, the main purpose of Prow is to serve as an external CI test tool that replaces the internal CI system.
 
 Prow configuration replies on this basic set of configurations:
-- Kubernetes cluster deployed in Google Container Engine (GKE).
+- Kubernetes cluster deployed in Google Kubernetes Engine (GKE).
 - GitHub bot account.
 - GitHub tokens:
     - `hmac-token` which is a Prow HMAC token used for validating GitHub webhooks.
@@ -40,7 +40,7 @@ Its structure looks as follows:
 ```
 
   ├── cluster               # All "yaml" files for Prow cluster provisioning.           
-  ├── images                # Images for Prow jobs that you can also use for generic builds.                                             
+  ├── images                # Images for Prow jobs.                                             
   ├── jobs                  # All files with jobs definitions.
   ├── scripts               # Scripts used by the test jobs.
   ├── config.yaml           # The main Prow configuration, without job definitions. For example, it contains Plank configuration and Preset definitions.
@@ -56,7 +56,7 @@ Read the [`docs`](../docs/prow/README.md) to lean how to configure the productio
 
 Read about the conventions for organizing and naming jobs in the `prow` subdirectories.
 
-### Strategy for organising jobs
+### Strategy for organizing jobs
 
 The `jobs/{repository_name}` directories have subdirectories which represent each component and contain job definitions. Each file must have a unique name. Job definitions not connected to a particular component, like integration jobs, are defined directly under the `jobs/{repository_name}` directory.
 

--- a/prow/cluster/README.md
+++ b/prow/cluster/README.md
@@ -13,6 +13,6 @@ The structure of the folder looks as follows:
 ```
   ├── 01-cert-manager.yaml        # Definition of the Cert Manager and related resources, required to manage the SSL certificates that ensure the trusted website connection.
   ├── 02-cluster-issuer.yaml      # Definition of the resource responsible for creating new certificates.
-  ├── 03-tls-ing_ingerss.yaml     # Definition of the encrypted Ingress that accesses the Prow cluster.
+  ├── 03-tls-ing_ingress.yaml     # Definition of the encrypted Ingress that accesses the Prow cluster.
   └── starter.yaml                # Basic definition of Prow, including ConfigMaps, deployments, and Custom Resource definitions.
 ```

--- a/prow/cluster/README.md
+++ b/prow/cluster/README.md
@@ -11,8 +11,8 @@ This folder contains files related to the configuration of the Prow production c
 The structure of the folder looks as follows:
 
 ```
-  ├── 01-cert-manager.yaml        # Definition of the Cert Manager and related resources, required to manage the SSL certificates that ensure the trusted website connection.
-  ├── 02-cluster-issuer.yaml      # Definition of the resource which creates new certificates.
-  ├── 03-tls-ing_ingress.yaml     # Definition of the encrypted Ingress that accesses the Prow cluster.
-  └── starter.yaml                # Basic definition of Prow, including ConfigMaps, Deployments, and CustomResourceDefinitions.
+  ├── 01-cert-manager.yaml        # The definition of the Cert Manager and related resources, required to manage the SSL certificates that ensure the trusted website connection
+  ├── 02-cluster-issuer.yaml      # The definition of the resource which creates new certificates
+  ├── 03-tls-ing_ingress.yaml     # The definition of the encrypted Ingress that accesses the Prow cluster
+  └── starter.yaml                # The basic definition of Prow, including ConfigMaps, Deployments, and CustomResourceDefinitions
 ```

--- a/prow/cluster/README.md
+++ b/prow/cluster/README.md
@@ -1,0 +1,18 @@
+# Cluster
+
+## Overview
+
+This folder contains files related to the configuration of the Prow production cluster that are used during the cluster provisioning.
+
+### Project structure
+
+<!-- Update the folder structure each time you modify it. -->
+
+The structure of the folder looks as follows:
+
+```
+  ├── 01-cert-manager.yaml        # Definition of the Cert Manager and related resources, required to manage the SSL certificates that ensure the trusted website connection.
+  ├── 02-cluster-issuer.yaml      # Definition of the resource responsible for creating new certificates.
+  ├── 03-tls-ing_ingerss.yaml     # Definition of the encrypted Ingress that accesses the Prow cluster.
+  └── starter.yaml                # Basic definition of Prow, including ConfigMaps, deployments, and Custom Resource definitions.
+```

--- a/prow/cluster/README.md
+++ b/prow/cluster/README.md
@@ -12,7 +12,7 @@ The structure of the folder looks as follows:
 
 ```
   ├── 01-cert-manager.yaml        # Definition of the Cert Manager and related resources, required to manage the SSL certificates that ensure the trusted website connection.
-  ├── 02-cluster-issuer.yaml      # Definition of the resource responsible for creating new certificates.
+  ├── 02-cluster-issuer.yaml      # Definition of the resource which creates new certificates.
   ├── 03-tls-ing_ingress.yaml     # Definition of the encrypted Ingress that accesses the Prow cluster.
-  └── starter.yaml                # Basic definition of Prow, including ConfigMaps, deployments, and Custom Resource definitions.
+  └── starter.yaml                # Basic definition of Prow, including ConfigMaps, Deployments, and CustomResourceDefinitions.
 ```

--- a/prow/images/README.md
+++ b/prow/images/README.md
@@ -11,8 +11,8 @@ This folder contains a list of images used in Prow jobs.
 The structure of the folder looks as follows:
 
 ```
-  ├── bootstrap             # A generic image that contains Docker and gcloud.            
-  ├── buildpack-golang      # An image for building Golang components.
-  ├── buildpack-node        # An image for building Node.js components.
-  └── cleaner               # An image with a script for cleaning SSH keys on service accounts in Google Cloud Storage.  
+  ├── bootstrap             # The generic image that contains Docker and gcloud            
+  ├── buildpack-golang      # The image for building Golang components
+  ├── buildpack-node        # The image for building Node.js components
+  └── cleaner               # The image with a script for cleaning SSH keys on service accounts in Google Cloud Storage  
 ```

--- a/prow/images/README.md
+++ b/prow/images/README.md
@@ -1,0 +1,18 @@
+# Images
+
+## Overview
+
+This folder contains a list of images used in Prow jobs.
+
+### Project structure
+
+<!-- Update the folder structure each time you modify it. -->
+
+The structure of the folder looks as follows:
+
+```
+  ├── bootstrap             # A generic image that contains Docker and gcloud.            
+  ├── buildpack-golang      # An image for building Golang components.
+  ├── buildpack-node        # An image for building Node.js components.
+  └── cleaner               # A script for cleaning SSH keys on service accounts in Google Cloud Storage.  
+```

--- a/prow/images/README.md
+++ b/prow/images/README.md
@@ -14,5 +14,5 @@ The structure of the folder looks as follows:
   ├── bootstrap             # A generic image that contains Docker and gcloud.            
   ├── buildpack-golang      # An image for building Golang components.
   ├── buildpack-node        # An image for building Node.js components.
-  └── cleaner               # A script for cleaning SSH keys on service accounts in Google Cloud Storage.  
+  └── cleaner               # An image with a script for cleaning SSH keys on service accounts in Google Cloud Storage.  
 ```

--- a/prow/images/bootstrap/README.md
+++ b/prow/images/bootstrap/README.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-This project includes the Bootstrap image for Prow infrastructure. Use it for a root image for other Prow images and for generic builds.
+This folder contains the Bootstrap image for Prow infrastructure. Use it for a root image for other Prow images and for generic builds.
 
-This image contains:
+The image consists of:
 
 - gcloud
 - Docker

--- a/prow/images/bootstrap/README.md
+++ b/prow/images/bootstrap/README.md
@@ -2,16 +2,16 @@
 
 ## Overview
 
-This project includes the Bootstrap image for Prow infrastructure. It can be used as a root image for other Prow images and also for generic builds.
+This project includes the Bootstrap image for Prow infrastructure. Use it for a root image for other Prow images and for generic builds.
 
 This image contains:
 
 - gcloud
 - Docker
 
-## Build
+## Installation
 
-To build Docker image, run this command:
+To build the Docker image, run this command:
 
 ```bash
 docker build bootstrap .

--- a/prow/images/buildpack-golang/README.md
+++ b/prow/images/buildpack-golang/README.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-This project includes the Buildpack Golang image that is based on the Bootstrap image. Use it to build node components.
+This folder contains the Buildpack Golang image that is based on the Bootstrap image. Use it to build node components.
 
-This image contains:
+The image consists of:
 
 - golang
 - dep

--- a/prow/images/buildpack-golang/README.md
+++ b/prow/images/buildpack-golang/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This folder contains the Buildpack Golang image that is based on the Bootstrap image. Use it to build node components.
+This folder contains the Buildpack Golang image that is based on the Bootstrap image. Use it to build Golang components.
 
 The image consists of:
 

--- a/prow/images/buildpack-golang/README.md
+++ b/prow/images/buildpack-golang/README.md
@@ -2,16 +2,16 @@
 
 ## Overview
 
-This project includes Buildpack Golang image that is based on Bootstrap image. It can be used for building node components
+This project includes the Buildpack Golang image that is based on the Bootstrap image. Use it to build node components.
 
 This image contains:
 
 - golang
 - dep
 
-## Build
+## Installation
 
-To build Docker image, run this command:
+To build the Docker image, run this command:
 
 ```bash
 docker build buildpack-golang .

--- a/prow/images/buildpack-node/README.md
+++ b/prow/images/buildpack-node/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This project includes Buildpack Node image that is based on Bootstrap image. It can be used for building node components.
+This project includes the Buildpack Node image that is based on the Bootstrap image. Use it to build node components.
 
 This image contains:
 
@@ -12,7 +12,7 @@ This image contains:
 - prettier
 - whitesource
 
-## Build
+## Installation
 
 To build the Docker image, run this command:
 

--- a/prow/images/buildpack-node/README.md
+++ b/prow/images/buildpack-node/README.md
@@ -1,8 +1,8 @@
-# Buildpack Node Docker Image
+# Buildpack Node.js Docker Image
 
 ## Overview
 
-This folder contains the Buildpack Node image that is based on the Bootstrap image. Use it to build node components.
+This folder contains the Buildpack Node.js image that is based on the Bootstrap image. Use it to build Node.js components.
 
 The image consists of:
 

--- a/prow/images/buildpack-node/README.md
+++ b/prow/images/buildpack-node/README.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-This project includes the Buildpack Node image that is based on the Bootstrap image. Use it to build node components.
+This folder contains the Buildpack Node image that is based on the Bootstrap image. Use it to build node components.
 
-This image contains:
+The image consists of:
 
 - nodejs
 - eslint

--- a/prow/scripts/README.md
+++ b/prow/scripts/README.md
@@ -11,11 +11,9 @@ The folder contains various scripts involved in integration tests.
 The structure of the folder looks as follows:
 
 ```
-  ├── cluster-integration               # Scripts for the cleanup of Google Cloud Platform (GCP) objects after completion of integration tests.             
-  ├── create-dns-entry.sh               # The script that creates a DNS entry on a GKE cluster for integration tests.
-  ├── generate-self-signed-cert.sh      # The script for creating a self-signed certificate on a GKE cluster for integration tests.
-  ├── library.sh                        # The script to be used as an integral part of other scripts. For example, the "pipeline.sh" script uses it. With proper parameters defined, it authenticates you in GCP and sets up the Docker-in-Docker environment.
-  ├── pipeline.sh                       # The script responsible for building and testing a given Kyma component by running the respective "Makefile".
-  ├── provision-vm-and-start-kyma.sh    # The script responsible for starting a virtual machine as part of the integration job and running integration tests for Kyma on Minikube.
-  └── reserve-ip-address.sh             # The script that reserves the static IP address for a cluster on GCP.
+  ├── cluster-integration                # Scripts for the cleanup of Google Cloud Platform (GCP) objects after completion of integration tests.             
+  ├── library.sh                         # The script to be used as an integral part of other scripts. For example, the "pipeline.sh" script uses it. With proper parameters defined, it authenticates you in GCP and sets up the Docker-in-Docker environment.
+  ├── pipeline.sh                        # The script responsible for building and testing a given Kyma component by running the respective "Makefile" target.
+  └──  provision-vm-and-start-kyma.sh    # The script responsible for starting a virtual machine as part of the integration job and running integration tests for Kyma on Minikube.
+
 ```

--- a/prow/scripts/README.md
+++ b/prow/scripts/README.md
@@ -1,0 +1,21 @@
+# Cluster
+
+## Overview
+
+The folder contains various scripts involved in integration tests.
+
+### Project structure
+
+<!-- Update the folder structure each time you modify it. -->
+
+The structure of the folder looks as follows:
+
+```
+  ├── cluster-integration               # Scripts for the cleanup of Google Cloud Platform (GCP) objects after completion of integration tests.             
+  ├── create-dns-entry.sh               # The script that creates a DNS entry on a GKE cluster for integration tests.
+  ├── generate-self-signed-cert.sh      # The script for creating a self-signed certificate on a GKE cluster for integration tests.
+  ├── library.sh                        # The script to be used as an integral part of other scripts. For example, the "pipeline.sh" script uses it. With proper parameters defined, it authenticates you in GCP and sets up the Docker-in-Docker environment.
+  ├── pipeline.sh                       # The script responsible for building and testing a given Kyma component by running the respective "Makefile".
+  ├── provision-vm-and-start-kyma.sh    # The script responsible for starting a virtual machine as part of the integration job and running integration tests for Kyma on Minikube.
+  └── reserve-ip-address.sh             # The script that reserves the static IP address for a cluster on GCP.
+```

--- a/prow/scripts/README.md
+++ b/prow/scripts/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The folder contains various scripts involved in integration tests.
+The folder contains scripts involved in integration tests.
 
 ### Project structure
 
@@ -12,7 +12,7 @@ The structure of the folder looks as follows:
 
 ```
   ├── cluster-integration                # Scripts for the cleanup of Google Cloud Platform (GCP) objects after completion of integration tests.             
-  ├── library.sh                         # The script to be used as an integral part of other scripts. For example, the "pipeline.sh" script uses it. With proper parameters defined, it authenticates you in GCP and sets up the Docker-in-Docker environment.
+  ├── library.sh                         # The script to be used as an integral part of other scripts, for example by the "pipeline.sh" script. With proper parameters defined, it authenticates you to GCP and sets up the Docker-in-Docker environment.
   ├── pipeline.sh                        # The script responsible for building and testing a given Kyma component by running the respective "Makefile" target.
   └──  provision-vm-and-start-kyma.sh    # The script responsible for starting a virtual machine as part of the integration job and running integration tests for Kyma on Minikube.
 

--- a/prow/scripts/README.md
+++ b/prow/scripts/README.md
@@ -13,7 +13,7 @@ The structure of the folder looks as follows:
 ```
   ├── cluster-integration                # Scripts for the cleanup of Google Cloud Platform (GCP) objects after completion of integration tests.             
   ├── library.sh                         # The script to be used as an integral part of other scripts, for example by the "pipeline.sh" script. With proper parameters defined, it authenticates you to GCP and sets up the Docker-in-Docker environment.
-  ├── pipeline.sh                        # The script responsible for building and testing a given Kyma component by running the respective "Makefile" target.
-  └──  provision-vm-and-start-kyma.sh    # The script responsible for starting a virtual machine as part of the integration job and running integration tests for Kyma on Minikube.
+  ├── pipeline.sh                        # The script which builds and tests a given Kyma component by running the respective "Makefile" target.
+  └──  provision-vm-and-start-kyma.sh    # The script which starts a virtual machine as part of the integration job and runs integration tests for Kyma on Minikube.
 
 ```

--- a/prow/scripts/README.md
+++ b/prow/scripts/README.md
@@ -12,8 +12,8 @@ The structure of the folder looks as follows:
 
 ```
   ├── cluster-integration                # Scripts for the cleanup of Google Cloud Platform (GCP) objects after completion of integration tests.             
-  ├── library.sh                         # The script to be used as an integral part of other scripts, for example by the "pipeline.sh" script. With proper parameters defined, it authenticates you to GCP and sets up the Docker-in-Docker environment.
-  ├── pipeline.sh                        # The script which builds and tests a given Kyma component by running the respective "Makefile" target.
-  └──  provision-vm-and-start-kyma.sh    # The script which starts a virtual machine as part of the integration job and runs integration tests for Kyma on Minikube.
+  ├── library.sh                         # This script is used as an integral part of other scripts, for example by the "pipeline.sh" script. With proper parameters defined, it authenticates you to GCP and sets up the Docker-in-Docker environment.
+  ├── pipeline.sh                        # This script builds and tests a given Kyma component by running the respective "Makefile" target.
+  └──  provision-vm-and-start-kyma.sh    # This script starts a virtual machine as part of the integration job and runs integration tests for Kyma on Minikube.
 
 ```

--- a/prow/scripts/cluster-integration/README.md
+++ b/prow/scripts/cluster-integration/README.md
@@ -11,10 +11,10 @@ The folder contains scripts that are involved in the preparation and removal of 
 The structure of the folder looks as follows:
 
 ```
-  ├── create-dns-entry.sh               # The script that creates a DNS entry on Google Cloud Platform (GCP) that points to the GKE cluster.
-  ├── delete-dns-record.sh              # The script which removes a DNS record from GCP after completion of integration tests.
-  ├── generate-self-signed-cert.sh      # The script for creating a self-signed certificate.
-  ├── pr-gke-integration.sh             # The script that provisions a cluster on GKE and deprovisions it when the tests complete.
-  └── release-ip-address.sh             # The script which releases the static IP address of a cluster on GCP.
-  └── reserve-ip-address.sh             # The script that reserves the static IP address for a cluster on GCP.
+  ├── create-dns-entry.sh               # This script creates a DNS entry on Google Cloud Platform (GCP) that points to the GKE cluster.
+  ├── delete-dns-record.sh              # This script removes a DNS record from GCP after completion of integration tests.
+  ├── generate-self-signed-cert.sh      # This script creates a self-signed certificate.
+  ├── pr-gke-integration.sh             # This script provisions a cluster on GKE and deprovisions it when the tests complete.
+  └── release-ip-address.sh             # This script releases the static IP address of a cluster on GCP.
+  └── reserve-ip-address.sh             # This script reserves the static IP address for a cluster on GCP.
 ```

--- a/prow/scripts/cluster-integration/README.md
+++ b/prow/scripts/cluster-integration/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The folder contains scripts that are involved in the preparation and removal of the cluster setup on Google Kubernetes Engine (GKE). 
+The folder contains scripts that are involved in the preparation and removal of the cluster setup on Google Kubernetes Engine (GKE).
 
 ### Project structure
 
@@ -14,7 +14,7 @@ The structure of the folder looks as follows:
   ├── create-dns-entry.sh               # The script that creates a DNS entry on Google Cloud Platform (GCP) that points to the GKE cluster.
   ├── delete-dns-record.sh              # The script responsible for removing a DNS record from GCP after completion of integration tests.
   ├── generate-self-signed-cert.sh      # The script for creating a self-signed certificate.
-  ├── pr-gke-integration.sh             # The script that provisions a cluster on GKE and deprovisions it the tests complete.
+  ├── pr-gke-integration.sh             # The script that provisions a cluster on GKE and deprovisions it when the tests complete.
   └── release-ip-address.sh             # The script which releases the static IP address of a cluster on GCP.
   └── reserve-ip-address.sh             # The script that reserves the static IP address for a cluster on GCP.
 ```

--- a/prow/scripts/cluster-integration/README.md
+++ b/prow/scripts/cluster-integration/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The folder contains scripts that are responsible for performing a cleanup of Google Cloud Platform (GCP) objects built as part of the integration tests that run on pull requests.
+The folder contains scripts that are involved in the preparation and removal of the cluster setup on Google Kubernetes Engine (GKE). 
 
 ### Project structure
 
@@ -11,7 +11,10 @@ The folder contains scripts that are responsible for performing a cleanup of Goo
 The structure of the folder looks as follows:
 
 ```
-  ├── delete-dns-record.sh            # The script responsible for removing DNS record of type A from a GKE cluster after completion of integration tests.
-  ├── pr-gke-integration.sh           # The script that provisions a cluster on GKE and deprovisions it the tests complete.
-  └── release-ip-address.sh           # The script which releases the static IP address of a cluster from GCP.
+  ├── create-dns-entry.sh               # The script that creates a DNS entry on Google Cloud Platform (GCP) that points to the GKE cluster.
+  ├── delete-dns-record.sh              # The script responsible for removing a DNS record from GCP after completion of integration tests.
+  ├── generate-self-signed-cert.sh      # The script for creating a self-signed certificate.
+  ├── pr-gke-integration.sh             # The script that provisions a cluster on GKE and deprovisions it the tests complete.
+  └── release-ip-address.sh             # The script which releases the static IP address of a cluster on GCP.
+  └── reserve-ip-address.sh             # The script that reserves the static IP address for a cluster on GCP.
 ```

--- a/prow/scripts/cluster-integration/README.md
+++ b/prow/scripts/cluster-integration/README.md
@@ -12,7 +12,7 @@ The structure of the folder looks as follows:
 
 ```
   ├── create-dns-entry.sh               # The script that creates a DNS entry on Google Cloud Platform (GCP) that points to the GKE cluster.
-  ├── delete-dns-record.sh              # The script responsible for removing a DNS record from GCP after completion of integration tests.
+  ├── delete-dns-record.sh              # The script which removes a DNS record from GCP after completion of integration tests.
   ├── generate-self-signed-cert.sh      # The script for creating a self-signed certificate.
   ├── pr-gke-integration.sh             # The script that provisions a cluster on GKE and deprovisions it when the tests complete.
   └── release-ip-address.sh             # The script which releases the static IP address of a cluster on GCP.

--- a/prow/scripts/cluster-integration/README.md
+++ b/prow/scripts/cluster-integration/README.md
@@ -1,0 +1,17 @@
+# Cluster Integration
+
+## Overview
+
+The folder contains scripts that are responsible for performing a cleanup of Google Cloud Platform (GCP) objects built as part of the integration tests that run on pull requests.
+
+### Project structure
+
+<!-- Update the folder structure each time you modify it. -->
+
+The structure of the folder looks as follows:
+
+```
+  ├── delete-dns-record.sh            # The script responsible for removing DNS record of type A from a GKE cluster after completion of integration tests.
+  ├── pr-gke-integration.sh           # The script that provisions a cluster on GKE and deprovisions it the tests complete.
+  └── release-ip-address.sh           # The script which releases the static IP address of a cluster from GCP.
+```


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Reworked the main installation and secret management documents to provide a clear order of guides.
- Corrected wrong script paths in the above-mentioned document (upon consultation).
- Extracted the installation docs and the document on secret management to the `docs/prow` subfolder.
- Added folder structure for the main `README.md` documents in the repository.
- Provided an explanation of what Prow is, what purpose it serves and what basic configuration it consists of.

**Related issue(s)**
Refers to #70 and #69 
