### PR TITLE
Abort gcloud DNS transaction if create-dns-entry.sh script fails

### DIFF
--- a/prow/scripts/cluster-integration/create-dns-record.sh
+++ b/prow/scripts/cluster-integration/create-dns-record.sh
@@ -28,8 +28,8 @@ fi
 trap cleanup EXIT
 
 cleanup() {
-    if [ ${CLEANUP_DNS_TRANSACTION} = true ]; then
-        gcloud dns record-sets transaction abort --zone=$(echo $CLOUDSDK_DNS_ZONE_NAME) --verbosity none
+    if [ "${CLEANUP_DNS_TRANSACTION}" == true ]; then
+        gcloud dns record-sets transaction abort --zone="${CLOUDSDK_DNS_ZONE_NAME}" --verbosity none
     fi
 }
 

--- a/prow/scripts/cluster-integration/create-dns-record.sh
+++ b/prow/scripts/cluster-integration/create-dns-record.sh
@@ -22,15 +22,15 @@ for var in CLOUDSDK_CORE_PROJECT CLOUDSDK_DNS_ZONE_NAME DNS_SUBDOMAIN IP_ADDRESS
 done
 
 if [ "${discoverUnsetVar}" = true ] ; then
-    exit 1
+    exit 2
 fi
 
 trap cleanup EXIT
 
 cleanup() {
-    set +e
-    gcloud dns record-sets transaction abort --zone=$(echo $DNS_ZONE) --verbosity none
-    set -e
+    if [ $(echo $?) -eq 1 ]; then
+        gcloud dns record-sets transaction abort --zone=$(echo $CLOUDSDK_DNS_ZONE_NAME) --verbosity none
+    fi
 }
 
 DNS_DOMAIN="$(gcloud dns managed-zones describe "${CLOUDSDK_DNS_ZONE_NAME}" --format="value(dnsName)")"
@@ -59,4 +59,4 @@ while [ ${SECONDS} -lt ${END_TIME} ];do
 done
 
 echo "Cannot resolve ${DNS_FULL_NAME} to expected IP_ADDRESS: ${IP_ADDRESS}."
-exit 1
+exit 2

--- a/prow/scripts/cluster-integration/create-dns-record.sh
+++ b/prow/scripts/cluster-integration/create-dns-record.sh
@@ -25,6 +25,14 @@ if [ "${discoverUnsetVar}" = true ] ; then
     exit 1
 fi
 
+trap cleanup EXIT
+
+cleanup() {
+    set +e
+    gcloud dns record-sets transaction abort --zone=$(echo $DNS_ZONE) --verbosity none
+    set -e
+}
+
 DNS_DOMAIN="$(gcloud dns managed-zones describe "${CLOUDSDK_DNS_ZONE_NAME}" --format="value(dnsName)")"
 DNS_FULL_NAME="${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
 

--- a/prow/scripts/cluster-integration/create-dns-record.sh
+++ b/prow/scripts/cluster-integration/create-dns-record.sh
@@ -22,13 +22,13 @@ for var in CLOUDSDK_CORE_PROJECT CLOUDSDK_DNS_ZONE_NAME DNS_SUBDOMAIN IP_ADDRESS
 done
 
 if [ "${discoverUnsetVar}" = true ] ; then
-    exit 2
+    exit 1
 fi
 
 trap cleanup EXIT
 
 cleanup() {
-    if [ $(echo $?) -eq 1 ]; then
+    if [ ${CLEANUP_DNS_TRANSACTION} = true ]; then
         gcloud dns record-sets transaction abort --zone=$(echo $CLOUDSDK_DNS_ZONE_NAME) --verbosity none
     fi
 }
@@ -36,11 +36,15 @@ cleanup() {
 DNS_DOMAIN="$(gcloud dns managed-zones describe "${CLOUDSDK_DNS_ZONE_NAME}" --format="value(dnsName)")"
 DNS_FULL_NAME="${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
 
+CLEANUP_DNS_TRANSACTION=true
+
 gcloud dns --project="${CLOUDSDK_CORE_PROJECT}" record-sets transaction start --zone="${CLOUDSDK_DNS_ZONE_NAME}"
 
 gcloud dns --project="${CLOUDSDK_CORE_PROJECT}" record-sets transaction add "${IP_ADDRESS}" --name="${DNS_FULL_NAME}" --ttl=300 --type=A --zone="${CLOUDSDK_DNS_ZONE_NAME}"
 
 gcloud dns --project="${CLOUDSDK_CORE_PROJECT}" record-sets transaction execute --zone="${CLOUDSDK_DNS_ZONE_NAME}"
+
+CLEANUP_DNS_TRANSACTION=false
 
 SECONDS=0
 END_TIME=$((SECONDS+600)) #600 seconds == 10 minutes
@@ -59,4 +63,4 @@ while [ ${SECONDS} -lt ${END_TIME} ];do
 done
 
 echo "Cannot resolve ${DNS_FULL_NAME} to expected IP_ADDRESS: ${IP_ADDRESS}."
-exit 2
+exit 1


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- gcloud DNS transaction will be aborted if create-dns-entry.sh script fails
- moved create-dns-entry.sh script to cluster-integration directory

**Related issue(s)**
Provisioning GKE cluster for integration tests #20
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
