### PR TITLE
Update buildpack postsubmits to use release

### DIFF
--- a/prow/images/bootstrap/Makefile
+++ b/prow/images/bootstrap/Makefile
@@ -3,7 +3,6 @@ IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(IMG_NAME)
 TAG = $(DOCKER_TAG)
 
 ci-pr: build-image push-image
-ci-master: build-image push-image
 ci-release: build-image push-image
 
 build-image:

--- a/prow/images/buildpack-golang/Makefile
+++ b/prow/images/buildpack-golang/Makefile
@@ -3,7 +3,6 @@ IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(IMG_NAME)
 TAG = $(DOCKER_TAG)
 
 ci-pr: build-image push-image
-ci-master: build-image push-image
 ci-release: build-image push-image
 
 build-image:

--- a/prow/images/buildpack-node/Makefile
+++ b/prow/images/buildpack-node/Makefile
@@ -3,7 +3,6 @@ IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(IMG_NAME)
 TAG = $(DOCKER_TAG)
 
 ci-pr: build-image push-image
-ci-master: build-image push-image
 ci-release: build-image push-image
 
 build-image:

--- a/prow/images/cleaner/Makefile
+++ b/prow/images/cleaner/Makefile
@@ -3,7 +3,6 @@ IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(IMG_NAME)
 TAG = $(DOCKER_TAG)
 
 ci-pr: build-image push-image
-ci-master: build-image push-image
 ci-release: build-image push-image
 
 build-image:

--- a/prow/jobs/test-infra/buildpack.jobs.yaml
+++ b/prow/jobs/test-infra/buildpack.jobs.yaml
@@ -92,21 +92,21 @@ postsubmits: # runs on master
   kyma-project/test-infra:
     - name: *bootstrap_name
       labels:
-        preset-build-master: "true"
+        preset-build-release: "true"
         <<: *job_labels_template
       <<: *bootstrap_job_template
     - name: *buildpack_golang_name
       labels:
-        preset-build-master: "true"
+        preset-build-release: "true"
         <<: *job_labels_template
       <<: *buildpack_golang_job_template
     - name: *buildpack_node_name
       labels:
-        preset-build-master: "true"
+        preset-build-release: "true"
         <<: *job_labels_template
       <<: *buildpack_node_job_template
     - name: *cleaner_name
       labels:
-        preset-build-master: "true"
+        preset-build-release: "true"
         <<: *job_labels_template
       <<: *cleaner_job_template

--- a/prow/scripts/publish-buildpack.sh
+++ b/prow/scripts/publish-buildpack.sh
@@ -23,8 +23,6 @@ pushd "${SOURCES_DIR}"
 
 if [[ "${BUILD_TYPE}" == "pr" ]]; then
     make ci-pr
-elif [[ "${BUILD_TYPE}" == "master" ]]; then
-    make ci-master
 elif [[ "${BUILD_TYPE}" == "release" ]]; then
     make ci-release
 else


### PR DESCRIPTION
Changes proposed in this pull request:

- Update buildpack postsubmits to use release

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #54 
