### PR TITLE
Increase hmac token to 32 bytes

### DIFF
--- a/development/install-prow.sh
+++ b/development/install-prow.sh
@@ -25,7 +25,7 @@ if [ -z "${LOCATION}" ]; then
 fi
 
 ## Create an HMAC token
-hmac_token="$(openssl rand -hex 20)"
+hmac_token="$(openssl rand -hex 32)"
 echo "$hmac_token" > hmac_token.txt
 echo "Token hmac stored in hmac_token.txt file"
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Increase hmac token to 32 bytes

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #174 
