### PR TITLE
GKE integration pipeline: fix wrong DNS name in UI tests

### DIFF
--- a/prow/scripts/cluster-integration/create-dns-record.sh
+++ b/prow/scripts/cluster-integration/create-dns-record.sh
@@ -5,8 +5,7 @@
 #Expected vars:
 # - CLOUDSDK_CORE_PROJECT: name of a GCP project where new DNS record is created.
 # - CLOUDSDK_DNS_ZONE_NAME: Name of an existing DNS zone in the project (NOT its DNS name!)
-# - DNS_DOMAIN: Name of DNS domain controlled by DNS zone CLOUDSDK_DNS_ZONE_NAME
-# - DNS_SUBDOMAIN: a subdomain to create entry for. Example: If DNS_DOMAIN referrs to "cool.dot.com." domain, use DNS_SUBDOMAIN="how" to create an entry: "how.cool.dot.com."
+# - DNS_FULL_NAME: Full DNS domain 
 # - IP_ADDRESS: v4 IP Address for the DNS record.
 #
 #Permissions: In order to run this script you need to use a service account with "DNS Administrator" role
@@ -15,7 +14,7 @@ set -o errexit
 
 discoverUnsetVar=false
 
-for var in CLOUDSDK_CORE_PROJECT CLOUDSDK_DNS_ZONE_NAME DNS_SUBDOMAIN DNS_DOMAIN IP_ADDRESS; do
+for var in CLOUDSDK_CORE_PROJECT CLOUDSDK_DNS_ZONE_NAME DNS_FULL_NAME IP_ADDRESS; do
     if [ -z "${!var}" ] ; then
         echo "ERROR: $var is not set"
         discoverUnsetVar=true
@@ -33,8 +32,6 @@ cleanup() {
         gcloud dns record-sets transaction abort --zone="${CLOUDSDK_DNS_ZONE_NAME}" --verbosity none
     fi
 }
-
-DNS_FULL_NAME="${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
 
 CLEANUP_DNS_TRANSACTION=true
 

--- a/prow/scripts/cluster-integration/create-dns-record.sh
+++ b/prow/scripts/cluster-integration/create-dns-record.sh
@@ -5,7 +5,7 @@
 #Expected vars:
 # - CLOUDSDK_CORE_PROJECT: name of a GCP project where new DNS record is created.
 # - CLOUDSDK_DNS_ZONE_NAME: Name of an existing DNS zone in the project (NOT its DNS name!)
-# - DNS_FULL_NAME: Full DNS domain 
+# - DNS_FULL_NAME: DNS name
 # - IP_ADDRESS: v4 IP Address for the DNS record.
 #
 #Permissions: In order to run this script you need to use a service account with "DNS Administrator" role

--- a/prow/scripts/cluster-integration/delete-dns-record.sh
+++ b/prow/scripts/cluster-integration/delete-dns-record.sh
@@ -5,7 +5,7 @@
 #Expected vars:
 # - CLOUDSDK_CORE_PROJECT: name of a GCP project containing the Zone with the record.
 # - CLOUDSDK_DNS_ZONE_NAME: Name of the existing DNS zone in the project (NOT it's DNS name!)
-# - DNS_FULL_NAME: Full DNS domain.
+# - DNS_FULL_NAME: DNS name
 # - IP_ADDRESS: v4 IP Address of the DNS record.
 #
 #Permissions: In order to run this script you need to use a service account with "DNS Administrator" role

--- a/prow/scripts/cluster-integration/delete-dns-record.sh
+++ b/prow/scripts/cluster-integration/delete-dns-record.sh
@@ -5,7 +5,7 @@
 #Expected vars:
 # - CLOUDSDK_CORE_PROJECT: name of a GCP project containing the Zone with the record.
 # - CLOUDSDK_DNS_ZONE_NAME: Name of the existing DNS zone in the project (NOT it's DNS name!)
-# - DNS_SUBDOMAIN: a subdomain in the Zone.
+# - DNS_FULL_NAME: Full DNS domain.
 # - IP_ADDRESS: v4 IP Address of the DNS record.
 #
 #Permissions: In order to run this script you need to use a service account with "DNS Administrator" role
@@ -13,7 +13,7 @@ set -o errexit
 
 discoverUnsetVar=false
 
-for var in CLOUDSDK_CORE_PROJECT CLOUDSDK_DNS_ZONE_NAME DNS_SUBDOMAIN IP_ADDRESS; do
+for var in CLOUDSDK_CORE_PROJECT CLOUDSDK_DNS_ZONE_NAME DNS_FULL_NAME IP_ADDRESS; do
     if [ -z "${!var}" ] ; then
         echo "ERROR: $var is not set"
         discoverUnsetVar=true
@@ -23,9 +23,6 @@ done
 if [ "${discoverUnsetVar}" = true ] ; then
     exit 1
 fi
-
-DNS_DOMAIN="$(gcloud dns managed-zones describe "${CLOUDSDK_DNS_ZONE_NAME}" --format="value(dnsName)")"
-DNS_FULL_NAME="${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
 
 gcloud dns --project="${CLOUDSDK_CORE_PROJECT}" record-sets transaction start --zone="${CLOUDSDK_DNS_ZONE_NAME}"
 

--- a/prow/scripts/cluster-integration/pr-gke-integration.sh
+++ b/prow/scripts/cluster-integration/pr-gke-integration.sh
@@ -198,8 +198,6 @@ date
 kubectl label installation/kyma-installation action=install
 "${KYMA_SCRIPTS_DIR}"/is-installed.sh
 
-sleep 9h
-
 shout "Test Kyma"
 date
 "${KYMA_SCRIPTS_DIR}"/testing.sh

--- a/prow/scripts/cluster-integration/pr-gke-integration.sh
+++ b/prow/scripts/cluster-integration/pr-gke-integration.sh
@@ -198,6 +198,8 @@ date
 kubectl label installation/kyma-installation action=install
 "${KYMA_SCRIPTS_DIR}"/is-installed.sh
 
+sleep 9h
+
 shout "Test Kyma"
 date
 "${KYMA_SCRIPTS_DIR}"/testing.sh


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- generate correct self-signed certificate
- change the way IP_ADDRESS_NAME (and thus domain) is created:
IP_ADDRESS_NAME=~~"pr-${PULL_NUMBER}-job-${PROW_JOB_ID}"~~ -> IP_ADDRESS_NAME="pr-${PULL_NUMBER}-${BUILD_ID}". 

Since domains accepted by openssl must be shorter than 64 chars, PROW_JOB_ID turns out to be too long. For now, BUILD_ID is used. This is subject to further changes (e.g. BUILD_ID can be replaced by five-digit random int).

**Related issue(s)**

result of #20 
fixes #213 
results in #242 

** Follow-up **

- connector-service-tests fail. See #242
