### PR TITLE
support PhantomJS in node-buildpack

### DIFF
--- a/prow/images/buildpack-node/Dockerfile
+++ b/prow/images/buildpack-node/Dockerfile
@@ -1,6 +1,6 @@
 # Basic node buildpack
 
-FROM eu.gcr.io/kyma-project/prow/bootstrap:0.0.1
+FROM eu.gcr.io/kyma-project/prow/test-infra/bootstrap:v20181121-f3ea5ce
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/prow/images/buildpack-node/Dockerfile
+++ b/prow/images/buildpack-node/Dockerfile
@@ -4,6 +4,8 @@ FROM eu.gcr.io/kyma-project/prow/bootstrap:0.0.1
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    libfontconfig \
+    procps \
     nodejs \
     && apt-get clean
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- added `libfontconfig` & `procps`, both required to run PhantomJS

**Related issue(s)**
See also #249
