### PR TITLE
Limit concurrent prow jobs and define limit range.

### DIFF
--- a/prow/cluster/05-limit-range.yaml
+++ b/prow/cluster/05-limit-range.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: jobs-limit-range
+# Defines limit range for ProwJob pods. Most of our jobs build go applications that requires a lot of memory and CPU.
+# Specifying LimitRange should prevent from running jobs on heavily loaded nodes (such Pod can exit with error code and will not be restarted).
+spec:
+  limits:
+  - defaultRequest:
+      memory: 2Gi
+      cpu: 800m
+    default:
+      memory: 2Gi
+      cpu: 800m
+    type: Container

--- a/prow/cluster/README.md
+++ b/prow/cluster/README.md
@@ -15,7 +15,7 @@ The structure of the folder looks as follows:
   ├── 02-cluster-issuer.yaml            # The definition of the resource which creates new certificates
   ├── 03-tls-ing_ingress.yaml           # The definition of the encrypted Ingress that accesses the Prow cluster
   ├── 04-branchprotector_cronjob.yaml   # The definition of the Branch Protector CronJob that configures protection on branches
-  ├── 05-limit-range.yaml               # The definition of the Limit Range for ProwJob pods
+  ├── 05-limit-range.yaml               # The definition of the limit range for ProwJob Pods
   ├── starter.yaml                      # The basic definition of Prow, including ConfigMaps, Deployments, and CustomResourceDefinitions
   └── required-secrets.yaml             # A default list of required Secrets that must be stored in a storage bucket
 ```

--- a/prow/cluster/README.md
+++ b/prow/cluster/README.md
@@ -15,6 +15,7 @@ The structure of the folder looks as follows:
   ├── 02-cluster-issuer.yaml            # The definition of the resource which creates new certificates
   ├── 03-tls-ing_ingress.yaml           # The definition of the encrypted Ingress that accesses the Prow cluster
   ├── 04-branchprotector_cronjob.yaml   # The definition of the Branch Protector CronJob that configures protection on branches
+  ├── 05-limit-range.yaml               # The definition of the Limit Range for ProwJob pods
   ├── starter.yaml                      # The basic definition of Prow, including ConfigMaps, Deployments, and CustomResourceDefinitions
   └── required-secrets.yaml             # A default list of required Secrets that must be stored in a storage bucket
 ```

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -159,6 +159,7 @@ plank:
   job_url_template: 'https://status.build.kyma-project.io/view/gcs/prow-production/{{if eq .Spec.Type "presubmit"}}pr-logs/pull{{else if eq .Spec.Type "batch"}}pr-logs/pull{{else}}logs{{end}}{{if .Spec.Refs}}{{if ne .Spec.Refs.Org ""}}/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}{{end}}{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
   job_url_prefix: 'https://status.build.kyma-project.io/view/gcs/'
   allow_cancellations: true # AllowCancellations enables aborting presubmit jobs for commits that have been superseded by newer commits in Github pull requests.
+  max_concurrency: 10 # Limit of concurrent ProwJobs. Need to be adjusted depending of the cluster size.
   pod_pending_timeout: 60m
   default_decoration_config:
     timeout: 7200000000000 # 2h

--- a/prow/install-prow.sh
+++ b/prow/install-prow.sh
@@ -28,5 +28,8 @@ kubectl apply -f cluster/03-tls-ing_ingress.yaml
 # Install branch protector
 kubectl apply -f cluster/04-branchprotector_cronjob.yaml
 
+# Define limit range
+kubectl apply -f cluster/05-limit-range.yaml
+
 # Remove Insecure ingress 
 kubectl delete ingress ing


### PR DESCRIPTION
This PR limits concurrent ProwJobs to 10. 
In the current setup, our cluster consists of 2 nodes with 4CPUs and 15GB RAM each. Our jobs require a lot of memory and CPU (golang compiliation). On the basis of `kubectl top pods` I saw that they consume 0.8CPU and <2GB memory, and because of that, I set ProwJob limit to 10. Resource consumption of Prow components is small.
In this PR I also introduced limtRange. It should prevent from running jobs on heavily loaded nodes (such Pod can exit with an error code and will not be restarted).