### PR TITLE
Checks: test-infra-governance and website-governace should not be marked as required

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -142,7 +142,7 @@ branch-protection:
             required_approving_review_count: 1
           protect: true
           #TODO: end move
-          # all jobs that has ContextRequired() set to true are also treated as required_status_checks, so there is no point to mention it here.
+          # all jobs that have ContextRequired() set to true are also treated as required_status_checks, so there is no point to mention it here.
           required_status_checks:
             contexts:
               - license/cla #TODO: move to default config for organization

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -142,19 +142,11 @@ branch-protection:
             required_approving_review_count: 1
           protect: true
           #TODO: end move
+          # all jobs that has ContextRequired() set to true are also treated as required_status_checks, so there is no point to mention it here.
           required_status_checks:
             contexts:
               - license/cla #TODO: move to default config for organization
-              - test-infra-bootstrap
-              - test-infra-bootstrap-helm
-              - test-infra-buildpack-golang
-              - test-infra-buildpack-node
-              - test-infra-buildpack-node-chromium
-              - test-infra-cleaner
-              - test-infra-development-tools
-              - test-infra-test-jobs-yaml-definitions
-              - test-infra-validate-scripts
-              - test-infra-validate-configs
+
         website:
           #TODO: move to default config for organization
           enforce_admins: false
@@ -169,8 +161,6 @@ branch-protection:
           required_status_checks:
             contexts:
               - license/cla #TODO: move to default config for organization
-              - website
-              - website-tools-documentation-generator
               - continuous-integration/jenkins/pr-head #TODO: replace by governance job
 
 plank:

--- a/prow/jobs/test-infra/test-infra-governance.yaml
+++ b/prow/jobs/test-infra/test-infra-governance.yaml
@@ -3,6 +3,7 @@ presubmits: # runs on PRs
     - name: test-infra-governance
       decorate: true
       max_concurrency: 10
+      optional: true
       branches:
         - master
       labels:

--- a/prow/jobs/website/website-governance.yaml
+++ b/prow/jobs/website/website-governance.yaml
@@ -2,6 +2,7 @@ presubmits: # runs on PRs
   kyma-project/website:
     - name: website-governance
       decorate: true
+      optional: true
       max_concurrency: 10
       branches:
         - master


### PR DESCRIPTION
Interesting fact:
- all jobs that have ContextRequired() set to true are also treated as required_status_checks.

```
func (ps Presubmit) ContextRequired() bool {
	if ps.Optional || ps.SkipReport {
		return false
	}
	return true
}
```

In this PR I set `optional` flag to true for ` test-infra-governance` and `website-governace`.
Additionally, I reduced the list of `required_status_checks` for `branch-protection` to checks that are not derived from presubmit jobs configuration.  

TODO: After merging PR enable cronjob