### PR TITLE
Orphaned clusters removal periodic job

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -21,9 +21,9 @@ The `development` folder has the following structure:
   ├── update-plugins.sh        # This script updates the new configuration of the "plugins.yaml" file on a cluster.
   ├── validate-config.sh       # This script runs the "Checker" application.
   ├── validate-scripts.sh      # This script performs a static analysis of bash scripts in the "test-infra" repository.
-  ├── clusters-cleanup.sh      # This script invokes the tool for cleaning orphaned clusters created by kyma-gke-integration job.
-  ├── disks-cleanup.sh         # This script invokes the tool for cleaning orphaned disks created by kyma-gke-integration job.
-  ├── loadbalancer-cleanup.sh  # This script invokes the tool for cleaning orphaned load balancers created by kyma-gke-integration job.
+  ├── clusters-cleanup.sh      # This script invokes the tool for cleaning orphaned clusters created by the kyma-gke-integration job.
+  ├── disks-cleanup.sh         # This script invokes the tool for cleaning orphaned disks created by the kyma-gke-integration job.
+  ├── loadbalancer-cleanup.sh  # This script invokes the tool for cleaning orphaned load balancers created by the kyma-gke-integration job.
   └── resources-cleanup.sh     # This script is a generic resource cleanup tool launcher.
 
 ```

--- a/development/README.md
+++ b/development/README.md
@@ -20,6 +20,10 @@ The `development` folder has the following structure:
   ├── update-jobs.sh           # This script updates the new configuration of the jobs on a cluster.
   ├── update-plugins.sh        # This script updates the new configuration of the "plugins.yaml" file on a cluster.
   ├── validate-config.sh       # This script runs the "Checker" application.
-  └── validate-scripts.sh      # This script performs a static analysis of bash scripts in the "test-infra" repository.
+  ├── validate-scripts.sh      # This script performs a static analysis of bash scripts in the "test-infra" repository.
+  ├── clusters-cleanup.sh      # This script invokes the tool for cleaning orphaned clusters created by kyma-gke-integration job.
+  ├── disks-cleanup.sh         # This script invokes the tool for cleaning orphaned disks created by kyma-gke-integration job.
+  ├── loadbalancer-cleanup.sh  # This script invokes the tool for cleaning orphaned load balancers created by kyma-gke-integration job.
+  └── resources-cleanup.sh     # This script is a generic resource cleanup tool launcher.
 
 ```

--- a/development/README.md
+++ b/development/README.md
@@ -21,9 +21,9 @@ The `development` folder has the following structure:
   ├── update-plugins.sh        # This script updates the new configuration of the "plugins.yaml" file on a cluster.
   ├── validate-config.sh       # This script runs the "Checker" application.
   ├── validate-scripts.sh      # This script performs a static analysis of bash scripts in the "test-infra" repository.
-  ├── clusters-cleanup.sh      # This script invokes the tool for cleaning orphaned clusters created by the kyma-gke-integration job.
-  ├── disks-cleanup.sh         # This script invokes the tool for cleaning orphaned disks created by the kyma-gke-integration job.
-  ├── loadbalancer-cleanup.sh  # This script invokes the tool for cleaning orphaned load balancers created by the kyma-gke-integration job.
+  ├── clusters-cleanup.sh      # This script invokes the tool for cleaning orphaned clusters created by the "kyma-gke-integration" job.
+  ├── disks-cleanup.sh         # This script invokes the tool for cleaning orphaned disks created by the "kyma-gke-integration" job.
+  ├── loadbalancer-cleanup.sh  # This script invokes the tool for cleaning orphaned load balancers created by the "kyma-gke-integration" job.
   └── resources-cleanup.sh     # This script is a generic resource cleanup tool launcher.
 
 ```

--- a/development/clusters-cleanup.sh
+++ b/development/clusters-cleanup.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 readonly DEVELOPMENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-readonly TOOL_DIR=diskscollector
-readonly OBJECT_NAME="disk resources"
+readonly TOOL_DIR=clusterscollector
+readonly OBJECT_NAME="clusters"
 
 "${DEVELOPMENT_DIR}"/resources-cleanup.sh "${TOOL_DIR}" "${OBJECT_NAME}" $@

--- a/development/clusters-cleanup.sh
+++ b/development/clusters-cleanup.sh
@@ -8,4 +8,4 @@ readonly DEVELOPMENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 readonly TOOL_DIR=clusterscollector
 readonly OBJECT_NAME="clusters"
 
-"${DEVELOPMENT_DIR}"/resources-cleanup.sh "${TOOL_DIR}" "${OBJECT_NAME}" $@
+"${DEVELOPMENT_DIR}"/resources-cleanup.sh "${TOOL_DIR}" "${OBJECT_NAME}" "$@"

--- a/development/disks-cleanup.sh
+++ b/development/disks-cleanup.sh
@@ -8,4 +8,4 @@ readonly DEVELOPMENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 readonly TOOL_DIR=diskscollector
 readonly OBJECT_NAME="disk resources"
 
-"${DEVELOPMENT_DIR}"/resources-cleanup.sh "${TOOL_DIR}" "${OBJECT_NAME}" $@
+"${DEVELOPMENT_DIR}"/resources-cleanup.sh "${TOOL_DIR}" "${OBJECT_NAME}" "$@"

--- a/development/loadbalancer-cleanup.sh
+++ b/development/loadbalancer-cleanup.sh
@@ -8,5 +8,5 @@ readonly DEVELOPMENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 readonly TOOL_DIR=orphanremover
 readonly OBJECT_NAME="LoadBalancer resources"
 
-"${DEVELOPMENT_DIR}"/resources-cleanup.sh "${TOOL_DIR}" "${OBJECT_NAME}" $@
+"${DEVELOPMENT_DIR}"/resources-cleanup.sh "${TOOL_DIR}" "${OBJECT_NAME}" "$@"
 

--- a/development/loadbalancer-cleanup.sh
+++ b/development/loadbalancer-cleanup.sh
@@ -5,38 +5,8 @@ set -o pipefail
 
 readonly DEVELOPMENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-usage () {
-    echo "Usage: \$ ${BASH_SOURCE[1]} gcpProjectName"
-    exit 1
-}
+readonly TOOL_DIR=orphanremover
+readonly OBJECT_NAME="LoadBalancer resources"
 
-if [ -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
-   echo "GOOGLE_APPLICATION_CREDENTIALS environment variable is missing!"
-   exit 1
-fi
+"${DEVELOPMENT_DIR}"/resources-cleanup.sh "${TOOL_DIR}" "${OBJECT_NAME}" $@
 
-readonly PROJECT="$1"
-
-if [ -z "${PROJECT}" ]; then
-    usage
-fi
-
-echo "Removing GCP LoadBalancer resources allocated by failed/terminated integration jobs..."
-
-if [ ! -d "${DEVELOPMENT_DIR}/tools/vendor" ]; then
-    echo "Vendoring 'tools'"
-    pushd "${DEVELOPMENT_DIR}/tools"
-    dep ensure -v -vendor-only
-    popd
-fi
-
-go run "${DEVELOPMENT_DIR}"/tools/cmd/orphanremover/main.go  --project="${PROJECT}" --dry-run=false
-status=$?
-
-if [ ${status} -ne 0 ]
-then
-    echo "ERROR"
-    exit 1
-else
-    echo "SUCCESS"
-fi

--- a/development/resources-cleanup.sh
+++ b/development/resources-cleanup.sh
@@ -46,7 +46,7 @@ if [ ! -d "${DEVELOPMENT_DIR}/tools/vendor" ]; then
 fi
 
 
-go run "${DEVELOPMENT_DIR}"/tools/cmd/${TOOL_DIR}/main.go  --project="${PROJECT}" $@
+go run "${DEVELOPMENT_DIR}/tools/cmd/${TOOL_DIR}/main.go"  --project="${PROJECT}" "$@"
 status=$?
 
 if [ ${status} -ne 0 ]

--- a/development/resources-cleanup.sh
+++ b/development/resources-cleanup.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+################################################################################
+# DO NOT INVOKE DIRECTLY, USE FROM OTHER SCRIPTS
+################################################################################
+
+set -e
+set -o pipefail
+
+readonly DEVELOPMENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
+   echo "GOOGLE_APPLICATION_CREDENTIALS environment variable is missing!"
+   exit 1
+fi
+
+readonly TOOL_DIR="$1"
+if [ -z "${TOOL_DIR}" ]; then
+    echo "TOOL_DIR variable is missing!"
+		exit 1
+fi
+
+readonly OBJECT_NAME="$2"
+if [ -z "${OBJECT_NAME}" ]; then
+    echo "OBJECT_NAME variable is missing!"
+		exit 1
+fi
+
+readonly PROJECT="$3"
+
+shift #pass $1
+shift #pass $2
+if [ -n "$3" ]; then
+    shift #pass $3
+fi
+
+echo "--------------------------------------------------------------------------------"
+echo "Removing GCP ${OBJECT_NAME} allocated by failed/terminated integration jobs...  "
+echo "--------------------------------------------------------------------------------"
+
+if [ ! -d "${DEVELOPMENT_DIR}/tools/vendor" ]; then
+    echo "Vendoring 'tools'"
+    pushd "${DEVELOPMENT_DIR}/tools"
+    dep ensure -v -vendor-only
+    popd
+fi
+
+
+go run "${DEVELOPMENT_DIR}"/tools/cmd/${TOOL_DIR}/main.go  --project="${PROJECT}" $@
+status=$?
+
+if [ ${status} -ne 0 ]
+then
+    echo "ERROR"
+    exit 1
+else
+    echo "SUCCESS"
+fi

--- a/development/resources-cleanup.sh
+++ b/development/resources-cleanup.sh
@@ -4,6 +4,18 @@
 # DO NOT INVOKE DIRECTLY, USE FROM OTHER SCRIPTS
 ################################################################################
 
+################################################################################
+# Generic resource cleanup tool launcher
+# This script invokes a cleanup tool specified by input arguments.
+# It passes all input parameters, unchanged, to the target tool.
+# The script also checks for existence of the mandatory
+# GOOGLE_APPLICATION_CREDENTIALS environment variable.
+#
+# Input parameters (positional):
+# $1 - tool subdirectory in the existing hierarchy: ../development/tools/cmd/<tool-directory>/
+# $2 - name of the object subject to cleanup, for nice log messages.
+################################################################################
+
 set -e
 set -o pipefail
 
@@ -39,7 +51,6 @@ if [ ! -d "${DEVELOPMENT_DIR}/tools/vendor" ]; then
     dep ensure -v -vendor-only
     popd
 fi
-
 
 go run "${DEVELOPMENT_DIR}/tools/cmd/${TOOL_DIR}/main.go" "$@"
 status=$?

--- a/development/resources-cleanup.sh
+++ b/development/resources-cleanup.sh
@@ -26,13 +26,8 @@ if [ -z "${OBJECT_NAME}" ]; then
 		exit 1
 fi
 
-readonly PROJECT="$3"
-
 shift #pass $1
 shift #pass $2
-if [ -n "$3" ]; then
-    shift #pass $3
-fi
 
 echo "--------------------------------------------------------------------------------"
 echo "Removing GCP ${OBJECT_NAME} allocated by failed/terminated integration jobs...  "
@@ -46,7 +41,7 @@ if [ ! -d "${DEVELOPMENT_DIR}/tools/vendor" ]; then
 fi
 
 
-go run "${DEVELOPMENT_DIR}/tools/cmd/${TOOL_DIR}/main.go"  --project="${PROJECT}" "$@"
+go run "${DEVELOPMENT_DIR}/tools/cmd/${TOOL_DIR}/main.go" "$@"
 status=$?
 
 if [ ${status} -ne 0 ]

--- a/development/tools/cmd/diskscollector/main.go
+++ b/development/tools/cmd/diskscollector/main.go
@@ -19,7 +19,7 @@ import (
 const defaultDiskNameRegex = "^gke-gkeint.*[-]pvc[-]"
 
 var (
-	project       = flag.String("project", "", "Project ID")
+	project       = flag.String("project", "", "Project ID [Required]")
 	dryRun        = flag.Bool("dryRun", true, "Dry Run enabled, nothing is deleted")
 	ageInHours    = flag.Int("ageInHours", 2, "Disk age in hours. Disks older than: now()-ageInHours are considered for removal.")
 	diskNameRegex = flag.String("diskNameRegex", defaultDiskNameRegex, "Disk name regex. Matching disks are considered for removal.")

--- a/development/tools/cmd/orphanremover/main.go
+++ b/development/tools/cmd/orphanremover/main.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	project = flag.String("project", "", "Project ID")
-	dryRun  = flag.Bool("dry-run", true, "Dry Run enabled")
+	project = flag.String("project", "", "Project ID [Required]")
+	dryRun  = flag.Bool("dryRun", true, "Dry Run enabled")
 )
 
 func main() {

--- a/development/tools/jobs/tester/tester.go
+++ b/development/tools/jobs/tester/tester.go
@@ -37,6 +37,10 @@ const (
 	PresetBotGithubToken Preset = "preset-bot-github-token"
 	// PresetBotGithubSSH means github ssh
 	PresetBotGithubSSH Preset = "preset-bot-github-ssh"
+	// PresetSaGKEKymaIntegration means access to service account capable of creating clusters and related resources
+	PresetSaGKEKymaIntegration = "preset-sa-gke-kyma-integration"
+	// PresetGCProjectEnv means project name is injected as env variable
+	PresetGCProjectEnv = "preset-gc-project-env"
 
 	// ImageGolangBuildpackLatest means Golang buildpack image
 	ImageGolangBuildpackLatest = "eu.gcr.io/kyma-project/prow/test-infra/buildpack-golang:v20181119-afd3fbd"

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -117,7 +117,8 @@ periodics:
     containers:
     - image: eu.gcr.io/kyma-project/prow/cleaner:0.0.1 # see test-infra/prow/images/cleaner
 - name: orphaned-disks-cleaner
-  cron: "0 * * * *" # "Every hour"
+  #cron: "0 * * * *" # "Every hour"
+  cron: "*/10 * * * *" # "Every ten minutes (Temporary Dry Run to ensure it works)"
   labels:
     preset-sa-gke-kyma-integration: "true"
     preset-gc-project-env: "true"
@@ -134,9 +135,30 @@ periodics:
         - "bash"
       args:
         - "-c"
-        - "development/disks-cleanup.sh ${CLOUDSDK_CORE_PROJECT}"
+        - "development/disks-cleanup.sh -project=${CLOUDSDK_CORE_PROJECT} -dryRun=true"
+- name: orphaned-clusters-cleaner
+  #cron: "0 */4 * * *" # "Every four hours"
+  cron: "*/10 * * * *" # "Every ten minutes (Temporary Dry Run to ensure it works)"
+  labels:
+    preset-sa-gke-kyma-integration: "true"
+    preset-gc-project-env: "true"
+  decorate: true
+  extra_refs:
+    - org: kyma-project
+      repo: test-infra
+      base_ref: master
+      path_alias: github.com/kyma-project/test-infra
+  spec:
+    containers:
+    - image: eu.gcr.io/kyma-project/prow/buildpack-golang:0.0.1
+      command:
+        - "bash"
+      args:
+        - "-c"
+        - "development/clusters-cleanup.sh -project=${CLOUDSDK_CORE_PROJECT} -dryRun=true"
 - name: orphaned-loadbalancer-cleaner
-  cron: "30 7 * * 1-5" # "At 07:30 on every day-of-week from Monday through Friday."
+  #cron: "30 7 * * 1-5" # "At 07:30 on every day-of-week from Monday through Friday."
+  cron: "*/10 * * * *" # "Every ten minutes (Temporary Dry Run to ensure it works)"
   labels:
     preset-sa-gke-kyma-integration: "true"
     preset-gc-project-env: "true"
@@ -153,5 +175,5 @@ periodics:
         - "bash"
       args:
         - "-c"
-        - "development/loadbalancer-cleanup.sh ${CLOUDSDK_CORE_PROJECT}"
+        - "development/loadbalancer-cleanup.sh -project=${CLOUDSDK_CORE_PROJECT} -dryRun=true"
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Introduces periodic job for removal of orphaned cluster
- Unifies scripts for launching tools (clusters, disks, load balancers)
- Adds tests for periodic jobs

Note for the reviewer: This PR changes jobs configuration to safe mode, dryRun = true.
This is on purpose because the changes can be tested only when they're merged on the master branch.
Once it's merged and a few runs on master confirm that configuration of jobs is correct, we'll switch the configuration to a "production" one with one subsequent PR.

See also #177 