### PR TITLE
Add VM instances cleanup prowjob in dryrun mode.

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -22,6 +22,7 @@ The `development` folder has the following structure:
   ├── validate-config.sh       # This script runs the "Checker" application.
   ├── validate-scripts.sh      # This script performs a static analysis of bash scripts in the "test-infra" repository.
   ├── clusters-cleanup.sh      # This script invokes the tool for cleaning orphaned clusters created by the "kyma-gke-integration" job.
+  ├── vms-cleanup.sh           # This script invokes the tool for cleaning orphaned VM instances created by the "kyma-gke-integration" job.
   ├── disks-cleanup.sh         # This script invokes the tool for cleaning orphaned disks created by the "kyma-gke-integration" job.
   ├── loadbalancer-cleanup.sh  # This script invokes the tool for cleaning orphaned load balancers created by the "kyma-gke-integration" job.
   └── resources-cleanup.sh     # This script is a generic resource cleanup tool launcher.

--- a/development/tools/jobs/kyma/kyma_integration_test.go
+++ b/development/tools/jobs/kyma/kyma_integration_test.go
@@ -124,7 +124,7 @@ func TestKymaIntegrationJobPeriodics(t *testing.T) {
 	assert.Equal(t, "*/13 * * * *", vmsCleanerPeriodic.Cron)
 	tester.AssertThatHasPresets(t, vmsCleanerPeriodic.JobBase, tester.PresetGCProjectEnv, tester.PresetSaGKEKymaIntegration)
 	tester.AssertThatHasExtraRefs(t, vmsCleanerPeriodic.JobBase.UtilityConfig, []string{"test-infra", "kyma"})
-	assert.Equal(t, "eu.gcr.io/kyma-project/prow/buildpack-golang:0.0.1", vmsCleanerPeriodic.Spec.Containers[0].Image)
+	assert.Equal(t, tester.ImageGolangBuildpackLatest, vmsCleanerPeriodic.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"bash"}, vmsCleanerPeriodic.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"-c", "development/vms-cleanup.sh -project=${CLOUDSDK_CORE_PROJECT} -dryRun=true"}, vmsCleanerPeriodic.Spec.Containers[0].Args)
 

--- a/development/vms-cleanup.sh
+++ b/development/vms-cleanup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+readonly DEVELOPMENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+readonly TOOL_DIR=vmscollector
+readonly OBJECT_NAME="VM instances"
+
+"${DEVELOPMENT_DIR}"/resources-cleanup.sh "${TOOL_DIR}" "${OBJECT_NAME}" "$@"

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -168,7 +168,7 @@ periodics:
       path_alias: github.com/kyma-project/test-infra
   spec:
     containers:
-    - image: eu.gcr.io/kyma-project/prow/buildpack-golang:0.0.1
+    - image: eu.gcr.io/kyma-project/prow/test-infra/buildpack-golang:v20181119-afd3fbd
       command:
         - "bash"
       args:

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -154,6 +154,26 @@ periodics:
       args:
         - "-c"
         - "development/clusters-cleanup.sh -project=${CLOUDSDK_CORE_PROJECT} -dryRun=false"
+- name: orphaned-vms-cleaner
+  #cron: "30 */4 * * *" # "At minute 30 past every 4th hour"
+  cron: "*/13 * * * *" # At every 13th minute. (Temporary in SAFE MODE)
+  labels:
+    preset-sa-gke-kyma-integration: "true"
+    preset-gc-project-env: "true"
+  decorate: true
+  extra_refs:
+    - org: kyma-project
+      repo: test-infra
+      base_ref: master
+      path_alias: github.com/kyma-project/test-infra
+  spec:
+    containers:
+    - image: eu.gcr.io/kyma-project/prow/buildpack-golang:0.0.1
+      command:
+        - "bash"
+      args:
+        - "-c"
+        - "development/vms-cleanup.sh -project=${CLOUDSDK_CORE_PROJECT} -dryRun=true"
 - name: orphaned-loadbalancer-cleaner
   cron: "30 7 * * 1-5" # "At 07:30 on every day-of-week from Monday through Friday."
   labels:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Introduces periodic job for removal of orphaned VM instances in SAFE MODE (dryRun=true)

Note for the reviewer: Once this PR is merged and a few runs on master confirm that the configuration of the job is correct, it will be switched to a "production" mode with one subsequent PR.

See also #177 