### PR TITLE
Configure resources requests for jobs

### DIFF
--- a/development/tools/jobs/kyma/kyma_integration_test.go
+++ b/development/tools/jobs/kyma/kyma_integration_test.go
@@ -61,7 +61,7 @@ func TestKymaIntegrationJobPostsubmit(t *testing.T) {
 	actualVM := kymaPostsubmits[0]
 	assert.Equal(t, "kyma-integration", actualVM.Name)
 	assert.Equal(t, []string{"master"}, actualVM.Branches)
-	assert.Equal(t, 10, actualVM.MaxConcurrency)
+	assert.Equal(t, 1, actualVM.MaxConcurrency)
 	assert.Equal(t, "", actualVM.RunIfChanged)
 	assert.True(t, actualVM.Decorate)
 	assert.Equal(t, "github.com/kyma-project/kyma", actualVM.PathAlias)
@@ -73,7 +73,7 @@ func TestKymaIntegrationJobPostsubmit(t *testing.T) {
 	actualGKE := kymaPostsubmits[1]
 	assert.Equal(t, "kyma-gke-integration", actualGKE.Name)
 	assert.Equal(t, "", actualGKE.RunIfChanged)
-	assert.Equal(t, 10, actualGKE.MaxConcurrency)
+	assert.Equal(t, 1, actualGKE.MaxConcurrency)
 	// TODO add assertions about presets
 	assert.Equal(t, []string{"master"}, actualGKE.Branches)
 	assert.True(t, actualGKE.Decorate)

--- a/docs/prow/migration-guide-release.md
+++ b/docs/prow/migration-guide-release.md
@@ -33,7 +33,7 @@ The differences between a release job and a job for the `master` branch are as f
 - The **always_run** parameter set to `true` instead of specifying the **run_if_changed** parameter
 
 See an example:
-```
+```yaml
 test_infra_ref: &test_infra_ref
   org: kyma-project
   repo: test-infra
@@ -54,6 +54,10 @@ job_template: &job_template
       - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
       args:
       - "/home/prow/go/src/github.com/kyma-project/kyma/components/binding-usage-controller"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"
@@ -111,7 +115,7 @@ The component job configuration in this guide differs from the one defined in th
 ### Define a test for a release job
 
 See an example of a test configuration from the `binding_usage_controller_test.go` file:
-```
+```go
 func TestBucReleases(t *testing.T) {
 	// WHEN
 	for _, currentRelease := range tester.GetAllKymaReleaseBranches() {

--- a/docs/prow/migration-guide.md
+++ b/docs/prow/migration-guide.md
@@ -73,6 +73,10 @@ presubmits:
               - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
             args:
               - "/home/prow/go/src/github.com/kyma-project/kyma/components/binding-usage-controller"
+        resources:
+          requests:
+            memory: 1.5Gi
+            cpu: 0.8
 ```
 
 The table contains the list of all fields in the `yaml` file with their descriptions.
@@ -91,6 +95,7 @@ The table contains the list of all fields in the `yaml` file with their descript
 | **spec.containers.command** | Buildpacks have the `build.sh` script that allows you to easily trigger the build for your component. The `build.sh` script populates some environment variables, such as **DOCKER_TAG**. It also initializes Docker and executes one of the `Makefile` targets, depending on the value of the **BUILD_TYPE** variable. This environment variable can be injected by one of the build's Presets, which are **preset-build-pr**, **preset-build-release**, or **preset-build-master**. |
 | **spec.containers.args**    | The `build.sh` script requires a path to the directory where the `Makefile` for your component is located.                                                                                                                                                                                                                                                                                                                                                                        |
 | **labels**                  | Regular Kubernetes labels. They are used to enable PodPresets. The available Presets are defined in the `/prow/config.yaml` file. For their detailed descriptions, go to the [**Available Presets**](#available-presets) section.                                                                                                                                                                                                                                                     |
+| **spec.resources**          | Regular Kubernetes resources requirements for containers. |
 
 ### Check your configuration locally
 
@@ -208,6 +213,10 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/components/binding-usage-controller"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/bundles/bundles.yaml
+++ b/prow/jobs/bundles/bundles.yaml
@@ -20,9 +20,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/bundles/bundles.yaml
+++ b/prow/jobs/bundles/bundles.yaml
@@ -16,6 +16,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-bundles.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/bundles"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/community/community-governance.yaml
+++ b/prow/jobs/community/community-governance.yaml
@@ -25,6 +25,13 @@ presubmits: # runs on PRs
             args:
               - "--repository"
               - "community"
+        resources:
+          requests:
+            memory: 1.5Gi
+            cpu: 0.8
+          limits:
+            memory: 2Gi
+            cpu: 1.4
 
 periodics: # runs periodic on master
 - name: community-governance-nightly
@@ -55,4 +62,10 @@ periodics: # runs periodic on master
           - "/home/prow/go/src/github.com/kyma-project/community"
           - "--full-validation"
           - "true"
-
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4

--- a/prow/jobs/community/community-governance.yaml
+++ b/prow/jobs/community/community-governance.yaml
@@ -29,9 +29,6 @@ presubmits: # runs on PRs
           requests:
             memory: 1.5Gi
             cpu: 0.8
-          limits:
-            memory: 2Gi
-            cpu: 1.4
 
 periodics: # runs periodic on master
 - name: community-governance-nightly
@@ -66,6 +63,3 @@ periodics: # runs periodic on master
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4

--- a/prow/jobs/community/community-governance.yaml
+++ b/prow/jobs/community/community-governance.yaml
@@ -27,8 +27,8 @@ presubmits: # runs on PRs
               - "community"
         resources:
           requests:
-            memory: 1.5Gi
-            cpu: 0.8
+            memory: 10Mi
+            cpu: 100m
 
 periodics: # runs periodic on master
 - name: community-governance-nightly
@@ -61,5 +61,5 @@ periodics: # runs periodic on master
           - "true"
     resources:
       requests:
-        memory: 1.5Gi
-        cpu: 0.8
+        memory: 10Mi
+        cpu: 100m

--- a/prow/jobs/console/brokers/brokers.yaml
+++ b/prow/jobs/console/brokers/brokers.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/console/brokers/brokers.yaml
+++ b/prow/jobs/console/brokers/brokers.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/console/brokers"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/console/catalog/catalog.yaml
+++ b/prow/jobs/console/catalog/catalog.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/console/catalog/catalog.yaml
+++ b/prow/jobs/console/catalog/catalog.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/console/catalog"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/console/components/react/react-components.yaml
+++ b/prow/jobs/console/components/react/react-components.yaml
@@ -16,6 +16,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/console/components/react"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 presubmits:
   kyma-project/console:

--- a/prow/jobs/console/components/react/react-components.yaml
+++ b/prow/jobs/console/components/react/react-components.yaml
@@ -20,9 +20,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 presubmits:
   kyma-project/console:

--- a/prow/jobs/console/console-governance.yaml
+++ b/prow/jobs/console/console-governance.yaml
@@ -30,9 +30,6 @@ presubmits: # runs on PRs
           requests:
             memory: 1.5Gi
             cpu: 0.8
-          limits:
-            memory: 2Gi
-            cpu: 1.4
 
 periodics: # runs periodic on master
 - name: console-governance-nightly
@@ -67,6 +64,3 @@ periodics: # runs periodic on master
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4

--- a/prow/jobs/console/console-governance.yaml
+++ b/prow/jobs/console/console-governance.yaml
@@ -26,6 +26,13 @@ presubmits: # runs on PRs
             args:
               - "--repository"
               - "console"
+        resources:
+          requests:
+            memory: 1.5Gi
+            cpu: 0.8
+          limits:
+            memory: 2Gi
+            cpu: 1.4
 
 periodics: # runs periodic on master
 - name: console-governance-nightly
@@ -56,4 +63,10 @@ periodics: # runs periodic on master
           - "/home/prow/go/src/github.com/kyma-project/console"
           - "--full-validation"
           - "true"
-
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4

--- a/prow/jobs/console/console-governance.yaml
+++ b/prow/jobs/console/console-governance.yaml
@@ -28,8 +28,8 @@ presubmits: # runs on PRs
               - "console"
         resources:
           requests:
-            memory: 1.5Gi
-            cpu: 0.8
+            memory: 10Mi
+            cpu: 100m
 
 periodics: # runs periodic on master
 - name: console-governance-nightly
@@ -62,5 +62,5 @@ periodics: # runs periodic on master
           - "true"
     resources:
       requests:
-        memory: 1.5Gi
-        cpu: 0.8
+        memory: 10Mi
+        cpu: 100m

--- a/prow/jobs/console/content/content.yaml
+++ b/prow/jobs/console/content/content.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/console/content/content.yaml
+++ b/prow/jobs/console/content/content.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/console/content"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/console/core/core.yaml
+++ b/prow/jobs/console/core/core.yaml
@@ -22,10 +22,6 @@ job_template: &job_template
       requests:
         memory: 2Gi
         cpu: 1.5
-      limits:
-        memory: 2Gi
-        cpu: 1.5
-
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/console/instances/instances.yaml
+++ b/prow/jobs/console/instances/instances.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/console/instances/instances.yaml
+++ b/prow/jobs/console/instances/instances.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/console/instances"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/console/lambda/lambda.yaml
+++ b/prow/jobs/console/lambda/lambda.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/console/lambda/lambda.yaml
+++ b/prow/jobs/console/lambda/lambda.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/console/lambda"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/console/tests/console-tests.yaml
+++ b/prow/jobs/console/tests/console-tests.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/console/tests/console-tests.yaml
+++ b/prow/jobs/console/tests/console-tests.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/console/tests"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/examples/call-ec/call-ec.yaml
+++ b/prow/jobs/examples/call-ec/call-ec.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/examples/call-ec/call-ec.yaml
+++ b/prow/jobs/examples/call-ec/call-ec.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/examples/call-ec"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/examples/event-email-service/event-email-service.yaml
+++ b/prow/jobs/examples/event-email-service/event-email-service.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/examples/event-email-service/event-email-service.yaml
+++ b/prow/jobs/examples/event-email-service/event-email-service.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/examples/event-email-service"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/examples/examples-governance.yaml
+++ b/prow/jobs/examples/examples-governance.yaml
@@ -28,8 +28,8 @@ presubmits: # runs on PRs
               - "examples"
         resources:
           requests:
-            memory: 1.5Gi
-            cpu: 0.8
+            memory: 10Mi
+            cpu: 100m
 
 periodics: # runs periodic on master
 - name: examples-governance-nightly
@@ -62,5 +62,5 @@ periodics: # runs periodic on master
           - "true"
     resources:
       requests:
-        memory: 1.5Gi
-        cpu: 0.8
+        memory: 10Mi
+        cpu: 100m

--- a/prow/jobs/examples/examples-governance.yaml
+++ b/prow/jobs/examples/examples-governance.yaml
@@ -30,9 +30,6 @@ presubmits: # runs on PRs
           requests:
             memory: 1.5Gi
             cpu: 0.8
-          limits:
-            memory: 2Gi
-            cpu: 1.4
 
 periodics: # runs periodic on master
 - name: examples-governance-nightly
@@ -67,6 +64,3 @@ periodics: # runs periodic on master
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4

--- a/prow/jobs/examples/examples-governance.yaml
+++ b/prow/jobs/examples/examples-governance.yaml
@@ -26,6 +26,13 @@ presubmits: # runs on PRs
             args:
               - "--repository"
               - "examples"
+        resources:
+          requests:
+            memory: 1.5Gi
+            cpu: 0.8
+          limits:
+            memory: 2Gi
+            cpu: 1.4
 
 periodics: # runs periodic on master
 - name: examples-governance-nightly
@@ -56,4 +63,10 @@ periodics: # runs periodic on master
           - "/home/prow/go/src/github.com/kyma-project/examples"
           - "--full-validation"
           - "true"
-
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4

--- a/prow/jobs/examples/http-db-service/http-db-service.yaml
+++ b/prow/jobs/examples/http-db-service/http-db-service.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/examples/http-db-service/http-db-service.yaml
+++ b/prow/jobs/examples/http-db-service/http-db-service.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/examples/http-db-service"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/examples/monitoring-custom-metrics/monitoring-custom-metrics.yaml
+++ b/prow/jobs/examples/monitoring-custom-metrics/monitoring-custom-metrics.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/examples/monitoring-custom-metrics/monitoring-custom-metrics.yaml
+++ b/prow/jobs/examples/monitoring-custom-metrics/monitoring-custom-metrics.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/examples/monitoring-custom-metrics"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/examples/tests/http-db-service-acceptance-tests/http-db-service-acceptance-tests.yaml
+++ b/prow/jobs/examples/tests/http-db-service-acceptance-tests/http-db-service-acceptance-tests.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/examples/tests/http-db-service-acceptance-tests/http-db-service-acceptance-tests.yaml
+++ b/prow/jobs/examples/tests/http-db-service-acceptance-tests/http-db-service-acceptance-tests.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/examples/tests/http-db-service"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/examples/tracing/tracing.yaml
+++ b/prow/jobs/examples/tracing/tracing.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/examples/tracing/tracing.yaml
+++ b/prow/jobs/examples/tracing/tracing.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/examples/tracing"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/incubator/kymactl/kymactl.yaml
+++ b/prow/jobs/incubator/kymactl/kymactl.yaml
@@ -17,6 +17,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-incubator/kymactl"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/incubator/kymactl/kymactl.yaml
+++ b/prow/jobs/incubator/kymactl/kymactl.yaml
@@ -21,9 +21,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/incubator/service-catalog-tester/service-catalog-tester.yaml
+++ b/prow/jobs/incubator/service-catalog-tester/service-catalog-tester.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/incubator/service-catalog-tester/service-catalog-tester.yaml
+++ b/prow/jobs/incubator/service-catalog-tester/service-catalog-tester.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-incubator/service-catalog-tester"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/incubator/varkes/app-connector-client/app-connector-client.yaml
+++ b/prow/jobs/incubator/varkes/app-connector-client/app-connector-client.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/incubator/varkes/app-connector-client/app-connector-client.yaml
+++ b/prow/jobs/incubator/varkes/app-connector-client/app-connector-client.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-incubator/varkes/app-connector-client"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/incubator/varkes/odata-mock/odata-mock.yaml
+++ b/prow/jobs/incubator/varkes/odata-mock/odata-mock.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/incubator/varkes/odata-mock/odata-mock.yaml
+++ b/prow/jobs/incubator/varkes/odata-mock/odata-mock.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-incubator/varkes/odata-mock"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/incubator/varkes/openapi-mock/openapi-mock.yaml
+++ b/prow/jobs/incubator/varkes/openapi-mock/openapi-mock.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/incubator/varkes/openapi-mock/openapi-mock.yaml
+++ b/prow/jobs/incubator/varkes/openapi-mock/openapi-mock.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-incubator/varkes/openapi-mock"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/incubator/vstudio-extension/vstudio-extension.yaml
+++ b/prow/jobs/incubator/vstudio-extension/vstudio-extension.yaml
@@ -21,9 +21,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/incubator/vstudio-extension/vstudio-extension.yaml
+++ b/prow/jobs/incubator/vstudio-extension/vstudio-extension.yaml
@@ -17,6 +17,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-incubator/vstudio-extension"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/api-controller/api-controller.yaml
+++ b/prow/jobs/kyma/components/api-controller/api-controller.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/api-controller/api-controller.yaml
+++ b/prow/jobs/kyma/components/api-controller/api-controller.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/components/api-controller"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/apiserver-proxy/apiserver-proxy.yaml
+++ b/prow/jobs/kyma/components/apiserver-proxy/apiserver-proxy.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/apiserver-proxy/apiserver-proxy.yaml
+++ b/prow/jobs/kyma/components/apiserver-proxy/apiserver-proxy.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/components/apiserver-proxy"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/application-broker/application-broker.yaml
+++ b/prow/jobs/kyma/components/application-broker/application-broker.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/application-broker/application-broker.yaml
+++ b/prow/jobs/kyma/components/application-broker/application-broker.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/components/application-broker"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/application-operator/application-operator.yaml
+++ b/prow/jobs/kyma/components/application-operator/application-operator.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/application-operator/application-operator.yaml
+++ b/prow/jobs/kyma/components/application-operator/application-operator.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/components/application-operator"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/application-proxy/application-proxy.yaml
+++ b/prow/jobs/kyma/components/application-proxy/application-proxy.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/application-proxy/application-proxy.yaml
+++ b/prow/jobs/kyma/components/application-proxy/application-proxy.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/components/application-proxy"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/application-registry/application-registry.yaml
+++ b/prow/jobs/kyma/components/application-registry/application-registry.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/application-registry/application-registry.yaml
+++ b/prow/jobs/kyma/components/application-registry/application-registry.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/components/application-registry"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/binding-usage-controller/binding-usage-controller.yaml
+++ b/prow/jobs/kyma/components/binding-usage-controller/binding-usage-controller.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/binding-usage-controller/binding-usage-controller.yaml
+++ b/prow/jobs/kyma/components/binding-usage-controller/binding-usage-controller.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
       - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
       args:
       - "/home/prow/go/src/github.com/kyma-project/kyma/components/binding-usage-controller"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/configurations-generator/configurations-generator.yaml
+++ b/prow/jobs/kyma/components/configurations-generator/configurations-generator.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/components/configurations-generator"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/configurations-generator/configurations-generator.yaml
+++ b/prow/jobs/kyma/components/configurations-generator/configurations-generator.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/connection-token-handler/connection-token-handler.yaml
+++ b/prow/jobs/kyma/components/connection-token-handler/connection-token-handler.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/connection-token-handler/connection-token-handler.yaml
+++ b/prow/jobs/kyma/components/connection-token-handler/connection-token-handler.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/components/connection-token-handler"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/connector-service/connector-service.yaml
+++ b/prow/jobs/kyma/components/connector-service/connector-service.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/connector-service/connector-service.yaml
+++ b/prow/jobs/kyma/components/connector-service/connector-service.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/components/connector-service"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/environments/environments.yaml
+++ b/prow/jobs/kyma/components/environments/environments.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/environments/environments.yaml
+++ b/prow/jobs/kyma/components/environments/environments.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/components/environments"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/event-bus/event-bus.yaml
+++ b/prow/jobs/kyma/components/event-bus/event-bus.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/event-bus/event-bus.yaml
+++ b/prow/jobs/kyma/components/event-bus/event-bus.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/components/event-bus"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/event-service/event-service.yaml
+++ b/prow/jobs/kyma/components/event-service/event-service.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/event-service/event-service.yaml
+++ b/prow/jobs/kyma/components/event-service/event-service.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/components/event-service"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/helm-broker/helm-broker.yaml
+++ b/prow/jobs/kyma/components/helm-broker/helm-broker.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/helm-broker/helm-broker.yaml
+++ b/prow/jobs/kyma/components/helm-broker/helm-broker.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
       - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
       args:
       - "/home/prow/go/src/github.com/kyma-project/kyma/components/helm-broker"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/installer/installer.yaml
+++ b/prow/jobs/kyma/components/installer/installer.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/installer/installer.yaml
+++ b/prow/jobs/kyma/components/installer/installer.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/components/installer"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/istio-kyma-patch/istio-kyma-patch.yaml
+++ b/prow/jobs/kyma/components/istio-kyma-patch/istio-kyma-patch.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/istio-kyma-patch/istio-kyma-patch.yaml
+++ b/prow/jobs/kyma/components/istio-kyma-patch/istio-kyma-patch.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/components/istio-kyma-patch"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/k8s-dashboard-proxy/k8s-dashboard-proxy.yaml
+++ b/prow/jobs/kyma/components/k8s-dashboard-proxy/k8s-dashboard-proxy.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/k8s-dashboard-proxy/k8s-dashboard-proxy.yaml
+++ b/prow/jobs/kyma/components/k8s-dashboard-proxy/k8s-dashboard-proxy.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/components/k8s-dashboard-proxy"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/metadata-service/metadata-service.yaml
+++ b/prow/jobs/kyma/components/metadata-service/metadata-service.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/metadata-service/metadata-service.yaml
+++ b/prow/jobs/kyma/components/metadata-service/metadata-service.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/components/metadata-service"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/proxy-service/proxy-service.yaml
+++ b/prow/jobs/kyma/components/proxy-service/proxy-service.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/proxy-service/proxy-service.yaml
+++ b/prow/jobs/kyma/components/proxy-service/proxy-service.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/components/proxy-service"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/ui-api-layer/ui-api-layer.yaml
+++ b/prow/jobs/kyma/components/ui-api-layer/ui-api-layer.yaml
@@ -19,8 +19,8 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/kyma/components/ui-api-layer"
     resources:
       requests:
-        memory: 1.5Gi
-        cpu: 0.8
+        memory: 2Gi
+        cpu: 1.5
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/ui-api-layer/ui-api-layer.yaml
+++ b/prow/jobs/kyma/components/ui-api-layer/ui-api-layer.yaml
@@ -17,6 +17,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/components/ui-api-layer"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/ui-api-layer/ui-api-layer.yaml
+++ b/prow/jobs/kyma/components/ui-api-layer/ui-api-layer.yaml
@@ -21,9 +21,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/xip-patch/xip-patch.yaml
+++ b/prow/jobs/kyma/components/xip-patch/xip-patch.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/components/xip-patch/xip-patch.yaml
+++ b/prow/jobs/kyma/components/xip-patch/xip-patch.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/components/xip-patch"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/docs/docs.yaml
+++ b/prow/jobs/kyma/docs/docs.yaml
@@ -22,6 +22,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/docs"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/docs/docs.yaml
+++ b/prow/jobs/kyma/docs/docs.yaml
@@ -26,9 +26,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/kyma-governance.yaml
+++ b/prow/jobs/kyma/kyma-governance.yaml
@@ -28,8 +28,8 @@ presubmits: # runs on PRs
               - "kyma"
         resources:
           requests:
-            memory: 1.5Gi
-            cpu: 0.8
+            memory: 10Mi
+            cpu: 100m
 
 periodics: # runs periodic on master
 - name: kyma-governance-nightly
@@ -62,5 +62,5 @@ periodics: # runs periodic on master
           - "true"
     resources:
       requests:
-        memory: 1.5Gi
-        cpu: 0.8
+        memory: 10Mi
+        cpu: 100m

--- a/prow/jobs/kyma/kyma-governance.yaml
+++ b/prow/jobs/kyma/kyma-governance.yaml
@@ -30,9 +30,6 @@ presubmits: # runs on PRs
           requests:
             memory: 1.5Gi
             cpu: 0.8
-          limits:
-            memory: 2Gi
-            cpu: 1.4
 
 periodics: # runs periodic on master
 - name: kyma-governance-nightly
@@ -67,6 +64,3 @@ periodics: # runs periodic on master
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4

--- a/prow/jobs/kyma/kyma-governance.yaml
+++ b/prow/jobs/kyma/kyma-governance.yaml
@@ -26,6 +26,13 @@ presubmits: # runs on PRs
             args:
               - "--repository"
               - "kyma"
+        resources:
+          requests:
+            memory: 1.5Gi
+            cpu: 0.8
+          limits:
+            memory: 2Gi
+            cpu: 1.4
 
 periodics: # runs periodic on master
 - name: kyma-governance-nightly
@@ -56,4 +63,10 @@ periodics: # runs periodic on master
           - "/home/prow/go/src/github.com/kyma-project/kyma"
           - "--full-validation"
           - "true"
-
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -24,8 +24,8 @@ presubmits: # runs on PRs
               - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-and-start-kyma.sh"
         resources:
           requests:
-            memory: 1.5Gi
-            cpu: 0.8
+            memory: 100Mi
+            cpu: 50m
     - name: kyma-gke-integration
       run_if_changed: "^(resources|installation)"
       trigger: "(?m)^/test kyma-gke-integration"
@@ -60,8 +60,8 @@ presubmits: # runs on PRs
               - "${KYMA_PROJECT_DIR}/test-infra/prow/scripts/cluster-integration/kyma-gke-integration.sh"
         resources:
           requests:
-            memory: 1.5Gi
-            cpu: 0.8
+            memory: 200Mi
+            cpu: 80m
 
 postsubmits:
   kyma-project/kyma:
@@ -84,6 +84,10 @@ postsubmits:
           - image: eu.gcr.io/kyma-project/prow/bootstrap:0.0.1
             command:
               - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-and-start-kyma.sh"
+        resources:
+          requests:
+            memory: 100Mi
+            cpu: 50m
     - name: kyma-gke-integration
       branches:
         - master
@@ -112,6 +116,10 @@ postsubmits:
             args:
               - "-c"
               - "${KYMA_PROJECT_DIR}/test-infra/prow/scripts/cluster-integration/kyma-gke-integration.sh"
+        resources:
+          requests:
+            memory: 200Mi
+            cpu: 80m
 
 periodics:
 # kyma-integration-cleaner removes all sshPublic keys stored for service account "sa-vm-kyma-integration". Those keys refers to machines that in most cases were already removed.
@@ -124,6 +132,10 @@ periodics:
   spec:
     containers:
     - image: eu.gcr.io/kyma-project/prow/cleaner:0.0.1 # see test-infra/prow/images/cleaner
+    resources:
+      requests:
+        memory: 100Mi
+        cpu: 50m
 - name: orphaned-disks-cleaner
   cron: "15 */2 * * *" # "At minute 15 past every 2nd hour"
   labels:
@@ -143,6 +155,10 @@ periodics:
       args:
         - "-c"
         - "development/disks-cleanup.sh -project=${CLOUDSDK_CORE_PROJECT} -dryRun=false"
+    resources:
+      requests:
+        memory: 1Gi
+        cpu: 400m
 - name: orphaned-clusters-cleaner
   cron: "0 */4 * * *" # "Every four hours"
   labels:
@@ -162,6 +178,10 @@ periodics:
       args:
         - "-c"
         - "development/clusters-cleanup.sh -project=${CLOUDSDK_CORE_PROJECT} -dryRun=false"
+    resources:
+      requests:
+        memory: 1Gi
+        cpu: 400m
 - name: orphaned-vms-cleaner
   cron: "30 */4 * * *" # "At minute 30 past every 4th hour"
   labels:
@@ -181,6 +201,10 @@ periodics:
       args:
         - "-c"
         - "development/vms-cleanup.sh -project=${CLOUDSDK_CORE_PROJECT} -dryRun=false"
+    resources:
+      requests:
+        memory: 1Gi
+        cpu: 400m
 - name: orphaned-loadbalancer-cleaner
   cron: "30 7 * * 1-5" # "At 07:30 on every day-of-week from Monday through Friday."
   labels:
@@ -200,4 +224,7 @@ periodics:
       args:
         - "-c"
         - "development/loadbalancer-cleanup.sh -project=${CLOUDSDK_CORE_PROJECT} -dryRun=false"
-
+    resources:
+      requests:
+        memory: 1Gi
+        cpu: 400m

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -26,9 +26,6 @@ presubmits: # runs on PRs
           requests:
             memory: 1.5Gi
             cpu: 0.8
-          limits:
-            memory: 2Gi
-            cpu: 1.4
     - name: kyma-gke-integration
       run_if_changed: "^(resources|installation)"
       trigger: "(?m)^/test kyma-gke-integration"
@@ -65,9 +62,6 @@ presubmits: # runs on PRs
           requests:
             memory: 1.5Gi
             cpu: 0.8
-          limits:
-            memory: 2Gi
-            cpu: 1.4
 
 postsubmits:
   kyma-project/kyma:

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -22,6 +22,13 @@ presubmits: # runs on PRs
           - image: eu.gcr.io/kyma-project/prow/bootstrap:0.0.1
             command:
               - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-and-start-kyma.sh"
+        resources:
+          requests:
+            memory: 1.5Gi
+            cpu: 0.8
+          limits:
+            memory: 2Gi
+            cpu: 1.4
     - name: kyma-gke-integration
       run_if_changed: "^(resources|installation)"
       trigger: "(?m)^/test kyma-gke-integration"
@@ -54,13 +61,20 @@ presubmits: # runs on PRs
             args:
               - "-c"
               - "${KYMA_PROJECT_DIR}/test-infra/prow/scripts/cluster-integration/kyma-gke-integration.sh"
+        resources:
+          requests:
+            memory: 1.5Gi
+            cpu: 0.8
+          limits:
+            memory: 2Gi
+            cpu: 1.4
 
 postsubmits:
   kyma-project/kyma:
     - name: kyma-integration
       branches:
         - master
-      max_concurrency: 10
+      max_concurrency: 1
       labels:
         preset-sa-vm-kyma-integration: "true"
         preset-gc-project-env: "true"
@@ -79,7 +93,7 @@ postsubmits:
     - name: kyma-gke-integration
       branches:
         - master
-      max_concurrency: 10
+      max_concurrency: 1
       labels:
         preset-sa-gke-kyma-integration: "true"
         preset-gc-compute-envs: "true"

--- a/prow/jobs/kyma/tests/acceptance/acceptance.yaml
+++ b/prow/jobs/kyma/tests/acceptance/acceptance.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/acceptance/acceptance.yaml
+++ b/prow/jobs/kyma/tests/acceptance/acceptance.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tests/acceptance"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/api-controller-acceptance-tests/api-controller-acceptance-tests.yaml
+++ b/prow/jobs/kyma/tests/api-controller-acceptance-tests/api-controller-acceptance-tests.yaml
@@ -17,6 +17,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tests/api-controller-acceptance-tests"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/api-controller-acceptance-tests/api-controller-acceptance-tests.yaml
+++ b/prow/jobs/kyma/tests/api-controller-acceptance-tests/api-controller-acceptance-tests.yaml
@@ -21,9 +21,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/application-operator-tests/application-operator-tests.yaml
+++ b/prow/jobs/kyma/tests/application-operator-tests/application-operator-tests.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tests/application-operator-tests"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/application-operator-tests/application-operator-tests.yaml
+++ b/prow/jobs/kyma/tests/application-operator-tests/application-operator-tests.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/application-registry-tests/application-registry-tests.yaml
+++ b/prow/jobs/kyma/tests/application-registry-tests/application-registry-tests.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/application-registry-tests/application-registry-tests.yaml
+++ b/prow/jobs/kyma/tests/application-registry-tests/application-registry-tests.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tests/application-registry-tests"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/connector-service-tests/connector-service-tests.yaml
+++ b/prow/jobs/kyma/tests/connector-service-tests/connector-service-tests.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/connector-service-tests/connector-service-tests.yaml
+++ b/prow/jobs/kyma/tests/connector-service-tests/connector-service-tests.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tests/connector-service-tests"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/event-bus/test-event-bus.yaml
+++ b/prow/jobs/kyma/tests/event-bus/test-event-bus.yaml
@@ -17,6 +17,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tests/event-bus"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/event-bus/test-event-bus.yaml
+++ b/prow/jobs/kyma/tests/event-bus/test-event-bus.yaml
@@ -21,9 +21,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/gateway-tests/gateway-tests.yaml
+++ b/prow/jobs/kyma/tests/gateway-tests/gateway-tests.yaml
@@ -17,6 +17,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tests/gateway-tests"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/gateway-tests/gateway-tests.yaml
+++ b/prow/jobs/kyma/tests/gateway-tests/gateway-tests.yaml
@@ -21,9 +21,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/knative-serving-acceptance/knative-serving-acceptance.yaml
+++ b/prow/jobs/kyma/tests/knative-serving-acceptance/knative-serving-acceptance.yaml
@@ -17,6 +17,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tests/knative-serving-acceptance"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/knative-serving-acceptance/knative-serving-acceptance.yaml
+++ b/prow/jobs/kyma/tests/knative-serving-acceptance/knative-serving-acceptance.yaml
@@ -21,9 +21,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/kubeless-integration/kubeless-integration.yaml
+++ b/prow/jobs/kyma/tests/kubeless-integration/kubeless-integration.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/kubeless-integration/kubeless-integration.yaml
+++ b/prow/jobs/kyma/tests/kubeless-integration/kubeless-integration.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tests/kubeless-integration"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/kubeless/kubeless.yaml
+++ b/prow/jobs/kyma/tests/kubeless/kubeless.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/kubeless/kubeless.yaml
+++ b/prow/jobs/kyma/tests/kubeless/kubeless.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tests/kubeless"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/logging/logging.yaml
+++ b/prow/jobs/kyma/tests/logging/logging.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/logging/logging.yaml
+++ b/prow/jobs/kyma/tests/logging/logging.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tests/logging"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/metadata-service-tests/metadata-service-tests.yaml
+++ b/prow/jobs/kyma/tests/metadata-service-tests/metadata-service-tests.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/metadata-service-tests/metadata-service-tests.yaml
+++ b/prow/jobs/kyma/tests/metadata-service-tests/metadata-service-tests.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tests/metadata-service-tests"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/test-environments/test-environments.yaml
+++ b/prow/jobs/kyma/tests/test-environments/test-environments.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/test-environments/test-environments.yaml
+++ b/prow/jobs/kyma/tests/test-environments/test-environments.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tests/test-environments"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/test-logging-monitoring/test-logging-monitoring.yaml
+++ b/prow/jobs/kyma/tests/test-logging-monitoring/test-logging-monitoring.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/test-logging-monitoring/test-logging-monitoring.yaml
+++ b/prow/jobs/kyma/tests/test-logging-monitoring/test-logging-monitoring.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tests/test-logging-monitoring"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/ui-api-layer-acceptance-tests/ui-api-layer-acceptance-tests.yaml
+++ b/prow/jobs/kyma/tests/ui-api-layer-acceptance-tests/ui-api-layer-acceptance-tests.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tests/ui-api-layer-acceptance-tests/ui-api-layer-acceptance-tests.yaml
+++ b/prow/jobs/kyma/tests/ui-api-layer-acceptance-tests/ui-api-layer-acceptance-tests.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tests/ui-api-layer-acceptance-tests"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tools/alpine-net/alpine-net.yaml
+++ b/prow/jobs/kyma/tools/alpine-net/alpine-net.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tools/alpine-net/alpine-net.yaml
+++ b/prow/jobs/kyma/tools/alpine-net/alpine-net.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tools/alpine-net"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tools/ark-plugins/ark-plugins.yaml
+++ b/prow/jobs/kyma/tools/ark-plugins/ark-plugins.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tools/ark-plugins/ark-plugins.yaml
+++ b/prow/jobs/kyma/tools/ark-plugins/ark-plugins.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tools/ark-plugins"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tools/docsbuilder/docsbuilder.yaml
+++ b/prow/jobs/kyma/tools/docsbuilder/docsbuilder.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tools/docsbuilder/docsbuilder.yaml
+++ b/prow/jobs/kyma/tools/docsbuilder/docsbuilder.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tools/docsbuilder"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tools/etcd-backup/etcd-backup.yaml
+++ b/prow/jobs/kyma/tools/etcd-backup/etcd-backup.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tools/etcd-backup/etcd-backup.yaml
+++ b/prow/jobs/kyma/tools/etcd-backup/etcd-backup.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tools/etcd-backup"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tools/etcd-tls-setup/etcd-tls-setup.yaml
+++ b/prow/jobs/kyma/tools/etcd-tls-setup/etcd-tls-setup.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tools/etcd-tls-setup/etcd-tls-setup.yaml
+++ b/prow/jobs/kyma/tools/etcd-tls-setup/etcd-tls-setup.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tools/etcd-tls-setup"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tools/failery/failery.yaml
+++ b/prow/jobs/kyma/tools/failery/failery.yaml
@@ -20,9 +20,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 presubmits: # runs on PRs
   kyma-project/kyma:

--- a/prow/jobs/kyma/tools/failery/failery.yaml
+++ b/prow/jobs/kyma/tools/failery/failery.yaml
@@ -16,6 +16,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tools/failery"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 presubmits: # runs on PRs
   kyma-project/kyma:

--- a/prow/jobs/kyma/tools/gcp-broker-provider/gcp-broker-provider.yaml
+++ b/prow/jobs/kyma/tools/gcp-broker-provider/gcp-broker-provider.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tools/gcp-broker-provider/gcp-broker-provider.yaml
+++ b/prow/jobs/kyma/tools/gcp-broker-provider/gcp-broker-provider.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tools/gcp-broker-provider"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tools/load-test/load-test.yaml
+++ b/prow/jobs/kyma/tools/load-test/load-test.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tools/load-test/load-test.yaml
+++ b/prow/jobs/kyma/tools/load-test/load-test.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tools/load-test"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tools/stability-checker/stability-checker.yaml
+++ b/prow/jobs/kyma/tools/stability-checker/stability-checker.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
       - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
       args:
       - "/home/prow/go/src/github.com/kyma-project/kyma/tools/stability-checker"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tools/stability-checker/stability-checker.yaml
+++ b/prow/jobs/kyma/tools/stability-checker/stability-checker.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tools/static-users-generator/static-users-generator.yaml
+++ b/prow/jobs/kyma/tools/static-users-generator/static-users-generator.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tools/static-users-generator/static-users-generator.yaml
+++ b/prow/jobs/kyma/tools/static-users-generator/static-users-generator.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tools/static-users-generator"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tools/watch-pods/watch-pods.yaml
+++ b/prow/jobs/kyma/tools/watch-pods/watch-pods.yaml
@@ -22,9 +22,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/kyma/tools/watch-pods/watch-pods.yaml
+++ b/prow/jobs/kyma/tools/watch-pods/watch-pods.yaml
@@ -18,6 +18,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tools/watch-pods"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/test-infra/buildpack.yaml
+++ b/prow/jobs/test-infra/buildpack.yaml
@@ -27,9 +27,6 @@ bootstrap_job_template: &bootstrap_job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 bootstrap_helm_template: &bootstrap_helm_template
   run_if_changed: "^prow/images/bootstrap-helm/"
@@ -47,9 +44,6 @@ bootstrap_helm_template: &bootstrap_helm_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 buildpack_golang_job_template: &buildpack_golang_job_template
   run_if_changed: "^prow/images/buildpack-golang/"
@@ -67,9 +61,6 @@ buildpack_golang_job_template: &buildpack_golang_job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 buildpack_node_job_template: &buildpack_node_job_template
   run_if_changed: "^prow/images/buildpack-node/"
@@ -87,9 +78,6 @@ buildpack_node_job_template: &buildpack_node_job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 buildpack_node_chromium_job_template: &buildpack_node_chromium_job_template
   run_if_changed: "^prow/images/buildpack-node-chromium/"
@@ -107,9 +95,6 @@ buildpack_node_chromium_job_template: &buildpack_node_chromium_job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 cleaner_job_template: &cleaner_job_template
   run_if_changed: "^prow/images/cleaner/"
@@ -127,9 +112,6 @@ cleaner_job_template: &cleaner_job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 presubmits: # runs on PRs
   kyma-project/test-infra:

--- a/prow/jobs/test-infra/buildpack.yaml
+++ b/prow/jobs/test-infra/buildpack.yaml
@@ -23,6 +23,13 @@ bootstrap_job_template: &bootstrap_job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/publish-buildpack.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/images/bootstrap"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 bootstrap_helm_template: &bootstrap_helm_template
   run_if_changed: "^prow/images/bootstrap-helm/"
@@ -36,6 +43,13 @@ bootstrap_helm_template: &bootstrap_helm_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/publish-buildpack.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/images/bootstrap-helm"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 buildpack_golang_job_template: &buildpack_golang_job_template
   run_if_changed: "^prow/images/buildpack-golang/"
@@ -49,6 +63,13 @@ buildpack_golang_job_template: &buildpack_golang_job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/publish-buildpack.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/images/buildpack-golang"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 buildpack_node_job_template: &buildpack_node_job_template
   run_if_changed: "^prow/images/buildpack-node/"
@@ -62,6 +83,13 @@ buildpack_node_job_template: &buildpack_node_job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/publish-buildpack.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/images/buildpack-node"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 buildpack_node_chromium_job_template: &buildpack_node_chromium_job_template
   run_if_changed: "^prow/images/buildpack-node-chromium/"
@@ -75,6 +103,13 @@ buildpack_node_chromium_job_template: &buildpack_node_chromium_job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/publish-buildpack.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/images/buildpack-node-chromium"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 cleaner_job_template: &cleaner_job_template
   run_if_changed: "^prow/images/cleaner/"
@@ -88,6 +123,13 @@ cleaner_job_template: &cleaner_job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/publish-buildpack.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/images/cleaner"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 presubmits: # runs on PRs
   kyma-project/test-infra:

--- a/prow/jobs/test-infra/test-infra-governance.yaml
+++ b/prow/jobs/test-infra/test-infra-governance.yaml
@@ -24,9 +24,6 @@ presubmits: # runs on PRs
           requests:
             memory: 1.5Gi
             cpu: 0.8
-          limits:
-            memory: 2Gi
-            cpu: 1.4
 
 periodics: # runs periodic on master
 - name: test-infra-governance-nightly
@@ -57,6 +54,3 @@ periodics: # runs periodic on master
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4

--- a/prow/jobs/test-infra/test-infra-governance.yaml
+++ b/prow/jobs/test-infra/test-infra-governance.yaml
@@ -22,8 +22,8 @@ presubmits: # runs on PRs
               - "test-infra"
         resources:
           requests:
-            memory: 1.5Gi
-            cpu: 0.8
+            memory: 10Mi
+            cpu: 100m
 
 periodics: # runs periodic on master
 - name: test-infra-governance-nightly
@@ -52,5 +52,5 @@ periodics: # runs periodic on master
           - "true"
     resources:
       requests:
-        memory: 1.5Gi
-        cpu: 0.8
+        memory: 10Mi
+        cpu: 100m

--- a/prow/jobs/test-infra/test-infra-governance.yaml
+++ b/prow/jobs/test-infra/test-infra-governance.yaml
@@ -20,6 +20,13 @@ presubmits: # runs on PRs
             args:
               - "--repository"
               - "test-infra"
+        resources:
+          requests:
+            memory: 1.5Gi
+            cpu: 0.8
+          limits:
+            memory: 2Gi
+            cpu: 1.4
 
 periodics: # runs periodic on master
 - name: test-infra-governance-nightly
@@ -46,4 +53,10 @@ periodics: # runs periodic on master
           - "/home/prow/go/src/github.com/kyma-project/test-infra"
           - "--full-validation"
           - "true"
-
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4

--- a/prow/jobs/test-infra/validation.yaml
+++ b/prow/jobs/test-infra/validation.yaml
@@ -13,9 +13,6 @@ presubmits:
           requests:
             memory: 1.5Gi
             cpu: 0.8
-          limits:
-            memory: 2Gi
-            cpu: 1.4
     - name: test-infra-validate-configs
       run_if_changed: "^prow/((plugins|config).yaml|jobs/)"
       decorate: true
@@ -33,9 +30,6 @@ presubmits:
           requests:
             memory: 1.5Gi
             cpu: 0.8
-          limits:
-            memory: 2Gi
-            cpu: 1.4
     - name: test-infra-validate-prow
       run_if_changed: "^(development/tools|prow)" # Also for any changes in prow directory
       branches:
@@ -58,6 +52,3 @@ presubmits:
           requests:
             memory: 1.5Gi
             cpu: 0.8
-          limits:
-            memory: 2Gi
-            cpu: 1.4

--- a/prow/jobs/test-infra/validation.yaml
+++ b/prow/jobs/test-infra/validation.yaml
@@ -9,6 +9,13 @@ presubmits:
           - image: eu.gcr.io/kyma-project/prow/test-infra/bootstrap:v20181121-f3ea5ce
             command:
               - "/home/prow/go/src/github.com/kyma-project/test-infra/development/validate-scripts.sh"
+        resources:
+          requests:
+            memory: 1.5Gi
+            cpu: 0.8
+          limits:
+            memory: 2Gi
+            cpu: 1.4
     - name: test-infra-validate-configs
       run_if_changed: "^prow/((plugins|config).yaml|jobs/)"
       decorate: true
@@ -22,6 +29,13 @@ presubmits:
               - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/plugins.yaml"
               - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/config.yaml"
               - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/jobs"
+        resources:
+          requests:
+            memory: 1.5Gi
+            cpu: 0.8
+          limits:
+            memory: 2Gi
+            cpu: 1.4
     - name: test-infra-validate-prow
       run_if_changed: "^(development/tools|prow)" # Also for any changes in prow directory
       branches:
@@ -40,3 +54,10 @@ presubmits:
               - "-C"
               - "development/tools"
               - "validate"
+        resources:
+          requests:
+            memory: 1.5Gi
+            cpu: 0.8
+          limits:
+            memory: 2Gi
+            cpu: 1.4

--- a/prow/jobs/website/tools/documentation-generator/website-tools-documentation-generator.yaml
+++ b/prow/jobs/website/tools/documentation-generator/website-tools-documentation-generator.yaml
@@ -17,6 +17,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/website/tools/documentation-generator"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/website/tools/documentation-generator/website-tools-documentation-generator.yaml
+++ b/prow/jobs/website/tools/documentation-generator/website-tools-documentation-generator.yaml
@@ -21,9 +21,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/website/website-governance.yaml
+++ b/prow/jobs/website/website-governance.yaml
@@ -25,6 +25,13 @@ presubmits: # runs on PRs
             args:
               - "--repository"
               - "website"
+        resources:
+          requests:
+            memory: 1.5Gi
+            cpu: 0.8
+          limits:
+            memory: 2Gi
+            cpu: 1.4
 
 periodics: # runs periodic on master
 - name: website-governance-nightly
@@ -55,4 +62,10 @@ periodics: # runs periodic on master
           - "/home/prow/go/src/github.com/kyma-project/website"
           - "--full-validation"
           - "true"
-
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4

--- a/prow/jobs/website/website-governance.yaml
+++ b/prow/jobs/website/website-governance.yaml
@@ -27,8 +27,8 @@ presubmits: # runs on PRs
               - "website"
         resources:
           requests:
-            memory: 1.5Gi
-            cpu: 0.8
+            memory: 10Mi
+            cpu: 100m
 
 periodics: # runs periodic on master
 - name: website-governance-nightly
@@ -61,5 +61,5 @@ periodics: # runs periodic on master
           - "true"
     resources:
       requests:
-        memory: 1.5Gi
-        cpu: 0.8
+        memory: 10Mi
+        cpu: 100m

--- a/prow/jobs/website/website-governance.yaml
+++ b/prow/jobs/website/website-governance.yaml
@@ -29,9 +29,6 @@ presubmits: # runs on PRs
           requests:
             memory: 1.5Gi
             cpu: 0.8
-          limits:
-            memory: 2Gi
-            cpu: 1.4
 
 periodics: # runs periodic on master
 - name: website-governance-nightly
@@ -66,6 +63,3 @@ periodics: # runs periodic on master
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4

--- a/prow/jobs/website/website.yaml
+++ b/prow/jobs/website/website.yaml
@@ -16,6 +16,13 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/website"
+    resources:
+      requests:
+        memory: 1.5Gi
+        cpu: 0.8
+      limits:
+        memory: 2Gi
+        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"

--- a/prow/jobs/website/website.yaml
+++ b/prow/jobs/website/website.yaml
@@ -20,9 +20,6 @@ job_template: &job_template
       requests:
         memory: 1.5Gi
         cpu: 0.8
-      limits:
-        memory: 2Gi
-        cpu: 1.4
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Configured resources requests for jobs

For most jobs configured resources requests as follow:
```yaml
resources:
  requests:
    memory: 1.5Gi
    cpu: 0.8
```

There are few jobs that have different settings:
 - kyma/ui-api - 2GB, 1.5 core
 - kyma/gke-integration - 200MB, 0.08 core
 - kyma/integration - 100MB, 0.05 core
 - kyma/periodics - 1GB, 0.4 core
 - console/core - 2GB, 1.5 core
 - governance - 10MB, 0.1 core

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

#409