### PR TITLE
Create alert rules for integration tests

### DIFF
--- a/docs/prow/prow-monitoring.md
+++ b/docs/prow/prow-monitoring.md
@@ -38,7 +38,7 @@ Follow these steps:
 4. Install the monitoring chart:
 
    ```bash
-   helm install --name {releaseName} --namespace {namespaceName} resources/monitoring -f resources/monitoring/values.yaml
+   helm install --name {releaseName} --namespace {namespaceName} resources/monitoring
    ```
 
 5. Open the Grafana dashboard.

--- a/docs/prow/prow-monitoring.md
+++ b/docs/prow/prow-monitoring.md
@@ -9,6 +9,14 @@ Install the following tools:
 - Helm v2.11.0
 - kubectl
 
+## Configure Slack for failure notifications
+
+Follow these steps:
+
+1. Create a Slack channel and create an [Incoming Webhook](https://api.slack.com/incoming-webhooks) for this channel. Copy the resulting Webhook URL.
+
+2. Replace <SLACK_URL> on [values.yaml] with the Weebhook URL you obtaied and replace <SLACK_CHANNEL> with the channel name.
+
 ## Provision a monitoring chart
 
 Follow these steps:
@@ -30,7 +38,7 @@ Follow these steps:
 4. Install the monitoring chart:
 
    ```bash
-   helm install --name {releaseName} --namespace {namespaceName} resources/monitoring
+   helm install --name {releaseName} --namespace {namespaceName} resources/monitoring -f resources/monitoring/values.yaml
    ```
 
 5. Open the Grafana dashboard.

--- a/docs/prow/prow-monitoring.md
+++ b/docs/prow/prow-monitoring.md
@@ -15,7 +15,7 @@ Follow these steps:
 
 1. Create a Slack channel and create an [Incoming Webhook](https://api.slack.com/incoming-webhooks) for this channel. Copy the resulting Webhook URL.
 
-2. Replace <SLACK_URL> on [values.yaml](./../../prow/cluster/resources/monitoring/values.yaml) with the Weebhook URL you obtaied and replace <SLACK_CHANNEL> with the channel name.
+2. Replace **<SLACK_URL>** on [values.yaml](./../../prow/cluster/resources/monitoring/values.yaml) with the Weebhook URL you obtaied and replace **<SLACK_CHANNEL>** with the channel name.
 
 ## Provision a monitoring chart
 

--- a/docs/prow/prow-monitoring.md
+++ b/docs/prow/prow-monitoring.md
@@ -15,7 +15,7 @@ Follow these steps:
 
 1. Create a Slack channel and create an [Incoming Webhook](https://api.slack.com/incoming-webhooks) for this channel. Copy the resulting Webhook URL.
 
-2. Replace <SLACK_URL> on [values.yaml] with the Weebhook URL you obtaied and replace <SLACK_CHANNEL> with the channel name.
+2. Replace <SLACK_URL> on [values.yaml](./../../prow/cluster/resources/monitoring/values.yaml) with the Weebhook URL you obtaied and replace <SLACK_CHANNEL> with the channel name.
 
 ## Provision a monitoring chart
 

--- a/docs/prow/prow-monitoring.md
+++ b/docs/prow/prow-monitoring.md
@@ -13,9 +13,9 @@ Install the following tools:
 
 Follow these steps:
 
-1. Create a Slack channel and create an [Incoming Webhook](https://api.slack.com/incoming-webhooks) for this channel. Copy the resulting Webhook URL.
+1. Create a Slack channel and an [Incoming Webhook](https://api.slack.com/incoming-webhooks) for this channel. Copy the resulting Webhook URL.
 
-2. Replace **<SLACK_URL>** on [values.yaml](./../../prow/cluster/resources/monitoring/values.yaml) with the Weebhook URL you obtaied and replace **<SLACK_CHANNEL>** with the channel name.
+2. Replace `{SLACK_URL}` in [values.yaml](./../../prow/cluster/resources/monitoring/values.yaml) with the Weebhook URL and `{SLACK_CHANNEL}` with the channel name.
 
 ## Provision a monitoring chart
 

--- a/prow/cluster/resources/monitoring/templates/prometheus-rule.yaml
+++ b/prow/cluster/resources/monitoring/templates/prometheus-rule.yaml
@@ -10,14 +10,14 @@ spec:
   - name: ./prow.rules
     rules:
     - alert: KymaIntegration
-      expr: (max(kube_pod_status_phase{phase="Failed"} == 1) by(pod) * on(pod) topk (1, (max (kube_pod_labels{namespace="default", label_prow_k8s_io_job="kyma-integration", label_prow_k8s_io_type="postsubmit"}) by(pod)) * on(pod) max(kube_pod_completion_time{namespace="default"}) by(pod)) != 0)
+      expr: topk (1, kube_pod_completion_time{namespace="default"} and on(pod) kube_pod_labels{namespace="default", label_prow_k8s_io_job="kyma-integration", label_prow_k8s_io_type="postsubmit"}) and on(pod) kube_pod_status_phase{phase="Failed"} == 1
       labels:
         severity: critical
       annotations:
-        description: "Kyma integration tests failed!"
+        description: "Kyma integration tests failed! Pod: {{`{{$labels.pod}}`}}"
     - alert: KymaGKEIntegration
-      expr: (max(kube_pod_status_phase{phase="Failed"} == 1) by(pod) * on(pod) topk (1, (max (kube_pod_labels{namespace="default", label_prow_k8s_io_job="kyma-gke-integration", label_prow_k8s_io_type="postsubmit"}) by(pod)) * on(pod) max(kube_pod_completion_time{namespace="default"}) by(pod)) != 0)
+      expr: topk (1, kube_pod_completion_time{namespace="default"} and on(pod) kube_pod_labels{namespace="default", label_prow_k8s_io_job="kyma-gke-integration", label_prow_k8s_io_type="postsubmit"}) and on(pod) kube_pod_status_phase{phase="Failed"} == 1
       labels:
         severity: critical
       annotations:
-        description: "Kyma integration tests on GKE failed!"
+        description: "Kyma integration tests on GKE failed! Pod: {{`{{$labels.pod}}`}}"

--- a/prow/cluster/resources/monitoring/templates/prometheus-rule.yaml
+++ b/prow/cluster/resources/monitoring/templates/prometheus-rule.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: prometheus-prow-job-failure-rules
+  labels:
+    app: prometheus-operator
+{{ include "prometheus-operator.labels" . | indent 4 }}
+spec:
+  groups:
+  - name: ./prow.rules
+    rules:
+    - alert: KymaIntegration
+      expr: (max(kube_pod_status_phase{phase="Failed"} == 1) by(pod) * on(pod) topk (1, (max (kube_pod_labels{namespace="default", label_prow_k8s_io_job="kyma-integration", label_prow_k8s_io_type="postsubmit"}) by(pod)) * on(pod) max(kube_pod_completion_time{namespace="default"}) by(pod)) != 0)
+      labels:
+        severity: critical
+      annotations:
+        description: "Kyma integration tests failed!"
+    - alert: KymaGKEIntegration
+      expr: (max(kube_pod_status_phase{phase="Failed"} == 1) by(pod) * on(pod) topk (1, (max (kube_pod_labels{namespace="default", label_prow_k8s_io_job="kyma-gke-integration", label_prow_k8s_io_type="postsubmit"}) by(pod)) * on(pod) max(kube_pod_completion_time{namespace="default"}) by(pod)) != 0)
+      labels:
+        severity: critical
+      annotations:
+        description: "Kyma integration tests on GKE failed!"

--- a/prow/cluster/resources/monitoring/templates/prometheus-rule.yaml
+++ b/prow/cluster/resources/monitoring/templates/prometheus-rule.yaml
@@ -14,10 +14,10 @@ spec:
       labels:
         severity: critical
       annotations:
-        description: "Kyma integration tests failed! Pod: {{`{{$labels.pod}}`}}"
+        description: "Kyma integration tests failed! Pod: {{`{{$labels.pod}}`}} \nPlease check https://status.build.kyma-project.io/?type=postsubmit&job=kyma-integration"
     - alert: KymaGKEIntegration
       expr: topk (1, kube_pod_completion_time{namespace="default"} and on(pod) kube_pod_labels{namespace="default", label_prow_k8s_io_job="kyma-gke-integration", label_prow_k8s_io_type="postsubmit"}) and on(pod) kube_pod_status_phase{phase="Failed"} == 1
       labels:
         severity: critical
       annotations:
-        description: "Kyma integration tests on GKE failed! Pod: {{`{{$labels.pod}}`}}"
+        description: "Kyma integration tests on GKE failed! Pod: {{`{{$labels.pod}}`}} \nPlease check https://status.build.kyma-project.io/?type=postsubmit&job=kyma-gke-integration"

--- a/prow/cluster/resources/monitoring/values.yaml
+++ b/prow/cluster/resources/monitoring/values.yaml
@@ -10,9 +10,9 @@ prometheus-operator:
       - name: "null"
       - name: "slack"
         slack_configs:
-        - channel: <SLACK_CHANNEL>
+        - channel: {SLACK_CHANNEL}
           send_resolved: true
-          api_url: <SLACK_URL>
+          api_url: {SLACK_URL}
           title: "{{ .CommonAnnotations.description }}"
           text: "<!channel> \nDescription: {{ .CommonAnnotations.description }}"
       route:

--- a/prow/cluster/resources/monitoring/values.yaml
+++ b/prow/cluster/resources/monitoring/values.yaml
@@ -2,6 +2,32 @@ grafana:
   provisionDashboards: true
 
 prometheus-operator:
+  alertmanager:
+    config:
+      global:
+        resolve_timeout: 5m
+      receivers:
+      - name: "null"
+      - name: "slack"
+        slack_configs:
+        - channel: <SLACK_CHANNEL>
+          send_resolved: true
+          api_url: <SLACK_URL>
+          text: "<!channel> \ndescription: {{ .CommonAnnotations.description }}"
+      route:
+        group_by:
+        - job
+        group_interval: 5m
+        group_wait: 30s
+        receiver: "null"
+        repeat_interval: 12h
+        routes:
+        - match:
+            alertname: KymaIntegration
+          receiver: "slack"
+        - match:
+            alertname: KymaGKEIntegration
+          receiver: "slack"
   grafana:
     env:
       GF_AUTH_ANONYMOUS_ENABLED: true

--- a/prow/cluster/resources/monitoring/values.yaml
+++ b/prow/cluster/resources/monitoring/values.yaml
@@ -13,11 +13,12 @@ prometheus-operator:
         - channel: <SLACK_CHANNEL>
           send_resolved: true
           api_url: <SLACK_URL>
-          text: "<!channel> \ndescription: {{ .CommonAnnotations.description }}"
+          title: "{{ .CommonAnnotations.description }}"
+          text: "<!channel> \nDescription: {{ .CommonAnnotations.description }}"
       route:
         group_by:
         - job
-        group_interval: 5m
+        group_interval: 30m
         group_wait: 30s
         receiver: "null"
         repeat_interval: 12h


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Create alert rules on Prometheus for integration test failures 
- Add Slack configurations to Alertmanager
- Update documentation

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #15 