### PR TITLE
Add Bot github token label to kyma-artifacts job

### DIFF
--- a/prow/jobs/kyma/kyma-artifacts.yaml
+++ b/prow/jobs/kyma/kyma-artifacts.yaml
@@ -25,6 +25,7 @@ job_labels_template: &job_labels_template
   preset-dind-enabled: "true"
   preset-sa-kyma-artifacts: "true"
   preset-kyma-artifacts-bucket: "true"
+  preset-bot-github-token: "true"
 
 # TODO only for testing purposes
 presubmits: # runs on PRs


### PR DESCRIPTION
Changelog generator require github token to generate files so label `preset-bot-github-token: "true"` is necessary in `kyma-artifacts.yaml`