### PR TITLE
Update branch protection rules for release 0.6. 

### DIFF
--- a/development/tools/cmd/configuploader/main.go
+++ b/development/tools/cmd/configuploader/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kyma-project/test-infra/development/tools/pkg/file"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"

--- a/development/tools/cmd/configuploader/main_test.go
+++ b/development/tools/cmd/configuploader/main_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )

--- a/development/tools/cmd/secretspopulator/main_test.go
+++ b/development/tools/cmd/secretspopulator/main_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/cloudkms/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/development/tools/jobs/kyma/kyma_installer_test.go
+++ b/development/tools/jobs/kyma/kyma_installer_test.go
@@ -21,7 +21,7 @@ func TestKymaInstallerReleases(t *testing.T) {
 			assert.Equal(t, "github.com/kyma-project/kyma", actualPresubmit.PathAlias)
 			tester.AssertThatHasExtraRefTestInfra(t, actualPresubmit.JobBase.UtilityConfig, currentRelease)
 			tester.AssertThatHasPresets(t, actualPresubmit.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepo, tester.PresetGcrPush, tester.PresetBuildRelease)
-			assert.True(t, actualPresubmit.AlwaysRun)
+			assert.False(t, actualPresubmit.AlwaysRun)
 			assert.Len(t, actualPresubmit.Spec.Containers, 1)
 			testContainer := actualPresubmit.Spec.Containers[0]
 			assert.Equal(t, tester.ImageBootstrap20181204, testContainer.Image)

--- a/development/tools/jobs/testinfra/branchprotector_test.go
+++ b/development/tools/jobs/testinfra/branchprotector_test.go
@@ -64,10 +64,12 @@ func TestBranchProtectionRelease(t *testing.T) {
 			assert.NotNil(t, p)
 			assert.True(t, *p.Protect)
 			require.NotNil(t, p.RequiredStatusChecks)
-			assert.Len(t, p.RequiredStatusChecks.Contexts, 3)
+			assert.Len(t, p.RequiredStatusChecks.Contexts, 5)
 			assert.Contains(t, p.RequiredStatusChecks.Contexts, "license/cla")
 			assert.Contains(t, p.RequiredStatusChecks.Contexts, "kyma-integration")
 			assert.Contains(t, p.RequiredStatusChecks.Contexts, "kyma-gke-integration")
+			assert.Contains(t, p.RequiredStatusChecks.Contexts, "kyma-installer")
+			assert.Contains(t, p.RequiredStatusChecks.Contexts, "kyma-artifacts")
 		})
 	}
 }

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -197,9 +197,10 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
-                  # TODO this is just an example
                   - kyma-integration
                   - kyma-gke-integration
+                  - kyma-artifacts
+                  - kyma-installer
         website:
           branches:
             master:

--- a/prow/jobs/kyma/kyma-installer.yaml
+++ b/prow/jobs/kyma/kyma-installer.yaml
@@ -33,7 +33,7 @@ presubmits: # runs on PRs
   - branches:
     - release-0.6
     <<: *job_template
-    always_run: true
+    always_run: false
     extra_refs:
     - <<: *test_infra_ref
       base_ref: release-0.6


### PR DESCRIPTION
- Update branch protection rules for release 0.6. 
- Kyma-installer shoul be run manually because it has to build after component/installer


