### PR TITLE
Use default title for notifications

### DIFF
--- a/prow/cluster/resources/monitoring/values.yaml
+++ b/prow/cluster/resources/monitoring/values.yaml
@@ -13,7 +13,6 @@ prometheus-operator:
         - channel: {SLACK_CHANNEL}
           send_resolved: true
           api_url: {SLACK_URL}
-          title: "{{ .CommonAnnotations.description }}"
           text: "<!channel> \nDescription: {{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"
       route:
         group_by:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Use the default title. Customizing the title leads to the disappearance of some fields.
