### PR TITLE
Disable auto trigger of the gke-upgradeability job

### DIFF
--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -129,7 +129,7 @@ presubmits: # runs on PRs
     branches:
     - master
     <<: *gke_upgradeability_job_template
-    run_if_changed: "^(resources|installation)"
+    always_run: false
     labels:
       preset-bot-github-token: "true"
       preset-build-pr: "true"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Disable auto trigger of the gke-upgradeability job

**Related issue(s)**

- https://github.com/kyma-project/kyma/issues/2259