### PR TITLE
Hotfix for readonly property in gek-upgrade plan

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
@@ -153,7 +153,7 @@ function generateAndExportClusterName() {
         COMMON_NAME=$(echo "gke-upgrade-rel-${RANDOM_NAME_SUFFIX}" | tr "[:upper:]" "[:lower:]")
     else
         # Otherwise (master), operate on triggering commit id
-        readonly COMMIT_ID=$(cd "$KYMA_SOURCES_DIR" && git rev-parse --short HEAD)
+        COMMIT_ID=$(cd "$KYMA_SOURCES_DIR" && git rev-parse --short HEAD)
         COMMON_NAME=$(echo "gke-upgrade-commit-${COMMIT_ID}-${RANDOM_NAME_SUFFIX}" | tr "[:upper:]" "[:lower:]")
     fi
 
@@ -279,7 +279,7 @@ function upgradeKyma() {
     else
         shout "Build Kyma Installer Docker image"
         date
-        readonly COMMIT_ID=$(cd "$KYMA_SOURCES_DIR" && git rev-parse --short HEAD)
+        COMMIT_ID=$(cd "$KYMA_SOURCES_DIR" && git rev-parse --short HEAD)
         KYMA_INSTALLER_IMAGE="${DOCKER_PUSH_REPOSITORY}${DOCKER_PUSH_DIRECTORY}/gke-upgradeability/${REPO_OWNER}/${REPO_NAME}:COMMIT-${COMMIT_ID}"
         export KYMA_INSTALLER_IMAGE
         "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-image.sh"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Hot fix for:
```
# Build Kyma Installer Docker image
#################################################################################################
    
Tue Jan 22 11:20:01 UTC 2019
/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/kyma-gke-upgrade.sh: line 282: COMMIT_ID: readonly variable
```
