### PR TITLE
Add new prowjob for image "kyma-cluster-infra"

### DIFF
--- a/development/tools/jobs/testinfra/buildpack_test.go
+++ b/development/tools/jobs/testinfra/buildpack_test.go
@@ -167,6 +167,47 @@ func TestBuildpackGolangJobPostsubmit(t *testing.T) {
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/images/buildpack-golang"}, actualPost.Spec.Containers[0].Args)
 }
 
+func TestKymaClusterInfraPresubmit(t *testing.T) {
+	// WHEN
+	jobConfig, err := tester.ReadJobConfig("./../../../../prow/jobs/test-infra/buildpack.yaml")
+	// THEN
+	require.NoError(t, err)
+
+	actualPresubmit := tester.FindPresubmitJobByName(jobConfig.Presubmits["kyma-project/test-infra"], "pre-test-infra-kyma-cluster-infra", "master")
+	require.NotNil(t, actualPresubmit)
+
+	assert.False(t, actualPresubmit.SkipReport)
+	assert.True(t, actualPresubmit.Decorate)
+	assert.Equal(t, "github.com/kyma-project/test-infra", actualPresubmit.PathAlias)
+	tester.AssertThatJobRunIfChanged(t, actualPresubmit, "prow/images/kyma-cluster-infra/Dockerfile")
+	assert.Len(t, actualPresubmit.Spec.Containers, 1)
+	actualContainer := actualPresubmit.Spec.Containers[0]
+	assert.Equal(t, "eu.gcr.io/kyma-project/prow/test-infra/bootstrap:v20181204-a6e79be", actualContainer.Image)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/publish-buildpack.sh"}, actualContainer.Command)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/images/kyma-cluster-infra"}, actualContainer.Args)
+	tester.AssertThatSpecifiesResourceRequests(t, actualPresubmit.JobBase)
+}
+
+func TestKymaClusterInfraPostsubmit(t *testing.T) {
+	// WHEN
+	jobConfig, err := tester.ReadJobConfig("./../../../../prow/jobs/test-infra/buildpack.yaml")
+	// THEN
+	require.NoError(t, err)
+
+	actualPostsubmit := tester.FindPostsubmitJobByName(jobConfig.Postsubmits["kyma-project/test-infra"], "post-test-infra-kyma-cluster-infra", "master")
+	require.NotNil(t, actualPostsubmit)
+
+	assert.True(t, actualPostsubmit.Decorate)
+	assert.Equal(t, "github.com/kyma-project/test-infra", actualPostsubmit.PathAlias)
+	tester.AssertThatJobRunIfChanged(t, actualPostsubmit, "prow/images/kyma-cluster-infra/Dockerfile")
+	assert.Len(t, actualPostsubmit.Spec.Containers, 1)
+	actualContainer := actualPostsubmit.Spec.Containers[0]
+	assert.Equal(t, "eu.gcr.io/kyma-project/prow/test-infra/bootstrap:v20181204-a6e79be", actualContainer.Image)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/publish-buildpack.sh"}, actualContainer.Command)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/images/kyma-cluster-infra"}, actualContainer.Args)
+	tester.AssertThatSpecifiesResourceRequests(t, actualPostsubmit.JobBase)
+}
+
 func TestBuildpackNodeJobPresubmit(t *testing.T) {
 	// WHEN
 	jobConfig, err := tester.ReadJobConfig("./../../../../prow/jobs/test-infra/buildpack.yaml")

--- a/prow/images/bootstrap-helm/README.md
+++ b/prow/images/bootstrap-helm/README.md
@@ -13,5 +13,5 @@ The image consists of:
 To build the Docker image, run this command:
 
 ```bash
-docker build bootstrap-helm .
+docker build -t bootstrap-helm .
 ```

--- a/prow/jobs/test-infra/buildpack.yaml
+++ b/prow/jobs/test-infra/buildpack.yaml
@@ -45,18 +45,18 @@ bootstrap_helm_template: &bootstrap_helm_template
             memory: 1.5Gi
             cpu: 0.8
 
-bootstrap_go_helm_template: &bootstrap_go_helm_template
-  run_if_changed: "^prow/images/bootstrap-go-helm/"
+kyma_cluster_infra: &kyma_cluster_infra
+  run_if_changed: "^prow/images/kyma-cluster-infra/"
   <<: *common_job_template
   spec:
     containers:
-    - image: eu.gcr.io/kyma-project/prow/test-infra/bootstrap:v20181121-f3ea5ce
+    - image: eu.gcr.io/kyma-project/prow/test-infra/bootstrap:v20181204-a6e79be
       securityContext:
         privileged: true
       command:
       - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/publish-buildpack.sh"
       args:
-      - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/images/bootstrap-go-helm"
+      - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/images/kyma-cluster-infra"
       resources:
         requests:
           memory: 1.5Gi
@@ -142,11 +142,11 @@ presubmits: # runs on PRs
         preset-build-pr: "true"
         <<: *job_labels_template
       <<: *bootstrap_helm_template
-    - name: pre-test-infra-buildpack-go-helm
+    - name: pre-test-infra-kyma-cluster-infra
       labels:
         preset-build-pr: "true"
         <<: *job_labels_template
-      <<: *bootstrap_go_helm_template
+      <<: *kyma_cluster_infra
     - name: pre-test-infra-buildpack-golang
       labels:
         preset-build-pr: "true"
@@ -180,11 +180,11 @@ postsubmits: # runs on master
         preset-build-release: "true"
         <<: *job_labels_template
       <<: *bootstrap_helm_template
-    - name: post-test-infra-bootstrap-go-helm
+    - name: post-test-infra-kyma-cluster-infra
       labels:
         preset-build-release: "true"
         <<: *job_labels_template
-      <<: *bootstrap_go_helm_template
+      <<: *kyma_cluster_infra
     - name: post-test-infra-buildpack-golang
       labels:
         preset-build-release: "true"

--- a/prow/jobs/test-infra/buildpack.yaml
+++ b/prow/jobs/test-infra/buildpack.yaml
@@ -45,6 +45,23 @@ bootstrap_helm_template: &bootstrap_helm_template
             memory: 1.5Gi
             cpu: 0.8
 
+bootstrap_go_helm_template: &bootstrap_go_helm_template
+  run_if_changed: "^prow/images/bootstrap-go-helm/"
+  <<: *common_job_template
+  spec:
+    containers:
+    - image: eu.gcr.io/kyma-project/prow/test-infra/bootstrap:v20181121-f3ea5ce
+      securityContext:
+        privileged: true
+      command:
+      - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/publish-buildpack.sh"
+      args:
+      - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/images/bootstrap-go-helm"
+      resources:
+        requests:
+          memory: 1.5Gi
+          cpu: 0.8
+
 buildpack_golang_job_template: &buildpack_golang_job_template
   run_if_changed: "^prow/images/buildpack-golang/"
   <<: *common_job_template
@@ -125,6 +142,11 @@ presubmits: # runs on PRs
         preset-build-pr: "true"
         <<: *job_labels_template
       <<: *bootstrap_helm_template
+    - name: pre-test-infra-buildpack-go-helm
+      labels:
+        preset-build-pr: "true"
+        <<: *job_labels_template
+      <<: *bootstrap_go_helm_template
     - name: pre-test-infra-buildpack-golang
       labels:
         preset-build-pr: "true"
@@ -158,6 +180,11 @@ postsubmits: # runs on master
         preset-build-release: "true"
         <<: *job_labels_template
       <<: *bootstrap_helm_template
+    - name: post-test-infra-bootstrap-go-helm
+      labels:
+        preset-build-release: "true"
+        <<: *job_labels_template
+      <<: *bootstrap_go_helm_template
     - name: post-test-infra-buildpack-golang
       labels:
         preset-build-release: "true"


### PR DESCRIPTION
In this PR new prowjobs were created to publish a new image "kyma-cluster-infra".
Purpose of a new image is to have all tools needed for managing Kyma Cluster:
- gcloud
- helm
- go
- dep

In a next PR I am going to add Dockerfiles