### PR TITLE
Adding the option to label the custom image as default

### DIFF
--- a/development/custom-image/README.md
+++ b/development/custom-image/README.md
@@ -1,5 +1,5 @@
 # Create Custom Image
-The purpose of this document is to define how to create a new Google Compute Engine [custom image](https://cloud.google.com/compute/docs/images?authuser=1#custom_images) with required dependencies. You can use the new image to provision virtual machine (VM) instances with all dependencies already installed.
+The purpose of this document is to define how to create a new Google Compute Engine [custom image](https://cloud.google.com/compute/docs/images?authuser=1#custom_images) with required dependencies. You can use the new image to provision virtual machine (VM) instances with all dependencies already installed. To set the created image as default custom image, add the flag `--default` when running this script.
 
 > **NOTE:** To run the following script, make sure that you are signed in to the Google Cloud project with administrative rights.
 

--- a/development/custom-image/README.md
+++ b/development/custom-image/README.md
@@ -5,7 +5,10 @@ The purpose of this document is to define how to create a new Google Compute Eng
 
 ## Image creation process
 
-To run the script, use the command **create-custom-image.sh**. To set the created image created by this script as default custom image, add the flag `--default` to the command.
+To run the script, use the command **create-custom-image.sh**. To set the image created by this script as default custom image, add the flag `--default` to the command.
+
+> **NOTE:** Adding the flag `--default` to this script will add the label "default:yes" to the created custom image. By default, the script [`provision-vm-and-start-kyma.sh`](../../prow/scripts/provision-vm-and-start-kyma.sh) will select the latest default custom image available in Kyma project to provision the VM instance.
+
 
 The script performs the following steps:
 

--- a/development/custom-image/README.md
+++ b/development/custom-image/README.md
@@ -5,9 +5,9 @@ The purpose of this document is to define how to create a new Google Compute Eng
 
 ## Image creation process
 
-To run the script, use the command **create-custom-image.sh**. To set the image created by this script as default custom image, add the flag `--default` to the command.
+To run the script, use the `create-custom-image.sh` command. To set the image created by this script as a default custom image, add the `--default` flag to the command.
 
-> **NOTE:** Adding the flag `--default` to this script will add the label "default:yes" to the created custom image. By default, the script [`provision-vm-and-start-kyma.sh`](../../prow/scripts/provision-vm-and-start-kyma.sh) will select the latest default custom image available in Kyma project to provision the VM instance.
+> **NOTE:** Adding the `--default` flag to this script adds the `default:yes` label to the created custom image. By default, the [`provision-vm-and-start-kyma.sh`](../../prow/scripts/provision-vm-and-start-kyma.sh) script selects the latest default custom image available in Kyma project to provision the VM instance.
 
 
 The script performs the following steps:

--- a/development/custom-image/README.md
+++ b/development/custom-image/README.md
@@ -1,9 +1,11 @@
 # Create Custom Image
-The purpose of this document is to define how to create a new Google Compute Engine [custom image](https://cloud.google.com/compute/docs/images?authuser=1#custom_images) with required dependencies. You can use the new image to provision virtual machine (VM) instances with all dependencies already installed. To set the created image as default custom image, add the flag `--default` when running this script.
+The purpose of this document is to define how to create a new Google Compute Engine [custom image](https://cloud.google.com/compute/docs/images?authuser=1#custom_images) with required dependencies. You can use the new image to provision virtual machine (VM) instances with all dependencies already installed.
 
 > **NOTE:** To run the following script, make sure that you are signed in to the Google Cloud project with administrative rights.
 
 ## Image creation process
+
+To run the script, use the command **create-custom-image.sh**. To set the created image created by this script as default custom image, add the flag `--default` to the command.
 
 The script performs the following steps:
 


### PR DESCRIPTION
Updating create-custom-image with option --default to label the created custom image as default

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add the flag --default to allow specifying the created custom image as one of the default images by adding the label "default : yes"