### PR TITLE
Adding a new flag --image to provision-vm-and-start-kyma script

### DIFF
--- a/prow/scripts/provision-vm-and-start-kyma.sh
+++ b/prow/scripts/provision-vm-and-start-kyma.sh
@@ -48,9 +48,8 @@ do
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
-
 if [[ -z "$IMAGE" ]]; then
-    shout "Pprovisioning vm using the latest default custom image ..."   
+    shout "Provisioning vm using the latest default custom image ..."   
 
     DEFAULT_IMAGES=$(gcloud compute images list --project "kyma-project" \
          --sort-by "~creationTimestamp" \

--- a/prow/scripts/provision-vm-and-start-kyma.sh
+++ b/prow/scripts/provision-vm-and-start-kyma.sh
@@ -35,10 +35,6 @@ do
             IMAGE="$2"
             shift
             shift
-            IMAGE_EXISTS=$(gcloud compute images list --filter "${IMAGE}" | tail -n +2 | awk '{print $1}')
-            if [[ -z "$IMAGE_EXISTS" ]]; then
-               shout "${IMAGE} is invalid, it is not available in GCP images list, the script will terminate ..." && exit 1
-            fi
             ;;
         --*)
             echo "Unknown flag ${1}"
@@ -51,6 +47,13 @@ do
     esac
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
+
+
+IMAGE_EXISTS=$(gcloud compute images list --filter "${IMAGE}" | tail -n +2 | awk '{print $1}')
+
+if [[ -z "$IMAGE_EXISTS" ]]; then
+    shout "${IMAGE} is invalid, it is not available in GCP images list, the script will terminate ..." && exit 1
+fi
 
 if [[ -z "$IMAGE" ]]; then
     shout "Provisioning vm using the latest default custom image ..."   

--- a/prow/scripts/provision-vm-and-start-kyma.sh
+++ b/prow/scripts/provision-vm-and-start-kyma.sh
@@ -51,11 +51,8 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 if [[ -z "$IMAGE" ]]; then
     shout "Provisioning vm using the latest default custom image ..."   
     
-    DEFAULT_IMAGES=$(gcloud compute images list --sort-by "~creationTimestamp" \
-         --filter "family:custom images AND labels.default:yes" | tail -n +2 | awk '{print $1}')
-
-    default_image_arr=($DEFAULT_IMAGES)
-    IMAGE=${default_image_arr[0]}
+    IMAGE=$(gcloud compute images list --sort-by "~creationTimestamp" \
+         --filter "family:custom images AND labels.default:yes" --limit=1 | tail -n +2 | awk '{print $1}')
     
     if [[ -z "$IMAGE" ]]; then
        shout "There are no default custom images, the script will exit ..." && exit 1 

--- a/prow/scripts/provision-vm-and-start-kyma.sh
+++ b/prow/scripts/provision-vm-and-start-kyma.sh
@@ -50,7 +50,7 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 
 
 if [[ -z "$IMAGE" ]]; then
-    shout "Provisioning vm using the latest default custom image ..."   
+    shout "Pprovisioning vm using the latest default custom image ..."   
 
     DEFAULT_IMAGES=$(gcloud compute images list --project "kyma-project" \
          --sort-by "~creationTimestamp" \
@@ -83,8 +83,8 @@ for i in $(seq 1 5); do
     [[ ${i} -gt 1 ]] && echo 'Retrying in 15 seconds..' && sleep 15;
     gcloud compute scp --quiet --recurse --zone="${ZONE}" /home/prow/go/src/github.com/kyma-project/kyma "kyma-integration-test-${RANDOM_ID}":~/kyma && break;
     [[ ${i} -ge 5 ]] && echo "Failed after $i attempts." && exit 1
-done
+done;
 
 shout "Triggering the installation"
 
-gcloud compute ssh --quiet --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}" -- ./kyma/prow/kyma-integration-on-debian/deploy-and-test-kyma.sh
+gcloud compute ssh --quiet --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}" -- ./kyma/installation/scripts/prow/kyma-integration-on-debian/deploy-and-test-kyma.sh

--- a/prow/scripts/provision-vm-and-start-kyma.sh
+++ b/prow/scripts/provision-vm-and-start-kyma.sh
@@ -50,14 +50,17 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 
 if [[ -z "$IMAGE" ]]; then
     shout "Provisioning vm using the latest default custom image ..."   
-
-    DEFAULT_IMAGES=$(gcloud compute images list --project "kyma-project" \
-         --sort-by "~creationTimestamp" \
+    
+    DEFAULT_IMAGES=$(gcloud compute images list --sort-by "~creationTimestamp" \
          --filter "family:custom images AND labels.default:yes" | tail -n +2 | awk '{print $1}')
 
     default_image_arr=($DEFAULT_IMAGES)
     IMAGE=${default_image_arr[0]}
-   fi
+    
+    if [[ -z "$IMAGE" ]]; then
+       shout "There are no default custom images, the script will exit ..." && exit 1 
+    fi   
+ fi
 
 ZONE_LIMIT=${ZONE_LIMIT:-5}
 EU_ZONES=$(gcloud compute zones list --filter="name~europe" --limit="${ZONE_LIMIT}" | tail -n +2 | awk '{print $1}')

--- a/prow/scripts/provision-vm-and-start-kyma.sh
+++ b/prow/scripts/provision-vm-and-start-kyma.sh
@@ -35,6 +35,10 @@ do
             IMAGE="$2"
             shift
             shift
+            IMAGE_EXISTS=$(gcloud compute images list --filter "${IMAGE}" | tail -n +2 | awk '{print $1}')
+            if [[ -z "$IMAGE_EXISTS" ]]; then
+               shout "${IMAGE} is invalid, it is not available in GCP images list, the script will terminate ..." && exit 1
+            fi
             ;;
         --*)
             echo "Unknown flag ${1}"

--- a/prow/scripts/provision-vm-and-start-kyma.sh
+++ b/prow/scripts/provision-vm-and-start-kyma.sh
@@ -24,15 +24,50 @@ else
     LABELS=(--labels "pull-number=$PULL_NUMBER,job-name=kyma-integration")
 fi
 
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+
+    key="$1"
+
+    case ${key} in
+        --image)
+            IMAGE="$2"
+            shift
+            shift
+            ;;
+        --*)
+            echo "Unknown flag ${1}"
+            exit 1
+            ;;
+        *)    # unknown option
+            POSITIONAL+=("$1") # save it in an array for later
+            shift # past argument
+            ;;
+    esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
+
+if [[ -z "$IMAGE" ]]; then
+    shout "Provisioning vm using the latest default custom image ..."   
+
+    DEFAULT_IMAGES=$(gcloud compute images list --project "kyma-project" \
+         --sort-by "~creationTimestamp" \
+         --filter "family:custom images AND labels.default:yes" | tail -n +2 | awk '{print $1}')
+
+    default_image_arr=($DEFAULT_IMAGES)
+    IMAGE=${default_image_arr[0]}
+   fi
+
 ZONE_LIMIT=${ZONE_LIMIT:-5}
 EU_ZONES=$(gcloud compute zones list --filter="name~europe" --limit="${ZONE_LIMIT}" | tail -n +2 | awk '{print $1}')
 
 for ZONE in ${EU_ZONES}; do
-    shout "Attempting to create a new instance named kyma-integration-test-${RANDOM_ID} in zone ${ZONE}"
+    shout "Attempting to create a new instance named kyma-integration-test-${RANDOM_ID} in zone ${ZONE} using image ${IMAGE}"
     gcloud compute instances create "kyma-integration-test-${RANDOM_ID}" \
         --metadata enable-oslogin=TRUE \
-        --image debian-9-stretch-v20181011 \
-        --image-project debian-cloud \
+        --image "${IMAGE}" \
         --machine-type n1-standard-4 \
         --zone "${ZONE}" \
         --boot-disk-size 20 "${LABELS[@]}" &&\
@@ -48,8 +83,8 @@ for i in $(seq 1 5); do
     [[ ${i} -gt 1 ]] && echo 'Retrying in 15 seconds..' && sleep 15;
     gcloud compute scp --quiet --recurse --zone="${ZONE}" /home/prow/go/src/github.com/kyma-project/kyma "kyma-integration-test-${RANDOM_ID}":~/kyma && break;
     [[ ${i} -ge 5 ]] && echo "Failed after $i attempts." && exit 1
-done;
+done
 
 shout "Triggering the installation"
 
-gcloud compute ssh --quiet --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}" -- ./kyma/installation/scripts/prow/kyma-integration-on-debian/deploy-and-test-kyma.sh
+gcloud compute ssh --quiet --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}" -- ./kyma/prow/kyma-integration-on-debian/deploy-and-test-kyma.sh


### PR DESCRIPTION
Adding a new flag --image to provision-vm-and-start-kyma script
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Adding a new flag --image that allows to manually specify the image to be used upon the creation of the VM using provision-vm-and-start-kyma.sh, if no image is provided, the latest default custom image will be automatically selected

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
