### PR TITLE
Verify that release was not published before creating release images

### DIFF
--- a/development/github-release.sh
+++ b/development/github-release.sh
@@ -10,6 +10,14 @@ if [ -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
    exit 1
 fi
 
+NEXT_RELEASE=$(cat "${DEVELOPMENT_DIR}/../prow/RELEASE_VERSION")
+echo "Checking if ${NEXT_RELEASE} was already published on github..."
+RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" https://api.github.com/repos/kyma-project/kyma/releases/tags/"${NEXT_RELEASE}")
+if [[ $RESPONSE != 404* ]]; then
+    echo "The ${NEXT_RELEASE} is already published on github. Stopping."
+    exit 1
+fi
+
 echo "--------------------------------------------------------------------------------"
 echo "Creating the Github release for Kyma...  "
 echo "--------------------------------------------------------------------------------"

--- a/prow/scripts/build.sh
+++ b/prow/scripts/build.sh
@@ -42,6 +42,13 @@ if [[ "${BUILD_TYPE}" == "pr" ]]; then
 elif [[ "${BUILD_TYPE}" == "master" ]]; then
     make -C "${SOURCES_DIR}" ci-master
 elif [[ "${BUILD_TYPE}" == "release" ]]; then
+    NEXT_RELEASE=$(cat "${SCRIPT_DIR}/../RELEASE_VERSION")
+    echo "Checking if ${NEXT_RELEASE} was already published on github..."
+    RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" https://api.github.com/repos/kyma-project/kyma/releases/tags/${NEXT_RELEASE})
+    if [[ $RESPONSE != 404* ]]; then
+        echo "The ${NEXT_RELEASE} is already published on github. Stopping."
+        exit 1
+    fi
     make -C "${SOURCES_DIR}" ci-release
 else
     echo "Not supported build type - ${BUILD_TYPE}"

--- a/prow/scripts/build.sh
+++ b/prow/scripts/build.sh
@@ -44,7 +44,7 @@ elif [[ "${BUILD_TYPE}" == "master" ]]; then
 elif [[ "${BUILD_TYPE}" == "release" ]]; then
     NEXT_RELEASE=$(cat "${SCRIPT_DIR}/../RELEASE_VERSION")
     echo "Checking if ${NEXT_RELEASE} was already published on github..."
-    RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" https://api.github.com/repos/kyma-project/kyma/releases/tags/${NEXT_RELEASE})
+    RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" https://api.github.com/repos/kyma-project/kyma/releases/tags/"${NEXT_RELEASE}")
     if [[ $RESPONSE != 404* ]]; then
         echo "The ${NEXT_RELEASE} is already published on github. Stopping."
         exit 1


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- In case of release jobs, check if the release version was already published in github

**Related issue(s)**
Fixes https://github.com/kyma-project/test-infra/issues/364
