### PR TITLE
Change golang buildpacks in ui-api-layer and acceptance tests

### DIFF
--- a/development/tools/jobs/kyma/ui_api_layer_acceptance_tests_test.go
+++ b/development/tools/jobs/kyma/ui_api_layer_acceptance_tests_test.go
@@ -23,7 +23,7 @@ func TestUiApiLayerAcceptanceTestsJobReleases(t *testing.T) {
 			tester.AssertThatHasExtraRefTestInfra(t, actualPresubmit.JobBase.UtilityConfig, currentRelease)
 			tester.AssertThatHasPresets(t, actualPresubmit.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepo, tester.PresetGcrPush, tester.PresetBuildRelease)
 			assert.True(t, actualPresubmit.AlwaysRun)
-			tester.AssertThatExecGolangBuildpack(t, actualPresubmit.JobBase, tester.ImageGolangBuildpackLatest, "/home/prow/go/src/github.com/kyma-project/kyma/tests/ui-api-layer-acceptance-tests")
+			tester.AssertThatExecGolangBuildpack(t, actualPresubmit.JobBase, tester.ImageGolangBuildpack1_11, "/home/prow/go/src/github.com/kyma-project/kyma/tests/ui-api-layer-acceptance-tests")
 		})
 	}
 }
@@ -50,7 +50,7 @@ func TestUiApiLayerAcceptanceTestsJobPresubmit(t *testing.T) {
 	tester.AssertThatHasPresets(t, actualPresubmit.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepo, tester.PresetGcrPush, tester.PresetBuildPr)
 	assert.Equal(t, "^tests/ui-api-layer-acceptance-tests/", actualPresubmit.RunIfChanged)
 	tester.AssertThatJobRunIfChanged(t, *actualPresubmit, "tests/ui-api-layer-acceptance-tests/some_random_file.go")
-	tester.AssertThatExecGolangBuildpack(t, actualPresubmit.JobBase, tester.ImageGolangBuildpackLatest, "/home/prow/go/src/github.com/kyma-project/kyma/tests/ui-api-layer-acceptance-tests")
+	tester.AssertThatExecGolangBuildpack(t, actualPresubmit.JobBase, tester.ImageGolangBuildpack1_11, "/home/prow/go/src/github.com/kyma-project/kyma/tests/ui-api-layer-acceptance-tests")
 }
 
 func TestUiApiLayerAcceptanceTestsJobPostsubmit(t *testing.T) {
@@ -77,5 +77,5 @@ func TestUiApiLayerAcceptanceTestsJobPostsubmit(t *testing.T) {
 	tester.AssertThatHasPresets(t, actualPost.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepo, tester.PresetGcrPush, tester.PresetBuildMaster)
 	assert.Equal(t, "^tests/ui-api-layer-acceptance-tests/", actualPost.RunIfChanged)
 	tester.AssertThatJobRunIfChanged(t, *actualPost, "tests/ui-api-layer-acceptance-tests/some_random_file.go")
-	tester.AssertThatExecGolangBuildpack(t, actualPost.JobBase, tester.ImageGolangBuildpackLatest, "/home/prow/go/src/github.com/kyma-project/kyma/tests/ui-api-layer-acceptance-tests")
+	tester.AssertThatExecGolangBuildpack(t, actualPost.JobBase, tester.ImageGolangBuildpack1_11, "/home/prow/go/src/github.com/kyma-project/kyma/tests/ui-api-layer-acceptance-tests")
 }

--- a/development/tools/jobs/kyma/ui_api_layer_test.go
+++ b/development/tools/jobs/kyma/ui_api_layer_test.go
@@ -23,7 +23,7 @@ func TestUiApiLayerJobReleases(t *testing.T) {
 			tester.AssertThatHasExtraRefTestInfra(t, actualPresubmit.JobBase.UtilityConfig, currentRelease)
 			tester.AssertThatHasPresets(t, actualPresubmit.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepo, tester.PresetGcrPush, tester.PresetBuildRelease)
 			assert.True(t, actualPresubmit.AlwaysRun)
-			tester.AssertThatExecGolangBuildpack(t, actualPresubmit.JobBase, tester.ImageGolangBuildpackLatest, "/home/prow/go/src/github.com/kyma-project/kyma/components/ui-api-layer")
+			tester.AssertThatExecGolangBuildpack(t, actualPresubmit.JobBase, tester.ImageGolangBuildpack1_11, "/home/prow/go/src/github.com/kyma-project/kyma/components/ui-api-layer")
 		})
 	}
 }
@@ -50,7 +50,7 @@ func TestUiApiLayerJobPresubmit(t *testing.T) {
 	tester.AssertThatHasPresets(t, actualPresubmit.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepo, tester.PresetGcrPush, tester.PresetBuildPr)
 	assert.Equal(t, "^components/ui-api-layer/", actualPresubmit.RunIfChanged)
 	tester.AssertThatJobRunIfChanged(t, *actualPresubmit, "components/ui-api-layer/some_random_file.go")
-	tester.AssertThatExecGolangBuildpack(t, actualPresubmit.JobBase, tester.ImageGolangBuildpackLatest, "/home/prow/go/src/github.com/kyma-project/kyma/components/ui-api-layer")
+	tester.AssertThatExecGolangBuildpack(t, actualPresubmit.JobBase, tester.ImageGolangBuildpack1_11, "/home/prow/go/src/github.com/kyma-project/kyma/components/ui-api-layer")
 }
 
 func TestUiApiLayerJobPostsubmit(t *testing.T) {
@@ -77,5 +77,5 @@ func TestUiApiLayerJobPostsubmit(t *testing.T) {
 	tester.AssertThatHasPresets(t, actualPost.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepo, tester.PresetGcrPush, tester.PresetBuildMaster)
 	assert.Equal(t, "^components/ui-api-layer/", actualPost.RunIfChanged)
 	tester.AssertThatJobRunIfChanged(t, *actualPost, "components/ui-api-layer/some_random_file.go")
-	tester.AssertThatExecGolangBuildpack(t, actualPost.JobBase, tester.ImageGolangBuildpackLatest, "/home/prow/go/src/github.com/kyma-project/kyma/components/ui-api-layer")
+	tester.AssertThatExecGolangBuildpack(t, actualPost.JobBase, tester.ImageGolangBuildpack1_11, "/home/prow/go/src/github.com/kyma-project/kyma/components/ui-api-layer")
 }

--- a/prow/jobs/kyma/components/ui-api-layer/ui-api-layer.yaml
+++ b/prow/jobs/kyma/components/ui-api-layer/ui-api-layer.yaml
@@ -10,7 +10,7 @@ job_template: &job_template
   max_concurrency: 10
   spec:
     containers:
-      - image: eu.gcr.io/kyma-project/prow/test-infra/buildpack-golang:v20181119-afd3fbd
+      - image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
         securityContext:
           privileged: true
         command:

--- a/prow/jobs/kyma/tests/ui-api-layer-acceptance-tests/ui-api-layer-acceptance-tests.yaml
+++ b/prow/jobs/kyma/tests/ui-api-layer-acceptance-tests/ui-api-layer-acceptance-tests.yaml
@@ -10,7 +10,7 @@ job_template: &job_template
   max_concurrency: 10
   spec:
     containers:
-      - image: eu.gcr.io/kyma-project/prow/test-infra/buildpack-golang:v20181119-afd3fbd
+      - image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
         securityContext:
           privileged: true
         command:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Change golang buildpacks in ui-api-layer and ui-api-layer acceptance tests to use Go 1.11

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
kyma-project/kyma#2113
