### PR TITLE
Fix clusters removal process

### DIFF
--- a/development/tools/cmd/clusterscollector/README.md
+++ b/development/tools/cmd/clusterscollector/README.md
@@ -12,7 +12,7 @@ The garbage collector finds and removes such clusters.
 
 There are three conditions used to find clusters for removal:
 - The cluster name pattern that is specific for the `kyma-gke-integration` job
-- The value of a `job` label the cluster is annotated with
+- The value of a `volatile` label the cluster is annotated with
 - The cluster `createTime` value that is used to find clusters existing at least for a preconfigured number of hours
 
 Clusters that meet these conditions are subject to removal.
@@ -43,7 +43,6 @@ See the list of available flags:
 | **--dryRun**              |    No    | The boolean value that controls the dry-run mode. It defaults to `true`.
 | **--ageInHours**          |    No    | The integer value for the number of hours. It only matches clusters older than `now()-ageInHours`. It defaults to `3`.
 | **--clusterNameRegexp**   |    No    | The string value with a valid Golang regexp. It is used to match clusters by their name. It defaults to `^gkeint[-](pr|commit)[-].*`.
-| **--jobLabelRegexp**      |    No    | The string value with a valid Golang regexp. It is used to match clusters by the `job` label value. It defaults to `^kyma-gke-integration$`.
 
 ### Environment variables
 

--- a/development/tools/pkg/clusterscollector/collector.go
+++ b/development/tools/pkg/clusterscollector/collector.go
@@ -100,7 +100,7 @@ func (gc *ClustersGarbageCollector) list(project string) ([]*container.Cluster, 
 // ClusterRemovalPredicate returns true when the cluster should be deleted (matches removal criteria)
 type ClusterRemovalPredicate func(cluster *container.Cluster) (bool, error)
 
-// DefaultClusterRemovalPredicate returns an instance of ClusterRemovalPredicate that filters clusters based on clusterNameRegexp, label "temporary", ageInHours and Status
+// DefaultClusterRemovalPredicate returns an instance of ClusterRemovalPredicate that filters clusters based on clusterNameRegexp, label "volatile", ageInHours and Status
 func DefaultClusterRemovalPredicate(clusterNameRegexp *regexp.Regexp, ageInHours uint) ClusterRemovalPredicate {
 	return func(cluster *container.Cluster) (bool, error) {
 		if cluster == nil {

--- a/prow/scripts/cluster-integration/helpers/provision-gke-cluster.sh
+++ b/prow/scripts/cluster-integration/helpers/provision-gke-cluster.sh
@@ -43,7 +43,7 @@ if [ "${NUM_NODES}" ]; then NUM_NODES_PARAM="--num-nodes=${NUM_NODES}"; fi
 
 APPENDED_LABELS=""
 if [ "${ADDITIONAL_LABELS}" ]; then APPENDED_LABELS=(",${ADDITIONAL_LABELS}") ; fi
-LABELS_PARAM=(--labels="job=${JOB_NAME},job-id=${PROW_JOB_ID},cluster=${CLUSTER_NAME}${APPENDED_LABELS[@]}")
+LABELS_PARAM=(--labels="job=${JOB_NAME},job-id=${PROW_JOB_ID},cluster=${CLUSTER_NAME},volatile=true${APPENDED_LABELS[@]}")
 
 command -v gcloud
 


### PR DESCRIPTION
Cluster collector removes clusters with a name that matches regexp. In addition to that, collector took into account label "job" which had a default value `^kyma-gke-integration`.
Currently, clusters are provisioned by many plans:
- kyma-gke-integrarion
- kyma-gke-upgrade
- weekly cluster
- nightly cluster

Some time ago, we fixed `provision-gke-cluster.sh` to use real name of the job - weekly cluster should not have label: `job:kyma-gke-integration`. This change caused that collector stopped to work. 

In this PR, all clusters provisioned by our scripts are marked with label "volatile=true" and collector can remove only volatile clusters.
