### PR TITLE
Release tool: fix RELEASE_VERSION regexp

### DIFF
--- a/development/tools/pkg/release/version.go
+++ b/development/tools/pkg/release/version.go
@@ -44,7 +44,7 @@ func (*kymaVersionReader) ReadFromFile(filePath string) (string, bool, error) {
 
 func parseVersion(releaseVersion string) (bool, error) {
 
-	r, err := regexp.Compile("^(\\d+.){2}\\d+(-rc)?$")
+	r, err := regexp.Compile("^(\\d+.){2}\\d+(-rc(\\d+)?)?$")
 	if err != nil {
 		return false, err
 	}

--- a/development/tools/pkg/release/version_test.go
+++ b/development/tools/pkg/release/version_test.go
@@ -52,6 +52,20 @@ func TestParseVersion(t *testing.T) {
 
 		})
 
+		Convey("should return true and no error if case of multiple versions of the same pre-release", func() {
+
+			//given
+			version := "0.0.3-rc8"
+
+			//when
+			isPreRel, err := parseVersion(version)
+
+			//then
+			So(err, ShouldBeNil)
+			So(isPreRel, ShouldBeTrue)
+
+		})
+
 		Convey("should return an error if the provided version is not in line with SemVer specification", func() {
 
 			//given


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- fix the regexp that matches RELEASE_VERSION