### PR TITLE
Remove unnecessary update call when data are the same

### DIFF
--- a/development/tools/Gopkg.lock
+++ b/development/tools/Gopkg.lock
@@ -750,6 +750,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e85b76e1a596eaf589dbd6803d33bda9349d922b49e7aca2d36c2b129be0c260"
+  inputs-digest = "96f6c3e2bc46a3c6a9fc6d21c59586b7b5c93a950894b8f3c8acf7d5083a7cc6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/development/tools/cmd/secretspopulator/main.go
+++ b/development/tools/cmd/secretspopulator/main.go
@@ -9,13 +9,12 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-
-	"github.com/sirupsen/logrus"
-
-	"github.com/ghodss/yaml"
+	"strings"
 
 	"cloud.google.com/go/storage"
+	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/cloudkms/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -30,21 +29,19 @@ import (
 const fileNameExtension = "encrypted"
 
 func main() {
-	argBucket := flag.String("bucket", "", "")
-	argKeyring := flag.String("keyring", "", "")
-	argKey := flag.String("key", "", "")
-	argLocation := flag.String("location", "", "")
-	argKubeconfigPath := flag.String("kubeconfig", "", "")
-	argProject := flag.String("project", "", "")
-	argSecretsDefFile := flag.String("secrets-def-file", "", "")
+	var (
+		argBucket         = flag.String("bucket", "", "")
+		argKeyring        = flag.String("keyring", "", "")
+		argKey            = flag.String("key", "", "")
+		argLocation       = flag.String("location", "", "")
+		argKubeconfigPath = flag.String("kubeconfig", "", "")
+		argProject        = flag.String("project", "", "")
+		argSecretsDefFile = flag.String("secrets-def-file", "", "")
+	)
 	flag.Parse()
-	fatalOnMissingArg("bucket", argBucket)
-	fatalOnMissingArg("keyring", argKeyring)
-	fatalOnMissingArg("key", argKey)
-	fatalOnMissingArg("location", argLocation)
-	fatalOnMissingArg("kubeconfig", argKubeconfigPath)
-	fatalOnMissingArg("project", argProject)
-	fatalOnMissingArg("secrets-def-file", argSecretsDefFile)
+
+	err := checkRequiredFlags(flag.CommandLine, "bucket", "keyring", "key", "location", "kubeconfig", "project", "secrets-def-file")
+	fatalOnError(err)
 
 	logger := logrus.StandardLogger()
 
@@ -126,7 +123,7 @@ func (s *SecretsPopulator) PopulateSecrets(ctx context.Context, project string, 
 		project, location, keyring, key)
 
 	for _, sec := range secrets {
-		name := fmt.Sprintf("%s.%s", sec.Prefix, fileNameExtension)
+		name := fmt.Sprintf("%s.%s", sec.Name, fileNameExtension)
 		s.logger.Infof("Reading object [%s] from bucket [%s]", name, bucket)
 		r, err := s.storageReader.Read(ctx, bucket, name)
 		if err != nil {
@@ -148,33 +145,48 @@ func (s *SecretsPopulator) PopulateSecrets(ctx context.Context, project string, 
 			return err
 		}
 
-		curr, err := s.secretsClient.Get(sec.Prefix, metav1.GetOptions{})
+		curr, err := s.secretsClient.Get(sec.Name, metav1.GetOptions{})
 		switch {
 		case err == nil:
-			s.logger.Infof("Updating k8s secret [%s]", curr.Name)
+			if bytes.Equal(curr.Data[sec.Key], decoded) {
+				s.logSecretAction(curr, "Unchanged")
+				continue
+			}
+
 			curr.Data[sec.Key] = decoded
 			if _, err = s.secretsClient.Update(curr); err != nil {
 				return errors.Wrap(err, "while updating secret")
 			}
+			s.logSecretAction(curr, "Updated")
 
 		case k8serrors.IsNotFound(err):
-			s.logger.Infof("Creating k8s secret [%s] with key [%s]", sec.Prefix, sec.Key)
-			if _, err := s.secretsClient.Create(&corev1.Secret{
+			curr, err := s.secretsClient.Create(&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: sec.Prefix,
+					Name: sec.Name,
 				},
 				Data: map[string][]byte{
 					sec.Key: decoded,
 				},
-			}); err != nil {
-				return errors.Wrapf(err, "while creating secret [%s]", sec.Prefix)
+			})
+			if err != nil {
+				return errors.Wrapf(err, "while creating secret [%s]", sec.Name)
 			}
+			s.logSecretAction(curr, "Created")
 		default:
-			return errors.Wrapf(err, "while getting secret [%s]", sec.Prefix)
+			return errors.Wrapf(err, "while getting secret [%s]", sec.Name)
 		}
 
 	}
 	return nil
+}
+
+// logSecretAction receives a Secret, formats it and logs.
+func (s *SecretsPopulator) logSecretAction(secret *corev1.Secret, action string) {
+	var keys []string
+	for k := range secret.Data {
+		keys = append(keys, k)
+	}
+	s.logger.Infof("%s Secret [%s] with key(s) [%s]",action, secret.Name, strings.Join(keys, ", "))
 }
 
 // RequiredSecretsData represents secrets required by Prow cluster
@@ -196,18 +208,18 @@ type GenericSecret struct {
 
 // SecretModel defines secret to be stored in k8s
 type SecretModel struct {
-	Prefix string
-	Key    string
+	Name string
+	Key  string
 }
 
 // SecretsFromData converts input data to SecretModels
 func SecretsFromData(data RequiredSecretsData) []SecretModel {
 	out := make([]SecretModel, 0)
 	for _, sa := range data.ServiceAccounts {
-		out = append(out, SecretModel{Prefix: sa.Prefix, Key: "service-account.json"})
+		out = append(out, SecretModel{Name: sa.Prefix, Key: "service-account.json"})
 	}
 	for _, g := range data.Generics {
-		out = append(out, SecretModel{Prefix: g.Prefix, Key: g.Key})
+		out = append(out, SecretModel{Name: g.Prefix, Key: g.Key})
 	}
 	return out
 }
@@ -235,8 +247,26 @@ func fatalOnError(err error) {
 		logrus.Fatal(err)
 	}
 }
-func fatalOnMissingArg(argName string, val *string) {
-	if val == nil || *val == "" {
-		logrus.Fatalf("missing argument [%s]", argName)
+
+func checkRequiredFlags(flags *flag.FlagSet, requiredFlags ...string) error {
+	required := map[string]struct{}{}
+	for _, name := range requiredFlags {
+		required[name] = struct{}{}
 	}
+
+	var unSetFlags []string
+
+	flags.VisitAll(func(flag *flag.Flag) {
+		_, flagRequired := required[flag.Name]
+
+		if flagRequired && flag.Value.String() == "" {
+			unSetFlags = append(unSetFlags, flag.Name)
+		}
+	})
+
+	if len(unSetFlags) > 0 {
+		return fmt.Errorf(`missing required flag(s): "%s"`, strings.Join(unSetFlags, `", "`))
+	}
+
+	return nil
 }

--- a/development/tools/cmd/secretspopulator/main.go
+++ b/development/tools/cmd/secretspopulator/main.go
@@ -186,7 +186,7 @@ func (s *SecretsPopulator) logSecretAction(secret *corev1.Secret, action string)
 	for k := range secret.Data {
 		keys = append(keys, k)
 	}
-	s.logger.Infof("%s Secret [%s] with key(s) [%s]",action, secret.Name, strings.Join(keys, ", "))
+	s.logger.Infof("%s Secret [%s] with key(s) [%s]", action, secret.Name, strings.Join(keys, ", "))
 }
 
 // RequiredSecretsData represents secrets required by Prow cluster

--- a/development/tools/cmd/secretspopulator/main_test.go
+++ b/development/tools/cmd/secretspopulator/main_test.go
@@ -13,11 +13,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/cloudkms/v1"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
 	k8s_testing "k8s.io/client-go/testing"
 )
@@ -41,70 +38,129 @@ func TestSecretsFromData(t *testing.T) {
 	actual := SecretsFromData(givenData)
 	// THEN
 	assert.Len(t, actual, 2)
-	assert.Contains(t, actual, SecretModel{Key: "givenKey", Prefix: "givenPrefix"})
-	assert.Contains(t, actual, SecretModel{Key: "service-account.json", Prefix: "givenSAPrefix"})
+	assert.Contains(t, actual, SecretModel{Key: "givenKey", Name: "givenPrefix"})
+	assert.Contains(t, actual, SecretModel{Key: "service-account.json", Name: "givenSAPrefix"})
 }
 
-const (
-	existingSecretName = "existing"
-	newSecretName      = "new"
-)
+func TestPopulateSecretsSuccess(t *testing.T) {
+	tests := map[string]struct {
+		secretAlreadyInK8s v1.Secret
 
-func TestPopulateSecrets(t *testing.T) {
-	// GIVEN
-	mockDecryptor := &automock.Decryptor{}
-	defer mockDecryptor.AssertExpectations(t)
-	mockStorageReader := &automock.StorageReader{}
-	defer mockStorageReader.AssertExpectations(t)
-	fakeClientset := fake.NewSimpleClientset(&v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      existingSecretName,
-			Namespace: metav1.NamespaceDefault,
+		decodedDataFromBucket string
+		secretToProcess       SecretModel
+		expWriteK8sActions    int
+	}{
+		"Should create not existing Secret": {
+			secretAlreadyInK8s: v1.Secret{}, /* no matching secrets */
+			secretToProcess: SecretModel{
+				Name: "not-existing-secret",
+				Key:  "key-no1",
+			},
+			decodedDataFromBucket: "decode-data",
+
+			expWriteK8sActions: 1,
 		},
-		Data: make(map[string][]byte),
-	})
+		"Should update existing Secret when data is different": {
+			secretAlreadyInK8s: v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-secret",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Data: map[string][]byte{
+					"key-no1": []byte("old-data"),
+				},
+			},
+			secretToProcess: SecretModel{
+				Name: "existing-secret",
+				Key:  "key-no1",
+			},
+			decodedDataFromBucket: "new-data",
 
-	fakeClientset.PrependReactor("get", "secrets", func(action k8s_testing.Action) (handled bool, ret runtime.Object, err error) {
-		impl := action.(k8s_testing.GetActionImpl)
-		if impl.Name == newSecretName {
-			return true, nil, errors.NewNotFound(schema.GroupResource{}, "")
+			expWriteK8sActions: 1,
+		},
+		"Should not update existing Secret when data wasn't changed": {
+			secretAlreadyInK8s: v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-secret",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Data: map[string][]byte{
+					"key-no1": []byte("same-data"),
+				},
+			},
+			secretToProcess: SecretModel{
+				Name: "existing-secret",
+				Key:  "key-no1",
+			},
+			decodedDataFromBucket: "same-data",
+
+			expWriteK8sActions: 0,
+		},
+	}
+	for tn, tc := range tests {
+		t.Run(tn, func(t *testing.T) {
+			// GIVEN
+			mockDecryptor := &automock.Decryptor{}
+			defer mockDecryptor.AssertExpectations(t)
+			mockStorageReader := &automock.StorageReader{}
+			defer mockStorageReader.AssertExpectations(t)
+
+			fakeCli := fake.NewSimpleClientset(&tc.secretAlreadyInK8s)
+
+			mockStorageReader.On("Read", mock.Anything, "bucket", tc.secretToProcess.Name+".encrypted").
+				Return(bytes.NewBufferString("encrypted"), nil).
+				Once()
+
+			parentName := fmt.Sprintf("projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s", "project", "location", "keyring", "key")
+			mockDecryptor.On("Decrypt", parentName, []byte("encrypted")).
+				Return(&cloudkms.DecryptResponse{Plaintext: base64.StdEncoding.EncodeToString([]byte(tc.decodedDataFromBucket))}, nil).
+				Once()
+
+			sut := SecretsPopulator{
+				decryptor:     mockDecryptor,
+				storageReader: mockStorageReader,
+				secretsClient: fakeCli.CoreV1().Secrets(metav1.NamespaceDefault),
+				logger:        logrus.StandardLogger(),
+			}
+
+			// WHEN
+			err := sut.PopulateSecrets(context.Background(), "project",
+				[]SecretModel{tc.secretToProcess},
+				"bucket", "keyring",
+				"key", "location")
+
+			// THEN
+			require.NoError(t, err)
+
+			performedActions := filterOutReadonlyActions(fakeCli.Actions())
+			assert.Len(t, performedActions, tc.expWriteK8sActions)
+
+			secretsList, err := fakeCli.CoreV1().Secrets(metav1.NamespaceDefault).List(metav1.ListOptions{})
+			require.NoError(t, err)
+			assert.Len(t, secretsList.Items, 1)
+			assert.Equal(t, tc.secretToProcess.Name, secretsList.Items[0].Name)
+			assert.Equal(t, []byte(tc.decodedDataFromBucket), secretsList.Items[0].Data[tc.secretToProcess.Key])
+		})
+	}
+}
+
+func filterOutReadonlyActions(actions []k8s_testing.Action) []k8s_testing.Action {
+	// based on API request verb, see:
+	// https://kubernetes.io/docs/reference/access-authn-authz/authorization/#review-your-request-attributes
+	readonlyAction := map[string]struct{}{
+		"get":      {},
+		"list":     {},
+		"watch":    {},
+		"proxy":    {},
+		"redirect": {},
+	}
+	var ret []k8s_testing.Action
+	for _, action := range actions {
+		if _, readonly := readonlyAction[action.GetVerb()]; readonly {
+			continue
 		}
-		return false, nil, nil
-
-	})
-
-	mockStorageReader.On("Read", mock.Anything, "bucket", "existing.encrypted").Return(bytes.NewBufferString("existingEncrypted"), nil)
-	mockStorageReader.On("Read", mock.Anything, "bucket", "new.encrypted").Return(bytes.NewBufferString("newEncrypted"), nil)
-
-	parentName := fmt.Sprintf("projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s",
-		"project", "location", "keyring", "key")
-	mockDecryptor.On("Decrypt", parentName, []byte("existingEncrypted")).Return(&cloudkms.DecryptResponse{Plaintext: base64.StdEncoding.EncodeToString([]byte("existingPlain"))}, nil)
-	mockDecryptor.On("Decrypt", parentName, []byte("newEncrypted")).Return(&cloudkms.DecryptResponse{Plaintext: base64.StdEncoding.EncodeToString([]byte("newPlain"))}, nil)
-
-	sut := SecretsPopulator{
-		decryptor:     mockDecryptor,
-		storageReader: mockStorageReader,
-		secretsClient: fakeClientset.CoreV1().Secrets(metav1.NamespaceDefault),
-		logger:        logrus.StandardLogger(),
+		ret = append(ret, action)
 	}
 
-	// WHEN
-	err := sut.PopulateSecrets(context.Background(), "project",
-		[]SecretModel{{Prefix: newSecretName, Key: "token"}, {Prefix: existingSecretName, Key: "service-account.json"}},
-		"bucket",
-		"keyring",
-		"key",
-		"location")
-
-	// THEN
-	require.NoError(t, err)
-
-	secretsList, err := fakeClientset.CoreV1().Secrets(metav1.NamespaceDefault).List(metav1.ListOptions{})
-	require.NoError(t, err)
-	assert.Len(t, secretsList.Items, 2)
-	assert.Equal(t, existingSecretName, secretsList.Items[0].Name)
-	assert.Equal(t, []byte("existingPlain"), secretsList.Items[0].Data["service-account.json"])
-	assert.Equal(t, newSecretName, secretsList.Items[1].Name)
-	assert.Equal(t, []byte("newPlain"), secretsList.Items[1].Data["token"])
-
+	return ret
 }

--- a/development/tools/cmd/secretspopulator/main_test.go
+++ b/development/tools/cmd/secretspopulator/main_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/cloudkms/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	k8s_testing "k8s.io/client-go/testing"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Remove unnecessary update call when Secret data wasnt changed. 
	##### Secrets: 
	- `oauth-token` already present in k8s and same as in bucket
	- `hmac-token` already present in k8s but different than the one in bucket
	- `kyma-alerts-slack-api-url` not defined in k8s

  previously:
  ```
  INFO[0002] Reading object [oauth-token.encrypted] from bucket [kyma-prow-secrets]
  INFO[0002] Updating k8s secret [oauth-token] with key [oauth]
  INFO[0002] Reading object [hmac-token.encrypted] from bucket [kyma-prow-secrets]
  INFO[0002] Updating k8s secret [hmac-token] with key [hmac]
  INFO[0005] Reading object [kyma-alerts-slack-api-url.encrypted] from bucket [kyma-prow-secrets]
  INFO[0005] Creating k8s secret [kyma-alerts-slack-api-url] with key [secret]
  ```
  
  currently:
  ```
  INFO[0003] Reading object [oauth-token.encrypted] from bucket [kyma-prow-secrets]
  INFO[0003] Unchanged Secret [oauth-token] with key(s) [oauth]
  INFO[0003] Reading object [hmac-token.encrypted] from bucket [kyma-prow-secrets]
  INFO[0003] Updated Secret [hmac-token] with key(s) [hmac]
  INFO[0005] Reading object [kyma-alerts-slack-api-url.encrypted] from bucket [kyma-prow-secrets]
  INFO[0005] Created Secret [kyma-alerts-slack-api-url] with key(s) [secret]
  ```

- Test converted to _table tests_ which covers such scenarios:
	- Should create not existing Secret
	- Should update existing Secret when data is different
	- Should not update existing Secret when data wasn't changed

- Change the process of validating required flags. Previously there was implemented fast return on error. Currently, you will get information about all unspecified flags.

	previously:
	```
	$ go run ./development/tools/cmd/secretspopulator/main.go
	FATA[0000] missing argument [bucket]
	exit status 1
	```
	currently:
	```
	$ go run ./development/tools/cmd/secretspopulator/main.go
	FATA[0000] missing required flag(s): "bucket", "key", "keyring", "kubeconfig", "location", "project", "secrets-def-file"
	exit status 1
	```