### PR TITLE
Add job for website tool - content-loader

### DIFF
--- a/development/tools/jobs/website/website_tools_content_loader_test.go
+++ b/development/tools/jobs/website/website_tools_content_loader_test.go
@@ -1,0 +1,67 @@
+package website_test
+
+import (
+	"testing"
+
+	"github.com/kyma-project/test-infra/development/tools/jobs/tester"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebsiteToolsContentLoaderJobPresubmit(t *testing.T) {
+	// WHEN
+	jobConfig, err := tester.ReadJobConfig("./../../../../prow/jobs/website/tools/website-tools-content-loader.yaml")
+	// THEN
+	require.NoError(t, err)
+
+	assert.Len(t, jobConfig.Presubmits, 1)
+	kymaPresubmits, ex := jobConfig.Presubmits["kyma-project/website"]
+	assert.True(t, ex)
+	assert.Len(t, kymaPresubmits, 1)
+
+	expName := "pre-master-website-tools-content-loader"
+	actualPresubmit := tester.FindPresubmitJobByName(kymaPresubmits, expName, "master")
+	require.NotNil(t, actualPresubmit)
+	assert.Equal(t, expName, actualPresubmit.Name)
+	assert.Equal(t, []string{"master"}, actualPresubmit.Branches)
+	assert.Equal(t, 10, actualPresubmit.MaxConcurrency)
+	assert.False(t, actualPresubmit.SkipReport)
+	assert.True(t, actualPresubmit.Decorate)
+	assert.False(t, actualPresubmit.Optional)
+	assert.Equal(t, "github.com/kyma-project/website", actualPresubmit.PathAlias)
+	tester.AssertThatHasExtraRefTestInfra(t, actualPresubmit.JobBase.UtilityConfig, "master")
+	tester.AssertThatHasPresets(t, actualPresubmit.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepo, tester.PresetGcrPush, tester.PresetBuildPr)
+	assert.Equal(t, "^tools/content-loader/", actualPresubmit.RunIfChanged)
+	tester.AssertThatJobRunIfChanged(t, *actualPresubmit, "tools/content-loader/some_random_file.js")
+	assert.Equal(t, tester.ImageNodeBuildpackLatest, actualPresubmit.Spec.Containers[0].Image)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPresubmit.Spec.Containers[0].Command)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/website/tools/content-loader"}, actualPresubmit.Spec.Containers[0].Args)
+}
+
+func TestWebsiteToolsContentLoaderJobPostsubmit(t *testing.T) {
+	// WHEN
+	jobConfig, err := tester.ReadJobConfig("./../../../../prow/jobs/website/tools/website-tools-content-loader.yaml")
+	// THEN
+	require.NoError(t, err)
+
+	assert.Len(t, jobConfig.Postsubmits, 1)
+	kymaPost, ex := jobConfig.Postsubmits["kyma-project/website"]
+	assert.True(t, ex)
+	assert.Len(t, kymaPost, 1)
+
+	expName := "post-master-website-tools-content-loader"
+	actualPost := tester.FindPostsubmitJobByName(kymaPost, expName, "master")
+	require.NotNil(t, actualPost)
+	assert.Equal(t, expName, actualPost.Name)
+	assert.Equal(t, []string{"master"}, actualPost.Branches)
+
+	assert.Equal(t, 10, actualPost.MaxConcurrency)
+	assert.True(t, actualPost.Decorate)
+	assert.Equal(t, "github.com/kyma-project/website", actualPost.PathAlias)
+	tester.AssertThatHasExtraRefTestInfra(t, actualPost.JobBase.UtilityConfig, "master")
+	tester.AssertThatHasPresets(t, actualPost.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepo, tester.PresetGcrPush, tester.PresetBuildMaster)
+	assert.Equal(t, "^tools/content-loader/", actualPost.RunIfChanged)
+	assert.Equal(t, tester.ImageNodeBuildpackLatest, actualPost.Spec.Containers[0].Image)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPost.Spec.Containers[0].Command)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/website/tools/content-loader"}, actualPost.Spec.Containers[0].Args)
+}

--- a/prow/jobs/website/tools/website-tools-content-loader.yaml
+++ b/prow/jobs/website/tools/website-tools-content-loader.yaml
@@ -1,0 +1,48 @@
+job_template: &job_template
+  run_if_changed: "^tools/content-loader/"
+  decorate: true
+  path_alias: github.com/kyma-project/website
+  max_concurrency: 10
+  extra_refs:
+    - org: kyma-project
+      repo: test-infra
+      base_ref: master
+      path_alias: github.com/kyma-project/test-infra
+  spec:
+    containers:
+      - image: eu.gcr.io/kyma-project/prow/test-infra/buildpack-node:v20181130-b28250b
+        securityContext:
+          privileged: true
+        command:
+          - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
+        args:
+          - "/home/prow/go/src/github.com/kyma-project/website/tools/content-loader"
+        resources:
+          requests:
+            memory: 1.5Gi
+            cpu: 0.8
+
+job_labels_template: &job_labels_template
+  preset-dind-enabled: "true"
+  preset-sa-gcr-push: "true"
+  preset-docker-push-repository: "true"
+
+presubmits: # runs on PRs
+  kyma-project/website:
+    - name: pre-master-website-tools-content-loader
+      branches:
+        - master
+      labels:
+        <<: *job_labels_template
+        preset-build-pr: "true"
+      <<: *job_template
+
+postsubmits:
+  kyma-project/website:
+    - name: post-master-website-tools-content-loader
+      branches:
+        - master
+      <<: *job_template
+      labels:
+        <<: *job_labels_template
+        preset-build-master: "true"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Add job for new website tool - `content-loader`. This tool is to enable only fetching content for website, like a documentation from root repository, or (in the future) issues for roadmap section.
After resolving https://github.com/kyma-project/website/issues/196 `documentation-generator` job must be removed, because it will not be needed anymore.

**Related issue(s)**
- https://github.com/kyma-project/website/issues/196