### PR TITLE
Fix the installation of the stability checker after refactoring in Kyma repo

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -254,6 +254,7 @@ function installStabilityChecker() {
 	kubectl exec stability-test-provisioner -n kyma-system --  mkdir -p /home/input
 	kubectl cp "${KYMA_SCRIPTS_DIR}/testing.sh" stability-test-provisioner:/home/input/ -n kyma-system
 	kubectl cp "${KYMA_SCRIPTS_DIR}/utils.sh" stability-test-provisioner:/home/input/ -n kyma-system
+	kubectl cp "${KYMA_SCRIPTS_DIR}/testing-common.sh" stability-test-provisioner:/home/input/ -n kyma-system
 	kubectl delete pod -n kyma-system stability-test-provisioner
 
     # create a secret with service account used for storing logs


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix the installation of the stability checker after refactoring in Kyma repo, see: https://github.com/kyma-project/kyma/pull/2646/files

currently in logs we can see:
```
Start test
Test end with error [start time: 2019-02-19 08:44:56.671759519 +0000 UTC m=+14401.893771668, duration: 42.981965ms]
/data/input/testing.sh: line 4: /data/input/testing-common.sh: No such file or directory
-------------------------------
- Ensure test Pods are deleted
-------------------------------
/data/input/testing.sh: line 10: cleanupHelmTestPods: command not found
/data/input/testing.sh: line 13: cleanupHelmTestPods: command not found
/data/input/testing.sh: line 16: cleanupHelmTestPods: command not found
/data/input/testing.sh: line 19: cleanupHelmTestPods: command not found
```