### PR TITLE
Document generation of development  artifacts

### DIFF
--- a/development/tools/jobs/kyma/development_artifacts_test.go
+++ b/development/tools/jobs/kyma/development_artifacts_test.go
@@ -17,8 +17,12 @@ func TestPresubmitDevelopmentArtifacts(t *testing.T) {
 	job := tester.FindPresubmitJobByName(jobConfig.Presubmits["kyma-project/kyma"], "pre-master-kyma-development-artifacts", "master")
 	require.NotNil(t, job)
 
+	tester.AssertThatJobRunIfChanged(t, job, "resources/helm-broker/values.yaml")
+	tester.AssertThatJobRunIfChanged(t, job, "installation/scripts/concat-yamls.sh")
+	tester.AssertThatJobRunIfChanged(t, job, "components/installer/Makefile")
+	tester.AssertThatJobRunIfChanged(t, job, "tools/kyma-installer/kyma.Dockerfile")
 	assert.False(t, job.SkipReport)
-	assert.True(t, job.AlwaysRun)
+	assert.False(t, job.AlwaysRun)
 	assert.True(t, job.Optional)
 	tester.AssertThatHasExtraRefTestInfra(t, job.UtilityConfig, "master")
 	tester.AssertThatHasPresets(t, job.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepo, "preset-kyma-development-artifacts-bucket", tester.PresetGcrPush, tester.PresetBuildPr)
@@ -44,7 +48,7 @@ func TestPostsubmitDevelopmentArtifcts(t *testing.T) {
 
 	job := tester.FindPostsubmitJobByName(jobConfig.Postsubmits["kyma-project/kyma"], "post-master-kyma-development-artifacts", "master")
 	require.NotNil(t, job)
-
+	assert.Empty(t, job.RunIfChanged)
 	tester.AssertThatHasExtraRefTestInfra(t, job.UtilityConfig, "master")
 	tester.AssertThatHasPresets(t, job.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepo, "preset-kyma-development-artifacts-bucket", tester.PresetGcrPush, tester.PresetBuildMaster)
 	require.Len(t, job.Spec.Containers, 1)

--- a/docs/prow/prow-architecture.md
+++ b/docs/prow/prow-architecture.md
@@ -65,14 +65,21 @@ Prow in Kyma uses the Docker-in-Docker (dind) approach to build a Docker image a
 Build logs are archived by Plank on GCS in a dedicated bucket. The bucket is configured to have a Secret with a dedicated Google service account for GCS.
 
 ## Generate development artifacts
-Two jobs `pre-master-kyma-development-artifacts` and `post-master-kyma-development-artifacts` defined in `prow/jobs/kyma/kyma-development-artifacts.yaml`
-generate artifacts that allow installing Kyma on a cluster from `master` branch or from Pull Request changes. 
-For Pull Requests, the job is executed only if introduced changes have an impact on an installed Kyma. 
-Artifacts are stored in the publicly available bucket: `gs://kyma-development-artifacts/`. The bucket has defined lifecycle management rule to automatically delete files older than 60 days. 
-For a Pull Request, artifacts are stored in the following location: `gs://kyma-development-artifacts/PR-<number>`.
-For changes to the `master` branch, artifacts are stored in the following location: `gs://kyma-development-artifacts/master-<commit_sha>`
-In addition to that, artifacts related to the latest changes in the master branch, are available in the following location:  `gs://kyma-development-artifacts/master`.
-In a directory with artifacts, following files can be found:
-- `is-installed.sh`
-- `kyma-config-cluster.yaml`
-- `kyma-installer-cluster.yaml`
+
+There are two jobs that generate artifacts which allow you to install Kyma on a cluster either from the `master` branch or from a pull request changes:
+- `pre-master-kyma-development-artifacts`
+- `post-master-kyma-development-artifacts`
+
+>**NOTE:** For pull requests, the job is executed only if the introduced changes have an impact on the installed Kyma version.
+
+Find the jobs definitions in [this](https://github.com/kyma-project/test-infra/blob/master/prow/jobs/kyma/kyma-development-artifacts.yaml) file.
+
+All artifacts are stored in the publicly available bucket under the `gs://kyma-development-artifacts/` location. The bucket has a defined lifecycle management rule to automatically delete files older than 60 days. These are the exact artifacts locations:
+* For pull requests: `gs://kyma-development-artifacts/PR-<number>`
+* For changes to the `master` branch: `gs://kyma-development-artifacts/master-<commit_sha>`
+* For the latest changes in the master branch:  `gs://kyma-development-artifacts/master`
+
+A directory with artifacts consists of the following files:
+- `kyma-installer-cluster.yaml` to deploy Kyma installer
+- `kyma-config-cluster.yaml` to configure Kyma installation
+- `is-installed.sh` to verify if Kyma installation process is finished

--- a/docs/prow/prow-architecture.md
+++ b/docs/prow/prow-architecture.md
@@ -63,3 +63,16 @@ Prow in Kyma uses the Docker-in-Docker (dind) approach to build a Docker image a
 
 ## Build logs on GCS
 Build logs are archived by Plank on GCS in a dedicated bucket. The bucket is configured to have a Secret with a dedicated Google service account for GCS.
+
+## Generate development artifacts
+Two jobs `pre-master-kyma-development-artifacts` and `post-master-kyma-development-artifacts` defined in `prow/jobs/kyma/kyma-development-artifacts.yaml`
+generate artifacts that allow installing Kyma on a cluster from `master` branch or from Pull Request changes. 
+For Pull Requests, the job is executed only if introduced changes have an impact on an installed Kyma. 
+Artifacts are stored in the publicly available bucket: `gs://kyma-development-artifacts/`. The bucket has defined lifecycle management rule to automatically delete files older than 60 days. 
+For a Pull Request, artifacts are stored in the following location: `gs://kyma-development-artifacts/PR-<number>`.
+For changes to the `master` branch, artifacts are stored in the following location: `gs://kyma-development-artifacts/master-<commit_sha>`
+In addition to that, artifacts related to the latest changes in the master branch, are available in the following location:  `gs://kyma-development-artifacts/master`.
+In a directory with artifacts, following files can be found:
+- `is-installed.sh`
+- `kyma-config-cluster.yaml`
+- `kyma-installer-cluster.yaml`

--- a/prow/jobs/kyma/kyma-development-artifacts.yaml
+++ b/prow/jobs/kyma/kyma-development-artifacts.yaml
@@ -5,7 +5,6 @@ test_infra_ref: &test_infra_ref
 
 job_template: &job_template
   optional: true
-  always_run: true
   decorate: true
   path_alias: github.com/kyma-project/kyma
   max_concurrency: 10
@@ -38,6 +37,7 @@ job_labels_template: &job_labels_template
 presubmits: # runs on PRs
   kyma-project/kyma:
   - name: pre-master-kyma-development-artifacts
+    run_if_changed: "^installation|^resources|^components/installer|^tools/kyma-installer"
     branches:
     - master
     <<: *job_template


### PR DESCRIPTION
- documentation for pre-master-kyma-development-artifacts and its postsubmit counterpart
- changed configuration that job on PR is executed only when any relevant changes to kyma were introduced that have an impact on the installed kyma. So if you changed only your component (for example helm-broker) but you have not updated charts, presubmit job will not be triggered. 