### PR TITLE
Add prow job for kyma-incubator/octopus

### DIFF
--- a/development/tools/jobs/incubator/octopus/octopus_test.go
+++ b/development/tools/jobs/incubator/octopus/octopus_test.go
@@ -1,0 +1,50 @@
+package testinfra_test
+
+import (
+	"testing"
+
+	"github.com/kyma-project/test-infra/development/tools/jobs/tester"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const octopusJobPath = "./../../../../../prow/jobs/incubator/octopus/octopus.yaml"
+
+func TestOctopusJobsPresubmit(t *testing.T) {
+	// when
+	jobConfig, err := tester.ReadJobConfig(octopusJobPath)
+
+	// then
+	require.NoError(t, err)
+	actualPresubmit := tester.FindPresubmitJobByName(jobConfig.Presubmits["kyma-incubator/octopus"], "pre-master-kyma-incubator-octopus", "master")
+	require.NotNil(t, actualPresubmit)
+
+	assert.Equal(t, 10, actualPresubmit.MaxConcurrency)
+	assert.False(t, actualPresubmit.SkipReport)
+	assert.True(t, actualPresubmit.Decorate)
+	assert.True(t, actualPresubmit.AlwaysRun)
+	assert.Equal(t, "github.com/kyma-incubator/octopus", actualPresubmit.PathAlias)
+	tester.AssertThatHasPresets(t, actualPresubmit.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepoIncubator, tester.PresetGcrPush, tester.PresetBuildPr)
+	assert.Equal(t, tester.ImageGolangKubebuilderBuildpackLatest, actualPresubmit.Spec.Containers[0].Image)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPresubmit.Spec.Containers[0].Command)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/octopus"}, actualPresubmit.Spec.Containers[0].Args)
+}
+
+func TestOctopusJobPostsubmit(t *testing.T) {
+	// when
+	jobConfig, err := tester.ReadJobConfig(octopusJobPath)
+
+	// then
+	require.NoError(t, err)
+
+	actualPostsubmit := tester.FindPostsubmitJobByName(jobConfig.Postsubmits["kyma-incubator/octopus"], "post-master-kyma-incubator-octopus", "master")
+	require.NotNil(t, actualPostsubmit)
+
+	assert.Equal(t, 10, actualPostsubmit.MaxConcurrency)
+	assert.True(t, actualPostsubmit.Decorate)
+	assert.Equal(t, "github.com/kyma-incubator/octopus", actualPostsubmit.PathAlias)
+	tester.AssertThatHasPresets(t, actualPostsubmit.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepoIncubator, tester.PresetGcrPush, tester.PresetBuildMaster)
+	assert.Equal(t, tester.ImageGolangKubebuilderBuildpackLatest, actualPostsubmit.Spec.Containers[0].Image)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPostsubmit.Spec.Containers[0].Command)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/octopus"}, actualPostsubmit.Spec.Containers[0].Args)
+}

--- a/prow/jobs/incubator/octopus/octopus.yaml
+++ b/prow/jobs/incubator/octopus/octopus.yaml
@@ -1,0 +1,50 @@
+job_template: &job_template
+  skip_report: false
+  always_run: true
+  decorate: true
+  path_alias: github.com/kyma-incubator/octopus
+  max_concurrency: 10
+  extra_refs:
+    - org: kyma-project
+      repo: test-infra
+      base_ref: master
+      path_alias: github.com/kyma-project/test-infra
+  spec:
+    containers:
+    - image: eu.gcr.io/kyma-project/test-infra/buildpack-golang-kubebuilder:v20190208-813daef
+      securityContext:
+        privileged: true
+      command:
+      - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
+      args:
+      - "/home/prow/go/src/github.com/kyma-incubator/octopus"
+      resources:
+        requests:
+          memory: 1.5Gi
+          cpu: 0.8
+
+job_labels_template: &job_labels_template
+  preset-dind-enabled: "true"
+  preset-sa-gcr-push: "true"
+  preset-docker-push-repository-incubator: "true"
+
+presubmits: # runs on PRs
+  kyma-incubator/octopus:
+  - name: pre-master-kyma-incubator-octopus
+    branches:
+    - master
+    <<: *job_template
+    labels:
+      <<: *job_labels_template
+      preset-build-pr: "true"
+
+postsubmits:
+  kyma-incubator/octopus:
+  - name: post-master-kyma-incubator-octopus
+    branches:
+    - master
+    <<: *job_template
+    labels:
+      <<: *job_labels_template
+      preset-build-master: "true"
+      prow.kyma-project.io/slack.skipReport: "true" # this job will be ignored by Slack reporter


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add prow job for kyma-incubator/octopus

  > **Note:** I've configured the job with `always_run: true` cause its separate repo not like in mono-repo Kyma. Of course, we can hardcode for some folders like *pkg*, *cmd* etc, but IMO it's easy to get out of sync and skip job check on some PR.

**Related issue(s)**

- https://github.com/kyma-project/kyma/issues/2639