### PR TITLE
Delete docker image

### DIFF
--- a/development/tools/jobs/kyma/kyma_integration_test.go
+++ b/development/tools/jobs/kyma/kyma_integration_test.go
@@ -349,7 +349,7 @@ func TestKymaIntegrationJobPeriodics(t *testing.T) {
 	require.NotNil(t, backupRestorePeriodic)
 	assert.Equal(t, expName, backupRestorePeriodic.Name)
 	assert.True(t, backupRestorePeriodic.Decorate)
-	assert.Equal(t, "0 5 * * 1-5", backupRestorePeriodic.Cron)
+	assert.Equal(t, "0 * * * 1-5", backupRestorePeriodic.Cron)
 	tester.AssertThatHasPresets(t, backupRestorePeriodic.JobBase, tester.PresetKymaBackupRestoreBucket, tester.PresetKymaBackupCredentials, tester.PresetGCProjectEnv, tester.PresetSaGKEKymaIntegration, "preset-weekly-github-integration")
 	tester.AssertThatHasExtraRefs(t, backupRestorePeriodic.JobBase.UtilityConfig, []string{"test-infra", "kyma"})
 	assert.Equal(t, "eu.gcr.io/kyma-project/test-infra/kyma-cluster-infra:v20190129-c951cf2", backupRestorePeriodic.Spec.Containers[0].Image)

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -542,7 +542,7 @@ periodics:
             cpu: 80m
 
 - name: kyma-gke-end-to-end-test-backup-restore
-  cron: "0 5 * * 1-5" # "At 05:00 on every day-of-week from Monday through Friday."
+  cron: "0 * * * 1-5" # "At 05:00 on every day-of-week from Monday through Friday."
   labels:
     preset-build-master: "true"
     preset-weekly-github-integration: "true"

--- a/prow/scripts/cluster-integration/kyma-gke-end-to-end-test.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-end-to-end-test.sh
@@ -48,7 +48,7 @@ removeCluster() {
     EXIT_STATUS=$?
 
     shout "Fetching OLD_TIMESTAMP from cluster to be deleted"
-	readonly OLD_TIMESTAMP=$(gcloud container clusters describe "${CLUSTER_NAME}" --zone="${GCLOUD_COMPUTE_ZONE}" --project="${GCLOUD_PROJECT_NAME}" --format=json | jq --raw-output '.resourceLabels."created-at"')
+	readonly OLD_TIMESTAMP=$(gcloud container clusters describe "${CLUSTER_NAME}" --zone="${GCLOUD_COMPUTE_ZONE}" --project="${GCLOUD_PROJECT_NAME}"  --format=json | jq --raw-output '.createTime' | cut -f1 -d"T" | sed "s/-//g")
 
     shout "Deprovision cluster: \"${CLUSTER_NAME}\""
     date

--- a/prow/scripts/cluster-integration/kyma-gke-end-to-end-test.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-end-to-end-test.sh
@@ -232,6 +232,7 @@ shout "Success cluster created"
 shout "End To End Test"
 date
 cd "${KYMA_SCRIPTS_DIR}"
+set +e
 ./e2e-testing.sh
 TEST_STATUS=$?
 if [ ${TEST_STATUS} -ne 0 ]


### PR DESCRIPTION

- Fix deletetion of docker image in gke cluster script 
- Ignore errors from script to trigger the expected cleanup
- Set periodic job (kyma-gke-end-to-end-test-backup-restore) to be executed every hour 