### PR TITLE
Revert postsubmit Asset Store job and make old presubmit job as optional

### DIFF
--- a/development/tools/jobs/kyma/asset_store_controller_manager_test.go
+++ b/development/tools/jobs/kyma/asset_store_controller_manager_test.go
@@ -76,7 +76,7 @@ func TestAssetControllerPostsubmit(t *testing.T) {
 	assert.Len(t, jobConfig.Postsubmits, 1)
 	kymaPost, ex := jobConfig.Postsubmits["kyma-project/kyma"]
 	assert.True(t, ex)
-	assert.Len(t, kymaPost, 1)
+	assert.Len(t, kymaPost, 2)
 
 	expName := "post-master-kyma-components-asset-store-controller-manager"
 	actualPost := tester.FindPostsubmitJobByName(kymaPost, expName, "master")

--- a/prow/jobs/kyma/components/asset-store-controller-manager/asset-store-controller-manager.yaml
+++ b/prow/jobs/kyma/components/asset-store-controller-manager/asset-store-controller-manager.yaml
@@ -48,7 +48,8 @@ job_labels_template: &job_labels_template
 
 presubmits: # runs on PRs
   kyma-project/kyma:
-    - name: pre-master-kyma-components-assetstore-controller-manager
+    - name: pre-master-kyma-components-assetstore-controller-manager-temp
+      optional: true
       branches:
         - master
       <<: *old_job_template
@@ -95,6 +96,17 @@ presubmits: # runs on PRs
 
 postsubmits:
   kyma-project/kyma:
+    - name: post-master-kyma-components-assetstore-controller-manager-temp
+      branches:
+        - master
+      <<: *old_job_template
+      run_if_changed: "^components/assetstore-controller-manager/"
+      extra_refs:
+      - <<: *test_infra_ref
+        base_ref: master
+      labels:
+        <<: *job_labels_template
+        preset-build-master: "true"
     - name: post-master-kyma-components-asset-store-controller-manager
       branches:
         - master


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Reverted postsubmit job for old Asset Store location
- Made presubmit job for old Asset Store location as optional

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
