### PR TITLE
Change timeout fot AKS nightly cluster

### DIFF
--- a/development/tools/jobs/kyma/kyma_integration_test.go
+++ b/development/tools/jobs/kyma/kyma_integration_test.go
@@ -335,7 +335,7 @@ func TestKymaIntegrationJobPeriodics(t *testing.T) {
 	tester.AssertThatSpecifiesResourceRequests(t, nightlyAksPeriodic.JobBase)
 	assert.Len(t, nightlyAksPeriodic.Spec.Containers[0].Env, 8)
 	tester.AssertThatContainerHasEnv(t, nightlyAksPeriodic.Spec.Containers[0], "RS_GROUP", "kyma-nightly-aks")
-	tester.AssertThatContainerHasEnv(t, nightlyAksPeriodic.Spec.Containers[0], "REGION", "westeurope")
+	tester.AssertThatContainerHasEnv(t, nightlyAksPeriodic.Spec.Containers[0], "REGION", "northeurope")
 	tester.AssertThatContainerHasEnv(t, nightlyAksPeriodic.Spec.Containers[0], "INPUT_CLUSTER_NAME", "nightly-aks")
 	tester.AssertThatContainerHasEnv(t, nightlyAksPeriodic.Spec.Containers[0], "TEST_RESULT_WINDOW_TIME", "6h")
 	tester.AssertThatContainerHasEnv(t, nightlyAksPeriodic.Spec.Containers[0], "STABILITY_SLACK_CLIENT_CHANNEL_ID", "#c4core-kyma-ci-force")

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -550,7 +550,7 @@ periodics:
           - name: RS_GROUP
             value: "kyma-nightly-aks"
           - name: REGION
-            value: "westeurope"
+            value: "northeurope"
           - name: INPUT_CLUSTER_NAME
             value: "nightly-aks"
           - name: TEST_RESULT_WINDOW_TIME

--- a/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
@@ -356,7 +356,7 @@ function installStabilityChecker() {
 	        "${SC_DIR}/deploy/chart/stability-checker" \
 	        --namespace=kyma-system \
 	        --name=stability-checker \
-	        --wait
+	        --wait \
 	        --timeout=600
 }
 

--- a/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
@@ -206,16 +206,6 @@ function addGithubDexConnector() {
     go run "${KYMA_PROJECT_DIR}/test-infra/development/tools/cmd/enablegithubauth/main.go"
 }
 
-function genSelfSignedCert() {
-    shout "Generate self-signed certificate"
-    date
-    DOMAIN="${DNS_SUBDOMAIN}.${DNS_DOMAIN%?}"
-    export DOMAIN
-    CERT_KEY=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/generate-self-signed-cert.sh")
-    TLS_CERT=$(echo "${CERT_KEY}" | head -1)
-    TLS_KEY=$(echo "${CERT_KEY}" | tail -1)
-}
-
 function generateAndExportLetsEncryptCert() {
 	shout "Generate lets encrypt certificate"
 	date
@@ -373,7 +363,7 @@ createGroup
 installCluster
 
 createPublicIPandDNS
-genSelfSignedCert
+generateAndExportLetsEncryptCert
 
 setupKubeconfig
 installTiller

--- a/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
@@ -312,7 +312,7 @@ function installKyma() {
 
     sed -e "s/__VERSION__/0.0.1/g" "${INSTALLER_CR}"  | sed -e "s/__.*__//g" | kubectl apply -f-
     kubectl label installation/kyma-installation action=install
-    "${KYMA_SCRIPTS_DIR}"/is-installed.sh --timeout 60m
+    "${KYMA_SCRIPTS_DIR}"/is-installed.sh --timeout 80m
 
     if [ -n "$(kubectl get  service -n kyma-system apiserver-proxy-ssl --ignore-not-found)" ]; then
         shout "Create DNS Record for Apiserver proxy IP"
@@ -357,6 +357,7 @@ function installStabilityChecker() {
 	        --namespace=kyma-system \
 	        --name=stability-checker \
 	        --wait
+	        --timeout=600
 }
 
 init


### PR DESCRIPTION
In this PR I extended timeouts for Kyma and Stability Checker Installation, and change region where a cluster is provisioned. On old and new region time required for Kyma installation seems to be similar. Additionally, a new Azure subscription is used (changes on the bucket with encrypted secrets). 
To get more information about the root cause, see comments https://github.com/kyma-project/kyma/issues/3170 