### PR TITLE
Allow newline in RELEASE_VERSION file

### DIFF
--- a/development/tools/pkg/release/version.go
+++ b/development/tools/pkg/release/version.go
@@ -49,7 +49,7 @@ func parseVersion(releaseVersion string) (bool, error) {
 		return false, err
 	}
 
-	if !r.MatchString(releaseVersion) {
+	if !r.MatchString(strings.TrimSpace(releaseVersion)) {
 		return false, errors.New("Kyma version provided in the RELEASE_VERSION file is malformed")
 	}
 

--- a/development/tools/pkg/release/version_test.go
+++ b/development/tools/pkg/release/version_test.go
@@ -38,6 +38,21 @@ func TestParseVersion(t *testing.T) {
 
 		})
 
+		Convey("should trim newlines", func() {
+
+			//given
+			version := `10.204.35000
+`
+
+			//when
+			isPreRel, err := parseVersion(version)
+
+			//then
+			So(err, ShouldBeNil)
+			So(isPreRel, ShouldBeFalse)
+
+		})
+
 		Convey("should return true and no error if the provided version is valid and refers to a pre-release", func() {
 
 			//given


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Github release job is pretty dumb and it fails if RELEASE_VERSION file contains a newline at the end. As many text editors (including GitHub) automatically add newline at the end of the file, I thought we could make it more liberal. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
