### PR TITLE
Add load test and e2etest clusters to the cleaner

### DIFF
--- a/development/tools/cmd/dnscollector/main.go
+++ b/development/tools/cmd/dnscollector/main.go
@@ -16,7 +16,7 @@ import (
 	dns "google.golang.org/api/dns/v1"
 )
 
-const defaultAddressRegexpList = "(remoteenvs-)?gkeint-(pr|commit)-.*,(remoteenvs-)?gke-upgrade-(pr|commit)-.*"
+const defaultAddressRegexpList = "(remoteenvs-)?gkeint-(pr|commit)-.*,(remoteenvs-)?gke-upgrade-(pr|commit)-.*,(remoteenvs-)?(load-test|e2etest)"
 const minAgeInHours = 1
 const minPatternLength = 5
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Add load-test and e2etest clusters in the dns cleanup cron 

**Reason**
-  DNS records:`*.load-test.build.kyma-project.io.` `gateway.load-test.build.kyma-project.io` `gateway.e2etest.build.kyma-project.io` `*.e2etest.build.kyma-project.io` are not cleaned up
- External IP: `e2etest` `remoteenvs-e2etest``load-test` `remoteenvs-load-test` are not cleaned up




