### PR TITLE
Cluster cleanup

### DIFF
--- a/development/tools/cmd/clusterscollector/README.md
+++ b/development/tools/cmd/clusterscollector/README.md
@@ -8,14 +8,19 @@ The `kyma-gke-integration` job creates a GKE cluster to install and test Kyma.
 Usually, the job also cleans up the cluster.
 It can happen, however, that the job is terminated before its clean-up finishes.
 This causes a resource leak that generates unwanted costs.
-The garbage collector finds and removes such clusters.
+The garbage collector finds and removes such clusters based on two different strategies, specified by the caller.
 
-There are three conditions used to find clusters for removal:
+In the 'default' filter strategy, there are three conditions used to find clusters for removal:
 - The cluster name pattern that is specific for the `kyma-gke-integration` job
 - The value of a `volatile` label the cluster is annotated with
 - The cluster `createTime` value that is used to find clusters existing at least for a preconfigured number of hours
 
-Clusters that meet these conditions are subject to removal.
+In the 'time' filter strategy, there are three conditions used to find clusters for removal:
+- The label value of `volatile` that the cluster is annotated with
+- The label value of `created-at`, which holds the unix timestamp of when the cluster was created
+- The label value of `ttl`, which specifies the clusters maximum intended runtime in hours
+
+Clusters that meet these conditions in the specified strategy are subject to removal.
 
 ## Usage
 
@@ -41,8 +46,9 @@ See the list of available flags:
 | :------------------------ | :------: | :--------------------------------------------------------------------------------------------------- |
 | **--project**             |   Yes    | GCP project name
 | **--dryRun**              |    No    | The boolean value that controls the dry-run mode. It defaults to `true`.
-| **--ageInHours**          |    No    | The integer value for the number of hours. It only matches clusters older than `now()-ageInHours`. It defaults to `3`.
-| **--clusterNameRegexp**   |    No    | The string value with a valid Golang regexp. It is used to match clusters by their name. It defaults to `^gkeint[-](pr|commit)[-].*`.
+| **--strategy**            |    No    | The cluster filter strategy. Defaults to `default`, can be switched to `time`.
+| **--ageInHours**          |    No    | The integer value for the number of hours. It only matches clusters older than `now()-ageInHours`. It defaults to `3`. [Only honored in `default` strategy]
+| **--clusterNameRegexp**   |    No    | The string value with a valid Golang regexp. It is used to match clusters by their name. It defaults to `^gkeint[-](pr|commit)[-].*`. [Only honored in `default` strategy]
 
 ### Environment variables
 

--- a/development/tools/cmd/clusterscollector/README.md
+++ b/development/tools/cmd/clusterscollector/README.md
@@ -10,12 +10,12 @@ It can happen, however, that the job is terminated before its clean-up finishes.
 This causes a resource leak that generates unwanted costs.
 The garbage collector finds and removes such clusters based on two different strategies, specified by the caller.
 
-In the 'default' filter strategy, there are three conditions used to find clusters for removal:
+In the `default` filter strategy, there are three conditions used to find clusters for removal:
 - The cluster name pattern that is specific for the `kyma-gke-integration` job
 - The value of a `volatile` label the cluster is annotated with
 - The cluster `createTime` value that is used to find clusters existing at least for a preconfigured number of hours
 
-In the 'time' filter strategy, there are three conditions used to find clusters for removal:
+In the `time` filter strategy, there are three conditions used to find clusters for removal:
 - The label value of `volatile` that the cluster is annotated with
 - The label value of `created-at`, which holds the unix timestamp of when the cluster was created
 - The label value of `ttl`, which specifies the clusters maximum intended runtime in hours

--- a/development/tools/pkg/clusterscollector/collector.go
+++ b/development/tools/pkg/clusterscollector/collector.go
@@ -14,6 +14,7 @@ import (
 
 const volatileLabelName = "volatile"
 const createdAtLabelName = "created-at"
+const ttlLabelName = "ttl"
 
 //go:generate mockery -name=ClusterAPI -output=automock -outpkg=automock -case=underscore
 
@@ -116,18 +117,6 @@ func DefaultClusterRemovalPredicate(clusterNameRegexp *regexp.Regexp, ageInHours
 			isVolatileCluster = true
 		}
 
-		isPastAgeMark := false
-		if cluster.ResourceLabels != nil && cluster.ResourceLabels[createdAtLabelName] != "" {
-			i, err := strconv.ParseInt(cluster.ResourceLabels[createdAtLabelName], 10, 64)
-			if err != nil {
-				return false, errors.New("invalid timestamp on field")
-			}
-			tm := time.Unix(i, 0)
-			if time.Now().Add(time.Duration(ageInHours) * time.Hour).Before(tm) {
-				isPastAgeMark = true
-			}
-		}
-
 		var ageMatches bool
 
 		clusterCreationTime, err := time.Parse(time.RFC3339, cluster.CreateTime)
@@ -139,10 +128,63 @@ func DefaultClusterRemovalPredicate(clusterNameRegexp *regexp.Regexp, ageInHours
 		clusterAgeThreshold := time.Since(clusterCreationTime).Hours() - float64(ageInHours)
 		ageMatches = clusterAgeThreshold > 0
 
-		if nameMatches && isVolatileCluster && (ageMatches || isPastAgeMark) {
+		if nameMatches && isVolatileCluster && ageMatches {
 			//Filter out clusters that are being deleted at this moment
 			if cluster.Status == "STOPPING" {
-				log.Warnf("Cluster is already in STOPPING status, skipping. Name: \"%s\", zone: \"%s\", createTime: \"%s\"", cluster.Name, cluster.Zone, cluster.CreateTime)
+				log.Warnf("Cluster is already in STOPPING status, skipping. Name: \"%s\", zone: \"%s\", createTime: \"%s\", label createdAt: \"%s\"", cluster.Name, cluster.Zone, cluster.CreateTime, cluster.ResourceLabels[createdAtLabelName])
+				return false, nil
+			}
+			return true, nil
+		}
+
+		return false, nil
+	}
+}
+
+// TimeBasedClusterRemovalPredicate returns an instance of ClusterRemovalPredicate that filters clusters based on label "volatile", "created-at", "ttl" and status
+func TimeBasedClusterRemovalPredicate() ClusterRemovalPredicate {
+	return func(cluster *container.Cluster) (bool, error) {
+		var timestamp int64
+		var ageInHours uint64
+		var err error
+
+		isVolatileCluster := false
+		if cluster.ResourceLabels != nil && cluster.ResourceLabels[volatileLabelName] == "true" {
+			isVolatileCluster = true
+		}
+
+		isPastAgeMark := false
+		if cluster.ResourceLabels != nil && cluster.ResourceLabels[createdAtLabelName] != "" {
+			timestamp, err = strconv.ParseInt(cluster.ResourceLabels[createdAtLabelName], 10, 64)
+			if err != nil {
+				return false, errors.New("invalid timestamp value")
+			}
+		}
+
+		if timestamp == 0 { // old cluster, does not have timestamp label, skip
+			log.Warnf("Cluster does not have 'created-at' label, skipping. Name: Name: \"%s\", zone: \"%s\"", cluster.Name, cluster.Zone)
+			return false, nil
+		}
+
+		hasTTL := false
+		if cluster.ResourceLabels != nil && cluster.ResourceLabels[ttlLabelName] != "" {
+			ageInHours, err = strconv.ParseUint(cluster.ResourceLabels[ttlLabelName], 10, 64)
+			if err != nil {
+				return false, errors.New("invalid ttl value")
+			}
+			hasTTL = true
+		}
+
+		createdAtTime := time.Unix(timestamp, 0)
+
+		oneHourAgo := time.Now().Add(time.Duration(-ageInHours) * time.Hour)
+		if oneHourAgo.After(createdAtTime) {
+			isPastAgeMark = true
+		}
+		if hasTTL && isVolatileCluster && isPastAgeMark {
+			//Filter out clusters that are being deleted at this moment
+			if cluster.Status == "STOPPING" {
+				log.Warnf("Cluster is already in STOPPING status, skipping. Name: \"%s\", zone: \"%s\", createTime: \"%s\", label createdAt: \"%s\", ttl: \"%s\"", cluster.Name, cluster.Zone, cluster.CreateTime, cluster.ResourceLabels[createdAtLabelName], cluster.ResourceLabels[ttlLabelName])
 				return false, nil
 			}
 			return true, nil

--- a/development/tools/pkg/clusterscollector/collector_test.go
+++ b/development/tools/pkg/clusterscollector/collector_test.go
@@ -196,13 +196,13 @@ func TestTimeBasedClusterRemovalPredicate(t *testing.T) {
 
 func TestClustersGarbageCollector(t *testing.T) {
 
-	clusterMatching1 := createCluster(sampleClusterName+"1", timeOneHourAgoFormatted, volatileLabel, timeOneHourAgoUnix, "", sampleStatus)       //matches removal filter
-	clusterNonMatchingName := createCluster("otherName"+"2", timeOneHourAgoFormatted, volatileLabel, timeOneHourAgoUnix, "", sampleStatus)       //non matching name
-	clusterNonMatchingLabel := createCluster(sampleClusterName+"3", timeOneHourAgoFormatted, "otherLabel", timeOneHourAgoUnix, "", sampleStatus) //non matching label
-	clusterCreatedTooRecently := createCluster(sampleClusterName+"4", timeNowFormatted, volatileLabel, timeNowUnix, "", sampleStatus)            //not old enough
-	clusterMatching2 := createCluster(sampleClusterName+"5", timeOneHourAgoFormatted, volatileLabel, timeOneHourAgoUnix, "", sampleStatus)       //matches removal filter
+	clusterMatching1 := createCluster(sampleClusterName+"1", timeOneHourAgoFormatted, volatileLabel, timeOneHourAgoUnix, ttlLabel, sampleStatus)       //matches removal filter
+	clusterNonMatchingName := createCluster("otherName"+"2", timeOneHourAgoFormatted, volatileLabel, timeOneHourAgoUnix, "", sampleStatus)             //non matching name
+	clusterNonMatchingLabel := createCluster(sampleClusterName+"3", timeOneHourAgoFormatted, "otherLabel", timeOneHourAgoUnix, ttlLabel, sampleStatus) //non matching label
+	clusterCreatedTooRecently := createCluster(sampleClusterName+"4", timeNowFormatted, volatileLabel, timeNowUnix, ttlLabel, sampleStatus)            //not old enough
+	clusterMatching2 := createCluster(sampleClusterName+"5", timeOneHourAgoFormatted, volatileLabel, timeOneHourAgoUnix, ttlLabel, sampleStatus)       //matches removal filter
 
-	t.Run("list() should select two clusters out of five", func(t *testing.T) {
+	t.Run("list() should select two clusters out of five - DefaultClusterRemovalPredicate", func(t *testing.T) {
 
 		mockClusterAPI := &automock.ClusterAPI{}
 		defer mockClusterAPI.AssertExpectations(t)
@@ -223,7 +223,28 @@ func TestClustersGarbageCollector(t *testing.T) {
 		assert.Equal(t, clusterMatching2, res[1])
 	})
 
-	t.Run("Run() should fail if list() fails", func(t *testing.T) {
+	t.Run("list() should select two clusters out of five - TimeBasedClusterRemovalPredicate", func(t *testing.T) {
+
+		mockClusterAPI := &automock.ClusterAPI{}
+		defer mockClusterAPI.AssertExpectations(t)
+
+		testProject := "testProject"
+
+		//Given
+		mockClusterAPI.On("ListClusters", testProject).Return([]*container.Cluster{clusterMatching1, clusterNonMatchingName, clusterNonMatchingLabel, clusterCreatedTooRecently, clusterMatching2}, nil)
+
+		//When
+		gdc := NewClustersGarbageCollector(mockClusterAPI, labelFilterFunc)
+		res, err := gdc.list(testProject)
+
+		//Then
+		require.NoError(t, err)
+		assert.Len(t, res, 2)
+		assert.Equal(t, clusterMatching1, res[0])
+		assert.Equal(t, clusterMatching2, res[1])
+	})
+
+	t.Run("Run() should fail if list() fails - DefaultClusterRemovalPredicate", func(t *testing.T) {
 
 		mockClusterAPI := &automock.ClusterAPI{}
 		defer mockClusterAPI.AssertExpectations(t)
@@ -239,7 +260,23 @@ func TestClustersGarbageCollector(t *testing.T) {
 		assert.Equal(t, testError, err)
 	})
 
-	t.Run("Run(makeChanges=true) should remove matching clusters", func(t *testing.T) {
+	t.Run("Run() should fail if list() fails - TimeBasedClusterRemovalPredicate", func(t *testing.T) {
+
+		mockClusterAPI := &automock.ClusterAPI{}
+		defer mockClusterAPI.AssertExpectations(t)
+
+		testError := errors.New("testError")
+		testProject := "testProject"
+		mockClusterAPI.On("ListClusters", testProject).Return(nil, testError)
+
+		gdc := NewClustersGarbageCollector(mockClusterAPI, labelFilterFunc)
+
+		_, err := gdc.Run(testProject, true)
+		require.Error(t, err)
+		assert.Equal(t, testError, err)
+	})
+
+	t.Run("Run(makeChanges=true) should remove matching clusters - DefaultClusterRemovalPredicate", func(t *testing.T) {
 
 		mockClusterAPI := &automock.ClusterAPI{}
 		defer mockClusterAPI.AssertExpectations(t)
@@ -257,7 +294,25 @@ func TestClustersGarbageCollector(t *testing.T) {
 		assert.True(t, allSucceeded)
 	})
 
-	t.Run("Run(makeChanges=true) should continue process if a previous call failed", func(t *testing.T) {
+	t.Run("Run(makeChanges=true) should remove matching clusters - TimeBasedClusterRemovalPredicate", func(t *testing.T) {
+
+		mockClusterAPI := &automock.ClusterAPI{}
+		defer mockClusterAPI.AssertExpectations(t)
+
+		testProject := "testProject"
+		mockClusterAPI.On("ListClusters", testProject).Return([]*container.Cluster{clusterMatching1, clusterNonMatchingName, clusterNonMatchingLabel, clusterCreatedTooRecently, clusterMatching2}, nil)
+
+		mockClusterAPI.On("RemoveCluster", testProject, clusterMatching1.Zone, clusterMatching1.Name).Return(nil)
+		mockClusterAPI.On("RemoveCluster", testProject, clusterMatching2.Zone, clusterMatching2.Name).Return(nil)
+
+		gdc := NewClustersGarbageCollector(mockClusterAPI, labelFilterFunc)
+
+		allSucceeded, err := gdc.Run(testProject, true)
+		require.NoError(t, err)
+		assert.True(t, allSucceeded)
+	})
+
+	t.Run("Run(makeChanges=true) should continue process if a previous call failed - DefaultClusterRemovalPredicate", func(t *testing.T) {
 
 		mockClusterAPI := &automock.ClusterAPI{}
 		defer mockClusterAPI.AssertExpectations(t)
@@ -279,7 +334,29 @@ func TestClustersGarbageCollector(t *testing.T) {
 		assert.False(t, allSucceeded)
 	})
 
-	t.Run("Run(makeChanges=false) should not invoke RemoveCluster() (dry run)", func(t *testing.T) {
+	t.Run("Run(makeChanges=true) should continue process if a previous call failed - TimeBasedClusterRemovalPredicate", func(t *testing.T) {
+
+		mockClusterAPI := &automock.ClusterAPI{}
+		defer mockClusterAPI.AssertExpectations(t)
+
+		testProject := "testProject"
+
+		//Given
+		mockClusterAPI.On("ListClusters", testProject).Return([]*container.Cluster{clusterMatching1, clusterNonMatchingName, clusterNonMatchingLabel, clusterCreatedTooRecently, clusterMatching2}, nil)
+
+		mockClusterAPI.On("RemoveCluster", testProject, clusterMatching1.Zone, clusterMatching1.Name).Return(errors.New("testError"))
+		mockClusterAPI.On("RemoveCluster", testProject, clusterMatching2.Zone, clusterMatching2.Name).Return(nil)
+		//When
+		gdc := NewClustersGarbageCollector(mockClusterAPI, labelFilterFunc)
+		allSucceeded, err := gdc.Run(testProject, true)
+
+		//Then
+		mockClusterAPI.AssertCalled(t, "RemoveCluster", mock.Anything, mock.Anything, mock.Anything)
+		require.NoError(t, err)
+		assert.False(t, allSucceeded)
+	})
+
+	t.Run("Run(makeChanges=false) should not invoke RemoveCluster() (dry run) - DefaultClusterRemovalPredicate", func(t *testing.T) {
 
 		mockClusterAPI := &automock.ClusterAPI{}
 		defer mockClusterAPI.AssertExpectations(t)
@@ -291,6 +368,27 @@ func TestClustersGarbageCollector(t *testing.T) {
 
 		//When
 		gdc := NewClustersGarbageCollector(mockClusterAPI, filterFunc)
+		allSucceeded, err := gdc.Run(testProject, false)
+
+		//Then
+		mockClusterAPI.AssertCalled(t, "ListClusters", testProject)
+		mockClusterAPI.AssertNotCalled(t, "RemoveCluster", mock.Anything, mock.Anything, mock.Anything)
+		require.NoError(t, err)
+		assert.True(t, allSucceeded)
+	})
+
+	t.Run("Run(makeChanges=false) should not invoke RemoveCluster() (dry run) - TimeBasedClusterRemovalPredicate", func(t *testing.T) {
+
+		mockClusterAPI := &automock.ClusterAPI{}
+		defer mockClusterAPI.AssertExpectations(t)
+
+		testProject := "testProject"
+
+		//Given
+		mockClusterAPI.On("ListClusters", testProject).Return([]*container.Cluster{clusterMatching1, clusterNonMatchingName, clusterNonMatchingLabel, clusterCreatedTooRecently, clusterMatching2}, nil)
+
+		//When
+		gdc := NewClustersGarbageCollector(mockClusterAPI, labelFilterFunc)
 		allSucceeded, err := gdc.Run(testProject, false)
 
 		//Then

--- a/development/tools/pkg/clusterscollector/collector_test.go
+++ b/development/tools/pkg/clusterscollector/collector_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
 	"testing"
 	"time"
 
@@ -19,17 +20,21 @@ const sampleClusterNameRegexp = "^gkeint[-](pr|commit)[-].*"
 const sampleClusterName = "gkeint-pr-2991-abc"
 const volatileLabel = "true"
 const sampleStatus = "RUNNING"
+const ttlLabel = "1" // max ttl of a cluster in hours
 
 var (
-	clusterNameRegexp        = regexp.MustCompile(sampleClusterNameRegexp)
-	filterFunc               = DefaultClusterRemovalPredicate(clusterNameRegexp, 1) //age is 1 hour
-	timeNow                  = time.Now()
-	timeNowFormatted         = timeNow.Format(time.RFC3339Nano)
-	timeTwoHoursAgo          = timeNow.Add(time.Duration(-1) * time.Hour)
-	timeTwoHoursAgoFormatted = timeTwoHoursAgo.Format(time.RFC3339Nano)
+	clusterNameRegexp       = regexp.MustCompile(sampleClusterNameRegexp)
+	filterFunc              = DefaultClusterRemovalPredicate(clusterNameRegexp, 1) //age is 1 hour
+	labelFilterFunc         = TimeBasedClusterRemovalPredicate()
+	timeNow                 = time.Now()
+	timeNowFormatted        = timeNow.Format(time.RFC3339Nano)
+	timeNowUnix             = strconv.FormatInt(timeNow.Unix(), 10)
+	timeOneHourAgo          = timeNow.Add(time.Duration(-1) * time.Hour)
+	timeOneHourAgoFormatted = timeOneHourAgo.Format(time.RFC3339Nano)
+	timeOneHourAgoUnix      = strconv.FormatInt(timeOneHourAgo.Unix(), 10)
 )
 
-func TestNewClusterRemovalPredicate(t *testing.T) {
+func TestDefaultClusterRemovalPredicate(t *testing.T) {
 
 	//given
 	var testCases = []struct {
@@ -43,13 +48,13 @@ func TestNewClusterRemovalPredicate(t *testing.T) {
 		{name: "Should filter matching cluster",
 			expectedFilterValue: true,
 			clusterName:         sampleClusterName,
-			clusterCreateTime:   timeTwoHoursAgoFormatted,
+			clusterCreateTime:   timeOneHourAgoFormatted,
 			volatileLabelValue:  volatileLabel,
 			clusterStatus:       sampleStatus},
 		{name: "Should skip cluster with non matching name",
 			expectedFilterValue: false,
 			clusterName:         "otherName",
-			clusterCreateTime:   timeTwoHoursAgoFormatted,
+			clusterCreateTime:   timeOneHourAgoFormatted,
 			volatileLabelValue:  volatileLabel,
 			clusterStatus:       sampleStatus},
 		{name: "Should skip cluster recently created",
@@ -61,13 +66,13 @@ func TestNewClusterRemovalPredicate(t *testing.T) {
 		{name: "Should skip cluster with invalid label",
 			expectedFilterValue: false,
 			clusterName:         sampleClusterName,
-			clusterCreateTime:   timeTwoHoursAgoFormatted,
+			clusterCreateTime:   timeOneHourAgoFormatted,
 			volatileLabelValue:  "no",
 			clusterStatus:       sampleStatus},
 		{name: "Should skip cluster in STOPPING status",
 			expectedFilterValue: false,
 			clusterName:         sampleClusterName,
-			clusterCreateTime:   timeTwoHoursAgoFormatted,
+			clusterCreateTime:   timeOneHourAgoFormatted,
 			volatileLabelValue:  volatileLabel,
 			clusterStatus:       "STOPPING"},
 	}
@@ -75,7 +80,7 @@ func TestNewClusterRemovalPredicate(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			//when
-			cluster := createCluster(testCase.clusterName, testCase.clusterCreateTime, testCase.volatileLabelValue, testCase.clusterStatus)
+			cluster := createCluster(testCase.clusterName, testCase.clusterCreateTime, testCase.volatileLabelValue, "", "", testCase.clusterStatus)
 			collected, err := filterFunc(cluster)
 
 			//then
@@ -97,13 +102,105 @@ func TestNewClusterRemovalPredicate(t *testing.T) {
 	})
 }
 
+func TestTimeBasedClusterRemovalPredicate(t *testing.T) {
+	//given
+	var testCases = []struct {
+		name                string
+		expectedFilterValue bool
+		volatileLabelValue  string
+		createdAtLabelValue string
+		ttlLabelValue       string
+		clusterStatus       string
+	}{
+		{name: "Should filter matching cluster",
+			expectedFilterValue: true,
+			volatileLabelValue:  volatileLabel,
+			createdAtLabelValue: timeOneHourAgoUnix,
+			ttlLabelValue:       ttlLabel,
+			clusterStatus:       sampleStatus},
+		{name: "Should skip cluster recently created",
+			expectedFilterValue: false,
+			volatileLabelValue:  volatileLabel,
+			createdAtLabelValue: timeNowUnix,
+			ttlLabelValue:       ttlLabel,
+			clusterStatus:       sampleStatus},
+		{name: "Should skip cluster with invalid label 1/?",
+			expectedFilterValue: false,
+			volatileLabelValue:  volatileLabel,
+			createdAtLabelValue: timeNowUnix,
+			ttlLabelValue:       "",
+			clusterStatus:       sampleStatus},
+		{name: "Should skip cluster with invalid label 2/?",
+			expectedFilterValue: false,
+			volatileLabelValue:  volatileLabel,
+			createdAtLabelValue: "",
+			ttlLabelValue:       ttlLabel,
+			clusterStatus:       sampleStatus},
+		{name: "Should skip cluster with invalid label 3/?",
+			expectedFilterValue: false,
+			volatileLabelValue:  "no",
+			createdAtLabelValue: timeNowUnix,
+			ttlLabelValue:       ttlLabel,
+			clusterStatus:       sampleStatus},
+		{name: "Should skip cluster in STOPPING status",
+			expectedFilterValue: false,
+			volatileLabelValue:  volatileLabel,
+			createdAtLabelValue: timeOneHourAgoUnix,
+			ttlLabelValue:       ttlLabel,
+			clusterStatus:       "STOPPING"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			//when
+			cluster := createCluster("", "", testCase.volatileLabelValue, testCase.createdAtLabelValue, testCase.ttlLabelValue, testCase.clusterStatus)
+			collected, err := labelFilterFunc(cluster)
+
+			//then
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedFilterValue, collected)
+		})
+	}
+	var errorMessageTestCases = []struct {
+		name                string
+		expectedFilterValue bool
+		expectedErrorValue  string
+		createdAtLabelValue string
+		ttlLabelValue       string
+	}{
+		{name: "Should return error on invalid created-at label value",
+			expectedFilterValue: false,
+			expectedErrorValue:  "invalid timestamp value",
+			createdAtLabelValue: "@@@",
+			ttlLabelValue:       "1"},
+		{name: "Should return error on invalid ttl label value",
+			expectedFilterValue: false,
+			expectedErrorValue:  "invalid ttl value",
+			createdAtLabelValue: "1",
+			ttlLabelValue:       "@@@"},
+	}
+	for _, errorTestCase := range errorMessageTestCases {
+		t.Run(errorTestCase.name, func(t *testing.T) {
+			//given
+			cluster := &container.Cluster{
+				ResourceLabels: map[string]string{createdAtLabelName: errorTestCase.createdAtLabelValue, ttlLabelName: errorTestCase.ttlLabelValue},
+			}
+
+			//test
+			_, err := labelFilterFunc(cluster)
+			assert.Contains(t, err.Error(), errorTestCase.expectedErrorValue)
+		})
+	}
+
+}
+
 func TestClustersGarbageCollector(t *testing.T) {
 
-	clusterMatching1 := createCluster(sampleClusterName+"1", timeTwoHoursAgoFormatted, volatileLabel, sampleStatus)       //matches removal filter
-	clusterNonMatchingName := createCluster("otherName"+"2", timeTwoHoursAgoFormatted, volatileLabel, sampleStatus)       //non matching name
-	clusterNonMatchingLabel := createCluster(sampleClusterName+"3", timeTwoHoursAgoFormatted, "otherLabel", sampleStatus) //non matching label
-	clusterCreatedTooRecently := createCluster(sampleClusterName+"4", timeNowFormatted, volatileLabel, sampleStatus)      //not old enough
-	clusterMatching2 := createCluster(sampleClusterName+"5", timeTwoHoursAgoFormatted, volatileLabel, sampleStatus)       //matches removal filter
+	clusterMatching1 := createCluster(sampleClusterName+"1", timeOneHourAgoFormatted, volatileLabel, timeOneHourAgoUnix, "", sampleStatus)       //matches removal filter
+	clusterNonMatchingName := createCluster("otherName"+"2", timeOneHourAgoFormatted, volatileLabel, timeOneHourAgoUnix, "", sampleStatus)       //non matching name
+	clusterNonMatchingLabel := createCluster(sampleClusterName+"3", timeOneHourAgoFormatted, "otherLabel", timeOneHourAgoUnix, "", sampleStatus) //non matching label
+	clusterCreatedTooRecently := createCluster(sampleClusterName+"4", timeNowFormatted, volatileLabel, timeNowUnix, "", sampleStatus)            //not old enough
+	clusterMatching2 := createCluster(sampleClusterName+"5", timeOneHourAgoFormatted, volatileLabel, timeOneHourAgoUnix, "", sampleStatus)       //matches removal filter
 
 	t.Run("list() should select two clusters out of five", func(t *testing.T) {
 
@@ -204,12 +301,12 @@ func TestClustersGarbageCollector(t *testing.T) {
 	})
 }
 
-func createCluster(name, createTime, jobLabelValue, status string) *container.Cluster {
+func createCluster(name, createTime, volatileValue, createdAtValue, ttlValue, status string) *container.Cluster {
 	return &container.Cluster{
 		Name:           name,
 		Zone:           name + "-zone",
 		CreateTime:     createTime,
-		ResourceLabels: map[string]string{volatileLabelName: jobLabelValue},
+		ResourceLabels: map[string]string{volatileLabelName: volatileValue, createdAtLabelName: createdAtValue, ttlLabelName: ttlValue},
 		Status:         status,
 	}
 }

--- a/prow/scripts/cluster-integration/helpers/provision-gke-cluster.sh
+++ b/prow/scripts/cluster-integration/helpers/provision-gke-cluster.sh
@@ -52,7 +52,7 @@ if [ "${GCLOUD_NETWORK_NAME}" ] && [ "${GCLOUD_SUBNET_NAME}" ]; then NETWORK_PAR
 
 APPENDED_LABELS=""
 if [ "${ADDITIONAL_LABELS}" ]; then APPENDED_LABELS=(",${ADDITIONAL_LABELS}") ; fi
-LABELS_PARAM=(--labels="job=${JOB_NAME},job-id=${PROW_JOB_ID},cluster=${CLUSTER_NAME},volatile=true${APPENDED_LABELS[@]},${CLEANER_LABELS}")
+LABELS_PARAM=(--labels="job=${JOB_NAME},job-id=${PROW_JOB_ID},cluster=${CLUSTER_NAME},volatile=true${APPENDED_LABELS[@]},${CLEANER_LABELS_PARAM}")
 
 command -v gcloud
 

--- a/prow/scripts/cluster-integration/helpers/provision-gke-cluster.sh
+++ b/prow/scripts/cluster-integration/helpers/provision-gke-cluster.sh
@@ -35,10 +35,13 @@ if [ "${discoverUnsetVar}" = true ] ; then
     exit 1
 fi
 
+readonly CURRENT_TIMESTAMP=$(date +%Y%m%d)
+
 CLUSTER_VERSION_PARAM="--cluster-version=1.12"
 MACHINE_TYPE_PARAM="--machine-type=n1-standard-2"
 NUM_NODES_PARAM="--num-nodes=3"
 NETWORK_PARAM=(--network=default)
+ADDITIONAL_LABELS="created-at=${CURRENT_TIMESTAMP}"
 
 if [ "${CLUSTER_VERSION}" ]; then CLUSTER_VERSION_PARAM="--cluster-version=${CLUSTER_VERSION}"; fi
 if [ "${MACHINE_TYPE}" ]; then MACHINE_TYPE_PARAM="--machine-type=${MACHINE_TYPE}"; fi

--- a/prow/scripts/cluster-integration/helpers/provision-gke-cluster.sh
+++ b/prow/scripts/cluster-integration/helpers/provision-gke-cluster.sh
@@ -36,12 +36,13 @@ if [ "${discoverUnsetVar}" = true ] ; then
 fi
 
 readonly CURRENT_TIMESTAMP=$(date +%Y%m%d)
+readonly TTL_HOURS="3"
 
 CLUSTER_VERSION_PARAM="--cluster-version=1.12"
 MACHINE_TYPE_PARAM="--machine-type=n1-standard-2"
 NUM_NODES_PARAM="--num-nodes=3"
 NETWORK_PARAM=(--network=default)
-ADDITIONAL_LABELS="created-at=${CURRENT_TIMESTAMP}"
+ADDITIONAL_LABELS="created-at=${CURRENT_TIMESTAMP},ttl=${TTL_HOURS}"
 
 if [ "${CLUSTER_VERSION}" ]; then CLUSTER_VERSION_PARAM="--cluster-version=${CLUSTER_VERSION}"; fi
 if [ "${MACHINE_TYPE}" ]; then MACHINE_TYPE_PARAM="--machine-type=${MACHINE_TYPE}"; fi

--- a/prow/scripts/cluster-integration/helpers/provision-gke-cluster.sh
+++ b/prow/scripts/cluster-integration/helpers/provision-gke-cluster.sh
@@ -35,14 +35,15 @@ if [ "${discoverUnsetVar}" = true ] ; then
     exit 1
 fi
 
-readonly CURRENT_TIMESTAMP=$(date +%Y%m%d)
-readonly TTL_HOURS="3"
+readonly CURRENT_TIMESTAMP_PARAM=$(date +%Y%m%d)
 
+TTL_HOURS_PARAM="3"
 CLUSTER_VERSION_PARAM="--cluster-version=1.12"
 MACHINE_TYPE_PARAM="--machine-type=n1-standard-2"
 NUM_NODES_PARAM="--num-nodes=3"
 NETWORK_PARAM=(--network=default)
-ADDITIONAL_LABELS="created-at=${CURRENT_TIMESTAMP},ttl=${TTL_HOURS}"
+if [ "${TTL_HOURS}" ]; then TTL_HOURS_PARAM="${TTL_HOURS}"; fi
+CLEANER_LABELS_PARAM="created-at=${CURRENT_TIMESTAMP_PARAM},ttl=${TTL_HOURS_PARAM}"
 
 if [ "${CLUSTER_VERSION}" ]; then CLUSTER_VERSION_PARAM="--cluster-version=${CLUSTER_VERSION}"; fi
 if [ "${MACHINE_TYPE}" ]; then MACHINE_TYPE_PARAM="--machine-type=${MACHINE_TYPE}"; fi
@@ -51,7 +52,7 @@ if [ "${GCLOUD_NETWORK_NAME}" ] && [ "${GCLOUD_SUBNET_NAME}" ]; then NETWORK_PAR
 
 APPENDED_LABELS=""
 if [ "${ADDITIONAL_LABELS}" ]; then APPENDED_LABELS=(",${ADDITIONAL_LABELS}") ; fi
-LABELS_PARAM=(--labels="job=${JOB_NAME},job-id=${PROW_JOB_ID},cluster=${CLUSTER_NAME},volatile=true${APPENDED_LABELS[@]}")
+LABELS_PARAM=(--labels="job=${JOB_NAME},job-id=${PROW_JOB_ID},cluster=${CLUSTER_NAME},volatile=true${APPENDED_LABELS[@]},${CLEANER_LABELS}")
 
 command -v gcloud
 


### PR DESCRIPTION
**Description**
The pull request allows to the change of the filter strategy, based on which test-clusters get deleted. It also enables creation of `ttl` and `created-at` labels on clusters that will be affected by this, once the prow job uses this strategy.

Changes proposed in this pull request:
- provide an alternative filter strategy for cluster deletion
- add `ttl` and `created-at` labels to gke integration clusters


**Related issue(s)**
#565 
