### PR TITLE
rollback to old certificate retrieval

### DIFF
--- a/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
@@ -231,25 +231,6 @@ function generateAndExportLetsEncryptCert() {
     export TLS_CERT
     TLS_KEY=$(base64 -i ./letsencrypt/live/"${DOMAIN}"/privkey.pem   | tr -d '\n')
     export TLS_KEY
-    #encrypt the tls cert
-	gcloud kms encrypt --location global \
-	--keyring "${KYMA_KEYRING}" \
-	--key "${KYMA_ENCRYPTION_KEY}" \
-	--plaintext-file ./letsencrypt/live/"${DOMAIN}"/fullchain.pem  \
-	--ciphertext-file "nightly-aks-tls-integration-app-client-cert.encrypted"
-	
-	#encrypt the private cert
-	gcloud kms encrypt --location global \
-	--keyring "${KYMA_KEYRING}" \
-	--key "${KYMA_ENCRYPTION_KEY}" \
-	--plaintext-file ./letsencrypt/live/"${DOMAIN}"/privkey.pem \
-	--ciphertext-file "nightly-aks-tls-integration-app-client-key.encrypted"
-	#copy the cert
-	gsutil cp nightly-aks-tls-integration-app-client-cert.encrypted gs://kyma-prow-secrets/
-    #copy the private key
-	gsutil cp nightly-aks-tls-integration-app-client-key.encrypted gs://kyma-prow-secrets/
-
-
 }
 
 function setupKubeconfig() {

--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -181,6 +181,7 @@ function waitUntilInstallerApiAvailable() {
 function generateAndExportLetsEncryptCert() {
 	shout "Generate lets encrypt certificate"
 	date
+
     mkdir letsencrypt
     cp /etc/credentials/sa-gke-kyma-integration/service-account.json letsencrypt
     docker run  --name certbot \
@@ -196,29 +197,11 @@ function generateAndExportLetsEncryptCert() {
         --server https://acme-v02.api.letsencrypt.org/directory \
         --dns-google-propagation-seconds=600 \
         -d "*.${DOMAIN}"
-	
+
     TLS_CERT=$(base64 -i ./letsencrypt/live/"${DOMAIN}"/fullchain.pem | tr -d '\n')
     export TLS_CERT
     TLS_KEY=$(base64 -i ./letsencrypt/live/"${DOMAIN}"/privkey.pem   | tr -d '\n')
     export TLS_KEY
-	#encrypt the tls cert
-	gcloud kms encrypt --location global \
-	--keyring "${KYMA_KEYRING}" \
-	--key "${KYMA_ENCRYPTION_KEY}" \
-	--plaintext-file ./letsencrypt/live/"${DOMAIN}"/fullchain.pem  \
-	--ciphertext-file "nightly-gke-tls-integration-app-client-cert.encrypted"
-	
-	#encrypt the private cert
-	gcloud kms encrypt --location global \
-	--keyring "${KYMA_KEYRING}" \
-	--key "${KYMA_ENCRYPTION_KEY}" \
-	--plaintext-file ./letsencrypt/live/"${DOMAIN}"/privkey.pem  \
-	--ciphertext-file "nightly-gke-tls-integration-app-client-key.encrypted"
-	#copy the cert
-	gsutil cp nightly-gke-tls-integration-app-client-cert.encrypted gs://kyma-prow-secrets/
-    #copy the private key
-	gsutil cp nightly-gke-tls-integration-app-client-key.encrypted gs://kyma-prow-secrets/
-
 
 }
 


### PR DESCRIPTION
**Description**
Rolling back to old certificate retrieval to unblock nightly and weekly builds

Changes proposed in this pull request:
- Changing back to this commit: https://github.com/kyma-project/test-infra/tree/3ae46fbf8391c5663bc03605c703e0db29e5a55f/prow/scripts/cluster-integration
**Related issue(s)**
#646 
