### PR TITLE
Fix pointing Github release tag for 0.9

### DIFF
--- a/prow/jobs/kyma/kyma-github-release.yaml
+++ b/prow/jobs/kyma/kyma-github-release.yaml
@@ -60,7 +60,7 @@ postsubmits:
     labels:
       <<: *job_labels_template
       preset-build-release: "true"
-      preset-target-commit-0.8: "true"
+      preset-target-commit-0.9: "true"
 
 presets:
   - labels:
@@ -73,3 +73,8 @@ presets:
     env:
       - name: RELEASE_TARGET_COMMIT
         value: release-0.8
+  - labels:
+      preset-target-commit-0.9: "true"
+    env:
+      - name: RELEASE_TARGET_COMMIT
+        value: release-0.9


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix pointing Github release tag for 0.9

