### PR TITLE
Add domain name to script kyma-gke-upgrade.sh.

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
@@ -367,7 +367,8 @@ createTestResources() {
         --name "${UPGRADE_TEST_RELEASE_NAME}" \
         --namespace "${UPGRADE_TEST_NAMESPACE}" \
         --timeout "${UPGRADE_TEST_HELM_TIMEOUT_SEC}" \
-        --wait ${HELM_ARGS}
+        --wait ${HELM_ARGS} \
+        --set global.domainName="${DOMAIN}"
 
     prepareResult=$?
     if [ "${prepareResult}" != 0 ]; then


### PR DESCRIPTION
Add set variable **global.domainName** containing the domain.
It is required for upgrade function test
