### PR TITLE
enabling deletion of firewall rules

### DIFF
--- a/development/tools/pkg/firewallcleaner/cleaner.go
+++ b/development/tools/pkg/firewallcleaner/cleaner.go
@@ -117,7 +117,7 @@ func (c *Cleaner) checkAndDeleteFirewallRules(project string, dryRun bool) error
 		if !exist && len(rule.TargetTags) > 0 {
 			count = count + 1
 			if !dryRun {
-				// c.computeAPI.DeleteFirewallRule(project, rule.Name)
+				c.computeAPI.DeleteFirewallRule(project, rule.Name)
 				common.Shout("Deleting rule '%s' because there's no target running (%d TargetTags)", rule.Name, len(rule.TargetTags))
 				time.Sleep(sleepFactor * time.Second)
 			} else {


### PR DESCRIPTION
**Description**
This pull requests enables actual deletion of firewall rules, after we decide we're satisfied with the output.

Job will fail if 'compute.firewalls.delete' permission to job executor SA is not set.

Changes proposed in this pull request:
- enable deletion

**Related issue(s)**
#769 