### PR TITLE
Fix GKE upgrade plans: get helm certs before creating test resources

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
@@ -487,11 +487,11 @@ createCluster
 
 installKyma
 
+"${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/get-helm-certs.sh"
+
 createTestResources
 
 upgradeKyma
-
-"${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/get-helm-certs.sh"
 
 testKyma
 


### PR DESCRIPTION
```
#################################################################################################
# Create e2e upgrade test resources
#################################################################################################
    
Mon Apr  8 17:51:04 UTC 2019
Error: transport is closing
```

**Related issues**
Fixes #845 