### PR TITLE
GKE k8s version 1.12.6-gkeX specific logging deployment changes

### DIFF
--- a/prow/scripts/cluster-integration/helpers/install-kyma.sh
+++ b/prow/scripts/cluster-integration/helpers/install-kyma.sh
@@ -40,7 +40,7 @@ function installKyma() {
 	INSTALLER_YAML="${KYMA_RESOURCES_DIR}/installer.yaml"
 	INSTALLER_CONFIG="${KYMA_RESOURCES_DIR}/installer-config-cluster.yaml.tpl"
 	INSTALLER_CR="${KYMA_RESOURCES_DIR}/installer-cr-cluster.yaml.tpl"
-	
+	PROMTAIL_CONFIG_NAME=promtail-k8s-1-14.yaml
 	# shellcheck disable=SC1090
     source "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/generate-and-export-letsencrypt-TLS-cert.sh
 
@@ -54,6 +54,8 @@ function installKyma() {
 		| sed -e "s#__TLS_KEY__#${TLS_KEY}#g" \
 		| sed -e "s/__EXTERNAL_PUBLIC_IP__/${GATEWAY_IP_ADDRESS}/g" \
 		| sed -e "s/__SKIP_SSL_VERIFY__/true/g" \
+		| sed -e "s/__LOGGING_INSTALL_ENABLED__/true/g" \
+        | sed -e "s/__PROMTAIL_CONFIG_NAME__/${PROMTAIL_CONFIG_NAME}/g" \
 		| sed -e "s/__VERSION__/0.0.1/g" \
 		| sed -e "s/__.*__//g" \
 		| kubectl apply -f-

--- a/prow/scripts/cluster-integration/helpers/install-kyma.sh
+++ b/prow/scripts/cluster-integration/helpers/install-kyma.sh
@@ -55,7 +55,7 @@ function installKyma() {
 		| sed -e "s/__EXTERNAL_PUBLIC_IP__/${GATEWAY_IP_ADDRESS}/g" \
 		| sed -e "s/__SKIP_SSL_VERIFY__/true/g" \
 		| sed -e "s/__LOGGING_INSTALL_ENABLED__/true/g" \
-        | sed -e "s/__PROMTAIL_CONFIG_NAME__/${PROMTAIL_CONFIG_NAME}/g" \
+		| sed -e "s/__PROMTAIL_CONFIG_NAME__/${PROMTAIL_CONFIG_NAME}/g" \
 		| sed -e "s/__VERSION__/0.0.1/g" \
 		| sed -e "s/__.*__//g" \
 		| kubectl apply -f-

--- a/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
@@ -56,6 +56,8 @@ export CLUSTER_SIZE="Standard_DS2_v2"
 export CLUSTER_K8S_VERSION="1.11"
 export CLUSTER_ADDONS="monitoring,http_application_routing"
 
+PROMTAIL_CONFIG_NAME=promtail-k8s-1-14.yaml
+
 # shellcheck disable=SC1090
 source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/library.sh"
 
@@ -294,6 +296,8 @@ function installKyma() {
         | sed -e "s#__TLS_KEY__#${TLS_KEY}#g" \
         | sed -e "s/__EXTERNAL_PUBLIC_IP__/${GATEWAY_IP_ADDRESS}/g" \
         | sed -e "s/__SKIP_SSL_VERIFY__/true/g" \
+        | sed -e "s/__LOGGING_INSTALL_ENABLED__/true/g" \
+        | sed -e "s/__PROMTAIL_CONFIG_NAME__/${PROMTAIL_CONFIG_NAME}/g" \
         | sed -e "s/__VERSION__/0.0.1/g" \
         | sed -e "s/__SLACK_CHANNEL_VALUE__/${KYMA_ALERTS_CHANNEL}/g" \
         | sed -e "s#__SLACK_API_URL_VALUE__#${KYMA_ALERTS_SLACK_API_URL}#g" \

--- a/prow/scripts/cluster-integration/kyma-gke-central.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-central.sh
@@ -49,6 +49,8 @@ export TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS="${TEST_INFRA_SOURCES_DIR}/prow/sc
 # shellcheck disable=SC1090
 source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/library.sh"
 
+PROMTAIL_CONFIG_NAME=promtail-k8s-1-14.yaml
+
 trap cleanup EXIT INT
 
 #!Put cleanup code in this function!
@@ -274,6 +276,8 @@ if [[ "$BUILD_TYPE" == "release" ]]; then
         | sed -e "s/__TLS_KEY__/${TLS_KEY}/g" \
         | sed -e "s/__EXTERNAL_PUBLIC_IP__/${GATEWAY_IP_ADDRESS}/g" \
         | sed -e "s/__SKIP_SSL_VERIFY__/true/g" \
+        | sed -e "s/__LOGGING_INSTALL_ENABLED__/true/g" \
+        | sed -e "s/__PROMTAIL_CONFIG_NAME__/${PROMTAIL_CONFIG_NAME}/g" \
         | sed -e "s/__.*__//g" \
         | kubectl apply -f-
 else
@@ -286,6 +290,8 @@ else
     | sed -e "s/__TLS_KEY__/${TLS_KEY}/g" \
     | sed -e "s/__EXTERNAL_PUBLIC_IP__/${GATEWAY_IP_ADDRESS}/g" \
     | sed -e "s/__SKIP_SSL_VERIFY__/true/g" \
+    | sed -e "s/__LOGGING_INSTALL_ENABLED__/true/g" \
+    | sed -e "s/__PROMTAIL_CONFIG_NAME__/${PROMTAIL_CONFIG_NAME}/g" \
     | sed -e "s/__VERSION__/0.0.1/g" \
     | sed -e "s/__.*__//g" \
     | kubectl apply -f-

--- a/prow/scripts/cluster-integration/kyma-gke-end-to-end-test.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-end-to-end-test.sh
@@ -141,6 +141,8 @@ GATEWAY_DNS_FULL_NAME="*.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
 REMOTEENVS_DNS_FULL_NAME="gateway.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
 REMOTEENVS_IP_ADDRESS_NAME="remoteenvs-${STANDARIZED_NAME}"
 
+PROMTAIL_CONFIG_NAME=promtail-k8s-1-14.yaml
+
 shout "Cleanup"
 date
 cleanup
@@ -231,6 +233,8 @@ shout "Manual concatenating yamls"
 | sed -e "s/__TLS_KEY__/${TLS_KEY}/g" \
 | sed -e "s/__EXTERNAL_PUBLIC_IP__/${GATEWAY_IP_ADDRESS}/g" \
 | sed -e "s/__SKIP_SSL_VERIFY__/true/g" \
+| sed -e "s/__LOGGING_INSTALL_ENABLED__/true/g" \
+| sed -e "s/__PROMTAIL_CONFIG_NAME__/${PROMTAIL_CONFIG_NAME}/g" \
 | sed -e "s/__VERSION__/0.0.1/g" \
 | sed -e "s/__.*__//g" \
 | kubectl apply -f-

--- a/prow/scripts/cluster-integration/kyma-gke-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-integration.sh
@@ -174,6 +174,7 @@ KYMA_RESOURCES_DIR="${KYMA_SOURCES_DIR}/installation/resources"
 INSTALLER_YAML="${KYMA_RESOURCES_DIR}/installer.yaml"
 INSTALLER_CONFIG="${KYMA_RESOURCES_DIR}/installer-config-cluster.yaml.tpl"
 INSTALLER_CR="${KYMA_RESOURCES_DIR}/installer-cr-cluster.yaml.tpl"
+PROMTAIL_CONFIG_NAME=promtail-k8s-1-14.yaml
 
 #Used to detect errors for logging purposes
 ERROR_LOGGING_GUARD="true"
@@ -273,6 +274,8 @@ if [[ "$BUILD_TYPE" == "release" ]]; then
         | sed -e "s/__TLS_KEY__/${TLS_KEY}/g" \
         | sed -e "s/__EXTERNAL_PUBLIC_IP__/${GATEWAY_IP_ADDRESS}/g" \
         | sed -e "s/__SKIP_SSL_VERIFY__/true/g" \
+        | sed -e "s/__LOGGING_INSTALL_ENABLED__/true/g" \
+        | sed -e "s/__PROMTAIL_CONFIG_NAME__/${PROMTAIL_CONFIG_NAME}/g" \
         | sed -e "s/__.*__//g" \
         | kubectl apply -f-
 else
@@ -285,6 +288,8 @@ else
     | sed -e "s/__TLS_KEY__/${TLS_KEY}/g" \
     | sed -e "s/__EXTERNAL_PUBLIC_IP__/${GATEWAY_IP_ADDRESS}/g" \
     | sed -e "s/__SKIP_SSL_VERIFY__/true/g" \
+    | sed -e "s/__LOGGING_INSTALL_ENABLED__/true/g" \
+    | sed -e "s/__PROMTAIL_CONFIG_NAME__/${PROMTAIL_CONFIG_NAME}/g" \
     | sed -e "s/__VERSION__/0.0.1/g" \
     | sed -e "s/__.*__//g" \
     | kubectl apply -f-

--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -245,7 +245,7 @@ function installKyma() {
 		| sed -e "s#__TLS_KEY__#${TLS_KEY}#g" \
 		| sed -e "s/__EXTERNAL_PUBLIC_IP__/${GATEWAY_IP_ADDRESS}/g" \
 		| sed -e "s/__SKIP_SSL_VERIFY__/true/g" \
-        | sed -e "s/__LOGGING_INSTALL_ENABLED__/true/g" \
+		| sed -e "s/__LOGGING_INSTALL_ENABLED__/true/g" \
         | sed -e "s/__PROMTAIL_CONFIG_NAME__/${PROMTAIL_CONFIG_NAME}/g" \
 		| sed -e "s/__VERSION__/0.0.1/g" \
 		| sed -e "s/__SLACK_CHANNEL_VALUE__/${KYMA_ALERTS_CHANNEL}/g" \

--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -246,7 +246,7 @@ function installKyma() {
 		| sed -e "s/__EXTERNAL_PUBLIC_IP__/${GATEWAY_IP_ADDRESS}/g" \
 		| sed -e "s/__SKIP_SSL_VERIFY__/true/g" \
 		| sed -e "s/__LOGGING_INSTALL_ENABLED__/true/g" \
-        | sed -e "s/__PROMTAIL_CONFIG_NAME__/${PROMTAIL_CONFIG_NAME}/g" \
+		| sed -e "s/__PROMTAIL_CONFIG_NAME__/${PROMTAIL_CONFIG_NAME}/g" \
 		| sed -e "s/__VERSION__/0.0.1/g" \
 		| sed -e "s/__SLACK_CHANNEL_VALUE__/${KYMA_ALERTS_CHANNEL}/g" \
 		| sed -e "s#__SLACK_API_URL_VALUE__#${KYMA_ALERTS_SLACK_API_URL}#g" \

--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -36,7 +36,7 @@ export GCLOUD_NETWORK_NAME="gke-long-lasting-net"
 export GCLOUD_SUBNET_NAME="gke-long-lasting-subnet"
 
 TEST_RESULT_WINDOW_TIME=${TEST_RESULT_WINDOW_TIME:-3h}
-
+PROMTAIL_CONFIG_NAME=promtail-k8s-1-14.yaml
 # shellcheck disable=SC1090
 source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/library.sh"
 
@@ -245,6 +245,8 @@ function installKyma() {
 		| sed -e "s#__TLS_KEY__#${TLS_KEY}#g" \
 		| sed -e "s/__EXTERNAL_PUBLIC_IP__/${GATEWAY_IP_ADDRESS}/g" \
 		| sed -e "s/__SKIP_SSL_VERIFY__/true/g" \
+        | sed -e "s/__LOGGING_INSTALL_ENABLED__/true/g" \
+        | sed -e "s/__PROMTAIL_CONFIG_NAME__/${PROMTAIL_CONFIG_NAME}/g" \
 		| sed -e "s/__VERSION__/0.0.1/g" \
 		| sed -e "s/__SLACK_CHANNEL_VALUE__/${KYMA_ALERTS_CHANNEL}/g" \
 		| sed -e "s#__SLACK_API_URL_VALUE__#${KYMA_ALERTS_SLACK_API_URL}#g" \

--- a/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
@@ -61,6 +61,8 @@ export UPGRADE_TEST_RESOURCE_LABEL="kyma-project.io/upgrade-e2e-test"
 export UPGRADE_TEST_LABEL_VALUE_PREPARE="prepareData"
 export UPGRADE_TEST_LABEL_VALUE_EXECUTE="executeTests"
 
+PROMTAIL_CONFIG_NAME=promtail-k8s-1-14.yaml
+
 # shellcheck disable=SC1090
 source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/library.sh"
 
@@ -283,6 +285,8 @@ function installKyma() {
             | sed -e "s/__TLS_KEY__/${TLS_KEY}/g" \
             | sed -e "s/__EXTERNAL_PUBLIC_IP__/${GATEWAY_IP_ADDRESS}/g" \
             | sed -e "s/__SKIP_SSL_VERIFY__/true/g" \
+            | sed -e "s/__LOGGING_INSTALL_ENABLED__/true/g" \
+            | sed -e "s/__PROMTAIL_CONFIG_NAME__/${PROMTAIL_CONFIG_NAME}/g" \
             | sed -e "s/__.*__//g" \
             | kubectl apply -f-
     else
@@ -294,6 +298,8 @@ function installKyma() {
             | sed -e "s/__TLS_KEY__/${TLS_KEY}/g" \
             | sed -e "s/__EXTERNAL_PUBLIC_IP__/${GATEWAY_IP_ADDRESS}/g" \
             | sed -e "s/__SKIP_SSL_VERIFY__/true/g" \
+            | sed -e "s/__LOGGING_INSTALL_ENABLED__/true/g" \
+            | sed -e "s/__PROMTAIL_CONFIG_NAME__/${PROMTAIL_CONFIG_NAME}/g" \
             | sed -e "s/__.*__//g" \
             | kubectl apply -f-
     fi


### PR DESCRIPTION
Kyma logging solution loki usses some kubernetes CRI functionalities which changed in kubernetes version 1.14.X and 1.12.6-gkeX, this changes will deploy kyma logging with specific kubernetes CRI settings.

For details see https://github.com/kyma-project/kyma/issues/3652