### PR TITLE
Fix stability-checker deployment - enable for istio sidecar

### DIFF
--- a/stability-checker/deploy/chart/stability-checker/templates/deploy.yaml
+++ b/stability-checker/deploy/chart/stability-checker/templates/deploy.yaml
@@ -18,6 +18,11 @@ spec:
       maxUnavailable: 0
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+        #For pods running sidecars w/o service there's a problem with envoy readiness probe.
+        #Details https://github.com/istio/istio/issues/9504#issuecomment-439432130
+        status.sidecar.istio.io/port: "0"
       labels:
         app: {{ template "stability-checker.fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -129,9 +134,10 @@ spec:
             mountPath: /data
 
         readinessProbe:
-          httpGet:
-            path: /statusz
-            port: {{ .Values.service.internalPort }}
+          exec:
+            command:
+             - curl
+             - localhost:{{ .Values.service.internalPort }}/statusz
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 3
@@ -139,10 +145,10 @@ spec:
           timeoutSeconds: 2
 
         livenessProbe:
-          httpGet:
-            path: /statusz
-            port: {{ .Values.service.internalPort }}
-
+          exec:
+            command:
+             - curl
+             - localhost:{{ .Values.service.internalPort }}/statusz
           periodSeconds: 10
           timeoutSeconds: 2
           successThreshold: 1


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- configure stability-checker Pod template to work with readiness/liveness probes without k8s service

**Related issue(s)**
Resolves: #897 
