### PR TITLE
Stability-checker reads non json log entries

### DIFF
--- a/stability-checker/internal/printer/export_test.go
+++ b/stability-checker/internal/printer/export_test.go
@@ -1,0 +1,13 @@
+package printer
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// NewWithOutput returns new LgoPrinter instance with defined output
+func NewWithOutput(stream *json.Decoder, ids []string, out io.Writer) *LogPrinter {
+	lp := New(stream, ids)
+	lp.out = out
+	return lp
+}

--- a/stability-checker/internal/printer/printer.go
+++ b/stability-checker/internal/printer/printer.go
@@ -1,12 +1,13 @@
 package printer
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/kyma-project/test-infra/stability-checker/internal/log"
-
 	"github.com/kyma-project/test-infra/stability-checker/internal/runner"
 )
 
@@ -19,6 +20,7 @@ const (
 type LogPrinter struct {
 	stream           *json.Decoder
 	requestedTestIDs map[string]struct{}
+	out              io.Writer
 }
 
 // New returns new instance of LogPrinter
@@ -34,6 +36,7 @@ func New(stream *json.Decoder, ids []string) *LogPrinter {
 	return &LogPrinter{
 		stream:           stream,
 		requestedTestIDs: mapped,
+		out:              os.Stdout,
 	}
 }
 
@@ -46,18 +49,48 @@ func (l *LogPrinter) PrintFailedTestOutput() error {
 		case io.EOF:
 			return nil
 		default:
-			return err
+			switch skipErr := l.skipNonJSON(); skipErr {
+			case nil:
+			case io.EOF:
+				return nil
+			default:
+				return skipErr
+			}
+			continue
 		}
 
 		if l.shouldSkipLogMsg(e) {
 			continue
 		}
 
-		fmt.Print(invertColor)
-		fmt.Printf("[%s] Output for test id %q", e.Log.Time, e.Log.TestRunID)
-		fmt.Print(noColor)
+		msg := fmt.Sprintf("%s[%s] Output for test id %q %s\n %s \n", invertColor, e.Log.Time, e.Log.TestRunID, noColor, e.Log.Message)
+		if _, err := l.out.Write([]byte(msg)); err != nil {
+			return err
+		}
+	}
+}
 
-		fmt.Printf("\n %s \n", e.Log.Message)
+func (l *LogPrinter) skipNonJSON() error {
+	r := l.stream.Buffered()
+	br, ok := r.(*bufio.Reader)
+	if !ok {
+		br = bufio.NewReader(r)
+	}
+
+	for {
+		// read characters until an error or beginning of a new json
+		ch, _, err := br.ReadRune()
+		if err != nil {
+			return err
+		}
+		if ch == '{' {
+			err := br.UnreadRune()
+			if err != nil {
+				return err
+			}
+			l.stream = json.NewDecoder(br)
+			return nil
+		}
 	}
 }
 

--- a/stability-checker/internal/printer/printer_test.go
+++ b/stability-checker/internal/printer/printer_test.go
@@ -1,0 +1,39 @@
+package printer_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kyma-project/test-infra/stability-checker/internal/printer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogPrinter(t *testing.T) {
+	// given
+	input := `
+	{"level":"error", "log":{"message":"message-one", "test-run-id":"tid-001", "type":"test-output-other-type", "time":"2017-11-02T16:00:00-04:00"}}
+	broken line 
+	{"level":"error", "log":{"message":"message-two", "test-run-id":"tid-001", "type":"test-output"}}
+	{"level":"info", "log":{"message":"message-three", "test-run-id":"tid-001", "type":"test-output"}}
+	{"level":"error", "log":{"message":"message-four", "test-run-id":"tid-002", "type":"test-output"}}
+	fail`
+	jsonReader := strings.NewReader(input)
+	decodeStream := json.NewDecoder(jsonReader)
+	var output bytes.Buffer
+	logPrinter := printer.NewWithOutput(decodeStream, []string{"tid-001"}, &output)
+
+	// when
+	err := logPrinter.PrintFailedTestOutput()
+	require.NoError(t, err)
+
+	// then
+	log := string(output.Bytes())
+	assert.NotContains(t, log, "message-one")
+	assert.Contains(t, log, "message-two")
+	assert.NotContains(t, log, "message-three")
+	assert.NotContains(t, log, "message-four")
+	assert.NotContains(t, log, "broken")
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Changes proposed in this pull request:
- enhance stability-checker to not fails if a log entry is not a valid JSON 

