### PR TITLE
Fix stability-checker summery - reading logs must not fail for non-js…

### DIFF
--- a/stability-checker/deploy/chart/stability-checker/values.yaml
+++ b/stability-checker/deploy/chart/stability-checker/values.yaml
@@ -6,7 +6,7 @@ containerRegistry:
   path: eu.gcr.io/kyma-project
 
 image:
-  tag: 1fe19d8b
+  tag: 5f05a013
   # valid values are "IfNotPresent", "Never", and "Always"
   pullPolicy: "IfNotPresent"
 

--- a/stability-checker/internal/summary/summary_test.go
+++ b/stability-checker/internal/summary/summary_test.go
@@ -54,7 +54,9 @@ func fixReadCloser() *fakeReadCloser {
 	buff := bytes.NewBuffer(nil)
 	for _, e := range fixLogEntries() {
 		b, _ := json.Marshal(e)
+		buff.Write([]byte("---"))
 		buff.Write(b)
+		buff.Write([]byte("not json"))
 	}
 
 	out := &fakeReadCloser{

--- a/stability-checker/internal/summary/summary_test.go
+++ b/stability-checker/internal/summary/summary_test.go
@@ -54,9 +54,10 @@ func fixReadCloser() *fakeReadCloser {
 	buff := bytes.NewBuffer(nil)
 	for _, e := range fixLogEntries() {
 		b, _ := json.Marshal(e)
-		buff.Write([]byte("---"))
+		buff.Write([]byte("---\n"))
 		buff.Write(b)
-		buff.Write([]byte("not json"))
+		buff.Write([]byte("\n"))
+		buff.Write([]byte("not json\n"))
 	}
 
 	out := &fakeReadCloser{


### PR DESCRIPTION
…on log entry

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- stability-checker summery must not fail if logs contains non-JSON entries

