### PR TITLE
add test-infra branch protection for release branches, same as kyma repo

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -302,6 +302,14 @@ branch-protection:
           branches:
             master:
               protect: true
+            release-0.7:
+              protect: true
+            release-0.8:
+              protect: true
+            release-0.9:
+              protect: true
+            release-1.0:
+              protect: true
         kyma:
           branches:
             master:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -297,25 +297,11 @@ branch-protection:
       - license/cla
   orgs:
     kyma-project:
+      protect: true # protect all repos & branches in kyma-project org
       repos:
-        test-infra:
-          branches:
-            master:
-              protect: true
-            release-0.7:
-              protect: true
-            release-0.8:
-              protect: true
-            release-0.9:
-              protect: true
-            release-1.0:
-              protect: true
         kyma:
           branches:
-            master:
-              protect: true
             release-0.7: # Already defined to ensure that check is defined for the new upgrade job
-              protect: true
               required_status_checks:
                 contexts:
                 - pre-rel07-kyma-integration
@@ -323,7 +309,6 @@ branch-protection:
                 - pre-rel07-kyma-artifacts
                 - pre-rel07-kyma-installer
             release-0.8: # Already defined to ensure that check is defined for the new upgrade job
-              protect: true
               required_status_checks:
                 contexts:
                 - pre-rel08-kyma-integration
@@ -331,7 +316,6 @@ branch-protection:
                 - pre-rel08-kyma-artifacts
                 - pre-rel08-kyma-installer
             release-0.9:
-              protect: true
               required_status_checks:
                 contexts:
                   - pre-rel09-kyma-integration
@@ -341,7 +325,6 @@ branch-protection:
                   - pre-rel09-kyma-artifacts
                   - pre-rel09-kyma-installer
             release-1.0:
-              protect: true
               required_status_checks:
                 contexts:
                   - pre-rel10-kyma-integration
@@ -350,56 +333,13 @@ branch-protection:
                   - pre-rel10-kyma-gke-central-connector
                   - pre-rel10-kyma-artifacts
                   - pre-rel10-kyma-installer
-        website:
-          branches:
-            master:
-              protect: true
-        community:
-          branches:
-            master:
-              protect: true
-        examples:
-          branches:
-            master:
-              protect: true
-        console:
-          branches:
-            master:
-              protect: true
-        bundles:
-          branches:
-            master:
-              protect: true
         luigi:
           required_pull_request_reviews:
             dismiss_stale_reviews: false
             require_code_owner_reviews: true
             required_approving_review_count: 2
-          branches:
-            master:
-              protect: true
     kyma-incubator:
-      repos:
-        varkes:
-          branches:
-            master:
-              protect: true
-        kymactl:
-          branches:
-            master:
-              protect: true
-        vstudio-extension:
-          branches:
-            master:
-              protect: true
-        service-catalog-tester:
-          branches:
-            master:
-              protect: true
-        octopus:
-          branches:
-            master:
-              protect: true
+      protect: true
 
 plank:
   job_url_template: 'https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/{{if eq .Spec.Type "presubmit"}}pr-logs/pull{{else if eq .Spec.Type "batch"}}pr-logs/pull{{else}}logs{{end}}{{if .Spec.Refs}}{{if ne .Spec.Refs.Org ""}}/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}{{end}}{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'


### PR DESCRIPTION
**Description**
Update branch protection for release branches.

Changes proposed in this pull request:
- Add branch protector to release branches (in sync with protection of kyma repo)

**Related issue(s)**
#494 
