### PR TITLE
folder creation should not fail when folder exists

### DIFF
--- a/prow/scripts/cluster-integration/helpers/generate-and-export-letsencrypt-TLS-cert.sh
+++ b/prow/scripts/cluster-integration/helpers/generate-and-export-letsencrypt-TLS-cert.sh
@@ -19,7 +19,7 @@ fi
 shout "Generate lets encrypt certificate"
 date
 
-mkdir letsencrypt
+mkdir -p letsencrypt
 cp /etc/credentials/sa-gke-kyma-integration/service-account.json letsencrypt
 docker run  --name certbot \
     --rm  \

--- a/prow/scripts/cluster-integration/helpers/get-letsencrypt-cert.sh
+++ b/prow/scripts/cluster-integration/helpers/get-letsencrypt-cert.sh
@@ -15,7 +15,7 @@ source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/library.sh"
 
 function generateLetsEncryptCert() {
     shout "Generate lets encrypt certificate"
-    mkdir letsencrypt
+    mkdir -p letsencrypt
     cp "${GOOGLE_APPLICATION_CREDENTIALS}" letsencrypt
     docker run  --name certbot \
         --rm  \


### PR DESCRIPTION
**Description**
Folder failed to create, because it already existed. `mkdir -p` should prevent that, by not failing if folder exists.

Changes proposed in this pull request:
- `mkdir -p letsencrypt`
