### PR TITLE
add documentation for manual job trigger (#939)

### DIFF
--- a/docs/prow/prow-jobs.md
+++ b/docs/prow/prow-jobs.md
@@ -96,7 +96,7 @@ Use a tool called [mkpj](https://github.com/kubernetes/test-infra/tree/master/pr
 go run prow/cmd/mkpj/main.go --job=kyma-gke-nightly --config-path="$GOPATH/src/github.com/kyma-project/test-infra/prow/config.yaml" --job-config-path="$GOPATH/src/github.com/kyma-project/test-infra/prow/jobs/" > job.yaml
 ```
 
-The job can then be triggered with `kubectl`:
+You can trigger this job manually. Run:
 ```shell
 kubectl apply -f job.yaml
 ```

--- a/docs/prow/prow-jobs.md
+++ b/docs/prow/prow-jobs.md
@@ -90,7 +90,7 @@ For further reference, read a more technical insight into the Kubernetes [ProwJo
 
 ## Trigger jobs manually
 
-If you need to trigger a new job, because re-running the job would would not use the new code base, you can do so manually.
+In most situations, re-running the job means that Prow uses the same commit. To make sure the job uses the updated code base, you can trigger the job manually.
 Use a tool called [mkpj](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/mkpj) that generates a valid `yaml` for the ProwJob. See the example of generating the `kyma-gke-nightly` target:
 ```shell
 go run prow/cmd/mkpj/main.go --job=kyma-gke-nightly --config-path="$GOPATH/src/github.com/kyma-project/test-infra/prow/config.yaml" --job-config-path="$GOPATH/src/github.com/kyma-project/test-infra/prow/jobs/" > job.yaml

--- a/docs/prow/prow-jobs.md
+++ b/docs/prow/prow-jobs.md
@@ -91,7 +91,7 @@ For further reference, read a more technical insight into the Kubernetes [ProwJo
 ## Manual job trigger
 
 If you need to trigger a new job, because re-running the job would would not use the new code base, you can do so manually.
-For that you'll need a tool from the called [mkpj](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/mkpj) that will generate a valid ProwJob yaml for you. In the example below `kyma-gke-nightly` is target to be triggered manually:
+Use a tool called [mkpj](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/mkpj) that generates a valid `yaml` for the ProwJob. See the example of generating the `kyma-gke-nightly` target:
 ```shell
 go run prow/cmd/mkpj/main.go --job=kyma-gke-nightly --config-path="$GOPATH/src/github.com/kyma-project/test-infra/prow/config.yaml" --job-config-path="$GOPATH/src/github.com/kyma-project/test-infra/prow/jobs/" > job.yaml
 ```

--- a/docs/prow/prow-jobs.md
+++ b/docs/prow/prow-jobs.md
@@ -88,7 +88,7 @@ For details on how to create jobs, see:
 
 For further reference, read a more technical insight into the Kubernetes [ProwJobs](https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md).
 
-## Manual job trigger
+## Trigger jobs manually
 
 If you need to trigger a new job, because re-running the job would would not use the new code base, you can do so manually.
 Use a tool called [mkpj](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/mkpj) that generates a valid `yaml` for the ProwJob. See the example of generating the `kyma-gke-nightly` target:

--- a/docs/prow/prow-jobs.md
+++ b/docs/prow/prow-jobs.md
@@ -87,3 +87,16 @@ For details on how to create jobs, see:
 - [Create release jobs](./release-jobs.md)
 
 For further reference, read a more technical insight into the Kubernetes [ProwJobs](https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md).
+
+## Manual job trigger
+
+If you need to trigger a new job, because re-running the job would would not use the new code base, you can do so manually.
+For that you'll need a tool from the called [mkpj](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/mkpj) that will generate a valid ProwJob yaml for you. In the example below `kyma-gke-nightly` is target to be triggered manually:
+```shell
+go run prow/cmd/mkpj/main.go --job=kyma-gke-nightly --config-path="$GOPATH/src/github.com/kyma-project/test-infra/prow/config.yaml" --job-config-path="$GOPATH/src/github.com/kyma-project/test-infra/prow/jobs/" > job.yaml
+```
+
+The job can then be triggered with `kubectl`:
+```shell
+kubectl apply -f job.yaml
+```


### PR DESCRIPTION
**Description**
Adds documentation to describe how to manually trigger a new run (with changed code).

Changes proposed in this pull request:
- modify docs to describe manual job run

**Related issue(s)**
#939 
