### PR TITLE
Fix stability checker deployment yaml

### DIFF
--- a/stability-checker/deploy/chart/stability-checker/templates/deploy.yaml
+++ b/stability-checker/deploy/chart/stability-checker/templates/deploy.yaml
@@ -96,7 +96,6 @@ spec:
         - /bin/sh
         - -c
         - |-
-        # process the output of the pre-start-scripts.sh by the jq tool to get output as json
           ./data/input/pre-start-scripts.sh 2>&1 | jq --slurp --raw-input 'split("\n")[:-1] | map({level: "info", log: {message: .}})' | jq -c -M '.[]' && ./root/stability-checker
         image: "{{ .Values.containerRegistry.path }}/develop/stability-checker:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"


### PR DESCRIPTION
Comment inside `command` section of deployment containers caused yaml file could not be parse properly. This PR removes comment, fixes the `deploy.yaml` file and yaml can be parse without error.