### PR TITLE
Simplify cluster removal tool

### DIFF
--- a/development/tools/jobs/kyma/kyma_integration_test.go
+++ b/development/tools/jobs/kyma/kyma_integration_test.go
@@ -379,7 +379,7 @@ func TestKymaIntegrationJobPeriodics(t *testing.T) {
 	tester.AssertThatHasExtraRefs(t, clustersCleanerPeriodic.JobBase.UtilityConfig, []string{"test-infra", "kyma"})
 	assert.Equal(t, "eu.gcr.io/kyma-project/prow/buildpack-golang:0.0.1", clustersCleanerPeriodic.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"bash"}, clustersCleanerPeriodic.Spec.Containers[0].Command)
-	assert.Equal(t, []string{"-c", "development/clusters-cleanup.sh -project=${CLOUDSDK_CORE_PROJECT} -dryRun=false -strategy=time"}, clustersCleanerPeriodic.Spec.Containers[0].Args)
+	assert.Equal(t, []string{"-c", "development/clusters-cleanup.sh -project=${CLOUDSDK_CORE_PROJECT} -dryRun=true -whitelisted-clusters=kyma-prow,workload-kyma-prow,nightly,weekly,service-catalog-nightly"}, clustersCleanerPeriodic.Spec.Containers[0].Args)
 	tester.AssertThatSpecifiesResourceRequests(t, clustersCleanerPeriodic.JobBase)
 
 	expName = "orphaned-vms-cleaner"

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -613,7 +613,7 @@ periodics:
       - "bash"
       args:
       - "-c"
-      - "development/clusters-cleanup.sh -project=${CLOUDSDK_CORE_PROJECT} -dryRun=false -strategy=time"
+      - "development/clusters-cleanup.sh -project=${CLOUDSDK_CORE_PROJECT} -dryRun=true -whitelisted-clusters=kyma-prow,workload-kyma-prow,nightly,weekly,service-catalog-nightly"
       resources:
         requests:
           memory: 1Gi


### PR DESCRIPTION
When I added a new "long-living cluster" it was removed by the clustercollector. It was a little bit surprising... 
Changes introduced in this PR:

- Remove not used strategy - it only mistook me, because where I saw:
```
if nameMatches && isVolatileCluster && ageMatches {
```
I thought my cluster should not be removed, but this strategy is not used. 
 
- Whitelisted clusters configurable; previously it was hardcoded in the go code, now I make it configurable to make it visible from Prow configuration
- Improve logging

Currently, I set `dryRun` flag to true, because I was not able to test it manually. 
If everything will work fine I will create another PR to set it to false.