### PR TITLE
Add --overwrite flag to 'kubectl label installation' command

### DIFF
--- a/prow/scripts/cluster-integration/helpers/install-kyma.sh
+++ b/prow/scripts/cluster-integration/helpers/install-kyma.sh
@@ -67,7 +67,7 @@ function installKyma() {
 	date
 
     sed -e "s/__VERSION__/0.0.1/g" "${INSTALLER_CR}"  | sed -e "s/__.*__//g" | kubectl apply -f-
-	kubectl label installation/kyma-installation action=install
+	kubectl label installation/kyma-installation action=install --overwrite
 	"${KYMA_SCRIPTS_DIR}"/is-installed.sh --timeout 30m
 }
 

--- a/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
@@ -281,7 +281,7 @@ function installKyma() {
 	date
 
     sed -e "s/__VERSION__/0.0.1/g" "${INSTALLER_CR}"  | sed -e "s/__.*__//g" | kubectl apply -f-
-    kubectl label installation/kyma-installation action=install
+    kubectl label installation/kyma-installation action=install --overwrite
     "${KYMA_SCRIPTS_DIR}"/is-installed.sh --timeout 80m
 
     if [ -n "$(kubectl get service -n kyma-system apiserver-proxy-ssl --ignore-not-found)" ]; then

--- a/prow/scripts/cluster-integration/kyma-gke-central-xip.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-central-xip.sh
@@ -234,7 +234,7 @@ EOF
 
 shout "Trigger installation"
 date
-kubectl label installation/kyma-installation action=install
+kubectl label installation/kyma-installation action=install --overwrite
 "${KYMA_SCRIPTS_DIR}"/is-installed.sh --timeout 30m
 
 "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/get-helm-certs.sh"

--- a/prow/scripts/cluster-integration/kyma-gke-central.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-central.sh
@@ -315,7 +315,7 @@ EOF
 
 shout "Trigger installation"
 date
-kubectl label installation/kyma-installation action=install
+kubectl label installation/kyma-installation action=install --overwrite
 "${KYMA_SCRIPTS_DIR}"/is-installed.sh --timeout 30m
 
 if [ -n "$(kubectl get  service -n kyma-system apiserver-proxy-ssl --ignore-not-found)" ]; then

--- a/prow/scripts/cluster-integration/kyma-gke-end-to-end-test.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-end-to-end-test.sh
@@ -241,7 +241,7 @@ shout "Manual concatenating yamls"
 
 shout "Trigger installation"
 date
-kubectl label installation/kyma-installation action=install
+kubectl label installation/kyma-installation action=install --overwrite
 "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/get-helm-certs.sh"
 "${KYMA_SCRIPTS_DIR}"/is-installed.sh --timeout 30m
 

--- a/prow/scripts/cluster-integration/kyma-gke-integration-xip.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-integration-xip.sh
@@ -216,7 +216,7 @@ fi
 
 shout "Trigger installation"
 date
-kubectl label installation/kyma-installation action=install
+kubectl label installation/kyma-installation action=install --overwrite
 "${KYMA_SCRIPTS_DIR}"/is-installed.sh --timeout 30m
 
 "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/get-helm-certs.sh"

--- a/prow/scripts/cluster-integration/kyma-gke-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-integration.sh
@@ -297,7 +297,7 @@ fi
 
 shout "Trigger installation"
 date
-kubectl label installation/kyma-installation action=install
+kubectl label installation/kyma-installation action=install --overwrite
 "${KYMA_SCRIPTS_DIR}"/is-installed.sh --timeout 30m
 
 if [ -n "$(kubectl get  service -n kyma-system apiserver-proxy-ssl --ignore-not-found)" ]; then

--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -246,7 +246,7 @@ function installKyma() {
 	date
 
     sed -e "s/__VERSION__/0.0.1/g" "${INSTALLER_CR}"  | sed -e "s/__.*__//g" | kubectl apply -f-
-	kubectl label installation/kyma-installation action=install
+	kubectl label installation/kyma-installation action=install --overwrite
 	"${KYMA_SCRIPTS_DIR}"/is-installed.sh --timeout 30m
 
 	if [ -n "$(kubectl get service -n kyma-system apiserver-proxy-ssl --ignore-not-found)" ]; then

--- a/prow/scripts/cluster-integration/kyma-gke-minio-gateway.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-minio-gateway.sh
@@ -343,7 +343,7 @@ EOF
 
 shout "Trigger installation"
 date
-kubectl label installation/kyma-installation action=install
+kubectl label installation/kyma-installation action=install --overwrite
 "${KYMA_SCRIPTS_DIR}"/is-installed.sh --timeout 30m
 
 if [ -n "$(kubectl get  service -n kyma-system apiserver-proxy-ssl --ignore-not-found)" ]; then

--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -248,7 +248,7 @@ sed -e "s/__DOMAIN__/${DOMAIN}/g" kyma-config-cluster.yaml \
 
 shout "Trigger installation"
 date
-kubectl label installation/kyma-installation action=install
+kubectl label installation/kyma-installation action=install --overwrite
 "${KYMA_SCRIPTS_DIR}"/is-installed.sh --timeout 30m
 
 if [ -n "$(kubectl get  service -n kyma-system apiserver-proxy-ssl --ignore-not-found)" ]; then

--- a/prow/scripts/cluster-integration/kyma-gke-upgrade-xip.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-upgrade-xip.sh
@@ -218,7 +218,7 @@ function installKyma() {
 
     shout "Trigger installation with timeout ${KYMA_INSTALL_TIMEOUT}"
     date
-    kubectl label installation/kyma-installation action=install
+    kubectl label installation/kyma-installation action=install --overwrite
     "${KYMA_SCRIPTS_DIR}"/is-installed.sh --timeout ${KYMA_INSTALL_TIMEOUT}
 }
 
@@ -352,7 +352,7 @@ function upgradeKyma() {
 
     shout "Trigger update with timeout ${KYMA_UPDATE_TIMEOUT}"
     date
-    kubectl label installation/kyma-installation action=install
+    kubectl label installation/kyma-installation action=install --overwrite
     "${KYMA_SCRIPTS_DIR}"/is-installed.sh --timeout ${KYMA_UPDATE_TIMEOUT}
 
 }

--- a/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
@@ -307,7 +307,7 @@ function installKyma() {
 
     shout "Trigger installation with timeout ${KYMA_INSTALL_TIMEOUT}"
     date
-    kubectl label installation/kyma-installation action=install
+    kubectl label installation/kyma-installation action=install --overwrite
     "${KYMA_SCRIPTS_DIR}"/is-installed.sh --timeout ${KYMA_INSTALL_TIMEOUT}
 }
 
@@ -438,7 +438,7 @@ function upgradeKyma() {
 
     shout "Trigger update with timeout ${KYMA_UPDATE_TIMEOUT}"
     date
-    kubectl label installation/kyma-installation action=install
+    kubectl label installation/kyma-installation action=install --overwrite
     "${KYMA_SCRIPTS_DIR}"/is-installed.sh --timeout ${KYMA_UPDATE_TIMEOUT}
 
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

Add `--overwrite` flag to the `kubectl label installation kyma-installation action=install` commands.

The `action=install` label is to be added to the `installer-cr.yaml.tpl` file. As a result, the custom resource doesn't have to be labelled manually ever time the installation is triggered.

Once the relevant PR is merged, the commands will be entirely removed. 

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/3932
