### PR TITLE
Add roles for stability-checker

### DIFF
--- a/prow/scripts/cluster-integration/helpers/install-stability-checker.sh
+++ b/prow/scripts/cluster-integration/helpers/install-stability-checker.sh
@@ -45,7 +45,7 @@ metadata:
   name: stability-checker-with-octopus
 rules:
 - apiGroups: ["testing.kyma-project.io"]
-  resources: ["clustertestsuites"]
+  resources: ["clustertestsuites", "testdefinitions"]
   verbs: ["*"]
 EOF
 

--- a/stability-checker/deploy/chart/stability-checker/templates/role.yaml
+++ b/stability-checker/deploy/chart/stability-checker/templates/role.yaml
@@ -10,6 +10,10 @@ rules:
     - "{{ .Chart.Name }}-test-results"
 
 - apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["GET"]
+
+- apiGroups: [""]
   resources: ["pods"]
   verbs: ["list","get","delete"]
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add roles for stability-checker

This PR should resolve this problem:
```
Error from server (Forbidden): configmaps \"dex-config\" is forbidden: User \"system:serviceaccount:kyma-system:stability-checker\" cannot get resource \"configmaps\" in API group \"\" in the namespace \"kyma-system\"
WARNING: following tests will be skipped due to the lack of static users:
Error from server (Forbidden): testdefinitions.testing.kyma-project.io is forbidden: User \"system:serviceaccount:kyma-system:stability-checker\" cannot list resource \"testdefinitions\" in API group \"testing.kyma-project.io\" at the cluster scope
```
