### PR TITLE
Add retries to RC provisioning job

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -233,7 +233,22 @@ echo "Use released artifacts"
 wget "https://github.com/kyma-project/kyma/releases/download/${RELEASE_VERSION}/kyma-config-cluster.yaml"
 wget "https://github.com/kyma-project/kyma/releases/download/${RELEASE_VERSION}/kyma-installer-cluster.yaml"
 
-kubectl apply -f kyma-installer-cluster.yaml
+# There is possibility of a race condition when applying kyma-installer-cluster.yaml
+# Retry should prevent job from failing
+n=0
+until [ $n -ge 2 ]
+do
+    kubectl apply -f kyma-installer-cluster.yaml && break
+    echo "Failed to apply kyma-installer-cluster.yaml"
+    n=$[$n+1]
+    if [ 2 -gt "$n" ]
+    then
+        echo "Retrying in 5 seconds"
+        sleep 5
+    else
+        exit 1
+    fi
+done
 
 sed -e "s/__DOMAIN__/${DOMAIN}/g" kyma-config-cluster.yaml \
     | sed -e "s/__REMOTE_ENV_IP__/${REMOTEENVS_IP_ADDRESS}/g" \

--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -240,7 +240,7 @@ until [ $n -ge 2 ]
 do
     kubectl apply -f kyma-installer-cluster.yaml && break
     echo "Failed to apply kyma-installer-cluster.yaml"
-    n=$(($n+1))
+    n=$((n+1))
     if [ 2 -gt "$n" ]
     then
         echo "Retrying in 5 seconds"

--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -240,7 +240,7 @@ until [ $n -ge 2 ]
 do
     kubectl apply -f kyma-installer-cluster.yaml && break
     echo "Failed to apply kyma-installer-cluster.yaml"
-    n=$[$n+1]
+    n=$(($n+1))
     if [ 2 -gt "$n" ]
     then
         echo "Retrying in 5 seconds"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Due to Custom Resource Definitions and Custom Resources being applied in a single file, applying `kyma-installer-cluster.yaml` often fails. Adding retry should make sure that the resources would be applied correctly and the job will not fail.

Changes proposed in this pull request:

- Add retries to RC provisioning job

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
