### PR TITLE
GCP constraints issue (temporary fix)

### DIFF
--- a/development/custom-image/install-deps-debian.sh
+++ b/development/custom-image/install-deps-debian.sh
@@ -40,7 +40,7 @@ sudo apt update
 sudo apt install -y docker-ce=${DOCKER_VERSION}
 
 # setup logging drived for docker
-cat << EOF > /etc/docker/daemon.json
+cat << EOF > /tmp/daemon.json
 {
    "log-driver": "gcplogs",
    "log-opts": {

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -3,9 +3,9 @@ presets:
       preset-gc-compute-envs: "true"
     env:
       - name: CLOUDSDK_COMPUTE_ZONE
-        value: "europe-west3-b"
+        value: "europe-west5-b"
       - name: CLOUDSDK_COMPUTE_REGION
-        value: "europe-west3"
+        value: "europe-west5"
   - labels:
       preset-gc-project-env: "true"
     env:


### PR DESCRIPTION
There were changes made on organisation lever so that we can setup resources only on `europe-west5`. 
