### PR TITLE
GKE central connector test job added

### DIFF
--- a/development/tools/jobs/kyma/kyma_integration_test.go
+++ b/development/tools/jobs/kyma/kyma_integration_test.go
@@ -1,11 +1,13 @@
 package kyma_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/kyma-project/test-infra/development/tools/jobs/tester"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/test-infra/prow/config"
 )
 
 func TestKymaIntegrationVMJobsReleases(t *testing.T) {
@@ -58,6 +60,8 @@ func TestKymaIntegrationGKEJobsReleases(t *testing.T) {
 func TestKymaIntegrationJobsPresubmit(t *testing.T) {
 	tests := map[string]struct {
 		givenJobName string
+		branch       string
+		org          string
 		expPresets   []tester.Preset
 		expJobImage  string
 	}{
@@ -90,6 +94,17 @@ func TestKymaIntegrationJobsPresubmit(t *testing.T) {
 			},
 			expJobImage: tester.ImageBootstrapHelm20181121,
 		},
+		"Should contains the gke-central-nosed job": {
+			givenJobName: "pre-master-kyma-gke-central-connector-nosed",
+			branch:       "simplify-installation-kyma-gke-central",
+			org:          "jakkab",
+			expPresets: []tester.Preset{
+				tester.PresetGCProjectEnv, tester.PresetBuildPr,
+				tester.PresetDindEnabled, "preset-sa-gke-kyma-integration",
+				"preset-gc-compute-envs", "preset-docker-push-repository-gke-integration",
+			},
+			expJobImage: tester.ImageBootstrapHelm20181121,
+		},
 	}
 
 	for tn, tc := range tests {
@@ -102,6 +117,33 @@ func TestKymaIntegrationJobsPresubmit(t *testing.T) {
 			actualJob := tester.FindPresubmitJobByName(jobConfig.Presubmits["kyma-project/kyma"], tc.givenJobName, "master")
 			require.NotNil(t, actualJob)
 
+			var branch = func() string {
+				if tc.branch != "" {
+					return tc.branch
+				}
+				return "master"
+			}
+
+			var org = func() string {
+				if tc.org != "" {
+					return tc.org
+				}
+
+				return "kyma-project"
+			}
+
+			var assertRepo = func(t *testing.T, in config.UtilityConfig, expectedBaseRef, expectedOrg string) {
+				for _, curr := range in.ExtraRefs {
+					if curr.PathAlias == "github.com/kyma-project/test-infra" &&
+						curr.Org == expectedOrg &&
+						curr.Repo == "test-infra" &&
+						curr.BaseRef == expectedBaseRef {
+						return
+					}
+				}
+				assert.Fail(t, fmt.Sprintf("Job has not configured extra ref to test-infra repository with base ref set to [%s]", expectedBaseRef))
+			}
+
 			// then
 			// the common expectation
 			assert.Equal(t, "github.com/kyma-project/kyma", actualJob.PathAlias)
@@ -111,7 +153,7 @@ func TestKymaIntegrationJobsPresubmit(t *testing.T) {
 			assert.True(t, actualJob.Decorate)
 			assert.False(t, actualJob.SkipReport)
 			assert.Equal(t, 10, actualJob.MaxConcurrency)
-			tester.AssertThatHasExtraRefTestInfra(t, actualJob.JobBase.UtilityConfig, "master")
+			assertRepo(t, actualJob.JobBase.UtilityConfig, branch(), org())
 			tester.AssertThatSpecifiesResourceRequests(t, actualJob.JobBase)
 
 			// the job specific expectation

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -9,6 +9,11 @@ kk_test_ref: &kk_test_ref
   repo: test-infra
   path_alias: github.com/kyma-project/test-infra
 
+test_infra_ref_nosed: &test_infra_ref_nosed
+  org: jakkab
+  repo: test-infra
+  path_alias: github.com/kyma-project/test-infra
+
 kyma_ref: &kyma_ref
   org: kyma-project
   repo: kyma
@@ -95,6 +100,27 @@ gke_upgrade_job_template: &gke_upgrade_job_template
           cpu: 80m
 
 gke_central_job_template: &gke_central_job_template
+  skip_report: false
+  decorate: true
+  path_alias: github.com/kyma-project/kyma
+  max_concurrency: 10
+  spec:
+    containers:
+    - image: eu.gcr.io/kyma-project/prow/test-infra/bootstrap-helm:v20181121-f2f12bc
+      securityContext:
+        privileged: true
+      command:
+      - "bash"
+      args:
+      - "-c"
+      - "${KYMA_PROJECT_DIR}/test-infra/prow/scripts/cluster-integration/kyma-gke-central.sh"
+      resources:
+        requests:
+          memory: 200Mi
+          cpu: 80m
+
+gke_central_job_template_nosed: &gke_central_job_template_nosed
+  optional: true
   skip_report: false
   decorate: true
   path_alias: github.com/kyma-project/kyma
@@ -359,6 +385,18 @@ presubmits: # runs on PRs
     - <<: *test_infra_ref
       base_ref: master
 
+  - name: pre-master-kyma-gke-central-connector-nosed
+    branches:
+    - master
+    <<: *gke_central_job_template_nosed
+    run_if_changed: "^(resources|installation)"
+    labels:
+      preset-build-pr: "true"
+      <<: *gke_job_labels_template
+    extra_refs:
+    - <<: *test_infra_ref_nosed
+      base_ref: simplify-installation-kyma-gke-central
+
   - name: pre-rel09-kyma-gke-central-connector
     branches:
       - release-0.9
@@ -394,7 +432,7 @@ presubmits: # runs on PRs
     extra_refs:
       - <<: *test_infra_ref
         base_ref: release-1.1
-        
+
   - name: pre-master-kyma-xip-integration
     branches:
        - master


### PR DESCRIPTION
**Description**
We're removing all usages of template file kyma-config-cluster.yaml from Kyma installation process. It requires changes in scripts used by several Prow Jobs.

Changes proposed in this pull request:

- Add a Job for testing new version of **pre-master-kyma-gke-central-connector**.


**Related issue(s)**
See also:
- #1024 
- https://github.com/kyma-project/kyma/pull/4118