### PR TITLE
Limit central-connector job to run on application-connector images change

### DIFF
--- a/development/tools/jobs/kyma/kyma_integration_test.go
+++ b/development/tools/jobs/kyma/kyma_integration_test.go
@@ -110,7 +110,7 @@ func TestKymaIntegrationJobsPresubmit(t *testing.T) {
 			// the common expectation
 			assert.Equal(t, "github.com/kyma-project/kyma", actualJob.PathAlias)
 			assert.Equal(t, tc.expRunIfChangedRegex, actualJob.RunIfChanged)
-			tester.AssertThatJobRunIfChanged(t, *actualJob, "resources/values.yaml")
+			tester.AssertThatJobRunIfChanged(t, *actualJob, "resources/application-connector/values.yaml")
 			tester.AssertThatJobRunIfChanged(t, *actualJob, "installation/file.yaml")
 			tester.AssertThatJobDoesNotRunIfChanged(t, *actualJob, "installation/README.md")
 			tester.AssertThatJobDoesNotRunIfChanged(t, *actualJob, "installation/test/test/README.MD")

--- a/development/tools/jobs/kyma/kyma_integration_test.go
+++ b/development/tools/jobs/kyma/kyma_integration_test.go
@@ -60,6 +60,7 @@ func TestKymaIntegrationJobsPresubmit(t *testing.T) {
 		givenJobName string
 		expPresets   []tester.Preset
 		expJobImage  string
+		expRunIfChangedRegex string
 	}{
 		"Should contains the kyma-integration job": {
 			givenJobName: "pre-master-kyma-integration",
@@ -69,6 +70,7 @@ func TestKymaIntegrationJobsPresubmit(t *testing.T) {
 			},
 
 			expJobImage: tester.ImageBootstrap001,
+			expRunIfChangedRegex: "^((resources\\S+|installation\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))",
 		},
 		"Should contains the gke-integration job": {
 			givenJobName: "pre-master-kyma-gke-integration",
@@ -79,6 +81,7 @@ func TestKymaIntegrationJobsPresubmit(t *testing.T) {
 				"preset-gc-compute-envs", "preset-docker-push-repository-gke-integration",
 			},
 			expJobImage: tester.ImageBootstrapHelm20181121,
+			expRunIfChangedRegex: "^((resources\\S+|installation\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))",
 		},
 		"Should contains the gke-central job": {
 			givenJobName: "pre-master-kyma-gke-central-connector",
@@ -89,6 +92,7 @@ func TestKymaIntegrationJobsPresubmit(t *testing.T) {
 				"preset-gc-compute-envs", "preset-docker-push-repository-gke-integration",
 			},
 			expJobImage: tester.ImageBootstrapHelm20181121,
+			expRunIfChangedRegex: "^((resources/application-connector\\S+|installation\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))",
 		},
 	}
 
@@ -105,7 +109,7 @@ func TestKymaIntegrationJobsPresubmit(t *testing.T) {
 			// then
 			// the common expectation
 			assert.Equal(t, "github.com/kyma-project/kyma", actualJob.PathAlias)
-			assert.Equal(t, "^((resources\\S+|installation\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))", actualJob.RunIfChanged)
+			assert.Equal(t, tc.expRunIfChangedRegex, actualJob.RunIfChanged)
 			tester.AssertThatJobRunIfChanged(t, *actualJob, "resources/values.yaml")
 			tester.AssertThatJobRunIfChanged(t, *actualJob, "installation/file.yaml")
 			tester.AssertThatJobDoesNotRunIfChanged(t, *actualJob, "installation/README.md")
@@ -261,11 +265,12 @@ func TestKymaGKECentralConnectorJobsPresubmit(t *testing.T) {
 
 	// then
 	assert.Equal(t, "github.com/kyma-project/kyma", actualJob.PathAlias)
-	assert.Equal(t, "^((resources\\S+|installation\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))", actualJob.RunIfChanged)
+	assert.Equal(t, "^((resources/application-connector\\S+|installation\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))", actualJob.RunIfChanged)
 	tester.AssertThatJobRunIfChanged(t, *actualJob, "resources/values.yaml")
 	tester.AssertThatJobRunIfChanged(t, *actualJob, "installation/file.yaml")
 	tester.AssertThatJobDoesNotRunIfChanged(t, *actualJob, "installation/README.md")
 	tester.AssertThatJobDoesNotRunIfChanged(t, *actualJob, "installation/test/test/README.MD")
+	tester.AssertThatJobDoesNotRunIfChanged(t, *actualJob, "resources/test/values.yaml")
 	assert.True(t, actualJob.Decorate)
 	assert.False(t, actualJob.SkipReport)
 	assert.Equal(t, 10, actualJob.MaxConcurrency)

--- a/development/tools/jobs/kyma/kyma_integration_test.go
+++ b/development/tools/jobs/kyma/kyma_integration_test.go
@@ -57,9 +57,9 @@ func TestKymaIntegrationGKEJobsReleases(t *testing.T) {
 
 func TestKymaIntegrationJobsPresubmit(t *testing.T) {
 	tests := map[string]struct {
-		givenJobName string
-		expPresets   []tester.Preset
-		expJobImage  string
+		givenJobName         string
+		expPresets           []tester.Preset
+		expJobImage          string
 		expRunIfChangedRegex string
 	}{
 		"Should contains the kyma-integration job": {
@@ -69,7 +69,7 @@ func TestKymaIntegrationJobsPresubmit(t *testing.T) {
 				tester.PresetGCProjectEnv, "preset-sa-vm-kyma-integration",
 			},
 
-			expJobImage: tester.ImageBootstrap001,
+			expJobImage:          tester.ImageBootstrap001,
 			expRunIfChangedRegex: "^((resources\\S+|installation\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))",
 		},
 		"Should contains the gke-integration job": {
@@ -80,7 +80,7 @@ func TestKymaIntegrationJobsPresubmit(t *testing.T) {
 				tester.PresetDindEnabled, "preset-sa-gke-kyma-integration",
 				"preset-gc-compute-envs", "preset-docker-push-repository-gke-integration",
 			},
-			expJobImage: tester.ImageBootstrapHelm20181121,
+			expJobImage:          tester.ImageBootstrapHelm20181121,
 			expRunIfChangedRegex: "^((resources\\S+|installation\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))",
 		},
 		"Should contains the gke-central job": {
@@ -91,7 +91,7 @@ func TestKymaIntegrationJobsPresubmit(t *testing.T) {
 				tester.PresetDindEnabled, "preset-sa-gke-kyma-integration",
 				"preset-gc-compute-envs", "preset-docker-push-repository-gke-integration",
 			},
-			expJobImage: tester.ImageBootstrapHelm20181121,
+			expJobImage:          tester.ImageBootstrapHelm20181121,
 			expRunIfChangedRegex: "^((resources/application-connector\\S+|installation\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))",
 		},
 	}

--- a/development/tools/jobs/kyma/kyma_integration_test.go
+++ b/development/tools/jobs/kyma/kyma_integration_test.go
@@ -266,7 +266,7 @@ func TestKymaGKECentralConnectorJobsPresubmit(t *testing.T) {
 	// then
 	assert.Equal(t, "github.com/kyma-project/kyma", actualJob.PathAlias)
 	assert.Equal(t, "^((resources/application-connector\\S+|installation\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))", actualJob.RunIfChanged)
-	tester.AssertThatJobRunIfChanged(t, *actualJob, "resources/values.yaml")
+	tester.AssertThatJobRunIfChanged(t, *actualJob, "resources/application-connector/values.yaml")
 	tester.AssertThatJobRunIfChanged(t, *actualJob, "installation/file.yaml")
 	tester.AssertThatJobDoesNotRunIfChanged(t, *actualJob, "installation/README.md")
 	tester.AssertThatJobDoesNotRunIfChanged(t, *actualJob, "installation/test/test/README.MD")

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -355,7 +355,7 @@ presubmits: # runs on PRs
     - master
     <<: *gke_central_job_template
     # following regexp won't start build if only Markdown files were changed
-    run_if_changed: "^((resources\\S+|installation\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
+    run_if_changed: "^((resources/application-connector\\S+|installation\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
     labels:
       preset-build-pr: "true"
       <<: *gke_job_labels_template


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Limit the `pre-master-kyma-gke-central-connector` job to run on the `resources/application-connector` images change instead of all `resources` images

**Related issue(s)**

See the issue #1015 