### PR TITLE
Use latest gcloud sdk version for performance tests

### DIFF
--- a/performance-tools/performance-cluster/Dockerfile
+++ b/performance-tools/performance-cluster/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && apt-get clean
 
 # Install gcloud
-ENV CLOUD_SDK_VERSION=219.0.1
+ENV CLOUD_SDK_VERSION=247.0.0
 ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
   CLOUDSDK_CORE_DISABLE_PROMPTS=1
 
@@ -57,8 +57,6 @@ RUN echo 'DOCKER_OPTS="${DOCKER_OPTS} --data-root=/docker-graph"' | \
   tee --append /etc/default/docker
 RUN mkdir /docker-graph
 
-
-RUN curl -Lo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl && chmod +x /usr/bin/kubectl
 
 RUN apt-get install dirmngr
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Use [gcloud sdk version 247.0.0](https://cloud.google.com/sdk/docs/release-notes)
- Remove duplicate kubectl commands (one installed by gcloud, one installed via curl)
- Use kubectl provided by gcloud only


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- The newer kubectl version provides the `kubectl wait` command which is useful for https://github.com/kyma-project/kyma/pull/4156

```bash
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"12+", GitVersion:"v1.12.8-dispatcher", GitCommit:"1215389331387f57594b42c5dd024a2fe27334f8", GitTreeState:"clean", BuildDate:"2019-05-13T18:09:56Z", GoVersion:"go1.10.8", Compiler:"gc", Platform:"linux/amd64"}
```