### PR TITLE
Added test job for gke-long-lasting (copy of nightly cluster)

### DIFF
--- a/development/tools/jobs/kyma/kyma_integration_test.go
+++ b/development/tools/jobs/kyma/kyma_integration_test.go
@@ -359,7 +359,7 @@ func TestKymaIntegrationJobPeriodics(t *testing.T) {
 	require.NoError(t, err)
 
 	periodics := jobConfig.Periodics
-	assert.Len(t, periodics, 15)
+	assert.Len(t, periodics, 16)
 
 	expName := "orphaned-disks-cleaner"
 	disksCleanerPeriodic := tester.FindPeriodicJobByName(periodics, expName)

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -733,7 +733,7 @@ periodics:
       - "bash"
       env:
       - name: INPUT_CLUSTER_NAME
-        value: "nightly"
+        value: "nightnosely"
       - name: TEST_RESULT_WINDOW_TIME
         value: "6h"
       - name: STABILITY_SLACK_CLIENT_CHANNEL_ID

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -700,7 +700,7 @@ periodics:
           cpu: 80m
 
 - name: kyma-gke-nightly-nosed
-  cron: "50 12 * * 1-5" # "At 04:00 on every day-of-week from Monday through Friday"
+  cron: "00 13 * * 1-5" # "At 04:00 on every day-of-week from Monday through Friday"
   labels:
     preset-kyma-keyring: "true"
     preset-kyma-encryption-key: "true"

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -699,6 +699,62 @@ periodics:
           memory: 200Mi
           cpu: 80m
 
+- name: kyma-gke-nightly-nosed
+  cron: "50 12 * * 1-5" # "At 04:00 on every day-of-week from Monday through Friday"
+  labels:
+    preset-kyma-keyring: "true"
+    preset-kyma-encryption-key: "true"
+    preset-build-master: "true"
+    preset-stability-checker-slack-notifications: "true"
+    preset-nightly-github-integration: "true"
+    <<: *gke_job_labels_template
+  decorate: true
+  extra_refs:
+  - org: jakkab
+    repo: test-infra
+    base_ref: simplify-installation-gke-long-lasting
+    path_alias: github.com/kyma-project/test-infra
+  - <<: *kyma_ref
+    base_ref: master
+  spec:
+    volumes:
+    - name: sa-stability-fluentd-storage-writer
+      secret:
+        secretName: sa-stability-fluentd-storage-writer
+    containers:
+    - image: eu.gcr.io/kyma-project/test-infra/kyma-cluster-infra:v20190129-c951cf2
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: sa-stability-fluentd-storage-writer
+        mountPath: /etc/credentials/sa-stability-fluentd-storage-writer
+        readOnly: true
+      command:
+      - "bash"
+      env:
+      - name: INPUT_CLUSTER_NAME
+        value: "nightly"
+      - name: TEST_RESULT_WINDOW_TIME
+        value: "6h"
+      - name: STABILITY_SLACK_CLIENT_CHANNEL_ID
+        value: "#c4core-kyma-ci-force"
+      - name: GITHUB_TEAMS_WITH_KYMA_ADMINS_RIGHTS
+        value: "cluster-access"
+      - name: KYMA_ALERTS_SLACK_API_URL
+        valueFrom:
+          secretKeyRef:
+            name: kyma-alerts-slack-api-url
+            key: secret
+      - name: KYMA_ALERTS_CHANNEL
+        value: "#c4core-kyma-ci-force"
+      args:
+      - "-c"
+      - "${KYMA_PROJECT_DIR}/test-infra/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh"
+      resources:
+        requests:
+          memory: 200Mi
+          cpu: 80m
+
 - name: kyma-gke-weekly
   cron: "0 6 * * 1" # "At 06:00 on Monday."
   labels:


### PR DESCRIPTION
**Description**

We remove all usages of template file **kyma-config-cluster.yaml** from Kyma installation process. It requires changes in scripts used by several Prow Jobs.

Changes proposed in this pull request:

- Add a Job for testing new version of **gke-long-lasting.sh**

**Related issue(s)**
See also #1024 
