### PR TITLE
Add helm installation to the Dockerfile

### DIFF
--- a/performance-tools/performance-cluster/Dockerfile
+++ b/performance-tools/performance-cluster/Dockerfile
@@ -57,7 +57,22 @@ RUN echo 'DOCKER_OPTS="${DOCKER_OPTS} --data-root=/docker-graph"' | \
   tee --append /etc/default/docker
 RUN mkdir /docker-graph
 
+# Install Helm
+ENV HELM_VERSION=v2.0.0
 
+ENV HELM_FILE_NAME helm-${HELM_VERSION}-linux-amd64.tar.gz
+ENV HELM_URL https://storage.googleapis.com/kubernetes-helm/${HELM_FILE_NAME}
+
+RUN echo $HELM_URL
+
+RUN curl -o /tmp/$HELM_FILE_NAME ${HELM_URL} \
+  && tar -zxvf /tmp/${HELM_FILE_NAME} -C /tmp \
+  && mv /tmp/linux-amd64/helm /usr/local/bin/helm \
+  && rm -rf /tmp
+
+RUN helm init --client-only
+
+# Install k6
 RUN apt-get install dirmngr
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61
 RUN echo "deb https://dl.bintray.com/loadimpact/deb stable main" | tee -a /etc/apt/sources.list

--- a/performance-tools/performance-cluster/Dockerfile
+++ b/performance-tools/performance-cluster/Dockerfile
@@ -61,19 +61,18 @@ RUN mkdir /docker-graph
 RUN apt-get install dirmngr
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61
 RUN echo "deb https://dl.bintray.com/loadimpact/deb stable main" | tee -a /etc/apt/sources.list
-RUN apt-get update
-RUN apt-get install k6
+RUN apt-get update && apt-get install k6 && rm -rf /var/lib/apt/lists/*
 
 # Install Helm
 ENV HELM_VERSION=v2.0.0
 
-ENV HELM_FILE_NAME helm-${HELM_VERSION}-linux-amd64.tar.gz
-ENV HELM_URL https://storage.googleapis.com/kubernetes-helm/${HELM_FILE_NAME}
+ENV HELM_FILE_NAME=helm-${HELM_VERSION}-linux-amd64.tar.gz
+ENV HELM_URL=https://storage.googleapis.com/kubernetes-helm/${HELM_FILE_NAME}
 
 RUN curl -o /tmp/$HELM_FILE_NAME ${HELM_URL} \
   && tar -zxvf /tmp/${HELM_FILE_NAME} -C /tmp \
   && mv /tmp/linux-amd64/helm /usr/local/bin/helm \
-  && rm -rf /tmp
+  && rm -rf /tmp/linux-amd64/helm
 
 RUN helm init --client-only
 

--- a/performance-tools/performance-cluster/Dockerfile
+++ b/performance-tools/performance-cluster/Dockerfile
@@ -57,13 +57,18 @@ RUN echo 'DOCKER_OPTS="${DOCKER_OPTS} --data-root=/docker-graph"' | \
   tee --append /etc/default/docker
 RUN mkdir /docker-graph
 
+
+RUN apt-get install dirmngr
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61
+RUN echo "deb https://dl.bintray.com/loadimpact/deb stable main" | tee -a /etc/apt/sources.list
+RUN apt-get update
+RUN apt-get install k6
+
 # Install Helm
 ENV HELM_VERSION=v2.0.0
 
 ENV HELM_FILE_NAME helm-${HELM_VERSION}-linux-amd64.tar.gz
 ENV HELM_URL https://storage.googleapis.com/kubernetes-helm/${HELM_FILE_NAME}
-
-RUN echo $HELM_URL
 
 RUN curl -o /tmp/$HELM_FILE_NAME ${HELM_URL} \
   && tar -zxvf /tmp/${HELM_FILE_NAME} -C /tmp \
@@ -71,13 +76,6 @@ RUN curl -o /tmp/$HELM_FILE_NAME ${HELM_URL} \
   && rm -rf /tmp
 
 RUN helm init --client-only
-
-# Install k6
-RUN apt-get install dirmngr
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61
-RUN echo "deb https://dl.bintray.com/loadimpact/deb stable main" | tee -a /etc/apt/sources.list
-RUN apt-get update
-RUN apt-get install k6
 
 RUN mkdir /test-infra
 


### PR DESCRIPTION
Prevent error happening in:

```
kubectl get -n kyma-installer secret helm-secret -o jsonpath="{.data['global\.helm\.ca\.crt']}" | base64 --decode > "$(helm home)/ca.pem"
kubectl get -n kyma-installer secret helm-secret -o jsonpath="{.data['global\.helm\.tls\.crt']}" | base64 --decode > "$(helm home)/cert.pem"
kubectl get -n kyma-installer secret helm-secret -o jsonpath="{.data['global\.helm\.tls\.key']}" | base64 --decode > "$(helm home)/key.pem"
```

**helm command not found.**