### PR TITLE
Ensure backward compatibility in upgrade jobs: restore CR labelling

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-upgrade-xip.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-upgrade-xip.sh
@@ -210,6 +210,8 @@ function installKyma() {
     curl -L --silent --fail --show-error "https://github.com/kyma-project/kyma/releases/download/${LAST_RELEASE_VERSION}/kyma-installer-cluster.yaml" --output /tmp/kyma-gke-upgradeability/last-release-installer.yaml
     kubectl apply -f /tmp/kyma-gke-upgradeability/last-release-installer.yaml
 
+    kubectl label installation/kyma-installation action=install --overwrite #Backward compatibility for releases <= 1.1.X
+
     shout "Installation triggered with timeout ${KYMA_INSTALL_TIMEOUT}"
     date
     "${KYMA_SCRIPTS_DIR}"/is-installed.sh --timeout ${KYMA_INSTALL_TIMEOUT}

--- a/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
@@ -304,6 +304,8 @@ function installKyma() {
     curl -L --silent --fail --show-error "https://github.com/kyma-project/kyma/releases/download/${LAST_RELEASE_VERSION}/kyma-installer-cluster.yaml" --output /tmp/kyma-gke-upgradeability/last-release-installer.yaml
     kubectl apply -f /tmp/kyma-gke-upgradeability/last-release-installer.yaml
 
+    kubectl label installation/kyma-installation action=install --overwrite #Backward compatibility for releases <= 1.1.X
+
     shout "Installation triggered with timeout ${KYMA_INSTALL_TIMEOUT}"
     date
     "${KYMA_SCRIPTS_DIR}"/is-installed.sh --timeout ${KYMA_INSTALL_TIMEOUT}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Ensure backward compatibility in upgrade jobs: restore CR labelling

**Related issue(s)**
caused by #1085 
