### PR TITLE
Add prowjob for moved apiserver-proxy tests

### DIFF
--- a/development/tools/jobs/kyma/apiserver_proxy_new_test_test.go
+++ b/development/tools/jobs/kyma/apiserver_proxy_new_test_test.go
@@ -22,6 +22,7 @@ func TestApiserverProxyTestReleasesNew(t *testing.T) {
 			require.NotNil(t, actualPresubmit)
 			assert.False(t, actualPresubmit.SkipReport)
 			assert.True(t, actualPresubmit.Decorate)
+			assert.True(t, actualPresubmit.Optional)
 			assert.Equal(t, "github.com/kyma-project/kyma", actualPresubmit.PathAlias)
 			tester.AssertThatHasExtraRefTestInfra(t, actualPresubmit.JobBase.UtilityConfig, currentRelease)
 			tester.AssertThatHasPresets(t, actualPresubmit.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepo, tester.PresetGcrPush, tester.PresetBuildRelease)
@@ -43,6 +44,7 @@ func TestApiserverProxyTestJobsPresubmitNew(t *testing.T) {
 	assert.Equal(t, 10, actualPresubmit.MaxConcurrency)
 	assert.False(t, actualPresubmit.SkipReport)
 	assert.True(t, actualPresubmit.Decorate)
+	assert.True(t, actualPresubmit.Optional)
 	assert.Equal(t, "github.com/kyma-project/kyma", actualPresubmit.PathAlias)
 
 	tester.AssertThatHasExtraRefTestInfra(t, actualPresubmit.JobBase.UtilityConfig, "master")

--- a/development/tools/jobs/kyma/apiserver_proxy_new_test_test.go
+++ b/development/tools/jobs/kyma/apiserver_proxy_new_test_test.go
@@ -8,17 +8,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const apiserverProxyTestJobConfigFilePath = "./../../../../prow/jobs/kyma/tests/apiserver-proxy-tests/apiserver-proxy-test.yaml"
+const apiserverProxyTestNewJobConfigFilePath = "./../../../../prow/jobs/kyma/tests/apiserver-proxy-tests/apiserver-proxy-test-new.yaml"
 
-func TestApiserverProxyTestReleases(t *testing.T) {
+func TestApiserverProxyTestReleasesNew(t *testing.T) {
 	// WHEN
 
 	for _, currentRelease := range tester.GetAllKymaReleaseBranches() {
 		t.Run(currentRelease, func(t *testing.T) {
-			jobConfig, err := tester.ReadJobConfig(apiserverProxyTestJobConfigFilePath)
+			jobConfig, err := tester.ReadJobConfig(apiserverProxyTestNewJobConfigFilePath)
 			// THEN
 			require.NoError(t, err)
-			actualPresubmit := tester.FindPresubmitJobByName(jobConfig.Presubmits["kyma-project/kyma"], tester.GetReleaseJobName("kyma-tests-apiserver-proxy-test", currentRelease), currentRelease)
+			actualPresubmit := tester.FindPresubmitJobByName(jobConfig.Presubmits["kyma-project/kyma"], tester.GetReleaseJobName("kyma-tests-integration-apiserver-proxy", currentRelease), currentRelease)
 			require.NotNil(t, actualPresubmit)
 			assert.False(t, actualPresubmit.SkipReport)
 			assert.True(t, actualPresubmit.Decorate)
@@ -26,18 +26,18 @@ func TestApiserverProxyTestReleases(t *testing.T) {
 			tester.AssertThatHasExtraRefTestInfra(t, actualPresubmit.JobBase.UtilityConfig, currentRelease)
 			tester.AssertThatHasPresets(t, actualPresubmit.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepo, tester.PresetGcrPush, tester.PresetBuildRelease)
 			assert.True(t, actualPresubmit.AlwaysRun)
-			tester.AssertThatExecGolangBuildpack(t, actualPresubmit.JobBase, tester.ImageGolangBuildpackLatest, "/home/prow/go/src/github.com/kyma-project/kyma/tests/apiserver-proxy-tests")
+			tester.AssertThatExecGolangBuildpack(t, actualPresubmit.JobBase, tester.ImageGolangBuildpackLatest, "/home/prow/go/src/github.com/kyma-project/kyma/tests/integration/apiserver-proxy")
 		})
 	}
 }
 
-func TestApiserverProxyTestJobsPresubmit(t *testing.T) {
+func TestApiserverProxyTestJobsPresubmitNew(t *testing.T) {
 	// WHEN
-	jobConfig, err := tester.ReadJobConfig(apiserverProxyTestJobConfigFilePath)
+	jobConfig, err := tester.ReadJobConfig(apiserverProxyTestNewJobConfigFilePath)
 	///Users/i500678/go/src/github.com/kyma-project/test-infra/prow/jobs/kyma/tests/apiserver-proxy-tests/apiserver-proxy-test.yaml
 	// THEN
 	require.NoError(t, err)
-	actualPresubmit := tester.FindPresubmitJobByName(jobConfig.Presubmits["kyma-project/kyma"], "pre-master-kyma-tests-apiserver-proxy-test", "master")
+	actualPresubmit := tester.FindPresubmitJobByName(jobConfig.Presubmits["kyma-project/kyma"], "pre-master-kyma-tests-integration-apiserver-proxy", "master")
 	require.NotNil(t, actualPresubmit)
 
 	assert.Equal(t, 10, actualPresubmit.MaxConcurrency)
@@ -47,15 +47,15 @@ func TestApiserverProxyTestJobsPresubmit(t *testing.T) {
 
 	tester.AssertThatHasExtraRefTestInfra(t, actualPresubmit.JobBase.UtilityConfig, "master")
 	tester.AssertThatHasPresets(t, actualPresubmit.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepo, tester.PresetGcrPush, tester.PresetBuildPr)
-	assert.Equal(t, "^tests/apiserver-proxy-tests/", actualPresubmit.RunIfChanged)
+	assert.Equal(t, "^tests/integration/apiserver-proxy/", actualPresubmit.RunIfChanged)
 	assert.Equal(t, tester.ImageGolangBuildpackLatest, actualPresubmit.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPresubmit.Spec.Containers[0].Command)
-	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/kyma/tests/apiserver-proxy-tests"}, actualPresubmit.Spec.Containers[0].Args)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/kyma/tests/integration/apiserver-proxy"}, actualPresubmit.Spec.Containers[0].Args)
 }
 
-func TestApiserverProxyTestJobPostsubmit(t *testing.T) {
+func TestApiserverProxyTestJobPostsubmitNew(t *testing.T) {
 	// WHEN
-	jobConfig, err := tester.ReadJobConfig(apiserverProxyTestJobConfigFilePath)
+	jobConfig, err := tester.ReadJobConfig(apiserverProxyTestNewJobConfigFilePath)
 	// THEN
 	require.NoError(t, err)
 
@@ -65,7 +65,7 @@ func TestApiserverProxyTestJobPostsubmit(t *testing.T) {
 	assert.Len(t, kymaPost, 1)
 
 	actualPost := kymaPost[0]
-	expName := "post-master-kyma-tests-apiserver-proxy-test"
+	expName := "post-master-kyma-tests-integration-apiserver-proxy"
 	assert.Equal(t, expName, actualPost.Name)
 	assert.Equal(t, []string{"master"}, actualPost.Branches)
 
@@ -74,8 +74,8 @@ func TestApiserverProxyTestJobPostsubmit(t *testing.T) {
 	assert.Equal(t, "github.com/kyma-project/kyma", actualPost.PathAlias)
 	tester.AssertThatHasExtraRefTestInfra(t, actualPost.JobBase.UtilityConfig, "master")
 	tester.AssertThatHasPresets(t, actualPost.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepo, tester.PresetGcrPush, tester.PresetBuildMaster)
-	assert.Equal(t, "^tests/apiserver-proxy-tests/", actualPost.RunIfChanged)
+	assert.Equal(t, "^tests/integration/apiserver-proxy/", actualPost.RunIfChanged)
 	assert.Equal(t, tester.ImageGolangBuildpackLatest, actualPost.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPost.Spec.Containers[0].Command)
-	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/kyma/tests/apiserver-proxy-tests"}, actualPost.Spec.Containers[0].Args)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/kyma/tests/integration/apiserver-proxy"}, actualPost.Spec.Containers[0].Args)
 }

--- a/development/tools/jobs/kyma/apiserver_proxy_new_test_test.go
+++ b/development/tools/jobs/kyma/apiserver_proxy_new_test_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const apiserverProxyTestNewJobConfigFilePath = "./../../../../prow/jobs/kyma/tests/apiserver-proxy-tests/apiserver-proxy-test-new.yaml"
+const apiserverProxyTestNewJobConfigFilePath = "./../../../../prow/jobs/kyma/tests/integration/apiserver-proxy/apiserver-proxy-integration.yaml"
 
 func TestApiserverProxyTestReleasesNew(t *testing.T) {
 	// WHEN

--- a/prow/jobs/kyma/tests/apiserver-proxy-tests/apiserver-proxy-test-new.yaml
+++ b/prow/jobs/kyma/tests/apiserver-proxy-tests/apiserver-proxy-test-new.yaml
@@ -1,0 +1,86 @@
+test_infra_ref: &test_infra_ref
+  org: kyma-project
+  repo: test-infra
+  path_alias: github.com/kyma-project/test-infra
+
+job_template: &job_template
+  optional: true
+  skip_report: false
+  decorate: true
+  path_alias: github.com/kyma-project/kyma
+  max_concurrency: 10
+  spec:
+    containers:
+      - image: eu.gcr.io/kyma-project/prow/test-infra/buildpack-golang:v20181119-afd3fbd
+        securityContext:
+          privileged: true
+        command:
+          - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
+        args:
+          - "/home/prow/go/src/github.com/kyma-project/kyma/tests/integration/apiserver-proxy"
+
+job_labels_template: &job_labels_template
+  preset-dind-enabled: "true"
+  preset-sa-gcr-push: "true"
+  preset-docker-push-repository: "true"
+
+presubmits: # runs on PRs
+  kyma-project/kyma:
+  - name: pre-master-kyma-tests-integration-apiserver-proxy
+    branches:
+    - master
+    <<: *job_template
+    run_if_changed: "^tests/integration/apiserver-proxy/"
+    extra_refs:
+    - <<: *test_infra_ref
+      base_ref: master
+    labels:
+      <<: *job_labels_template
+      preset-build-pr: "true"
+  - name: pre-rel10-kyma-tests-integration-apiserver-proxy
+    branches:
+      - release-1.0
+    <<: *job_template
+    always_run: true
+    extra_refs:
+      - <<: *test_infra_ref
+        base_ref: release-1.0
+    labels:
+      <<: *job_labels_template
+      preset-build-release: "true"
+  - name: pre-rel11-kyma-tests-integration-apiserver-proxy
+    branches:
+      - release-1.1
+    <<: *job_template
+    always_run: true
+    extra_refs:
+      - <<: *test_infra_ref
+        base_ref: release-1.1
+    labels:
+      <<: *job_labels_template
+      preset-build-release: "true"
+  - name: pre-rel12-kyma-tests-integration-apiserver-proxy
+    branches:
+      - release-1.2
+    <<: *job_template
+    always_run: true
+    extra_refs:
+      - <<: *test_infra_ref
+        base_ref: release-1.2
+    labels:
+      <<: *job_labels_template
+      preset-build-release: "true"
+
+postsubmits:
+  kyma-project/kyma:
+  - name: post-master-kyma-tests-integration-apiserver-proxy
+    branches:
+    - master
+    <<: *job_template
+    run_if_changed: "^tests/integration/apiserver-proxy/"
+    extra_refs:
+    - <<: *test_infra_ref
+      base_ref: master
+    labels:
+      <<: *job_labels_template
+      preset-build-master: "true"

--- a/prow/jobs/kyma/tests/integration/apiserver-proxy/apiserver-proxy-integration.yaml
+++ b/prow/jobs/kyma/tests/integration/apiserver-proxy/apiserver-proxy-integration.yaml
@@ -18,6 +18,10 @@ job_template: &job_template
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
           - "/home/prow/go/src/github.com/kyma-project/kyma/tests/integration/apiserver-proxy"
+        resources:
+          requests:
+            memory: 256Mi
+            cpu: 0.2
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"


### PR DESCRIPTION


**Description**
Copy apiserver-proxy integration tests to new destination directory.

Changes proposed in this pull request:
- New job definition for tests in the new location in Kyma sources
- Test for new job definition

**Related issue(s)**
Implements #https://github.com/kyma-project/kyma/issues/4441
See also #https://github.com/kyma-project/kyma/issues/4662
