### PR TITLE
Overwrite kube-dns-autoscaler config map

### DIFF
--- a/prow/set-up-workload-cluster.sh
+++ b/prow/set-up-workload-cluster.sh
@@ -43,6 +43,19 @@ kubectl apply -f "${PROW_WORKLOAD_CLUSTER_DIR}/00-clusterrolebinding.yaml"
 # Install PodDisruptionBudgets
 kubectl apply -f "${PROW_WORKLOAD_CLUSTER_DIR}/02-kube-system_poddisruptionbudgets.yaml"
 
+# Overwrite kube-dns-autoscaler config map
+cat <<EOF | kubectl replace -f -
+apiVersion: v1
+data:
+  linear: '{"coresPerReplica":256,"nodesPerReplica":8,"preventSinglePointFailure":true}'
+kind: ConfigMap
+metadata:
+  name: kube-dns-autoscaler
+  namespace: kube-system
+EOF
+}
+
+
 # Create secrets
 go run "${CURRENT_DIR}/../development/tools/cmd/secretspopulator/main.go" --project="${PROJECT}" --location "${LOCATION}" --bucket "${BUCKET_NAME}" --keyring "${KEYRING_NAME}" --key "${ENCRYPTION_KEY_NAME}" --kubeconfig "${KUBECONFIG}" --secrets-def-file="${PROW_WORKLOAD_CLUSTER_DIR}/required-secrets.yaml"
 

--- a/prow/set-up-workload-cluster.sh
+++ b/prow/set-up-workload-cluster.sh
@@ -53,7 +53,6 @@ metadata:
   name: kube-dns-autoscaler
   namespace: kube-system
 EOF
-}
 
 
 # Create secrets


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Replace default config map with new one 
   was `nodesPerReplica: 16` new settings `nodesPerReplica: 8`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/test-infra/issues/1198
