### PR TITLE
Revert "sa necessary for knative testing"

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -70,18 +70,6 @@ presets:
     - name: sa-kyma-artifacts
       mountPath: /etc/credentials/sa-kyma-artifacts
   - labels:
-      preset-knative-sa: "true" # Created for knative tests
-    env:
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/credentials/knative-sa/service-account.json
-    volumes:
-    - name: knative-sa
-      secret:
-        secretName: knative-sa
-    volumeMounts:
-    - name: knative-sa
-      mountPath: /etc/credentials/knative-sa
-  - labels:
       preset-creds-aks-kyma-integration: "true"
     env:
     - name: AZURE_SUBSCRIPTION_ID


### PR DESCRIPTION
Reverts kyma-project/test-infra#1255
It is no longer necessary.