### PR TITLE
Add the right buildpack-golang-kubebuilder image in the prow job

### DIFF
--- a/development/tools/jobs/kyma/knative_function_controller_test.go
+++ b/development/tools/jobs/kyma/knative_function_controller_test.go
@@ -25,7 +25,7 @@ func TestKnativeFunctionControllerAcceptanceReleases(t *testing.T) {
 			tester.AssertThatHasExtraRefTestInfra(t, actualPresubmit.JobBase.UtilityConfig, currentRelease)
 			tester.AssertThatHasPresets(t, actualPresubmit.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepo, tester.PresetGcrPush, tester.PresetBuildRelease)
 			assert.True(t, actualPresubmit.AlwaysRun)
-			tester.AssertThatExecGolangBuildpack(t, actualPresubmit.JobBase, tester.ImageGolangBuildpack1_11, "/home/prow/go/src/github.com/kyma-project/kyma/components/knative-function-controller")
+			tester.AssertThatExecGolangBuildpack(t, actualPresubmit.JobBase, tester.ImageGolangKubebuilderBuildpackLatest, "/home/prow/go/src/github.com/kyma-project/kyma/components/knative-function-controller")
 			assert.Len(t, actualPresubmit.JobBase.Spec.Containers[0].Command, 1)
 			assert.Equal(t, actualPresubmit.JobBase.Spec.Containers[0].Command[0], "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh")
 		})
@@ -47,7 +47,7 @@ func TestKnativeFunctionControllerAcceptanceJobsPresubmit(t *testing.T) {
 	tester.AssertThatHasExtraRefTestInfra(t, actualPresubmit.JobBase.UtilityConfig, "master")
 	tester.AssertThatHasPresets(t, actualPresubmit.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepo, tester.PresetGcrPush, tester.PresetBuildPr)
 	assert.Equal(t, "^components/knative-function-controller/", actualPresubmit.RunIfChanged)
-	assert.Equal(t, tester.ImageGolangBuildpack1_11, actualPresubmit.Spec.Containers[0].Image)
+	assert.Equal(t, tester.ImageGolangKubebuilderBuildpackLatest, actualPresubmit.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPresubmit.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/kyma/components/knative-function-controller"}, actualPresubmit.Spec.Containers[0].Args)
 }
@@ -74,7 +74,7 @@ func TestKnativeFunctionControllerAcceptanceJobPostsubmit(t *testing.T) {
 	tester.AssertThatHasExtraRefTestInfra(t, actualPost.JobBase.UtilityConfig, "master")
 	tester.AssertThatHasPresets(t, actualPost.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepo, tester.PresetGcrPush, tester.PresetBuildMaster)
 	assert.Equal(t, "^components/knative-function-controller/", actualPost.RunIfChanged)
-	assert.Equal(t, tester.ImageGolangBuildpack1_11, actualPost.Spec.Containers[0].Image)
+	assert.Equal(t, tester.ImageGolangKubebuilderBuildpackLatest, actualPost.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPost.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/kyma/components/knative-function-controller"}, actualPost.Spec.Containers[0].Args)
 }

--- a/prow/jobs/kyma/components/knative-function-controller/knative-function-controller.yaml
+++ b/prow/jobs/kyma/components/knative-function-controller/knative-function-controller.yaml
@@ -12,7 +12,7 @@ job_template: &job_template
   max_concurrency: 10
   spec:
     containers:
-      - image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
+      - image: eu.gcr.io/kyma-project/test-infra/buildpack-golang-kubebuilder:v20190208-813daef
         securityContext:
           privileged: true
         command:


### PR DESCRIPTION
**Description**
Update the prow job with right golang image.
The prow job fails because of the wrong golang image. 

**Related issue(s)**
kyma-project/kyma#4803