### PR TITLE
Adjust kyma-gke-compass-integration jobs after stabilization

### DIFF
--- a/prow/jobs/kyma/kyma-compass-integration.yaml
+++ b/prow/jobs/kyma/kyma-compass-integration.yaml
@@ -49,6 +49,7 @@ presubmits: # runs on PRs
       - ^master$
     run_if_changed: "^(resources/compass|resources/compass-runtime-agent|installation)/"
     labels:
+      prow.kyma-project.io/slack.skipReport: "true" # this job will be ignored by Slack reporter
       preset-build-pr: "true"
       <<: *gke_integration_job_labels_template
     extra_refs:
@@ -82,6 +83,7 @@ postsubmits:
     branches:
       - ^master$
     labels:
+      prow.kyma-project.io/slack.skipReport: "true" # this job will be ignored by Slack reporter
       preset-build-master: "true"
       <<: *gke_integration_job_labels_template
     extra_refs:

--- a/prow/jobs/kyma/kyma-compass-integration.yaml
+++ b/prow/jobs/kyma/kyma-compass-integration.yaml
@@ -9,11 +9,6 @@ kyma_ref: &kyma_ref
   repo: kyma
   path_alias: github.com/kyma-project/kyma
 
-compass_ref: &compass_ref
-  org: kyma-incubator
-  repo: compass
-  path_alias: github.com/kyma-incubator/compass
-
 gke_integration_job_labels_template: &gke_integration_job_labels_template
   preset-kyma-keyring: "true"
   preset-kyma-encryption-key: "true"
@@ -32,7 +27,6 @@ presubmits: # runs on PRs
     decorate: true
     path_alias: github.com/kyma-project/kyma
     skip_report: false
-    optional: true
     max_concurrency: 10
     spec:
       containers:
@@ -55,7 +49,6 @@ presubmits: # runs on PRs
       - ^master$
     run_if_changed: "^(resources/compass|resources/compass-runtime-agent|installation)/"
     labels:
-      prow.kyma-project.io/slack.skipReport: "true" # this job will be ignored by Slack reporter
       preset-build-pr: "true"
       <<: *gke_integration_job_labels_template
     extra_refs:
@@ -89,7 +82,6 @@ postsubmits:
     branches:
       - ^master$
     labels:
-      prow.kyma-project.io/slack.skipReport: "true" # this job will be ignored by Slack reporter
       preset-build-master: "true"
       <<: *gke_integration_job_labels_template
     extra_refs:


### PR DESCRIPTION
**Description**

**Do not merge until `pre-master-kyma-gke-compass-integration` is stable!**

Changes proposed in this pull request:

- Make `pre-master-kyma-gke-compass-integration` job required
- Do not skip Slack reports in `kyma-gke-compass-integration` jobs

**Related issue(s)**

See the issue #1335 
