### PR TITLE
Fix problem with jobs in hack-showcase

### DIFF
--- a/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
+++ b/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
@@ -19,7 +19,6 @@ func TestHackShowcaseJobPresubmit(t *testing.T) {
 	assert.True(t, ex)
 	assert.Len(t, kymaPresubmits, 1)
 
-	
 	actualPresubmit := kymaPresubmits[0]
 	expName := "pre-master-hack-showcase"
 	assert.Equal(t, expName, actualPresubmit.Name)

--- a/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
+++ b/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
@@ -19,7 +19,7 @@ func TestHackShowcaseJobPresubmit(t *testing.T) {
 	assert.True(t, ex)
 	assert.Len(t, kymaPresubmits, 1)
 
-	assert.Equal(t, 1, 1)
+	
 	actualPresubmit := kymaPresubmits[0]
 	expName := "pre-master-hack-showcase"
 	assert.Equal(t, expName, actualPresubmit.Name)
@@ -34,7 +34,7 @@ func TestHackShowcaseJobPresubmit(t *testing.T) {
 	tester.AssertThatHasPresets(t, actualPresubmit.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepoIncubator, tester.PresetGcrPush, tester.PresetBuildPr)
 	assert.Equal(t, tester.ImageGolangBuildpackLatest, actualPresubmit.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPresubmit.Spec.Containers[0].Command)
-	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/hack-showcase"}, actualPresubmit.Spec.Containers[0].Args)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/hack-showcase/github-connector"}, actualPresubmit.Spec.Containers[0].Args)
 
 }
 
@@ -61,6 +61,6 @@ func TestHackShowcaseJobPostsubmit(t *testing.T) {
 	assert.Equal(t, tester.ImageGolangBuildpackLatest, actualPost.Spec.Containers[0].Image)
 
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPost.Spec.Containers[0].Command)
-	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/hack-showcase"}, actualPost.Spec.Containers[0].Args)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/hack-showcase/github-connector"}, actualPost.Spec.Containers[0].Args)
 
 }

--- a/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
+++ b/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
@@ -24,6 +24,7 @@ func TestHackShowcaseJobPresubmit(t *testing.T) {
 	expName := "pre-master-hack-showcase"
 	assert.Equal(t, expName, actualPresubmit.Name)
 	assert.Equal(t, []string{"^master$"}, actualPresubmit.Branches)
+	assert.Equal(t, "true", actualPresubmit.AlwaysRun)
 	assert.Equal(t, 10, actualPresubmit.MaxConcurrency)
 	assert.False(t, actualPresubmit.SkipReport)
 	assert.True(t, actualPresubmit.Decorate)
@@ -52,7 +53,7 @@ func TestHackShowcaseJobPostsubmit(t *testing.T) {
 	expName := "post-master-hack-showcase"
 	assert.Equal(t, expName, actualPost.Name)
 	assert.Equal(t, []string{"^master$"}, actualPost.Branches)
-
+	assert.Equal(t, "true", actualPost.AlwaysRun)
 	assert.Equal(t, 10, actualPost.MaxConcurrency)
 	assert.True(t, actualPost.Decorate)
 	assert.Equal(t, "github.com/kyma-incubator/hack-showcase", actualPost.PathAlias)

--- a/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
+++ b/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
@@ -29,7 +29,6 @@ func TestHackShowcaseJobPresubmit(t *testing.T) {
 	assert.True(t, actualPresubmit.Decorate)
 	assert.Equal(t, "github.com/kyma-incubator/hack-showcase", actualPresubmit.PathAlias)
 
-	assert.True(t, actualPresubmit.AlwaysRun)
 	tester.AssertThatHasExtraRefTestInfra(t, actualPresubmit.JobBase.UtilityConfig, "master")
 	tester.AssertThatHasPresets(t, actualPresubmit.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepoIncubator, tester.PresetGcrPush, tester.PresetBuildPr)
 	assert.Equal(t, tester.ImageGolangBuildpackLatest, actualPresubmit.Spec.Containers[0].Image)
@@ -61,7 +60,6 @@ func TestHackShowcaseJobPostsubmit(t *testing.T) {
 	tester.AssertThatHasPresets(t, actualPost.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepoIncubator, tester.PresetGcrPush, tester.PresetBuildMaster)
 	assert.Equal(t, tester.ImageGolangBuildpackLatest, actualPost.Spec.Containers[0].Image)
 
-	assert.True(t, actualPost.AlwaysRun)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPost.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/hack-showcase"}, actualPost.Spec.Containers[0].Args)
 

--- a/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
+++ b/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
@@ -19,6 +19,7 @@ func TestHackShowcaseJobPresubmit(t *testing.T) {
 	assert.True(t, ex)
 	assert.Len(t, kymaPresubmits, 1)
 
+	assert.Equal(t, 1, 1)
 	actualPresubmit := kymaPresubmits[0]
 	expName := "pre-master-hack-showcase"
 	assert.Equal(t, expName, actualPresubmit.Name)
@@ -62,6 +63,5 @@ func TestHackShowcaseJobPostsubmit(t *testing.T) {
 	assert.Equal(t, "^hack-showcase/", actualPost.RunIfChanged)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPost.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/hack-showcase"}, actualPost.Spec.Containers[0].Args)
-
 
 }

--- a/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
+++ b/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
@@ -27,7 +27,8 @@ func TestHackShowcaseJobPresubmit(t *testing.T) {
 	assert.False(t, actualPresubmit.SkipReport)
 	assert.True(t, actualPresubmit.Decorate)
 	assert.Equal(t, "github.com/kyma-incubator/hack-showcase", actualPresubmit.PathAlias)
-	assert.True(t, actualPresubmit.AlwaysRun)
+	assert.Empty(t, actualPresubmit.AlwaysRun)
+	assert.Equal(t, "^hack-showcase/", actualPresubmit.RunIfChanged)
 	tester.AssertThatHasExtraRefTestInfra(t, actualPresubmit.JobBase.UtilityConfig, "master")
 	tester.AssertThatHasPresets(t, actualPresubmit.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepoIncubator, tester.PresetGcrPush, tester.PresetBuildPr)
 	assert.Equal(t, tester.ImageGolangBuildpackLatest, actualPresubmit.Spec.Containers[0].Image)
@@ -58,7 +59,7 @@ func TestHackShowcaseJobPostsubmit(t *testing.T) {
 	tester.AssertThatHasExtraRefTestInfra(t, actualPost.JobBase.UtilityConfig, "master")
 	tester.AssertThatHasPresets(t, actualPost.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepoIncubator, tester.PresetGcrPush, tester.PresetBuildMaster)
 	assert.Equal(t, tester.ImageGolangBuildpackLatest, actualPost.Spec.Containers[0].Image)
-	assert.True(t, actualPost.AlwaysRun)
+	assert.Equal(t, "^hack-showcase/", actualPost.RunIfChanged)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPost.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/hack-showcase"}, actualPost.Spec.Containers[0].Args)
 

--- a/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
+++ b/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
@@ -63,4 +63,5 @@ func TestHackShowcaseJobPostsubmit(t *testing.T) {
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPost.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/hack-showcase"}, actualPost.Spec.Containers[0].Args)
 
+
 }

--- a/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
+++ b/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
@@ -23,7 +23,7 @@ func TestHackShowcaseJobPresubmit(t *testing.T) {
 	expName := "pre-master-hack-showcase"
 	assert.Equal(t, expName, actualPresubmit.Name)
 	assert.Equal(t, []string{"^master$"}, actualPresubmit.Branches)
-	assert.Equal(t, "^hack-showcase/github-connector", actualPresubmit.RunIfChanged)
+	assert.Equal(t, "^github-connector", actualPresubmit.RunIfChanged)
 	assert.Equal(t, 10, actualPresubmit.MaxConcurrency)
 	assert.False(t, actualPresubmit.SkipReport)
 	assert.True(t, actualPresubmit.Decorate)
@@ -52,7 +52,7 @@ func TestHackShowcaseJobPostsubmit(t *testing.T) {
 	expName := "post-master-hack-showcase"
 	assert.Equal(t, expName, actualPost.Name)
 	assert.Equal(t, []string{"^master$"}, actualPost.Branches)
-	assert.Equal(t, "^hack-showcase/github-connector", actualPost.RunIfChanged)
+	assert.Equal(t, "^github-connector", actualPost.RunIfChanged)
 	assert.Equal(t, 10, actualPost.MaxConcurrency)
 	assert.True(t, actualPost.Decorate)
 	assert.Equal(t, "github.com/kyma-incubator/hack-showcase", actualPost.PathAlias)

--- a/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
+++ b/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
@@ -27,8 +27,7 @@ func TestHackShowcaseJobPresubmit(t *testing.T) {
 	assert.False(t, actualPresubmit.SkipReport)
 	assert.True(t, actualPresubmit.Decorate)
 	assert.Equal(t, "github.com/kyma-incubator/hack-showcase", actualPresubmit.PathAlias)
-	assert.Empty(t, actualPresubmit.AlwaysRun)
-	assert.Equal(t, "^hack-showcase/", actualPresubmit.RunIfChanged)
+	assert.True(t, actualPresubmit.AlwaysRun)
 	tester.AssertThatHasExtraRefTestInfra(t, actualPresubmit.JobBase.UtilityConfig, "master")
 	tester.AssertThatHasPresets(t, actualPresubmit.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepoIncubator, tester.PresetGcrPush, tester.PresetBuildPr)
 	assert.Equal(t, tester.ImageGolangBuildpackLatest, actualPresubmit.Spec.Containers[0].Image)
@@ -59,7 +58,7 @@ func TestHackShowcaseJobPostsubmit(t *testing.T) {
 	tester.AssertThatHasExtraRefTestInfra(t, actualPost.JobBase.UtilityConfig, "master")
 	tester.AssertThatHasPresets(t, actualPost.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepoIncubator, tester.PresetGcrPush, tester.PresetBuildMaster)
 	assert.Equal(t, tester.ImageGolangBuildpackLatest, actualPost.Spec.Containers[0].Image)
-	assert.Equal(t, "^hack-showcase/", actualPost.RunIfChanged)
+	assert.True(t, actualPost.AlwaysRun)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPost.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/hack-showcase"}, actualPost.Spec.Containers[0].Args)
 

--- a/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
+++ b/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
@@ -28,8 +28,8 @@ func TestHackShowcaseJobPresubmit(t *testing.T) {
 	assert.False(t, actualPresubmit.SkipReport)
 	assert.True(t, actualPresubmit.Decorate)
 	assert.Equal(t, "github.com/kyma-incubator/hack-showcase", actualPresubmit.PathAlias)
-	assert.Empty(t, actualPresubmit.AlwaysRun)
-	assert.Equal(t, "^hack-showcase/", actualPresubmit.RunIfChanged)
+
+	assert.True(t, actualPresubmit.AlwaysRun)
 	tester.AssertThatHasExtraRefTestInfra(t, actualPresubmit.JobBase.UtilityConfig, "master")
 	tester.AssertThatHasPresets(t, actualPresubmit.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepoIncubator, tester.PresetGcrPush, tester.PresetBuildPr)
 	assert.Equal(t, tester.ImageGolangBuildpackLatest, actualPresubmit.Spec.Containers[0].Image)
@@ -60,7 +60,8 @@ func TestHackShowcaseJobPostsubmit(t *testing.T) {
 	tester.AssertThatHasExtraRefTestInfra(t, actualPost.JobBase.UtilityConfig, "master")
 	tester.AssertThatHasPresets(t, actualPost.JobBase, tester.PresetDindEnabled, tester.PresetDockerPushRepoIncubator, tester.PresetGcrPush, tester.PresetBuildMaster)
 	assert.Equal(t, tester.ImageGolangBuildpackLatest, actualPost.Spec.Containers[0].Image)
-	assert.Equal(t, "^hack-showcase/", actualPost.RunIfChanged)
+
+	assert.True(t, actualPost.AlwaysRun)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPost.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/hack-showcase"}, actualPost.Spec.Containers[0].Args)
 

--- a/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
+++ b/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
@@ -24,7 +24,7 @@ func TestHackShowcaseJobPresubmit(t *testing.T) {
 	expName := "pre-master-hack-showcase"
 	assert.Equal(t, expName, actualPresubmit.Name)
 	assert.Equal(t, []string{"^master$"}, actualPresubmit.Branches)
-	assert.Equal(t, "true", actualPresubmit.AlwaysRun)
+	assert.True(t, actualPresubmit.AlwaysRun)
 	assert.Equal(t, 10, actualPresubmit.MaxConcurrency)
 	assert.False(t, actualPresubmit.SkipReport)
 	assert.True(t, actualPresubmit.Decorate)
@@ -53,7 +53,6 @@ func TestHackShowcaseJobPostsubmit(t *testing.T) {
 	expName := "post-master-hack-showcase"
 	assert.Equal(t, expName, actualPost.Name)
 	assert.Equal(t, []string{"^master$"}, actualPost.Branches)
-	assert.Equal(t, "true", actualPost.AlwaysRun)
 	assert.Equal(t, 10, actualPost.MaxConcurrency)
 	assert.True(t, actualPost.Decorate)
 	assert.Equal(t, "github.com/kyma-incubator/hack-showcase", actualPost.PathAlias)

--- a/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
+++ b/development/tools/jobs/incubator/hack-showcase/hack_showcase_test.go
@@ -23,7 +23,7 @@ func TestHackShowcaseJobPresubmit(t *testing.T) {
 	expName := "pre-master-hack-showcase"
 	assert.Equal(t, expName, actualPresubmit.Name)
 	assert.Equal(t, []string{"^master$"}, actualPresubmit.Branches)
-	assert.True(t, actualPresubmit.AlwaysRun)
+	assert.Equal(t, "^hack-showcase/github-connector", actualPresubmit.RunIfChanged)
 	assert.Equal(t, 10, actualPresubmit.MaxConcurrency)
 	assert.False(t, actualPresubmit.SkipReport)
 	assert.True(t, actualPresubmit.Decorate)
@@ -52,6 +52,7 @@ func TestHackShowcaseJobPostsubmit(t *testing.T) {
 	expName := "post-master-hack-showcase"
 	assert.Equal(t, expName, actualPost.Name)
 	assert.Equal(t, []string{"^master$"}, actualPost.Branches)
+	assert.Equal(t, "^hack-showcase/github-connector", actualPost.RunIfChanged)
 	assert.Equal(t, 10, actualPost.MaxConcurrency)
 	assert.True(t, actualPost.Decorate)
 	assert.Equal(t, "github.com/kyma-incubator/hack-showcase", actualPost.PathAlias)

--- a/prow/jobs/incubator/hack-showcase/hack-showcase.yaml
+++ b/prow/jobs/incubator/hack-showcase/hack-showcase.yaml
@@ -1,6 +1,6 @@
 job_template: &job_template
   skip_report: false
-  run_if_changed: "^hack-showcase/"
+  always_run: true
   decorate: true
   optional: true
   path_alias: github.com/kyma-incubator/hack-showcase

--- a/prow/jobs/incubator/hack-showcase/hack-showcase.yaml
+++ b/prow/jobs/incubator/hack-showcase/hack-showcase.yaml
@@ -1,4 +1,4 @@
-job_template: &job_template
+base_job_template: &base_job_template
   skip_report: false
   run_if_changed: "^hack-showcase/github-connector"
   decorate: true
@@ -34,7 +34,7 @@ presubmits: # runs on PRs
     - name: pre-master-hack-showcase
       branches:
         - ^master$
-      <<: *job_template
+      <<: *base_job_template
       labels:
         <<: *job_labels_template
         preset-build-pr: "true"
@@ -44,7 +44,7 @@ postsubmits:
     - name: post-master-hack-showcase
       branches:
         - ^master$
-      <<: *job_template
+      <<: *base_job_template
       labels:
         <<: *job_labels_template
         preset-build-master: "true"

--- a/prow/jobs/incubator/hack-showcase/hack-showcase.yaml
+++ b/prow/jobs/incubator/hack-showcase/hack-showcase.yaml
@@ -1,6 +1,6 @@
 job_template: &job_template
   skip_report: false
-  always_run: true
+  run_if_changed: "^hack-showcase/"
   decorate: true
   optional: true
   path_alias: github.com/kyma-incubator/hack-showcase

--- a/prow/jobs/incubator/hack-showcase/hack-showcase.yaml
+++ b/prow/jobs/incubator/hack-showcase/hack-showcase.yaml
@@ -1,6 +1,6 @@
 base_job_template: &base_job_template
   skip_report: false
-  run_if_changed: "^hack-showcase/github-connector"
+  run_if_changed: "^github-connector"
   decorate: true
   path_alias: github.com/kyma-incubator/hack-showcase
   max_concurrency: 10

--- a/prow/jobs/incubator/hack-showcase/hack-showcase.yaml
+++ b/prow/jobs/incubator/hack-showcase/hack-showcase.yaml
@@ -1,6 +1,6 @@
 job_template: &job_template
   skip_report: false
-  always_run: true
+  run_if_changed: "^hack-showcase/github-connector"
   decorate: true
   path_alias: github.com/kyma-incubator/hack-showcase
   max_concurrency: 10

--- a/prow/jobs/incubator/hack-showcase/hack-showcase.yaml
+++ b/prow/jobs/incubator/hack-showcase/hack-showcase.yaml
@@ -1,8 +1,7 @@
 job_template: &job_template
   skip_report: false
-  run_if_changed: "^hack-showcase/"
+  always_run: true
   decorate: true
-  optional: true
   path_alias: github.com/kyma-incubator/hack-showcase
   max_concurrency: 10
   extra_refs:

--- a/prow/jobs/incubator/hack-showcase/hack-showcase.yaml
+++ b/prow/jobs/incubator/hack-showcase/hack-showcase.yaml
@@ -17,7 +17,7 @@ job_template: &job_template
         command:
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
-          - "/home/prow/go/src/github.com/kyma-incubator/hack-showcase"
+          - "/home/prow/go/src/github.com/kyma-incubator/hack-showcase/github-connector"
         resources:
 
           requests:


### PR DESCRIPTION
**Description**
During the process of connecting our repository to Prow, we found a problem with jobs triggering caused by a wrong path in field "run_if_changed". To fix this problem and allow Prow to react on every change in our repository (triggering on every PR) we were advised to change this field to "always_run". 

Changes proposed in this pull request:

- Change the way of triggering jobs for [hack-showcase](https://github.com/kyma-incubator/hack-showcase)
- Add appropriate tests for this change


**Related issue**
https://github.com/kyma-incubator/hack-showcase/issues/39