### PR TITLE
Whitesource job is missing the workspace mapping

### DIFF
--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -1048,6 +1048,11 @@ periodics:
     preset-kyma-wssagent-config: "true"
     preset-kyma-keyring: "true"
     preset-kyma-encryption-key: "true"
+  extra_refs:
+    - <<: *test_infra_ref
+      base_ref: master
+    - <<: *kyma_ref
+      base_ref: master
   spec:
     containers:
       - image: eu.gcr.io/kyma-project/test-infra/wssagent:v20190729-00275a3


### PR DESCRIPTION
**Description**
Job failed due to workspace not being properly mapped.

Changes proposed in this pull request:
- map workspace ref
