### PR TITLE
Disable the tests manipulating the Application resource in kyma-gke-compass-integration

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
@@ -213,9 +213,26 @@ function installKyma() {
     --data "tests.enabled=false" \
     --label "component=application-operator"
 
+  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "application-connector-overrides" \
+    --data "tests.application_connector_tests.enabled=false" \
+    --label "component=application-connector"
+
   "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "application-registry-overrides" \
     --data "tests.enabled=false" \
     --label "component=application-registry"
+
+  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "apiserver-proxy-overrides" \
+    --data "tests.enabled=false" \
+    --label "component=apiserver-proxy"
+
+  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "console-backend-service-overrides" \
+    --data "tests.enabled=false" \
+    --label "component=console-backend-service"
+
+  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "core-test-acceptance-overrides" \
+    --data "test.acceptance.core.enabled=false" \
+    --data "test.acceptance.external_solution.enabled=false" \
+    --label "component=core"
 
   "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "core-test-ui-acceptance-overrides" \
     --data "test.acceptance.ui.logging.enabled=true" \

--- a/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
@@ -221,10 +221,6 @@ function installKyma() {
     --data "tests.enabled=false" \
     --label "component=application-registry"
 
-  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "apiserver-proxy-overrides" \
-    --data "tests.enabled=false" \
-    --label "component=apiserver-proxy"
-
   "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "console-backend-service-overrides" \
     --data "tests.enabled=false" \
     --label "component=console-backend-service"
@@ -233,6 +229,10 @@ function installKyma() {
     --data "test.acceptance.core.enabled=false" \
     --data "test.acceptance.external_solution.enabled=false" \
     --label "component=core"
+
+  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "core-console-overrides" \
+    --data "test.acceptance.enabled=false" \
+    --label "component=console"
 
   "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "core-test-ui-acceptance-overrides" \
     --data "test.acceptance.ui.logging.enabled=true" \

--- a/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
@@ -209,6 +209,14 @@ function installKyma() {
     --data "global.domainName=${DOMAIN}" \
     --data "global.loadBalancerIP=${GATEWAY_IP_ADDRESS}"
 
+  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "application-operator-overrides" \
+    --data "tests.enabled=false" \
+    --label "component=application-operator"
+
+  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "application-registry-overrides" \
+    --data "tests.enabled=false" \
+    --label "component=application-registry"
+
   "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "core-test-ui-acceptance-overrides" \
     --data "test.acceptance.ui.logging.enabled=true" \
     --label "component=core"

--- a/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
@@ -209,30 +209,14 @@ function installKyma() {
     --data "global.domainName=${DOMAIN}" \
     --data "global.loadBalancerIP=${GATEWAY_IP_ADDRESS}"
 
-  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "application-operator-overrides" \
-    --data "tests.enabled=false" \
-    --label "component=application-operator"
-
-  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "application-connector-overrides" \
-    --data "tests.application_connector_tests.enabled=false" \
-    --label "component=application-connector"
-
-  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "application-registry-overrides" \
-    --data "tests.enabled=false" \
-    --label "component=application-registry"
-
-  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "console-backend-service-overrides" \
-    --data "tests.enabled=false" \
-    --label "component=console-backend-service"
-
-  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "core-test-acceptance-overrides" \
-    --data "test.acceptance.core.enabled=false" \
-    --data "test.acceptance.external_solution.enabled=false" \
-    --label "component=core"
-
-  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "core-console-overrides" \
-    --data "test.acceptance.enabled=false" \
-    --label "component=console"
+  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "application-resource-tests-overrides" \
+    --data "application-operator.tests.enabled=false" \
+    --data "application-connector.tests.application_connector_tests.enabled=false" \
+    --data "application-registry.tests.enabled=false" \
+    --data "console-backend-service.tests.enabled=false" \
+    --data "core.test.acceptance.core.enabled=false" \
+    --data "core.test.acceptance.external_solution.enabled=false" \
+    --data "console.test.acceptance.enabled=false"
 
   "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "core-test-ui-acceptance-overrides" \
     --data "test.acceptance.ui.logging.enabled=true" \


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Disable the tests manipulating the Application resource in `kyma-gke-compass-integration` pipeline. These tests will fail due to the fact that Runtime Agent deletes the Applications if they don't exist in the Director Component.

**Related issue(s)**

See the issue [#1335 ](https://github.com/kyma-project/test-infra/issues/1335)
