### PR TITLE
plain text and cyphertext variables were switched

### DIFF
--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -29,10 +29,10 @@ export TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS="${TEST_INFRA_SOURCES_DIR}/prow/sc
 gsutil cp "gs://kyma-prow-secrets/whitesource-userkey.encrypted" "." 
 gsutil cp "gs://kyma-prow-secrets/whitesource-apikey.encrypted" "." 
 
-"${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/decrypt.sh" "whitesource-userkey.encrypted" "whitesource-userkey" 
+"${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/decrypt.sh" "whitesource-userkey" "whitesource-userkey.encrypted"
 USERKEY=$(cat "whitesource-userkey")
 
-"${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/decrypt.sh" "whitesource-apikey.encrypted" "whitesource-apikey"
+"${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/decrypt.sh" "whitesource-apikey" "whitesource-apikey.encrypted"
 APIKEY=$(cat "whitesource-apikey")
 
 echo "***********************************"


### PR DESCRIPTION
**Description**
parameters passed to the script were in the wrong order causing the script to fail to open a file that it should have created instead.

Changes proposed in this pull request:
- change parameter order