### PR TITLE
init sa account

### DIFF
--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -24,6 +24,9 @@ else
     exit 1;
 fi
 
+# authenticate gcloud client
+init
+
 export TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS="${TEST_INFRA_SOURCES_DIR}/prow/scripts/cluster-integration/helpers"
 
 gsutil cp "gs://kyma-prow-secrets/whitesource-userkey.encrypted" "." 


### PR DESCRIPTION
**Description**
Service account not logged in in gcloud

Changes proposed in this pull request:
- unauthenticated gcloud not allowed, so we authenticate now
