### PR TITLE
Fix compass and watch-pods templates configuration

### DIFF
--- a/prow/jobs/incubator/compass/components/connector/connector-old-releases.yaml
+++ b/prow/jobs/incubator/compass/components/connector/connector-old-releases.yaml
@@ -27,43 +27,40 @@ container_template: &container_template
 
 presubmits: # runs on PRs
   kyma-incubator/compass:
-    - name: pre-master-compass-components-healthchecker
+    - name: pre-rel14-compass-components-connector
       branches:
-        - ^master$
+        - release-1.4
       <<: *job_template
       path_alias: github.com/kyma-incubator/compass
+      always_run: true
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: release-1.4
       spec:
         containers:
           - <<: *container_template
             image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
             args:
-              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/healthchecker"
-      run_if_changed: "^components/healthchecker/"
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
+              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/connector"
       labels:
         <<: *job_labels_template
-        preset-build-pr: "true"
+        preset-build-release: "true"
+    - name: pre-rel13-compass-components-connector
+      branches:
+        - release-1.3
+      <<: *job_template
+      path_alias: github.com/kyma-incubator/compass
+      always_run: true
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: release-1.3
+      spec:
+        containers:
+          - <<: *container_template
+            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
+            args:
+              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/connector"
+      labels:
+        <<: *job_labels_template
+        preset-build-release: "true"
 
-postsubmits:
-  kyma-incubator/compass:
-    - name: post-master-compass-components-healthchecker
-      branches:
-        - ^master$
-      <<: *job_template
-      path_alias: github.com/kyma-incubator/compass
-      spec:
-        containers:
-          - <<: *container_template
-            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
-            args:
-              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/healthchecker"
-      run_if_changed: "^components/healthchecker/"
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
-      labels:
-        <<: *job_labels_template
-        preset-build-master: "true"
-        prow.kyma-project.io/slack.skipReport: "true"

--- a/prow/jobs/incubator/compass/components/connector/connector.yaml
+++ b/prow/jobs/incubator/compass/components/connector/connector.yaml
@@ -45,42 +45,6 @@ presubmits: # runs on PRs
       labels:
         <<: *job_labels_template
         preset-build-pr: "true"
-    - name: pre-rel14-compass-components-connector
-      branches:
-        - release-1.4
-      <<: *job_template
-      path_alias: github.com/kyma-incubator/compass
-      always_run: true
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: release-1.4
-      spec:
-        containers:
-          - <<: *container_template
-            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
-            args:
-              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/connector"
-      labels:
-        <<: *job_labels_template
-        preset-build-release: "true"
-    - name: pre-rel13-compass-components-connector
-      branches:
-        - release-1.3
-      <<: *job_template
-      path_alias: github.com/kyma-incubator/compass
-      always_run: true
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: release-1.3
-      spec:
-        containers:
-          - <<: *container_template
-            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
-            args:
-              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/connector"
-      labels:
-        <<: *job_labels_template
-        preset-build-release: "true"
 
 postsubmits:
   kyma-incubator/compass:

--- a/prow/jobs/incubator/compass/components/director/director-old-releases.yaml
+++ b/prow/jobs/incubator/compass/components/director/director-old-releases.yaml
@@ -27,43 +27,40 @@ container_template: &container_template
 
 presubmits: # runs on PRs
   kyma-incubator/compass:
-    - name: pre-master-compass-components-healthchecker
+    - name: pre-rel14-compass-components-director
       branches:
-        - ^master$
+        - release-1.4
       <<: *job_template
       path_alias: github.com/kyma-incubator/compass
+      always_run: true
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: release-1.4
       spec:
         containers:
           - <<: *container_template
             image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
             args:
-              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/healthchecker"
-      run_if_changed: "^components/healthchecker/"
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
+              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/director"
       labels:
         <<: *job_labels_template
-        preset-build-pr: "true"
+        preset-build-release: "true"
+    - name: pre-rel13-compass-components-director
+      branches:
+        - release-1.3
+      <<: *job_template
+      path_alias: github.com/kyma-incubator/compass
+      always_run: true
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: release-1.3
+      spec:
+        containers:
+          - <<: *container_template
+            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
+            args:
+              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/director"
+      labels:
+        <<: *job_labels_template
+        preset-build-release: "true"
 
-postsubmits:
-  kyma-incubator/compass:
-    - name: post-master-compass-components-healthchecker
-      branches:
-        - ^master$
-      <<: *job_template
-      path_alias: github.com/kyma-incubator/compass
-      spec:
-        containers:
-          - <<: *container_template
-            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
-            args:
-              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/healthchecker"
-      run_if_changed: "^components/healthchecker/"
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
-      labels:
-        <<: *job_labels_template
-        preset-build-master: "true"
-        prow.kyma-project.io/slack.skipReport: "true"

--- a/prow/jobs/incubator/compass/components/director/director.yaml
+++ b/prow/jobs/incubator/compass/components/director/director.yaml
@@ -45,42 +45,6 @@ presubmits: # runs on PRs
       labels:
         <<: *job_labels_template
         preset-build-pr: "true"
-    - name: pre-rel14-compass-components-director
-      branches:
-        - release-1.4
-      <<: *job_template
-      path_alias: github.com/kyma-incubator/compass
-      always_run: true
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: release-1.4
-      spec:
-        containers:
-          - <<: *container_template
-            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
-            args:
-              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/director"
-      labels:
-        <<: *job_labels_template
-        preset-build-release: "true"
-    - name: pre-rel13-compass-components-director
-      branches:
-        - release-1.3
-      <<: *job_template
-      path_alias: github.com/kyma-incubator/compass
-      always_run: true
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: release-1.3
-      spec:
-        containers:
-          - <<: *container_template
-            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
-            args:
-              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/director"
-      labels:
-        <<: *job_labels_template
-        preset-build-release: "true"
 
 postsubmits:
   kyma-incubator/compass:

--- a/prow/jobs/incubator/compass/components/gateway/gateway-old-releases.yaml
+++ b/prow/jobs/incubator/compass/components/gateway/gateway-old-releases.yaml
@@ -27,43 +27,40 @@ container_template: &container_template
 
 presubmits: # runs on PRs
   kyma-incubator/compass:
-    - name: pre-master-compass-components-healthchecker
+    - name: pre-rel14-compass-components-gateway
       branches:
-        - ^master$
+        - release-1.4
       <<: *job_template
       path_alias: github.com/kyma-incubator/compass
+      always_run: true
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: release-1.4
       spec:
         containers:
           - <<: *container_template
             image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
             args:
-              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/healthchecker"
-      run_if_changed: "^components/healthchecker/"
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
+              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/gateway"
       labels:
         <<: *job_labels_template
-        preset-build-pr: "true"
+        preset-build-release: "true"
+    - name: pre-rel13-compass-components-gateway
+      branches:
+        - release-1.3
+      <<: *job_template
+      path_alias: github.com/kyma-incubator/compass
+      always_run: true
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: release-1.3
+      spec:
+        containers:
+          - <<: *container_template
+            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
+            args:
+              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/gateway"
+      labels:
+        <<: *job_labels_template
+        preset-build-release: "true"
 
-postsubmits:
-  kyma-incubator/compass:
-    - name: post-master-compass-components-healthchecker
-      branches:
-        - ^master$
-      <<: *job_template
-      path_alias: github.com/kyma-incubator/compass
-      spec:
-        containers:
-          - <<: *container_template
-            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
-            args:
-              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/healthchecker"
-      run_if_changed: "^components/healthchecker/"
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
-      labels:
-        <<: *job_labels_template
-        preset-build-master: "true"
-        prow.kyma-project.io/slack.skipReport: "true"

--- a/prow/jobs/incubator/compass/components/gateway/gateway.yaml
+++ b/prow/jobs/incubator/compass/components/gateway/gateway.yaml
@@ -45,42 +45,6 @@ presubmits: # runs on PRs
       labels:
         <<: *job_labels_template
         preset-build-pr: "true"
-    - name: pre-rel14-compass-components-gateway
-      branches:
-        - release-1.4
-      <<: *job_template
-      path_alias: github.com/kyma-incubator/compass
-      always_run: true
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: release-1.4
-      spec:
-        containers:
-          - <<: *container_template
-            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
-            args:
-              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/gateway"
-      labels:
-        <<: *job_labels_template
-        preset-build-release: "true"
-    - name: pre-rel13-compass-components-gateway
-      branches:
-        - release-1.3
-      <<: *job_template
-      path_alias: github.com/kyma-incubator/compass
-      always_run: true
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: release-1.3
-      spec:
-        containers:
-          - <<: *container_template
-            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
-            args:
-              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/gateway"
-      labels:
-        <<: *job_labels_template
-        preset-build-release: "true"
 
 postsubmits:
   kyma-incubator/compass:

--- a/prow/jobs/incubator/compass/components/healthchecker/healthchecker-old-releases.yaml
+++ b/prow/jobs/incubator/compass/components/healthchecker/healthchecker-old-releases.yaml
@@ -27,43 +27,40 @@ container_template: &container_template
 
 presubmits: # runs on PRs
   kyma-incubator/compass:
-    - name: pre-master-compass-components-healthchecker
+    - name: pre-rel14-compass-components-healthchecker
       branches:
-        - ^master$
+        - release-1.4
       <<: *job_template
       path_alias: github.com/kyma-incubator/compass
+      always_run: true
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: release-1.4
       spec:
         containers:
           - <<: *container_template
             image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
             args:
               - "/home/prow/go/src/github.com/kyma-incubator/compass/components/healthchecker"
-      run_if_changed: "^components/healthchecker/"
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
       labels:
         <<: *job_labels_template
-        preset-build-pr: "true"
+        preset-build-release: "true"
+    - name: pre-rel13-compass-components-healthchecker
+      branches:
+        - release-1.3
+      <<: *job_template
+      path_alias: github.com/kyma-incubator/compass
+      always_run: true
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: release-1.3
+      spec:
+        containers:
+          - <<: *container_template
+            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
+            args:
+              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/healthchecker"
+      labels:
+        <<: *job_labels_template
+        preset-build-release: "true"
 
-postsubmits:
-  kyma-incubator/compass:
-    - name: post-master-compass-components-healthchecker
-      branches:
-        - ^master$
-      <<: *job_template
-      path_alias: github.com/kyma-incubator/compass
-      spec:
-        containers:
-          - <<: *container_template
-            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
-            args:
-              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/healthchecker"
-      run_if_changed: "^components/healthchecker/"
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
-      labels:
-        <<: *job_labels_template
-        preset-build-master: "true"
-        prow.kyma-project.io/slack.skipReport: "true"

--- a/prow/jobs/incubator/compass/components/schema-migrator/schema-migrator-old-releases.yaml
+++ b/prow/jobs/incubator/compass/components/schema-migrator/schema-migrator-old-releases.yaml
@@ -27,43 +27,40 @@ container_template: &container_template
 
 presubmits: # runs on PRs
   kyma-incubator/compass:
-    - name: pre-master-compass-components-healthchecker
+    - name: pre-rel14-compass-components-schema-migrator
       branches:
-        - ^master$
+        - release-1.4
       <<: *job_template
       path_alias: github.com/kyma-incubator/compass
+      always_run: true
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: release-1.4
       spec:
         containers:
           - <<: *container_template
-            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
+            image: eu.gcr.io/kyma-project/prow/test-infra/bootstrap:v20181204-a6e79be
             args:
-              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/healthchecker"
-      run_if_changed: "^components/healthchecker/"
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
+              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/schema-migrator"
       labels:
         <<: *job_labels_template
-        preset-build-pr: "true"
+        preset-build-release: "true"
+    - name: pre-rel13-compass-components-schema-migrator
+      branches:
+        - release-1.3
+      <<: *job_template
+      path_alias: github.com/kyma-incubator/compass
+      always_run: true
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: release-1.3
+      spec:
+        containers:
+          - <<: *container_template
+            image: eu.gcr.io/kyma-project/prow/test-infra/bootstrap:v20181204-a6e79be
+            args:
+              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/schema-migrator"
+      labels:
+        <<: *job_labels_template
+        preset-build-release: "true"
 
-postsubmits:
-  kyma-incubator/compass:
-    - name: post-master-compass-components-healthchecker
-      branches:
-        - ^master$
-      <<: *job_template
-      path_alias: github.com/kyma-incubator/compass
-      spec:
-        containers:
-          - <<: *container_template
-            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
-            args:
-              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/healthchecker"
-      run_if_changed: "^components/healthchecker/"
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
-      labels:
-        <<: *job_labels_template
-        preset-build-master: "true"
-        prow.kyma-project.io/slack.skipReport: "true"

--- a/prow/jobs/incubator/compass/components/schema-migrator/schema-migrator.yaml
+++ b/prow/jobs/incubator/compass/components/schema-migrator/schema-migrator.yaml
@@ -45,42 +45,6 @@ presubmits: # runs on PRs
       labels:
         <<: *job_labels_template
         preset-build-pr: "true"
-    - name: pre-rel14-compass-components-schema-migrator
-      branches:
-        - release-1.4
-      <<: *job_template
-      path_alias: github.com/kyma-incubator/compass
-      always_run: true
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: release-1.4
-      spec:
-        containers:
-          - <<: *container_template
-            image: eu.gcr.io/kyma-project/prow/test-infra/bootstrap:v20181204-a6e79be
-            args:
-              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/schema-migrator"
-      labels:
-        <<: *job_labels_template
-        preset-build-release: "true"
-    - name: pre-rel13-compass-components-schema-migrator
-      branches:
-        - release-1.3
-      <<: *job_template
-      path_alias: github.com/kyma-incubator/compass
-      always_run: true
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: release-1.3
-      spec:
-        containers:
-          - <<: *container_template
-            image: eu.gcr.io/kyma-project/prow/test-infra/bootstrap:v20181204-a6e79be
-            args:
-              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/schema-migrator"
-      labels:
-        <<: *job_labels_template
-        preset-build-release: "true"
 
 postsubmits:
   kyma-incubator/compass:

--- a/prow/jobs/incubator/compass/tests/end-to-end/end-to-end-old-releases.yaml
+++ b/prow/jobs/incubator/compass/tests/end-to-end/end-to-end-old-releases.yaml
@@ -27,43 +27,40 @@ container_template: &container_template
 
 presubmits: # runs on PRs
   kyma-incubator/compass:
-    - name: pre-master-compass-components-healthchecker
+    - name: pre-rel14-compass-tests-end-to-end
       branches:
-        - ^master$
+        - release-1.4
       <<: *job_template
       path_alias: github.com/kyma-incubator/compass
+      always_run: true
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: release-1.4
       spec:
         containers:
           - <<: *container_template
             image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
             args:
-              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/healthchecker"
-      run_if_changed: "^components/healthchecker/"
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
+              - "/home/prow/go/src/github.com/kyma-incubator/compass/tests/end-to-end"
       labels:
         <<: *job_labels_template
-        preset-build-pr: "true"
+        preset-build-release: "true"
+    - name: pre-rel13-compass-tests-end-to-end
+      branches:
+        - release-1.3
+      <<: *job_template
+      path_alias: github.com/kyma-incubator/compass
+      always_run: true
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: release-1.3
+      spec:
+        containers:
+          - <<: *container_template
+            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
+            args:
+              - "/home/prow/go/src/github.com/kyma-incubator/compass/tests/end-to-end"
+      labels:
+        <<: *job_labels_template
+        preset-build-release: "true"
 
-postsubmits:
-  kyma-incubator/compass:
-    - name: post-master-compass-components-healthchecker
-      branches:
-        - ^master$
-      <<: *job_template
-      path_alias: github.com/kyma-incubator/compass
-      spec:
-        containers:
-          - <<: *container_template
-            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
-            args:
-              - "/home/prow/go/src/github.com/kyma-incubator/compass/components/healthchecker"
-      run_if_changed: "^components/healthchecker/"
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
-      labels:
-        <<: *job_labels_template
-        preset-build-master: "true"
-        prow.kyma-project.io/slack.skipReport: "true"

--- a/prow/jobs/incubator/compass/tests/end-to-end/end-to-end.yaml
+++ b/prow/jobs/incubator/compass/tests/end-to-end/end-to-end.yaml
@@ -45,42 +45,6 @@ presubmits: # runs on PRs
       labels:
         <<: *job_labels_template
         preset-build-pr: "true"
-    - name: pre-rel14-compass-tests-end-to-end
-      branches:
-        - release-1.4
-      <<: *job_template
-      path_alias: github.com/kyma-incubator/compass
-      always_run: true
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: release-1.4
-      spec:
-        containers:
-          - <<: *container_template
-            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
-            args:
-              - "/home/prow/go/src/github.com/kyma-incubator/compass/tests/end-to-end"
-      labels:
-        <<: *job_labels_template
-        preset-build-release: "true"
-    - name: pre-rel13-compass-tests-end-to-end
-      branches:
-        - release-1.3
-      <<: *job_template
-      path_alias: github.com/kyma-incubator/compass
-      always_run: true
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: release-1.3
-      spec:
-        containers:
-          - <<: *container_template
-            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.11
-            args:
-              - "/home/prow/go/src/github.com/kyma-incubator/compass/tests/end-to-end"
-      labels:
-        <<: *job_labels_template
-        preset-build-release: "true"
 
 postsubmits:
   kyma-incubator/compass:

--- a/prow/jobs/test-infra/watch-pods.yaml
+++ b/prow/jobs/test-infra/watch-pods.yaml
@@ -1,5 +1,7 @@
 # DO NOT EDIT. THIS FILE IS GENERATED
 
+
+
 job_template: &job_template
   skip_report: false
   decorate: true

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -380,27 +380,45 @@ templates:
         values:
           <<: *bootstrap_kyma_component
           path: components/xip-patch
+      - to: ../prow/jobs/incubator/compass/components/connector/connector-old-releases.yaml
+        values:
+          <<: *go_compass_component_1_11
+          path: components/connector
+          skipSlackReport: true
+          since: '1.3'
+          until: '1.4'
       - to: ../prow/jobs/incubator/compass/components/connector/connector.yaml
         values:
           <<: *go_compass_component_1_11
           path: components/connector
           noRelease: yes
           skipSlackReport: true
-          since: '1.3'
       - to: ../prow/jobs/incubator/compass/tests/connector/connector-tests.yaml
         values:
           <<: *go_compass_component_1_11
           path: tests/connector-tests
           noRelease: yes
           skipSlackReport: true
-          since: '1.5'
+      - to: ../prow/jobs/incubator/compass/components/director/director-old-releases.yaml
+        values:
+          <<: *go_compass_component_1_11
+          path: components/director
+          skipSlackReport: true
+          since: '1.3'
+          until: '1.4'
       - to: ../prow/jobs/incubator/compass/components/director/director.yaml
         values:
           <<: *go_compass_component_1_11
           path: components/director
           noRelease: yes
           skipSlackReport: true
+      - to: ../prow/jobs/incubator/compass/components/gateway/gateway-old-releases.yaml
+        values:
+          <<: *go_compass_component_1_11
+          path: components/gateway
+          skipSlackReport: true
           since: '1.3'
+          until: '1.4'
       - to: ../prow/jobs/incubator/compass/components/gateway/gateway.yaml
         values:
           <<: *go_compass_component_1_11
@@ -408,27 +426,45 @@ templates:
           noRelease: yes
           skipSlackReport: true
           since: '1.3'
+      - to: ../prow/jobs/incubator/compass/components/healthchecker/healthchecker-old-releases.yaml
+        values:
+          <<: *go_compass_component_1_11
+          path: components/healthchecker
+          skipSlackReport: true
+          since: '1.3'
+          until: '1.4'
       - to: ../prow/jobs/incubator/compass/components/healthchecker/healthchecker.yaml
         values:
           <<: *go_compass_component_1_11
           path: components/healthchecker
           noRelease: yes
           skipSlackReport: true
+      - to: ../prow/jobs/incubator/compass/components/schema-migrator/schema-migrator-old-releases.yaml
+        values:
+          <<: *bootstrap_compass_component
+          path: components/schema-migrator
+          skipSlackReport: true
           since: '1.3'
+          until: '1.4'
       - to: ../prow/jobs/incubator/compass/components/schema-migrator/schema-migrator.yaml
         values:
           <<: *bootstrap_compass_component
           path: components/schema-migrator
           noRelease: yes
           skipSlackReport: true
+      - to: ../prow/jobs/incubator/compass/tests/end-to-end/end-to-end-old-releases.yaml
+        values:
+          <<: *go_compass_component_1_11
+          path: tests/end-to-end
+          skipSlackReport: true
           since: '1.3'
+          until: '1.4'
       - to: ../prow/jobs/incubator/compass/tests/end-to-end/end-to-end.yaml
         values:
           <<: *go_compass_component_1_11
           path: tests/end-to-end
           noRelease: yes
           skipSlackReport: true
-          since: '1.3'
       - to: ../prow/jobs/console/core/core.yaml
         values:
           repository: github.com/kyma-project/console

--- a/templates/templates/compass-integration.yaml
+++ b/templates/templates/compass-integration.yaml
@@ -47,7 +47,7 @@ presubmits: # runs on PRs
       base_ref: master
     - <<: *cli_ref
 
-{{- range (matchingReleases .Global.releases "1.3" nil) }}
+{{- range (matchingReleases .Global.releases "1.3" "1.4") }}
   - name: pre-rel{{ . | replace "." "" }}-compass-integration
     branches:
     - release-{{ . }}

--- a/templates/templates/component.yaml
+++ b/templates/templates/component.yaml
@@ -5,7 +5,7 @@
 {{- $releasable := and (not .Values.noRelease) (not (empty $releases)) -}}
 {{- $watch := .Values.watch | default (print "^" .Values.path "/") }}
 {{- define "repoNoHost" -}}{{ replace "github.com/" "" . }}{{- end -}}
-  {{- $isNotTestInfra := ne .Values.repository "github.com/kyma-project/test-infra"}}
+{{- $isNotTestInfra := ne .Values.repository "github.com/kyma-project/test-infra"}}
 
 {{- if or $releasable (not .Values.until) -}}
 {{- if $isNotTestInfra -}}

--- a/templates/templates/component.yaml
+++ b/templates/templates/component.yaml
@@ -5,12 +5,15 @@
 {{- $releasable := and (not .Values.noRelease) (not (empty $releases)) -}}
 {{- $watch := .Values.watch | default (print "^" .Values.path "/") }}
 {{- define "repoNoHost" -}}{{ replace "github.com/" "" . }}{{- end -}}
+  {{- $isNotTestInfra := ne .Values.repository "github.com/kyma-project/test-infra"}}
 
 {{- if or $releasable (not .Values.until) -}}
+{{- if $isNotTestInfra -}}
 test_infra_ref: &test_infra_ref
   org: kyma-project
   repo: test-infra
   path_alias: github.com/kyma-project/test-infra
+{{- end }}
 
 job_template: &job_template
   skip_report: false
@@ -54,9 +57,11 @@ presubmits: # runs on PRs
             args:
               - "/home/prow/go/src/{{ .Values.repository }}/{{ .Values.path }}"
       run_if_changed: "{{ $watch }}"
+{{- if $isNotTestInfra }}
       extra_refs:
         - <<: *test_infra_ref
           base_ref: master
+{{- end }}
       labels:
         <<: *job_labels_template
         preset-build-pr: "true"
@@ -69,9 +74,11 @@ presubmits: # runs on PRs
       <<: *job_template
       path_alias: {{ $.Values.repository }}
       always_run: true
+{{- if $isNotTestInfra }}
       extra_refs:
         - <<: *test_infra_ref
           base_ref: release-{{ . }}
+{{- end }}
       spec:
         containers:
           - <<: *container_template
@@ -99,9 +106,11 @@ postsubmits:
             args:
               - "/home/prow/go/src/{{ .Values.repository }}/{{ .Values.path }}"
       run_if_changed: "{{ $watch }}"
+{{- if $isNotTestInfra }}
       extra_refs:
         - <<: *test_infra_ref
           base_ref: master
+{{- end }}
       labels:
         <<: *job_labels_template
         preset-{{ $.Values.presets.build }}-master: "true"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Every compass component is split into two files with jobs: one for releases 1.3 (suffix `old-releases`) and one for master pre and post submits  
- Components from test infra no longer have extra-ref for test infra. That includes watch-pods for now. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#1416 