### PR TITLE
reserve-ip-address.sh returns the reserved IP on stdout

### DIFF
--- a/prow/scripts/cluster-integration/helpers/create-dns-record.sh
+++ b/prow/scripts/cluster-integration/helpers/create-dns-record.sh
@@ -39,7 +39,7 @@ function createDNSWithRetries() {
             break
         fi
 
-        gcloud dns record-sets transaction abort --zone="${CLOUDSDK_DNS_ZONE_NAME}" --verbosity none
+        gcloud dns --project="${CLOUDSDK_CORE_PROJECT}" record-sets transaction abort --zone="${CLOUDSDK_DNS_ZONE_NAME}" --verbosity none
 
         if [[ "${i}" -lt "${attempts}" ]]; then
             echo "Unable to create DNS record, let's wait ${retryTimeInSec} seconds and retry. Attempts ${i} of ${attempts}."

--- a/prow/scripts/cluster-integration/helpers/reserve-ip-address.sh
+++ b/prow/scripts/cluster-integration/helpers/reserve-ip-address.sh
@@ -24,6 +24,12 @@ if [ "${discoverUnsetVar}" = true ] ; then
     exit 1
 fi
 
-gcloud beta compute --project="${CLOUDSDK_CORE_PROJECT}" addresses create "${IP_ADDRESS_NAME}" --region="${CLOUDSDK_COMPUTE_REGION}" --network-tier=PREMIUM
+attempts=3
+for ((i=1; i<=attempts; i++)); do
+    gcloud beta compute --project="${CLOUDSDK_CORE_PROJECT}" addresses create "${IP_ADDRESS_NAME}" --region="${CLOUDSDK_COMPUTE_REGION}" --network-tier=PREMIUM
+    if [[ "${i}" -eq "${attempts}" ]]; then
+        exit 1
+    fi
+done
 
 gcloud compute addresses list --filter="name=${IP_ADDRESS_NAME}" --format="value(ADDRESS)"


### PR DESCRIPTION
**Description**
Redoing #1447. Since reserve-ip-address is returning the reserved IP address on stdout, there can be no other output on this script.

Changes proposed in this pull request:
- refactor of the previously proposed changes
