### PR TITLE
delete APIserver proxy ip from DNS

### DIFF
--- a/prow/scripts/cluster-integration/helpers/cleanup-cluster.sh
+++ b/prow/scripts/cluster-integration/helpers/cleanup-cluster.sh
@@ -85,6 +85,17 @@ function removeResources() {
     if [[ "${PERFORMACE_CLUSTER_SETUP}" == "" ]]; then
 		set +e
 
+		shout "Delete APIserver proxy IP"
+		date
+		APISERVER_IP_ADDRESS=$(kubectl get service -n kyma-system apiserver-proxy-ssl -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+		APISERVER_DNS_FULL_NAME="apiserver.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
+
+		shout "running /delete-dns-record.sh --project=${GCLOUD_PROJECT_NAME} --zone=${CLOUDSDK_DNS_ZONE_NAME} --name=${APISERVER_DNS_FULL_NAME} --address=${APISERVER_IP_ADDRESS} --dryRun=false"
+
+		"${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/delete-dns-record.sh --project="${GCLOUD_PROJECT_NAME}" --zone="${CLOUDSDK_DNS_ZONE_NAME}" --name="${APISERVER_DNS_FULL_NAME}" --address="${APISERVER_IP_ADDRESS}" --dryRun=false
+		TMP_STATUS=$?
+		if [[ ${TMP_STATUS} -ne 0 ]]; then EXIT_STATUS=${TMP_STATUS}; fi
+
 		shout "Delete Gateway DNS Record"
 		date
 		GATEWAY_IP_ADDRESS=$(gcloud compute addresses describe "${CLUSTER_NAME}" --format json --region "${CLOUDSDK_COMPUTE_REGION}" | jq '.address' | tr -d '"')


### PR DESCRIPTION
**Description**
Based on my findings, APIserver DNS entries are only created but not cleaned up as @kasiakepka suggested here: #1446 

Changes proposed in this pull request:
- delete dns entries for APIserver before deleting any other DNS entries

