### PR TITLE
Whitesource component split

### DIFF
--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -41,37 +41,71 @@ USERKEY=$(cat "whitesource-userkey")
 "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/decrypt.sh" "whitesource-apikey" "whitesource-apikey.encrypted"
 APIKEY=$(cat "whitesource-apikey")
 
+# backup config for re-use
+/bin/cp /wss/wss-unified-agent.config /wss/wss-unified-agent.config.bak
+
 echo "***********************************"
 echo "***********Starting Scan***********"
 echo "***********************************"
 
-sed -i.bak "s/apiKey=/apiKey=${APIKEY}/g
+KYMA_SRC="${KYMA_PROJECT_DIR}/${PROJECTNAME}"
+KYMA_COMMONS="${KYMA_SRC}/commons"
+KYMA_INSTALLATION="${KYMA_SRC}/installation"
+KYMA_COMPONENTS="${KYMA_SRC}/components"
+
+
+scanFolder "${KYMA_SRC}" "kyma"
+scanFolder "${KYMA_COMMONS}" "kyma/commons"
+scanFolder "${KYMA_INSTALLATION}" "kyma/installation"
+
+cd $KYMA_COMPONENTS
+for comp_dir in */; {
+    VAL=$(echo "${comp_dir}" | sed 's/.$//')
+    scanFolder "${KYMA_COMPONENTS}/${VAL}" "${VAL}"
+}
+
+function scanFolder() { # expects to get the fqdn of folder passed to scan
+    if [[ $1 == "" ]]; then
+        echo "path cannot be empty"
+        exit 1
+    fi
+    FOLDER=$1
+    if [[ $2 == "" ]]; then
+        echo "component name cannot be empty"
+        exit 1
+    fi
+    cd $FOLDER # change to passed parameter
+    PROJNAME=$2
+
+    /bin/cp /wss/wss-unified-agent.config.bak /wss/wss-unified-agent.config
+
+    sed -i.bak "s/apiKey=/apiKey=${APIKEY}/g
 s/productName=/productName=${PRODUCTNAME}/g
 s/userKey=/userKey=${USERKEY}/g
-s/projectName=/projectName=${PROJECTNAME}/g" /wss/wss-unified-agent.config
+s/projectName=/projectName=${PROJNAME}/g" /wss/wss-unified-agent.config
 
-echo "Dryrun state - $DRYRUN"
-echo "Product name - $PRODUCTNAME"
-echo "Project name - $PROJECTNAME"
-echo "Java Options - '$JAVA_OPTS'"
+    echo "Product name - $PRODUCTNAME"
+    echo "Project name - $PROJNAME"
+    echo "Java Options - '$JAVA_OPTS'"
 
-cd "${KYMA_PROJECT_DIR}/${PROJECTNAME}" # run from project directory
 
- if [ "${DRYRUN}" = false ];then
-    echo "***********************************"
-    echo "***********Scanning ***************"
-    echo "***********************************"
-    if [ -z "$JAVA_OPTS" ]; then
-        echo "no additional java_opts set"
-        java -jar /wss/wss-unified-agent.jar -c /wss/wss-unified-agent.config
-    else
-        java "${JAVA_OPTS}" -jar /wss/wss-unified-agent.jar -c /wss/wss-unified-agent.config
+    if [ "${DRYRUN}" = false ];then
+        echo "***********************************"
+        echo "******** Scanning $FOLDER ***"
+        echo "***********************************"
+        if [ -z "$JAVA_OPTS" ]; then
+            echo "no additional java_opts set"
+            java -jar /wss/wss-unified-agent.jar -c /wss/wss-unified-agent.config
+        else
+            java "${JAVA_OPTS}" -jar /wss/wss-unified-agent.jar -c /wss/wss-unified-agent.config
+        fi
+    else 
+        echo "***********************************"
+        echo "******** DRYRUN Successful for $FOLDER ***"  
+        echo "***********************************"
     fi
-else 
-    echo "***********************************"
-    echo "********* DRYRUN Success **********"  
-    echo "***********************************"
-fi
+}
+
 echo "***********************************"
 echo "*********Scanning Finished*********"
-echo "***********************************"  
+echo "***********************************"

--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -53,17 +53,6 @@ KYMA_COMMONS="${KYMA_SRC}/commons"
 KYMA_INSTALLATION="${KYMA_SRC}/installation"
 KYMA_COMPONENTS="${KYMA_SRC}/components"
 
-
-scanFolder "${KYMA_SRC}" "kyma"
-scanFolder "${KYMA_COMMONS}" "kyma/commons"
-scanFolder "${KYMA_INSTALLATION}" "kyma/installation"
-
-cd $KYMA_COMPONENTS
-for comp_dir in */; {
-    VAL=$(echo "${comp_dir}" | sed 's/.$//')
-    scanFolder "${KYMA_COMPONENTS}/${VAL}" "${VAL}"
-}
-
 function scanFolder() { # expects to get the fqdn of folder passed to scan
     if [[ $1 == "" ]]; then
         echo "path cannot be empty"
@@ -74,7 +63,7 @@ function scanFolder() { # expects to get the fqdn of folder passed to scan
         echo "component name cannot be empty"
         exit 1
     fi
-    cd $FOLDER # change to passed parameter
+    cd "${FOLDER}" # change to passed parameter
     PROJNAME=$2
 
     /bin/cp /wss/wss-unified-agent.config.bak /wss/wss-unified-agent.config
@@ -105,6 +94,18 @@ s/projectName=/projectName=${PROJNAME}/g" /wss/wss-unified-agent.config
         echo "***********************************"
     fi
 }
+
+scanFolder "${KYMA_SRC}" "kyma"
+scanFolder "${KYMA_COMMONS}" "kyma/commons"
+scanFolder "${KYMA_INSTALLATION}" "kyma/installation"
+
+cd "${KYMA_COMPONENTS}"
+for comp_dir in */;
+do
+    # shellcheck disable=SC2001
+    VAL=$(echo "${comp_dir}" | sed 's/.$//')
+    scanFolder "${KYMA_COMPONENTS}/${VAL}" "${VAL}"
+done
 
 echo "***********************************"
 echo "*********Scanning Finished*********"


### PR DESCRIPTION
**Description**
Scan results of the "full" project scan are useless. splitting up into component scans.

Changes proposed in this pull request:
- loop over components
- scan installation and commons

