### PR TITLE
Bump kubectl to 1.14.6 cluster image

### DIFF
--- a/prow/images/kyma-cluster-infra/Dockerfile
+++ b/prow/images/kyma-cluster-infra/Dockerfile
@@ -26,3 +26,9 @@ RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ "$(ls
         --recv-keys BC528686B50D79E339D3721CEB3E94ADBE1229CF && \
     apt-get update && \
     apt-get install -y azure-cli=${AZURE_CLI_VERSION}
+
+# Install kubectl
+ENV KUBECTL_VERSION="v1.14.6"
+RUN curl -LO curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl &&\
+	chmod +x ./kubectl &&\
+	mv ./kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Bumped kubectl

As Kubernetes 1.14 is available on AKS and GKE, we can set it as a default version.
