### PR TITLE
change dependency manager to dep

### DIFF
--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -41,6 +41,8 @@ USERKEY=$(cat "whitesource-userkey")
 "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/decrypt.sh" "whitesource-apikey" "whitesource-apikey.encrypted"
 APIKEY=$(cat "whitesource-apikey")
 
+sed -i.bak "s|go.dependencyManager=godep|go.dependencyManager=dep|g" /wss/wss-unified-agent.config
+
 # backup config for re-use
 /bin/cp /wss/wss-unified-agent.config /wss/wss-unified-agent.config.backup
 


### PR DESCRIPTION
**Description**
Dependencies were not resolved properly. This PR changes the dependency manager config from `godep` to `dep` on scan.

Changes proposed in this pull request:
- `go.dependencyManager=godep` to `go.dependencyManager=dep`