### PR TITLE
Vmcleaner test

### DIFF
--- a/development/tools/cmd/vmscollector/main.go
+++ b/development/tools/cmd/vmscollector/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 const defaultVMNameRegexp = "^kyma-integration-test-.*|^compass-integration-test-*"
-const defaultJobLabelRegexp = "^kyma-integration$"
+const defaultJobLabelRegexp = "^kyma-integration$|^compass-integration*"
 
 var (
 	project        = flag.String("project", "", "Project ID [Required]")

--- a/development/tools/cmd/vmscollector/main.go
+++ b/development/tools/cmd/vmscollector/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 const defaultVMNameRegexp = "^kyma-integration-test-.*|^compass-integration-test-*"
-const defaultJobLabelRegexp = "^kyma-integration$|^compass-integration*"
+const defaultJobLabelRegexp = "^kyma-integration$|^compass-integration$"
 
 var (
 	project        = flag.String("project", "", "Project ID [Required]")

--- a/development/tools/cmd/vmscollector/main.go
+++ b/development/tools/cmd/vmscollector/main.go
@@ -17,8 +17,8 @@ import (
 	compute "google.golang.org/api/compute/v1"
 )
 
-const defaultVMNameRegexp = "^kyma-integration-test-.*|^compass-integration-test-*"
-const defaultJobLabelRegexp = "^kyma-integration$|^compass-integration$"
+const defaultVMNameRegexp = ".*-integration-test-.*"
+const defaultJobLabelRegexp = ".*-integration$"
 
 var (
 	project        = flag.String("project", "", "Project ID [Required]")

--- a/development/tools/cmd/vmscollector/main.go
+++ b/development/tools/cmd/vmscollector/main.go
@@ -17,7 +17,7 @@ import (
 	compute "google.golang.org/api/compute/v1"
 )
 
-const defaultVMNameRegexp = "^kyma-integration-test-.*"
+const defaultVMNameRegexp = "^kyma-integration-test-.*|^compass-integration-test-*"
 const defaultJobLabelRegexp = "^kyma-integration$"
 
 var (


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Improve VM cleaner so that it deletes not only `kyma-integration-test-*` VMs but also `compass-integration-test-*`, `cli-integration-test-*` etc. 
- Compas and CLI integration VMs are tagged with `cli-integration` and `compass-integrtion` so I also changed  a regexp.


Test pipeline: https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/logs/kk-orphaned-vms-cleaner/1173867685830725633

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
