### PR TITLE
remove kyma-gke-service-catalog-crd-periodic job

### DIFF
--- a/development/tools/cmd/dnscollector/main.go
+++ b/development/tools/cmd/dnscollector/main.go
@@ -16,7 +16,7 @@ import (
 	dns "google.golang.org/api/dns/v1"
 )
 
-const defaultAddressRegexpList = "(remoteenvs-)?gkeint-(pr|commit)-.*,(remoteenvs-)?gke-upgrade-(pr|commit)-.*,(remoteenvs-)?(load-test|e2etest),gke-central-(pr|commit)-.*,gke-backup-(pr|commit)-.*,service-catalog-crd-periodic,gkecompint-(pr|commit)-.*,gke-minio-(pr|commit)-.*,gke-minio-min-(pr|commit).*"
+const defaultAddressRegexpList = "(remoteenvs-)?gkeint-(pr|commit)-.*,(remoteenvs-)?gke-upgrade-(pr|commit)-.*,(remoteenvs-)?(load-test|e2etest),gke-central-(pr|commit)-.*,gke-backup-(pr|commit)-.*,gkecompint-(pr|commit)-.*,gke-minio-(pr|commit)-.*,gke-minio-min-(pr|commit).*"
 const minAgeInHours = 1
 const minPatternLength = 5
 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -329,19 +329,6 @@ presets:
             name: nightly-github-integration-app-client-secret
             key: client-secret
   - labels:
-      preset-service-catalog-crd-periodic-github-integration: "true"
-    env:
-    - name: GITHUB_INTEGRATION_APP_CLIENT_ID
-      valueFrom:
-        secretKeyRef:
-          name: service-catalog-crd-periodic-github-integration-app-client-id
-          key: client-id
-    - name: GITHUB_INTEGRATION_APP_CLIENT_SECRET
-      valueFrom:
-        secretKeyRef:
-          name: service-catalog-crd-periodic-github-integration-app-client-secret
-          key: client-secret
-  - labels:
       preset-weekly-github-integration: "true"
     env:
       - name: GITHUB_INTEGRATION_APP_CLIENT_ID

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -737,7 +737,7 @@ periodics:
             - "bash"
           args:
             - "-c"
-            - "development/clusters-cleanup.sh -project=${CLOUDSDK_CORE_PROJECT} -dryRun=false -whitelisted-clusters=kyma-prow,workload-kyma-prow,nightly,weekly,service-catalog-crd-periodic"
+            - "development/clusters-cleanup.sh -project=${CLOUDSDK_CORE_PROJECT} -dryRun=false -whitelisted-clusters=kyma-prow,workload-kyma-prow,nightly,weekly"
           resources:
             requests:
               memory: 1Gi
@@ -1142,62 +1142,3 @@ periodics:
             requests:
               memory: 1Gi
               cpu: 400m
-
-  - name: kyma-gke-service-catalog-crd-periodic
-    cron: "0 5 * * 2,5" # "At 05:00 on Tuesday and Friday
-    labels:
-      preset-kyma-keyring: "true"
-      preset-kyma-encryption-key: "true"
-      preset-build-master: "true"
-      preset-stability-checker-slack-notifications: "true"
-      preset-service-catalog-crd-periodic-github-integration: "true"
-      preset-kms-gc-project-env: "true"
-      <<: *gke_job_labels_template
-    decorate: true
-    extra_refs:
-      - <<: *test_infra_ref
-        base_ref: master
-      - <<: *kyma_ref
-        base_ref: master
-    spec:
-      volumes:
-        - name: sa-stability-fluentd-storage-writer
-          secret:
-            secretName: sa-stability-fluentd-storage-writer
-      containers:
-        - image: eu.gcr.io/kyma-project/test-infra/kyma-cluster-infra:v20190129-c951cf2
-          securityContext:
-            privileged: true
-          volumeMounts:
-            - name: sa-stability-fluentd-storage-writer
-              mountPath: /etc/credentials/sa-stability-fluentd-storage-writer
-              readOnly: true
-          env:
-            - name: INPUT_CLUSTER_NAME
-              value: "service-catalog-crd-periodic"
-            - name: TEST_RESULT_WINDOW_TIME
-              value: "24h"
-            - name: STABILITY_SLACK_CLIENT_CHANNEL_ID
-              value: "#c4core-kyma-gopher-pr"
-            - name: GITHUB_TEAMS_WITH_KYMA_ADMINS_RIGHTS
-              value: "cluster-access"
-            - name: SERVICE_CATALOG_CRD
-              value: "true"
-            - name: KYMA_ALERTS_SLACK_API_URL
-              valueFrom:
-                secretKeyRef:
-                  name: kyma-alerts-slack-api-url
-                  key: secret
-            - name: KYMA_ALERTS_CHANNEL
-              value: "#not-exists"
-            - name: CLOUDSDK_COMPUTE_ZONE
-              value: "europe-west4-b"
-          command:
-            - "bash"
-          args:
-            - "-c"
-            - "${KYMA_PROJECT_DIR}/test-infra/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh"
-          resources:
-            requests:
-              memory: 200Mi
-              cpu: 80m

--- a/prow/workload-cluster/required-secrets.yaml
+++ b/prow/workload-cluster/required-secrets.yaml
@@ -43,7 +43,3 @@ generics:
     key: client-id
   - prefix: nightly-aks-github-integration-app-client-secret
     key: client-secret
-  - prefix: service-catalog-crd-periodic-github-integration-app-client-id
-    key: client-id
-  - prefix: service-catalog-crd-periodic-github-integration-app-client-secret
-    key: client-secret

--- a/templates/templates/kyma-integration.yaml
+++ b/templates/templates/kyma-integration.yaml
@@ -663,7 +663,7 @@ periodics:
             - "bash"
           args:
             - "-c"
-            - "development/clusters-cleanup.sh -project=${CLOUDSDK_CORE_PROJECT} -dryRun=false -whitelisted-clusters=kyma-prow,workload-kyma-prow,nightly,weekly,service-catalog-crd-periodic"
+            - "development/clusters-cleanup.sh -project=${CLOUDSDK_CORE_PROJECT} -dryRun=false -whitelisted-clusters=kyma-prow,workload-kyma-prow,nightly,weekly"
           resources:
             requests:
               memory: 1Gi
@@ -1068,62 +1068,3 @@ periodics:
             requests:
               memory: 1Gi
               cpu: 400m
-
-  - name: kyma-gke-service-catalog-crd-periodic
-    cron: "0 5 * * 2,5" # "At 05:00 on Tuesday and Friday
-    labels:
-      preset-kyma-keyring: "true"
-      preset-kyma-encryption-key: "true"
-      preset-build-master: "true"
-      preset-stability-checker-slack-notifications: "true"
-      preset-service-catalog-crd-periodic-github-integration: "true"
-      preset-kms-gc-project-env: "true"
-      <<: *gke_job_labels_template
-    decorate: true
-    extra_refs:
-      - <<: *test_infra_ref
-        base_ref: master
-      - <<: *kyma_ref
-        base_ref: master
-    spec:
-      volumes:
-        - name: sa-stability-fluentd-storage-writer
-          secret:
-            secretName: sa-stability-fluentd-storage-writer
-      containers:
-        - image: eu.gcr.io/kyma-project/test-infra/kyma-cluster-infra:v20190129-c951cf2
-          securityContext:
-            privileged: true
-          volumeMounts:
-            - name: sa-stability-fluentd-storage-writer
-              mountPath: /etc/credentials/sa-stability-fluentd-storage-writer
-              readOnly: true
-          env:
-            - name: INPUT_CLUSTER_NAME
-              value: "service-catalog-crd-periodic"
-            - name: TEST_RESULT_WINDOW_TIME
-              value: "24h"
-            - name: STABILITY_SLACK_CLIENT_CHANNEL_ID
-              value: "#c4core-kyma-gopher-pr"
-            - name: GITHUB_TEAMS_WITH_KYMA_ADMINS_RIGHTS
-              value: "cluster-access"
-            - name: SERVICE_CATALOG_CRD
-              value: "true"
-            - name: KYMA_ALERTS_SLACK_API_URL
-              valueFrom:
-                secretKeyRef:
-                  name: kyma-alerts-slack-api-url
-                  key: secret
-            - name: KYMA_ALERTS_CHANNEL
-              value: "#not-exists"
-            - name: CLOUDSDK_COMPUTE_ZONE
-              value: "europe-west4-b"
-          command:
-            - "bash"
-          args:
-            - "-c"
-            - "${KYMA_PROJECT_DIR}/test-infra/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh"
-          resources:
-            requests:
-              memory: 200Mi
-              cpu: 80m

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -327,19 +327,6 @@ presets:
             name: nightly-github-integration-app-client-secret
             key: client-secret
   - labels:
-      preset-service-catalog-crd-periodic-github-integration: "true"
-    env:
-    - name: GITHUB_INTEGRATION_APP_CLIENT_ID
-      valueFrom:
-        secretKeyRef:
-          name: service-catalog-crd-periodic-github-integration-app-client-id
-          key: client-id
-    - name: GITHUB_INTEGRATION_APP_CLIENT_SECRET
-      valueFrom:
-        secretKeyRef:
-          name: service-catalog-crd-periodic-github-integration-app-client-secret
-          key: client-secret
-  - labels:
       preset-weekly-github-integration: "true"
     env:
       - name: GITHUB_INTEGRATION_APP_CLIENT_ID


### PR DESCRIPTION
PR removes `kyma-gke-service-catalog-crd-periodic` jobs which test periodically new version of ServiceCatalog  with CRDs.