### PR TITLE
Rename hack showcase into github-slack-connectors

### DIFF
--- a/development/tools/jobs/incubator/github-slack-connectors/github_connector_test.go
+++ b/development/tools/jobs/incubator/github-slack-connectors/github_connector_test.go
@@ -9,59 +9,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSlackConnectorJobPresubmit(t *testing.T) {
+func TestGithubConnectorJobPresubmit(t *testing.T) {
 	//WHEN
-	jobConfig, err := tester.ReadJobConfig("./../../../../../prow/jobs/incubator/hack-showcase/slack-connector/slack-connector.yaml")
+	jobConfig, err := tester.ReadJobConfig("./../../../../../prow/jobs/incubator/github-slack-connectors/github-connector/github-connector.yaml")
 	// THEN
 	require.NoError(t, err)
 
 	assert.Len(t, jobConfig.Presubmits, 1)
-	kymaPresubmits, ex := jobConfig.Presubmits["kyma-incubator/hack-showcase"]
+	kymaPresubmits, ex := jobConfig.Presubmits["kyma-incubator/github-slack-connectors"]
 	assert.True(t, ex)
 	assert.Len(t, kymaPresubmits, 1)
 
 	actualPresubmit := kymaPresubmits[0]
-	expName := "pre-master-slack-connector"
+	expName := "pre-master-github-connector"
 	assert.Equal(t, expName, actualPresubmit.Name)
 	assert.Equal(t, []string{"^master$"}, actualPresubmit.Branches)
-	assert.Equal(t, "^slack-connector", actualPresubmit.RunIfChanged)
+	assert.Equal(t, "^github-connector", actualPresubmit.RunIfChanged)
 	assert.Equal(t, 10, actualPresubmit.MaxConcurrency)
 	assert.False(t, actualPresubmit.SkipReport)
 	assert.True(t, actualPresubmit.Decorate)
-	assert.Equal(t, "github.com/kyma-incubator/hack-showcase", actualPresubmit.PathAlias)
+	assert.Equal(t, "github.com/kyma-incubator/github-slack-connectors", actualPresubmit.PathAlias)
 
 	tester.AssertThatHasExtraRefTestInfra(t, actualPresubmit.JobBase.UtilityConfig, "master")
 	tester.AssertThatHasPresets(t, actualPresubmit.JobBase, preset.DindEnabled, preset.DockerPushRepoIncubator, preset.GcrPush, preset.BuildPr)
 	assert.Equal(t, tester.ImageGolangBuildpack1_12, actualPresubmit.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPresubmit.Spec.Containers[0].Command)
-	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/hack-showcase/slack-connector"}, actualPresubmit.Spec.Containers[0].Args)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/github-slack-connectors/github-connector"}, actualPresubmit.Spec.Containers[0].Args)
 
 }
 
-func TestSlackConnectorJobPostsubmit(t *testing.T) {
+func TestGithubConnectorJobPostsubmit(t *testing.T) {
 	// WHEN
-	jobConfig, err := tester.ReadJobConfig("./../../../../../prow/jobs/incubator/hack-showcase/slack-connector/slack-connector.yaml")
+	jobConfig, err := tester.ReadJobConfig("./../../../../../prow/jobs/incubator/github-slack-connectors/github-connector/github-connector.yaml")
 	// THEN
 	require.NoError(t, err)
 
 	assert.Len(t, jobConfig.Postsubmits, 1)
-	kymaPost, ex := jobConfig.Postsubmits["kyma-incubator/hack-showcase"]
+	kymaPost, ex := jobConfig.Postsubmits["kyma-incubator/github-slack-connectors"]
 	assert.True(t, ex)
 	assert.Len(t, kymaPost, 1)
 
 	actualPost := kymaPost[0]
-	expName := "post-master-slack-connector"
+	expName := "post-master-github-connector"
 	assert.Equal(t, expName, actualPost.Name)
 	assert.Equal(t, []string{"^master$"}, actualPost.Branches)
-	assert.Equal(t, "^slack-connector", actualPost.RunIfChanged)
+	assert.Equal(t, "^github-connector", actualPost.RunIfChanged)
 	assert.Equal(t, 10, actualPost.MaxConcurrency)
 	assert.True(t, actualPost.Decorate)
-	assert.Equal(t, "github.com/kyma-incubator/hack-showcase", actualPost.PathAlias)
+	assert.Equal(t, "github.com/kyma-incubator/github-slack-connectors", actualPost.PathAlias)
 	tester.AssertThatHasExtraRefTestInfra(t, actualPost.JobBase.UtilityConfig, "master")
 	tester.AssertThatHasPresets(t, actualPost.JobBase, preset.DindEnabled, preset.DockerPushRepoIncubator, preset.GcrPush, preset.BuildMaster)
 	assert.Equal(t, tester.ImageGolangBuildpack1_12, actualPost.Spec.Containers[0].Image)
 
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPost.Spec.Containers[0].Command)
-	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/hack-showcase/slack-connector"}, actualPost.Spec.Containers[0].Args)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/github-slack-connectors/github-connector"}, actualPost.Spec.Containers[0].Args)
 
 }

--- a/development/tools/jobs/incubator/github-slack-connectors/slack_connector_test.go
+++ b/development/tools/jobs/incubator/github-slack-connectors/slack_connector_test.go
@@ -9,59 +9,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGithubConnectorJobPresubmit(t *testing.T) {
+func TestSlackConnectorJobPresubmit(t *testing.T) {
 	//WHEN
-	jobConfig, err := tester.ReadJobConfig("./../../../../../prow/jobs/incubator/hack-showcase/github-connector/github-connector.yaml")
+	jobConfig, err := tester.ReadJobConfig("./../../../../../prow/jobs/incubator/github-slack-connectors/slack-connector/slack-connector.yaml")
 	// THEN
 	require.NoError(t, err)
 
 	assert.Len(t, jobConfig.Presubmits, 1)
-	kymaPresubmits, ex := jobConfig.Presubmits["kyma-incubator/hack-showcase"]
+	kymaPresubmits, ex := jobConfig.Presubmits["kyma-incubator/github-slack-connectors"]
 	assert.True(t, ex)
 	assert.Len(t, kymaPresubmits, 1)
 
 	actualPresubmit := kymaPresubmits[0]
-	expName := "pre-master-github-connector"
+	expName := "pre-master-slack-connector"
 	assert.Equal(t, expName, actualPresubmit.Name)
 	assert.Equal(t, []string{"^master$"}, actualPresubmit.Branches)
-	assert.Equal(t, "^github-connector", actualPresubmit.RunIfChanged)
+	assert.Equal(t, "^slack-connector", actualPresubmit.RunIfChanged)
 	assert.Equal(t, 10, actualPresubmit.MaxConcurrency)
 	assert.False(t, actualPresubmit.SkipReport)
 	assert.True(t, actualPresubmit.Decorate)
-	assert.Equal(t, "github.com/kyma-incubator/hack-showcase", actualPresubmit.PathAlias)
+	assert.Equal(t, "github.com/kyma-incubator/github-slack-connectors", actualPresubmit.PathAlias)
 
 	tester.AssertThatHasExtraRefTestInfra(t, actualPresubmit.JobBase.UtilityConfig, "master")
 	tester.AssertThatHasPresets(t, actualPresubmit.JobBase, preset.DindEnabled, preset.DockerPushRepoIncubator, preset.GcrPush, preset.BuildPr)
 	assert.Equal(t, tester.ImageGolangBuildpack1_12, actualPresubmit.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPresubmit.Spec.Containers[0].Command)
-	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/hack-showcase/github-connector"}, actualPresubmit.Spec.Containers[0].Args)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/github-slack-connectors/slack-connector"}, actualPresubmit.Spec.Containers[0].Args)
 
 }
 
-func TestGithubConnectorJobPostsubmit(t *testing.T) {
+func TestSlackConnectorJobPostsubmit(t *testing.T) {
 	// WHEN
-	jobConfig, err := tester.ReadJobConfig("./../../../../../prow/jobs/incubator/hack-showcase/github-connector/github-connector.yaml")
+	jobConfig, err := tester.ReadJobConfig("./../../../../../prow/jobs/incubator/github-slack-connectors/slack-connector/slack-connector.yaml")
 	// THEN
 	require.NoError(t, err)
 
 	assert.Len(t, jobConfig.Postsubmits, 1)
-	kymaPost, ex := jobConfig.Postsubmits["kyma-incubator/hack-showcase"]
+	kymaPost, ex := jobConfig.Postsubmits["kyma-incubator/github-slack-connectors"]
 	assert.True(t, ex)
 	assert.Len(t, kymaPost, 1)
 
 	actualPost := kymaPost[0]
-	expName := "post-master-github-connector"
+	expName := "post-master-slack-connector"
 	assert.Equal(t, expName, actualPost.Name)
 	assert.Equal(t, []string{"^master$"}, actualPost.Branches)
-	assert.Equal(t, "^github-connector", actualPost.RunIfChanged)
+	assert.Equal(t, "^slack-connector", actualPost.RunIfChanged)
 	assert.Equal(t, 10, actualPost.MaxConcurrency)
 	assert.True(t, actualPost.Decorate)
-	assert.Equal(t, "github.com/kyma-incubator/hack-showcase", actualPost.PathAlias)
+	assert.Equal(t, "github.com/kyma-incubator/github-slack-connectors", actualPost.PathAlias)
 	tester.AssertThatHasExtraRefTestInfra(t, actualPost.JobBase.UtilityConfig, "master")
 	tester.AssertThatHasPresets(t, actualPost.JobBase, preset.DindEnabled, preset.DockerPushRepoIncubator, preset.GcrPush, preset.BuildMaster)
 	assert.Equal(t, tester.ImageGolangBuildpack1_12, actualPost.Spec.Containers[0].Image)
 
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPost.Spec.Containers[0].Command)
-	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/hack-showcase/github-connector"}, actualPost.Spec.Containers[0].Args)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/github-slack-connectors/slack-connector"}, actualPost.Spec.Containers[0].Args)
 
 }

--- a/prow/jobs/incubator/github-slack-connectors/github-connector/github-connector.yaml
+++ b/prow/jobs/incubator/github-slack-connectors/github-connector/github-connector.yaml
@@ -30,7 +30,7 @@ job_labels_template: &job_labels_template
   preset-docker-push-repository-incubator: "true"
 
 presubmits: # runs on PRs
-  kyma-incubator/github-slack-connector:
+  kyma-incubator/github-slack-connectors:
     - name: pre-master-github-connector
       branches:
         - ^master$
@@ -40,7 +40,7 @@ presubmits: # runs on PRs
         preset-build-pr: "true"
 
 postsubmits:
-  kyma-incubator/github-slack-connector:
+  kyma-incubator/github-slack-connectors:
     - name: post-master-github-connector
       branches:
         - ^master$

--- a/prow/jobs/incubator/github-slack-connectors/github-connector/github-connector.yaml
+++ b/prow/jobs/incubator/github-slack-connectors/github-connector/github-connector.yaml
@@ -2,7 +2,7 @@ base_job_template: &base_job_template
   skip_report: false
   run_if_changed: "^github-connector"
   decorate: true
-  path_alias: github.com/kyma-incubator/github-slack-connector
+  path_alias: github.com/kyma-incubator/github-slack-connectors
   max_concurrency: 10
   extra_refs:
     - org: kyma-project
@@ -17,7 +17,7 @@ base_job_template: &base_job_template
         command:
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
-          - "/home/prow/go/src/github.com/kyma-incubator/github-slack-connector/github-connector"
+          - "/home/prow/go/src/github.com/kyma-incubator/github-slack-connectors/github-connector"
         resources:
 
           requests:

--- a/prow/jobs/incubator/github-slack-connectors/github-connector/github-connector.yaml
+++ b/prow/jobs/incubator/github-slack-connectors/github-connector/github-connector.yaml
@@ -1,8 +1,8 @@
 base_job_template: &base_job_template
   skip_report: false
-  run_if_changed: "^slack-connector"
+  run_if_changed: "^github-connector"
   decorate: true
-  path_alias: github.com/kyma-incubator/hack-showcase
+  path_alias: github.com/kyma-incubator/github-slack-connector
   max_concurrency: 10
   extra_refs:
     - org: kyma-project
@@ -17,8 +17,9 @@ base_job_template: &base_job_template
         command:
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
-          - "/home/prow/go/src/github.com/kyma-incubator/hack-showcase/slack-connector"
+          - "/home/prow/go/src/github.com/kyma-incubator/github-slack-connector/github-connector"
         resources:
+
           requests:
             memory: 1.5Gi
             cpu: 0.8
@@ -29,8 +30,8 @@ job_labels_template: &job_labels_template
   preset-docker-push-repository-incubator: "true"
 
 presubmits: # runs on PRs
-  kyma-incubator/hack-showcase:
-    - name: pre-master-slack-connector
+  kyma-incubator/github-slack-connector:
+    - name: pre-master-github-connector
       branches:
         - ^master$
       <<: *base_job_template
@@ -39,8 +40,8 @@ presubmits: # runs on PRs
         preset-build-pr: "true"
 
 postsubmits:
-  kyma-incubator/hack-showcase:
-    - name: post-master-slack-connector
+  kyma-incubator/github-slack-connector:
+    - name: post-master-github-connector
       branches:
         - ^master$
       <<: *base_job_template

--- a/prow/jobs/incubator/github-slack-connectors/slack-connector/slack-connector.yaml
+++ b/prow/jobs/incubator/github-slack-connectors/slack-connector/slack-connector.yaml
@@ -29,7 +29,7 @@ job_labels_template: &job_labels_template
   preset-docker-push-repository-incubator: "true"
 
 presubmits: # runs on PRs
-  kyma-incubator/hack-showcase:
+  kyma-incubator/github-slack-connectors:
     - name: pre-master-slack-connector
       branches:
         - ^master$
@@ -39,7 +39,7 @@ presubmits: # runs on PRs
         preset-build-pr: "true"
 
 postsubmits:
-  kyma-incubator/hack-showcase:
+  kyma-incubator/github-slack-connectors:
     - name: post-master-slack-connector
       branches:
         - ^master$

--- a/prow/jobs/incubator/github-slack-connectors/slack-connector/slack-connector.yaml
+++ b/prow/jobs/incubator/github-slack-connectors/slack-connector/slack-connector.yaml
@@ -1,8 +1,8 @@
 base_job_template: &base_job_template
   skip_report: false
-  run_if_changed: "^github-connector"
+  run_if_changed: "^slack-connector"
   decorate: true
-  path_alias: github.com/kyma-incubator/hack-showcase
+  path_alias: github.com/kyma-incubator/github-slack-connectors
   max_concurrency: 10
   extra_refs:
     - org: kyma-project
@@ -17,9 +17,8 @@ base_job_template: &base_job_template
         command:
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"
         args:
-          - "/home/prow/go/src/github.com/kyma-incubator/hack-showcase/github-connector"
+          - "/home/prow/go/src/github.com/kyma-incubator/github-slack-connectors/slack-connector"
         resources:
-
           requests:
             memory: 1.5Gi
             cpu: 0.8
@@ -31,7 +30,7 @@ job_labels_template: &job_labels_template
 
 presubmits: # runs on PRs
   kyma-incubator/hack-showcase:
-    - name: pre-master-github-connector
+    - name: pre-master-slack-connector
       branches:
         - ^master$
       <<: *base_job_template
@@ -41,7 +40,7 @@ presubmits: # runs on PRs
 
 postsubmits:
   kyma-incubator/hack-showcase:
-    - name: post-master-github-connector
+    - name: post-master-slack-connector
       branches:
         - ^master$
       <<: *base_job_template


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- rename hack-showcase jobs to github-slack-connectors
