### PR TITLE
Fix kubectl version in cluster infra image

### DIFF
--- a/prow/images/kyma-cluster-infra/Dockerfile
+++ b/prow/images/kyma-cluster-infra/Dockerfile
@@ -27,8 +27,11 @@ RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ "$(ls
     apt-get update && \
     apt-get install -y azure-cli=${AZURE_CLI_VERSION}
 
+# Remove kubectl installed with gcloud
+RUN rm -rf "$(which kubectl)"
+
 # Install kubectl
 ENV KUBECTL_VERSION="v1.14.6"
-RUN curl -LO curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl &&\
-	chmod +x ./kubectl &&\
-	mv ./kubectl /usr/local/bin/kubectl
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl --fail &&\
+	chmod +x kubectl &&\
+	mv kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fixed kubectl version in cluster infra image

Job with new kubernetes that is using this image: https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/pr-logs/pull/kyma-project_kyma/5789/pre-master-kyma-gke-integration/1178615946688860160

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
