### PR TITLE
Add kind to toolbox image and high load node pool to workload cluster

### DIFF
--- a/development/provision-cluster.sh
+++ b/development/provision-cluster.sh
@@ -38,6 +38,7 @@ if [ -z "$WORKLOAD_CLUSTER_NAMER" ]; then
         --num-nodes 0 \
         --enable-autoscaling \
         --max-nodes 5 \
-        --min-nodes 0
+        --min-nodes 0 \
+        --disk-type pd-ssd
 fi
 

--- a/development/provision-cluster.sh
+++ b/development/provision-cluster.sh
@@ -30,13 +30,14 @@ if [ -z "$WORKLOAD_CLUSTER_NAMER" ]; then
 
     echo "Adding high load node pool to cluster ${WORKLOAD_CLUSTER_NAME}' in project '${PROJECT}' and zone '${ZONE}'"
     gcloud container node-pools create high-load \
+        --project "${PROJECT}" \
         --cluster "${WORKLOAD_CLUSTER_NAME}" \
+        --zone "${ZONE}" \
         --machine-type n1-standard-16 \
         --node-taints resources-usage=high:NoSchedule \
         --num-nodes 0 \
         --enable-autoscaling \
         --max-nodes 5 \
-        --min-nodes 0 \
-        --zone "${ZONE}"
+        --min-nodes 0
 fi
 

--- a/development/provision-cluster.sh
+++ b/development/provision-cluster.sh
@@ -27,5 +27,16 @@ if [ -z "$WORKLOAD_CLUSTER_NAMER" ]; then
     echo "Provisioning workload cluster '${WORKLOAD_CLUSTER_NAME}' (${NUM_NODES} nodes) in project '${PROJECT}' and zone '${ZONE}'"
     gcloud container --project "${PROJECT}" clusters create "${WORKLOAD_CLUSTER_NAME}" \
         --zone "${ZONE}" --issue-client-certificate --enable-basic-auth --machine-type n1-standard-1 --num-nodes "${NUM_NODES}"
+
+    echo "Adding high load node pool to cluster ${WORKLOAD_CLUSTER_NAME}' in project '${PROJECT}' and zone '${ZONE}'"
+    gcloud container node-pools create high-load \
+        --cluster "${WORKLOAD_CLUSTER_NAME}" \
+        --machine-type n1-standard-16 \
+        --node-taints resources-usage=high:NoSchedule \
+        --num-nodes 0 \
+        --enable-autoscaling \
+        --max-nodes 5 \
+        --min-nodes 0 \
+        --zone "${ZONE}"
 fi
 

--- a/prow/images/buildpack-golang-toolbox/Dockerfile
+++ b/prow/images/buildpack-golang-toolbox/Dockerfile
@@ -8,6 +8,7 @@ RUN go get golang.org/x/tools/cmd/goimports
 RUN go get golang.org/x/lint/golint
 RUN go get github.com/vektra/mockery
 RUN go get github.com/kisielk/errcheck
+RUN GO111MODULE="on" go get sigs.k8s.io/kind@v0.5.1
 
 COPY ./license-puller.sh /license-puller.sh
 ENV LICENSE_PULLER_PATH=/license-puller.sh

--- a/prow/images/buildpack-golang-toolbox/README.md
+++ b/prow/images/buildpack-golang-toolbox/README.md
@@ -10,6 +10,7 @@ In addition to the version introduced in Buildpack Golang, this image adds these
 - golint
 - mockery
 - failery
+- kind (v0.5.1)
 
 > **CAUTION:** The `go get` command that downloads these tools always fetches the latest packages. Because of that, the image may contain different versions of the tools every time it is rebuilt.
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Added kind
- Added high load node pool to workload cluster

The high load pool is needed for testing Kyma on kind, and building kubernetes image with kind. This node pool will scale to zero (max 5 nodes). Thanks to taints (https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) configuration only pods with proper (see below) toleration will be scheduled in this pool.

```yaml
  tolerations:
  - key: resources-usage
    value: high
    operator: Equal
    effect: NoSchedule
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

#1470 
