### PR TITLE
Migrate octopus to go modules

### DIFF
--- a/development/tools/jobs/incubator/octopus/octopus_test.go
+++ b/development/tools/jobs/incubator/octopus/octopus_test.go
@@ -26,7 +26,9 @@ func TestOctopusJobsPresubmit(t *testing.T) {
 	assert.True(t, actualPresubmit.AlwaysRun)
 	assert.Equal(t, "github.com/kyma-incubator/octopus", actualPresubmit.PathAlias)
 	tester.AssertThatHasPresets(t, actualPresubmit.JobBase, preset.DindEnabled, preset.DockerPushRepoIncubator, preset.GcrPush, preset.BuildPr)
-	assert.Equal(t, tester.ImageGolangKubebuilderBuildpackLatest, actualPresubmit.Spec.Containers[0].Image)
+	assert.Equal(t, tester.ImageGolangKubebuilder2BuildpackLatest, actualPresubmit.Spec.Containers[0].Image)
+	assert.Equal(t, "GO111MODULE", actualPresubmit.Spec.Containers[0].Env[0].Name)
+	assert.Equal(t, "on", actualPresubmit.Spec.Containers[0].Env[0].Value)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPresubmit.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/octopus"}, actualPresubmit.Spec.Containers[0].Args)
 }
@@ -45,7 +47,9 @@ func TestOctopusJobPostsubmit(t *testing.T) {
 	assert.True(t, actualPostsubmit.Decorate)
 	assert.Equal(t, "github.com/kyma-incubator/octopus", actualPostsubmit.PathAlias)
 	tester.AssertThatHasPresets(t, actualPostsubmit.JobBase, preset.DindEnabled, preset.DockerPushRepoIncubator, preset.GcrPush, preset.BuildMaster)
-	assert.Equal(t, tester.ImageGolangKubebuilderBuildpackLatest, actualPostsubmit.Spec.Containers[0].Image)
+	assert.Equal(t, tester.ImageGolangKubebuilder2BuildpackLatest, actualPostsubmit.Spec.Containers[0].Image)
+	assert.Equal(t, "GO111MODULE", actualPostsubmit.Spec.Containers[0].Env[0].Name)
+	assert.Equal(t, "on", actualPostsubmit.Spec.Containers[0].Env[0].Value)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPostsubmit.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/octopus"}, actualPostsubmit.Spec.Containers[0].Args)
 }

--- a/prow/jobs/incubator/octopus/octopus.yaml
+++ b/prow/jobs/incubator/octopus/octopus.yaml
@@ -11,7 +11,7 @@ job_template: &job_template
       path_alias: github.com/kyma-project/test-infra
   spec:
     containers:
-    - image: eu.gcr.io/kyma-project/test-infra/buildpack-golang-kubebuilder:v20190208-813daef
+    - image: eu.gcr.io/kyma-project/test-infra/buildpack-golang-kubebuilder2:v20190823-24e14d1
       securityContext:
         privileged: true
       command:
@@ -22,6 +22,9 @@ job_template: &job_template
         requests:
           memory: 1.5Gi
           cpu: 0.8
+      env:
+        - name: GO111MODULE
+          value: "on"
 
 job_labels_template: &job_labels_template
   preset-dind-enabled: "true"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Migrated octopus to go modules:
  - Changed image to kubebuilder2
  - Added GO111MODULE env for octopus jobs 
