### PR TITLE
Switch to generic prow job for api-controller tests

### DIFF
--- a/development/tools/jobs/kyma/tests_test.go
+++ b/development/tools/jobs/kyma/tests_test.go
@@ -61,13 +61,13 @@ var tests = []struct {
 	{path: "integration/api-controller", image: tester.ImageGolangBuildpack1_12,
 		additionalOptions: []jobsuite.Option{
 			jobsuite.JobFileSuffix("tests"),
+			jobsuite.Until(releases.Release15),
 		},
 	},
 	{path: "integration/api-controller", image: tester.ImageBootstrap20181204, suite: tester.NewGenericComponentSuite,
 		additionalOptions: []jobsuite.Option{
 			jobsuite.JobFileSuffix("tests-generic"),
 			jobsuite.Since(releases.Release17),
-			jobsuite.Optional(),
 		},
 	},
 	{path: "integration/apiserver-proxy", image: tester.ImageGolangBuildpack1_12,

--- a/prow/jobs/kyma/tests/integration/api-controller/api-controller-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/integration/api-controller/api-controller-tests-generic.yaml
@@ -38,11 +38,10 @@ presubmits: # runs on PRs
   kyma-project/kyma:
     - name: pre-kyma-tests-integration-api-controller
       skip_report: false
-      optional: true
+      optional: false
       <<: *job_template
 
 postsubmits:
   kyma-project/kyma:
     - name: post-kyma-tests-integration-api-controller
-      prow.kyma-project.io/slack.skipReport: "true"
       <<: *job_template

--- a/prow/jobs/kyma/tests/integration/api-controller/api-controller-tests.yaml
+++ b/prow/jobs/kyma/tests/integration/api-controller/api-controller-tests.yaml
@@ -27,24 +27,6 @@ container_template: &container_template
 
 presubmits: # runs on PRs
   kyma-project/kyma:
-    - name: pre-master-kyma-tests-integration-api-controller
-      branches:
-        - ^master$
-      <<: *job_template
-      path_alias: github.com/kyma-project/kyma
-      spec:
-        containers:
-          - <<: *container_template
-            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.12
-            args:
-              - "/home/prow/go/src/github.com/kyma-project/kyma/tests/integration/api-controller"
-      run_if_changed: "^tests/integration/api-controller/"
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
-      labels:
-        <<: *job_labels_template
-        preset-build-pr: "true"
     - name: pre-rel15-kyma-tests-integration-api-controller
       branches:
         - release-1.5
@@ -81,24 +63,3 @@ presubmits: # runs on PRs
       labels:
         <<: *job_labels_template
         preset-build-release: "true"
-
-postsubmits:
-  kyma-project/kyma:
-    - name: post-master-kyma-tests-integration-api-controller
-      branches:
-        - ^master$
-      <<: *job_template
-      path_alias: github.com/kyma-project/kyma
-      spec:
-        containers:
-          - <<: *container_template
-            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.12
-            args:
-              - "/home/prow/go/src/github.com/kyma-project/kyma/tests/integration/api-controller"
-      run_if_changed: "^tests/integration/api-controller/"
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
-      labels:
-        <<: *job_labels_template
-        preset-build-master: "true"

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -211,7 +211,6 @@ templates:
           <<: *kyma_generic_component
           path: tests/integration/api-controller
           since: "1.7"
-          optional: true
       - to: ../prow/jobs/kyma/tests/integration/dex/dex-tests-generic.yaml
         values:
           <<: *kyma_generic_component

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -276,10 +276,12 @@ templates:
         values:
           <<: *go_kyma_component_1_12
           path: components/api-controller
+          until: "1.6"
       - to: ../prow/jobs/kyma/components/apiserver-proxy/apiserver-proxy.yaml
         values:
           <<: *go_kyma_component_1_12
           path: components/apiserver-proxy
+          until: "1.6"
       - to: ../prow/jobs/kyma/tests/acceptance/acceptance.yaml
         values:
           <<: *go_kyma_component_v20181119


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- add missing "until" to apiserver-proxy and api-controller components
- switch to generic prow jobs for api-controller tests

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also kyma-project/kyma#5763