### PR TITLE
fix-backup-restore-event-bus

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-backup-test.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-backup-test.sh
@@ -299,7 +299,7 @@ function restoreKyma() {
     sleep 15
 
     echo "Add backup plugins"
-    velero plugin add eu.gcr.io/kyma-project/backup-plugins:e7df9098
+    velero plugin add eu.gcr.io/kyma-project/backup-plugins:PR-6050
 
     sleep 15
 


### PR DESCRIPTION
Velero plugin to set the Owner Reference of the NATS Channel Services.

See also:
Issue: https://github.com/kyma-project/kyma/issues/5942
PR: https://github.com/kyma-project/kyma/pull/6050