### PR TITLE
Fix buildpack image for pre-master-test-infra-validate-generated-file…

### DIFF
--- a/prow/jobs/test-infra/validation.yaml
+++ b/prow/jobs/test-infra/validation.yaml
@@ -65,7 +65,7 @@ presubmits:
       path_alias: github.com/kyma-project/test-infra
       spec:
         containers:
-          - image: eu.gcr.io/kyma-project/prow/test-infra/buildpack-golang:v20190116-69aa0a1
+          - image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:v20190116-69aa0a1
             securityContext:
               privileged: true
             command:


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:
- fix pre-master-test-infra-validate-generated-files docker image

**Related issue(s)**
Related: https://github.com/kyma-project/test-infra/issues/1460