### PR TITLE
Add JUnit XML reports per Kyma integration tests

### DIFF
--- a/prow/scripts/kind-install-kyma.sh
+++ b/prow/scripts/kind-install-kyma.sh
@@ -265,10 +265,7 @@ function main {
         junit::test_skip
     fi
 
-    junit::test_start "Test_Kyma"
-    log::info "Testing Kyma" 2>&1 | junit::test_output
-    kyma::test "${KYMA_SOURCES}" 2>&1 | junit::test_output
-    junit::test_pass
+    kyma::test "${SCRIPT_DIR}"
 }
 
 read_flags "$@"

--- a/prow/scripts/kyma-testing.sh
+++ b/prow/scripts/kyma-testing.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+CURRENT_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+readonly TMP_DIR=$(mktemp -d)
+readonly JUNIT_REPORT_PATH="${ARTIFACTS:-${TMP_DIR}}/junit_Kyma_octopus-test-suite.xml"
+readonly CONCURRENCY=5
+readonly SUITE_NAME="testsuite-all-$(date '+%Y-%m-%d-%H-%M')"
+
+# shellcheck disable=SC1090
+source "${CURRENT_PATH}/lib/testing-helpers.sh"
+
+kc="kubectl $(context_arg)"
+
+cleanup() {
+    rm -rf "${TMP_DIR}"
+}
+
+trap cleanup EXIT
+
+host::os() {
+  local host_os
+  case "$(uname -s)" in
+    Darwin)
+      host_os=darwin
+      ;;
+    Linux)
+      host_os=linux
+      ;;
+    *)
+      log::error "Unsupported host OS. Must be Linux or Mac OS X."
+      exit 1
+      ;;
+  esac
+  echo "${host_os}"
+}
+
+install::kyma_cli() {
+    mkdir -p "${INSTALL_DIR}/bin"
+    export PATH="${INSTALL_DIR}/bin:${PATH}"
+    os=$(host::os)
+
+    pushd "${INSTALL_DIR}/bin"
+
+
+    log::info "- Install kyma CLI ${os} locally to a tempdir..."
+
+    curl -sSLo kyma "https://storage.googleapis.com/kyma-cli-develop-version/kyma-${os}?alt=media"
+    chmod +x kyma
+
+    log::success "OK"
+
+    popd
+}
+
+cts::check_crd_exist() {
+  ${kc} get clustertestsuites.testing.kyma-project.io > /dev/null 2>&1
+  if [[ $? -eq 1 ]]
+  then
+     echo "ERROR: script requires ClusterTestSuite CRD"
+     exit 1
+  fi
+}
+
+cts::delete() {
+  existingCTSs=$(${kc} get cts -o custom-columns=NAME:.metadata.name --no-headers=true)
+  for cts in ${existingCTSs}
+  do
+    kyma test delete "${cts}"
+  done
+
+}
+
+function main() {
+  echo "----------------------------"
+  echo "- Testing Kyma..."
+  echo "----------------------------"
+
+  export INSTALL_DIR=${TMP_DIR}
+  install::kyma_cli
+
+  cts::check_crd_exist
+
+  cts::delete
+
+  matchTests="" # match all tests
+
+  ${kc} get cm dex-config -n kyma-system -ojsonpath="{.data}" | grep --silent "#__STATIC_PASSWORDS__"
+  if [[ $? -eq 1 ]]
+  then
+    # if static users are not available, do not execute tests which requires them
+    matchTests=$(${kc} get testdefinitions --all-namespaces -l 'require-static-users!=true' -o=go-template='{{- range .items}} {{.metadata.name}}{{- end}}')
+    echo "WARNING: following tests will be skipped due to the lack of static users:"
+    ${kc} get testdefinitions --all-namespaces -l 'require-static-users=true' -o=go-template --template='{{- range .items}}{{printf " - %s\n" .metadata.name}}{{- end}}'
+  fi
+
+  log::info "- Creating ClusterAddonsConfiguration which provides the testing addons"
+  injectTestingAddons
+  if [[ $? -eq 1 ]]; then
+    exit 1
+  fi
+
+  trap removeTestingAddons EXIT
+
+  log::info "- Running Kyma tests"
+  # shellcheck disable=SC2086
+  kyma test run ${matchTests} \
+                --name "${SUITE_NAME}" \
+                --concurrency "${CONCURRENCY}" \
+                --max-retries 1 \
+                --timeout "1h" \
+                --watch \
+                --non-interactive
+
+  log::info "- Test summary"
+  kyma test status "${SUITE_NAME}" -owide
+
+  # TODO(mszostok): decide if this should be supported by `kyma test status`,
+  #  right now we do not have the exit code
+  statusSucceeded=$(${kc} get cts "${SUITE_NAME}"  -ojsonpath="{.status.conditions[?(@.type=='Succeeded')]}")
+  if [[ "${statusSucceeded}" != *"True"* ]]; then
+    log::info "- Fetching logs due to test suite failure"
+    testExitCode=1
+
+    echo "- Fetching logs from testing pods in Failed status..."
+    kyma test logs "${SUITE_NAME}" --test-status Failed
+
+    echo "- Fetching logs from testing pods in Unknown status..."
+    kyma test logs "${SUITE_NAME}" --test-status Unknown
+
+    echo "- Fetching logs from testing pods in Running status due to running afer test suite timeout..."
+    kyma test logs "${SUITE_NAME}" --test-status Running
+
+  fi
+
+  log::info "- Generate JUnit test summary"
+  kyma test status "${SUITE_NAME}" -ojunit > "${JUNIT_REPORT_PATH}"
+
+  log::info "All test pods should be terminated. Checking..."
+  waitForTestPodsTermination "${SUITE_NAME}"
+  cleanupExitCode=$?
+
+  log::info "- ClusterTestSuite details"
+  kubectl get cts "${SUITE_NAME}" -oyaml
+
+  cts::delete
+
+  log::info "Images with tag latest are not allowed. Checking..."
+  printImagesWithLatestTag
+  latestTagExitCode=$?
+
+  exit $((testExitCode + cleanupExitCode + latestTagExitCode))
+}
+
+main

--- a/prow/scripts/lib/kyma.sh
+++ b/prow/scripts/lib/kyma.sh
@@ -8,7 +8,6 @@ function kyma::install {
         | sed -e "s/__.*__//g" \
         | kubectl apply -f-
     
-    # TODO: Szostok wbijaj tutaj :)
     "${1}/installation/scripts/is-installed.sh" --timeout "${5}"
 }
 
@@ -21,8 +20,7 @@ function kyma::load_config {
 }
 
 function kyma::test {
-    # TODO: Szostok wbijaj tutaj :)
-    "${1}/installation/scripts/testing.sh" --cleanup "false" --concurrency 5
+    "${1}/kyma-testing.sh"
 }
 
 function kyma::build_installer {

--- a/prow/scripts/lib/log.sh
+++ b/prow/scripts/lib/log.sh
@@ -1,17 +1,28 @@
 #!/usr/bin/env bash
 
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly INVERTED='\033[7m'
+readonly YELLOW='\e[33m'
+readonly NC='\033[0m' # No Color
+
 function log::date {
     date +"%Y/%m/%d %T %Z"
 }
 
 function log::info {
-    echo "$(log::date) [INFO] ${1}"
+    echo -e "${INVERTED}$(log::date) [INFO] ${1}${NC}"
 }
 
+function log::success {
+    echo -e "${GREEN}$(log::date) [INFO] ${1}${NC}"
+}
+
+
 function log::warn {
-    echo "$(log::date) [WARN] ${1}"
+    echo -e "${YELLOW}$(log::date) [WARN] ${1}${NC}"
 }
 
 function log::error {
-    >&2 echo "$(log::date) [ERRO] ${1}"
+    >&2 echo -e "${RED}$(log::date) [ERRO] ${1}${NC}"
 }

--- a/prow/scripts/lib/testing-helpers.sh
+++ b/prow/scripts/lib/testing-helpers.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+# shellcheck disable=SC1090
+source "${CURRENT_DIR}/log.sh"
+
+function context_arg() {
+    if [ -n "$KUBE_CONTEXT" ]; then
+        echo "--context $KUBE_CONTEXT"
+    fi
+}
+
+# retries are useful when api call can fail due to the infrastructure issue
+function executeKubectlWithRetries() {
+    local command="$1"
+    local retry=0
+    local result=""
+
+    while [[ ${retry} -lt 10 ]]; do
+        result=$(${command})
+        if [[ $? -eq 0 ]]; then
+            echo "${result}"
+            return 0
+        else
+            sleep 5
+        fi
+        (( retry++ ))
+    done
+    echo "Maximum retries exceeded: ${result}"
+    return 1
+}
+
+function cmdGetPodsForSuite() {
+    local suiteName=$1
+    cmd="kubectl $(context_arg) get pods -l testing.kyma-project.io/suite-name=${suiteName} \
+            --all-namespaces \
+            --no-headers=true \
+            -o=custom-columns=name:metadata.name,ns:metadata.namespace"
+    result=$(executeKubectlWithRetries "${cmd}")
+    if [[ $? -eq 1 ]]; then
+        echo "${result}"
+        return 1
+    fi
+    echo "${result}"
+}
+
+function checkTestPodTerminated() {
+    local suiteName=$1
+    runningPods=false
+
+    pod=""
+    namespace=""
+    idx=0
+
+    result=$(cmdGetPodsForSuite "${suiteName}")
+    if [[ $? -eq 1 ]]; then
+        echo "${result}"
+        return 1
+    fi
+
+    for podOrNs in ${result}
+    do
+       n=$((idx%2))
+       if [[ "$n" == 0 ]];then
+         pod=${podOrNs}
+         idx=$((idx+1))
+         continue
+       fi
+        namespace=${podOrNs}
+        idx=$((idx+1))
+
+        phase=$(executeKubectlWithRetries "kubectl $(context_arg) get pod $pod -n ${namespace} -o jsonpath={.status.phase}")
+        if [[ $? -eq 1 ]]; then
+            echo "${phase}"
+            return 1
+        fi
+        # A Pod's phase  Failed or Succeeded means pod has terminated.
+        # see: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
+        if [ "${phase}" !=  "Succeeded" ] && [ "${phase}" != "Failed" ]
+        then
+          log::error "Test pod '${pod}' has not terminated, pod phase: ${phase}"
+          runningPods=true
+        fi
+    done
+
+    if [ ${runningPods} = true ];
+    then
+        return 1
+    fi
+}
+
+function waitForTestPodsTermination() {
+    local retry=0
+    local suiteName=$1
+
+    while [ ${retry} -lt 3 ]; do
+        checkTestPodTerminated "${suiteName}"
+        checkTestPodTerminatedErr=$?
+        if [ ${checkTestPodTerminatedErr} -ne 0 ]; then
+            echo "Waiting for test pods to terminate..."
+            sleep 1
+        else
+            log::success "OK"
+            return 0
+        fi
+        retry=$((retry + 1))
+    done
+    log::error "FAILED"
+    return 1
+}
+
+function printImagesWithLatestTag() {
+    retry=10
+    while true; do
+        # shellcheck disable=SC2046
+        images=$(kubectl $(context_arg)  get pods --all-namespaces -o jsonpath="{..image}" |\
+        tr -s '[:space:]' '\n' |\
+        grep ":latest")
+        if [[ $? -eq 0 ]]; then
+            break
+        fi
+        (( retry-- ))
+        if [[ ${retry} -eq 0 ]]; then
+        return 1
+        fi
+        sleep 5
+    done
+
+    if [ ${#images} -ne 0 ]; then
+        log::error "${images}"
+        log::error "FAILED"
+        return 1
+    fi
+    log::success "OK"
+    return 0
+}
+
+TESTING_ADDONS_CFG_NAME="testing-addons"
+
+function injectTestingAddons() {
+    retry=10
+    while true; do
+        cat <<EOF | kubectl apply -f -
+apiVersion: addons.kyma-project.io/v1alpha1
+kind: ClusterAddonsConfiguration
+metadata:
+  labels:
+    addons.kyma-project.io/managed: "true"
+  name: ${TESTING_ADDONS_CFG_NAME}
+spec:
+  repositories:
+  - url: "https://github.com/kyma-project/addons/releases/download/0.8.0/index-testing.yaml"
+EOF
+        if [[ $? -eq 0 ]]; then
+            break
+        fi
+        (( retry-- ))
+        if [[ ${retry} -eq 0 ]]; then
+            return 1
+        fi
+        sleep 5
+    done
+
+    local retry=0
+    while [[ ${retry} -lt 10 ]]; do
+        msg=$(kubectl get clusteraddonsconfiguration ${TESTING_ADDONS_CFG_NAME} -o=jsonpath='{.status.phase}')
+        if [[ "${msg}" = "Ready" ]]; then
+            log::success "Testing addons injected"
+            return 0
+        fi
+        if [[ "${msg}" = "Failed" ]]; then
+            log::error "Testing addons configuration failed"
+            removeTestingAddons
+            return 1
+        fi
+        echo "Waiting for ready testing addons ${retry}/10.. status: ${msg}"
+        retry=$((retry + 1))
+        sleep 3
+    done
+    log::error "Testing addons couldn't be injected"
+    return 1
+}
+
+function removeTestingAddons() {
+    result=$(executeKubectlWithRetries "kubectl delete clusteraddonsconfiguration ${TESTING_ADDONS_CFG_NAME}")
+    echo "${result}"
+    if [[ $? -eq 1 ]]; then
+        return 1
+    fi
+    log::success "Testing addons removed"
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add JUnit XML reports per Kyma integration tests


This PRs add the kyma-testing.sh script which is using the Kyma CLI to execute Kyma integration tests and generate JUnit XML report which is consumed by Prow Job.

If this solution will be stable that we will move other jobs to also use the `kyma-testing.sh` script from test-infra instead of using `testing.sh` script from kyma repo.

Here you can find information about the next changes that are planned:
https://gist.github.com/mszostok/497fcee59651220920477260607153e3

**Related issue(s)**

- https://github.com/kyma-project/test-infra/issues/1636

