### PR TITLE
Add opt to inject addons only if necessary

### DIFF
--- a/prow/scripts/kyma-testing.sh
+++ b/prow/scripts/kyma-testing.sh
@@ -42,7 +42,6 @@ install::kyma_cli() {
 
     pushd "${INSTALL_DIR}/bin"
 
-
     log::info "- Install kyma CLI ${os} locally to a tempdir..."
 
     curl -sSLo kyma "https://storage.googleapis.com/kyma-cli-stable/kyma-${os}?alt=media"
@@ -71,6 +70,23 @@ cts::delete() {
 
 }
 
+inject_addons_if_necessary() {
+  tdWithAddon=$(${kc} get td --all-namespaces -l testing.kyma-project.io/require-testing-addon=true -o custom-columns=NAME:.metadata.name --no-headers=true)
+
+  if [ -z "$tdWithAddon" ]
+  then
+      log::info "- Skipping injecting ClusterAddonsConfiguration"
+  else
+      log::info "- Creating ClusterAddonsConfiguration which provides the testing addons"
+      injectTestingAddons
+      if [[ $? -eq 1 ]]; then
+        exit 1
+      fi
+
+      trap removeTestingAddons EXIT
+  fi
+}
+
 function main() {
   echo "----------------------------"
   echo "- Testing Kyma..."
@@ -83,13 +99,7 @@ function main() {
 
   cts::delete
 
-  log::info "- Creating ClusterAddonsConfiguration which provides the testing addons"
-  injectTestingAddons
-  if [[ $? -eq 1 ]]; then
-    exit 1
-  fi
-
-  trap removeTestingAddons EXIT
+  inject_addons_if_necessary
 
   log::info "- Running Kyma tests"
   # match all tests


### PR DESCRIPTION
**Description**

Currently, we need to have transition phase. In test-infra we will check if the injecting addon is still necessary if some TD will be discovered then it will be injected if not then it will be skipped.

Changes proposed in this pull request:

- Add opt to inject addons only if necessary

**Blocked by:** https://github.com/kyma-project/kyma/pull/6491

**Related issue(s)**

- https://github.com/kyma-project/kyma/issues/6253