### PR TITLE
Fix the pre-master-kyma-gke-backup-k8s-1-14 job

### DIFF
--- a/prow/jobs/kyma/kyma-integration-k8s-1-14.yaml
+++ b/prow/jobs/kyma/kyma-integration-k8s-1-14.yaml
@@ -341,3 +341,5 @@ presubmits: # runs on PRs
         preset-build-pr: "true"
         <<: *gke_backup_job_labels_template
       extra_refs:
+        - <<: *test_infra_ref
+          base_ref: master


### PR DESCRIPTION
**Description**

Fix the **pre-master-kyma-gke-backup-k8s-1-14** job by adding the missing `extra_refs`.

**Related issue(s)**
https://github.com/kyma-project/kyma/pull/6265
