### PR TITLE
Add artifact trace of images contained in release

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -264,7 +264,7 @@ endif
 
 IMAGES_LIST=$(kubectl get pods --all-namespaces -o jsonpath="{..image}" | tr -s '[:space:]' '\n' | sort | uniq)
 
-echo "${IMAGES_LIST}" > "${ARTIFACTS}/${RELEASE_VERSION}.txt" # should write all the containers to a text file under the artifacts folder
+echo "${IMAGES_LIST}" > "${ARTIFACTS}/${RELEASE_VERSION}.txt" # should write all the images to a text file under the artifacts folder
 
 shout "Success"
 

--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -262,11 +262,9 @@ ifndef ARTIFACTS
 ARTIFACTS:=/tmp/artifacts
 endif
 
-CONTAINER_LIST=$(kubectl get pods --all-namespaces -o jsonpath="{..image}" | tr -s '[[:space:]]' '\n' | sort | uniq)
+CONTAINER_LIST=$(kubectl get pods --all-namespaces -o jsonpath="{..image}" | tr -s '[:space:]' '\n' | sort | uniq)
 
-FILE="${ARTIFACTS}/${RELEASE_VERSION}.txt"
-
-echo "${CONTAINER_LIST}" > $FILE # should write all the containers to a text file under the artifacts folder
+echo "${CONTAINER_LIST}" > "${ARTIFACTS}/${RELEASE_VERSION}.txt" # should write all the containers to a text file under the artifacts folder
 
 shout "Success"
 

--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -256,6 +256,18 @@ if [ -n "$(kubectl get  service -n kyma-system apiserver-proxy-ssl --ignore-not-
     IP_ADDRESS=${APISERVER_IP_ADDRESS} DNS_FULL_NAME=${APISERVER_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
 fi
 
+shout "Collect container labels"
+date
+ifndef ARTIFACTS
+ARTIFACTS:=/tmp/artifacts
+endif
+
+CONTAINER_LIST=$(kubectl get pods --all-namespaces -o jsonpath="{..image}" | tr -s '[[:space:]]' '\n' | sort | uniq)
+
+FILE="${ARTIFACTS}/${RELEASE_VERSION}.txt"
+
+echo "${CONTAINER_LIST}" > $FILE # should write all the containers to a text file under the artifacts folder
+
 shout "Success"
 
 #!!! Must be at the end of the script !!!

--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -262,9 +262,9 @@ ifndef ARTIFACTS
 ARTIFACTS:=/tmp/artifacts
 endif
 
-CONTAINER_LIST=$(kubectl get pods --all-namespaces -o jsonpath="{..image}" | tr -s '[:space:]' '\n' | sort | uniq)
+IMAGES_LIST=$(kubectl get pods --all-namespaces -o jsonpath="{..image}" | tr -s '[:space:]' '\n' | sort | uniq)
 
-echo "${CONTAINER_LIST}" > "${ARTIFACTS}/${RELEASE_VERSION}.txt" # should write all the containers to a text file under the artifacts folder
+echo "${IMAGES_LIST}" > "${ARTIFACTS}/${RELEASE_VERSION}.txt" # should write all the containers to a text file under the artifacts folder
 
 shout "Success"
 


### PR DESCRIPTION
**Description**
write out images and their tags running in the cluster, write them to artifacts folder

Changes proposed in this pull request:
- when release cluster is deployed, query running cluster for images running in that cluster
