### PR TITLE
Corrected volume name with prometheus db.

### DIFF
--- a/prow/scripts/resources/prometheus-operator-stackdriver-patch.yaml
+++ b/prow/scripts/resources/prometheus-operator-stackdriver-patch.yaml
@@ -38,4 +38,4 @@ spec:
           containerPort: 9091
       volumeMounts:
         - mountPath: /data
-          name: prometheus-monitoring-db
+          name: prometheus-monitoring-prometheus-db


### PR DESCRIPTION
Fixed wrong volume name with prometheus db in stackdriver collector sidecar container.
