### PR TITLE
Best-effort cleanup of nightly-aks cluster resources

### DIFF
--- a/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
@@ -66,7 +66,8 @@ function cleanup() {
 	shout "Cleanup"
 	date
 
-	#Turn off exit-on-error so that next step is executed even if previous one fails.
+	# Turn off exit-on-error so that next step is executed even if previous one fails.
+	# Cleanup is best-effort since we don't know in which state the previous cluster is, if there is any.
 	set +e
 	EXIT_STATUS=$?
 
@@ -87,13 +88,13 @@ function cleanup() {
 		if [[ ${TMP_STATUS} -ne 0 ]]; then EXIT_STATUS=${TMP_STATUS}; fi
 		if [[ -n ${GATEWAY_IP_ADDRESS} ]];then
 			echo "Fetched Azure Gateway IP: ${GATEWAY_IP_ADDRESS}"
+			# only try to delete the dns record if the ip address has been found
+			"${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/delete-dns-record.sh --project="${CLOUDSDK_CORE_PROJECT}" --zone="${CLOUDSDK_DNS_ZONE_NAME}" --name="${GATEWAY_DNS_FULL_NAME=}" --address="${GATEWAY_IP_ADDRESS}" --dryRun=false
+			TMP_STATUS=$?
+			if [[ ${TMP_STATUS} -ne 0 ]]; then EXIT_STATUS=${TMP_STATUS}; fi
 		else
 			echo "Could not fetch Azure Gateway IP: GATEWAY_IP_ADDRESS variable is empty. Something went wrong. Failing"
 		fi
-		TMP_STATUS=$?
-		if [[ ${TMP_STATUS} -ne 0 ]]; then EXIT_STATUS=${TMP_STATUS}; fi
-
-		"${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/delete-dns-record.sh --project="${CLOUDSDK_CORE_PROJECT}" --zone="${CLOUDSDK_DNS_ZONE_NAME}" --name="${GATEWAY_DNS_FULL_NAME=}" --address="${GATEWAY_IP_ADDRESS}" --dryRun=false
 		TMP_STATUS=$?
 		if [[ ${TMP_STATUS} -ne 0 ]]; then EXIT_STATUS=${TMP_STATUS}; fi
 

--- a/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
@@ -89,7 +89,6 @@ function cleanup() {
 			echo "Fetched Azure Gateway IP: ${GATEWAY_IP_ADDRESS}"
 		else
 			echo "Could not fetch Azure Gateway IP: GATEWAY_IP_ADDRESS variable is empty. Something went wrong. Failing"
-			exit 1
 		fi
 		TMP_STATUS=$?
 		if [[ ${TMP_STATUS} -ne 0 ]]; then EXIT_STATUS=${TMP_STATUS}; fi


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

- The nightly-aks job fails if there is no previous cluster to cleanup

Changes proposed in this pull request:

- Make whole cleanup of the old cluster best-effort (allowed to fail)

**What Happened**

The nightly-aks job failed [today](https://storage.googleapis.com/kyma-prow-logs/logs/kyma-aks-nightly/1204249446955618305/build-log.txt) with the following error message:

```
#################################################################################################
# Install Kubernetes on Azure
#################################################################################################
%ERROR: Deployment failed. Correlation ID: 6d04def2-c83d-41b5-9f0c-649e95a98129. We are unable to serve this request due to an internal error, Correlation ID: bf900714-c095-44d3-93e7-18aa1a8163c8, Operation ID: cbc05f43-99e4-4636-b50d-b5c18158c63e, Timestamp: 2019-12-10T04:22:49Z.
```


The timely following jobs, e.g. this [one](https://storage.googleapis.com/kyma-prow-logs/logs/kyma-aks-nightly/1204288452804218880/build-log.txt) will try to perform a cleanup of the old cluster resources, but will fail if the cluster does not exists. Error message:

```
#################################################################################################
# Cleanup
#################################################################################################
Tue Dec 10 06:35:33 UTC 2019
---
Remove DNS Record for Ingressgateway
---
ERROR: The Resource 'Microsoft.Network/publicIPAddresses/nightly-aks' under resource group 'MC_kyma-nightly-aks_nightly-aks_northeurope' was not found.
Could not fetch Azure Gateway IP: GATEWAY_IP_ADDRESS variable is empty. Something went wrong. Failing
```




<img width="1001" alt="Screenshot 2019-12-11 at 13 56 38" src="https://user-images.githubusercontent.com/8013145/70623276-10857600-1c1e-11ea-871b-25641065e2ec.png">

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
