### PR TITLE
Clean up test addons before e2e tests for remaining upgrade jobs

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-rel2rel-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-rel2rel-upgrade.sh
@@ -405,6 +405,21 @@ upgradeKyma() {
     fi
 }
 
+remove_addons_if_necessary() {
+  tdWithAddon=$(kubectl get td --all-namespaces -l testing.kyma-project.io/require-testing-addon=true -o custom-columns=NAME:.metadata.name --no-headers=true)
+
+  if [ -z "$tdWithAddon" ]
+  then
+      echo "- Removing ClusterAddonsConfiguration which provides the testing addons"
+      removeTestingAddons
+      if [[ $? -eq 1 ]]; then
+        exit 1
+      fi
+  else
+      echo "- Skipping removing ClusterAddonsConfiguration"
+  fi
+}
+
 testKyma() {
     shout "Test Kyma end-to-end upgrade scenarios"
     date
@@ -453,6 +468,8 @@ installKyma
 createTestResources
 
 upgradeKyma
+
+remove_addons_if_necessary
 
 testKyma
 

--- a/prow/scripts/cluster-integration/kyma-gke-upgrade-xip.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-upgrade-xip.sh
@@ -350,6 +350,21 @@ function upgradeKyma() {
 
 }
 
+remove_addons_if_necessary() {
+  tdWithAddon=$(kubectl get td --all-namespaces -l testing.kyma-project.io/require-testing-addon=true -o custom-columns=NAME:.metadata.name --no-headers=true)
+
+  if [ -z "$tdWithAddon" ]
+  then
+      echo "- Removing ClusterAddonsConfiguration which provides the testing addons"
+      removeTestingAddons
+      if [[ $? -eq 1 ]]; then
+        exit 1
+      fi
+  else
+      echo "- Skipping removing ClusterAddonsConfiguration"
+  fi
+}
+
 function testKyma() {
     shout "Test Kyma end-to-end upgrade scenarios"
     date
@@ -396,6 +411,8 @@ installKyma
 createTestResources
 
 upgradeKyma
+
+remove_addons_if_necessary
 
 testKyma
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Apply the same `remove_addons_if_necessary` function before final e2e testing for the two remaining upgrade jobs

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/6740