### PR TITLE
Adjust jobs definition after refactoring compass test directors

### DIFF
--- a/development/tools/jobs/incubator/tests_test.go
+++ b/development/tools/jobs/incubator/tests_test.go
@@ -15,7 +15,7 @@ var tests = []struct {
 	additionalOptions []jobsuite.Option
 }{
 	{
-		name: "connector-tests",
+		name:  "connector-tests",
 		image: tester.ImageBootstrap20181204,
 		suite: tester.NewGenericComponentSuite,
 		additionalOptions: []jobsuite.Option{
@@ -25,17 +25,29 @@ var tests = []struct {
 		},
 	},
 	{
-		name: "end-to-end",
+		name:  "end-to-end",
 		image: tester.ImageBootstrap20181204,
 		suite: tester.NewGenericComponentSuite,
 		additionalOptions: []jobsuite.Option{
 			jobsuite.JobFileSuffix("generic"),
 			jobsuite.CompassRepo(),
 			jobsuite.Since(releases.Release17),
+			jobsuite.Optional(),
 		},
 	},
 	{
-		name: "provisioner-tests",
+		name:  "director-tests",
+		image: tester.ImageBootstrap20181204,
+		suite: tester.NewGenericComponentSuite,
+		additionalOptions: []jobsuite.Option{
+			jobsuite.JobFileSuffix("generic"),
+			jobsuite.CompassRepo(),
+			jobsuite.Since(releases.Release110),
+			jobsuite.Optional(),
+		},
+	},
+	{
+		name:  "provisioner-tests",
 		image: tester.ImageBootstrap20181204,
 		suite: tester.NewGenericComponentSuite,
 		additionalOptions: []jobsuite.Option{

--- a/prow/jobs/incubator/compass/tests/director-tests/director-tests-generic.yaml
+++ b/prow/jobs/incubator/compass/tests/director-tests/director-tests-generic.yaml
@@ -20,8 +20,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
-    - ^release-(1\.9|1\.8|1\.7)-end-to-end$
-  run_if_changed: "^tests/end-to-end/|^scripts/"
+  run_if_changed: "^tests/director-tests/|^scripts/|components/director"
   spec:
     containers:
       - image: eu.gcr.io/kyma-project/prow/test-infra/bootstrap:v20181204-a6e79be
@@ -30,7 +29,7 @@ job_template: &job_template
         command:
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-generic.sh"
         args:
-          - "/home/prow/go/src/github.com/kyma-incubator/compass/tests/end-to-end"
+          - "/home/prow/go/src/github.com/kyma-incubator/compass/tests/director-tests"
         resources:
           requests:
             memory: 1.5Gi
@@ -38,12 +37,12 @@ job_template: &job_template
 
 presubmits: # runs on PRs
   kyma-incubator/compass:
-    - name: pre-compass-tests-end-to-end
+    - name: pre-compass-tests-director-tests
       skip_report: false
       optional: true
       <<: *job_template
 
 postsubmits:
   kyma-incubator/compass:
-    - name: post-compass-tests-end-to-end
+    - name: post-compass-tests-director-tests
       <<: *job_template

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -301,7 +301,19 @@ templates:
           <<: *compass_generic_component
           path: tests/end-to-end
           since: "1.7"
-          optional: false
+          optional: true
+      - to: ../prow/jobs/incubator/compass/tests/director-tests/director-tests-generic.yaml
+        values:
+          repository: github.com/kyma-incubator/compass
+          build: build
+          pushRepository: incubator
+          bootstrapTag: v20181204-a6e79be
+          additionalRunIfChanged:
+          - ^scripts/
+          - components/director
+          path: tests/director-tests
+          since: "1.10"
+          optional: true
       - to: ../prow/jobs/incubator/compass/tests/provisioner-tests/provisioner-tests-generic.yaml
         values:
           <<: *compass_generic_component


### PR DESCRIPTION
In Compass, we are going to rename `tests/end-to-end` to `tests/director-tests` to be consistent with other tests. In this PR, we add a new job that builds `director-tests` when it's code is changed, or `components/director` is modified (tests use Director code directly, not from vendored director).
For a transition phase, jobs `director-tests` and `end-to-end` are optional.