### PR TITLE
Extend kubebuilder buildpack image: add goimports

### DIFF
--- a/prow/images/buildpack-golang-kubebuilder2/Dockerfile
+++ b/prow/images/buildpack-golang-kubebuilder2/Dockerfile
@@ -1,6 +1,6 @@
 # Golang buildpack with kubebuilder
 
-FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.12
+FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20191011-51ed45a
 
 # Buildpack variables
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add goimports to kubebuilder buildpack image
