### PR TITLE
Upgrade buildpack-golang-toolbox to go 1.13

### DIFF
--- a/prow/images/buildpack-golang-toolbox/Dockerfile
+++ b/prow/images/buildpack-golang-toolbox/Dockerfile
@@ -1,6 +1,6 @@
 # Basic golang buildpack
 
-FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.12
+FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.13
 
 # Install additional tools
 


### PR DESCRIPTION
**Description**
Upgrade buildpack-golang-toolbox to go 1.13

Changes proposed in this pull request:

- Upgrade buildpack-golang-toolbox to go 1.13

**Related issue(s)**
