### PR TITLE
Upgrade alpine-kubectl base image, kubectl and helm versions

### DIFF
--- a/prow/images/alpine-kubectl/Dockerfile
+++ b/prow/images/alpine-kubectl/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.8
+FROM alpine:3.10
 
 LABEL source=git@github.com:kyma-project/test-infra.git
 
-ENV HELM_VERSION="v2.10.0"
-ENV KUBECTL_VERSION="v1.13.0"
+ENV HELM_VERSION="v2.16.1"
+ENV KUBECTL_VERSION="v1.16.3"
 
 RUN apk update &&\
 	apk add openssl coreutils curl bash &&\


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Upgrade alpine-kubectl base image, kubectl and helm versions

Changes proposed in this pull request:
- upgrade alpine to 3.10
- upgrade kubectl to v1.16.3
- upgrade helm to v2.16.1

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also: kyma-project/kyma#5530