### PR TITLE
Use newer toolbox with Go 1.13 in Kubebuilder image

### DIFF
--- a/prow/images/buildpack-golang-kubebuilder2/Dockerfile
+++ b/prow/images/buildpack-golang-kubebuilder2/Dockerfile
@@ -1,6 +1,6 @@
 # Golang buildpack with kubebuilder
 
-FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20191011-51ed45a
+FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200117-d3885041
 
 # Buildpack variables
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Compass Provisioner in the new version needs buildpack image with Go 1.13 and Kubebuilder. The newest `golang-toolbox` image already has Go 1.13

Changes proposed in this pull request:

- Use newer toolbox with Go 1.13 in Kubebuilder image

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
