### PR TITLE
Fix logs display for prepare data upgrade test pod

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
@@ -363,7 +363,8 @@ createTestResources() {
     set -o errexit
 
     echo "Logs for prepare data operation to test e2e upgrade: "
-    kubectl logs -n "${UPGRADE_TEST_NAMESPACE}" -l "${UPGRADE_TEST_RESOURCE_LABEL}=${UPGRADE_TEST_LABEL_VALUE_PREPARE}" -c "${TEST_CONTAINER_NAME}"
+    # shellcheck disable=SC2046
+    kubectl logs -n "${UPGRADE_TEST_NAMESPACE}" $(kubectl get pod -n "${UPGRADE_TEST_NAMESPACE}" -l "${UPGRADE_TEST_RESOURCE_LABEL}=${UPGRADE_TEST_LABEL_VALUE_PREPARE}" -o json | jq -r '.items | .[] | .metadata.name') -c "${TEST_CONTAINER_NAME}"
     if [ "${prepareTestResult}" != 0 ]; then
         echo "Exit status for prepare upgrade e2e tests: ${prepareTestResult}"
         exit "${prepareTestResult}"


### PR DESCRIPTION
**Description**
When `kubectl` logs command is called with `-l` flag, sometimes for long content, logs are truncated:
```
kubectl logs -l <labelKey>=<labelValue> -c <containerName>
```

I couldn't find any related issue in `kubectl` but you can easily check it with some pods where logs are long (e.g. service-catalog controller manager on Kyma)

In the proposed PR new way of display logs are implemented.

**Related issue(s)**
[6676](https://github.com/kyma-project/kyma/issues/6676)
