### PR TITLE
Increase kyma timeout for gardener to 60m

### DIFF
--- a/prow/jobs/kyma/kyma-integration-gardener-azure.yaml
+++ b/prow/jobs/kyma/kyma-integration-gardener-azure.yaml
@@ -2,7 +2,6 @@ periodics:
 - name: kyma-gardener-azure-integration
   decorate: true
   decoration_config:
-
     timeout: 11700000000000 # 3h:15m
     grace_period: 600000000000 # 10min
   cron: "00 11 * * *"

--- a/prow/jobs/kyma/kyma-integration-gardener-azure.yaml
+++ b/prow/jobs/kyma/kyma-integration-gardener-azure.yaml
@@ -2,7 +2,8 @@ periodics:
 - name: kyma-gardener-azure-integration
   decorate: true
   decoration_config:
-    timeout: 10800000000000 # 3h
+
+    timeout: 11700000000000 # 3h:15m
     grace_period: 600000000000 # 10min
   cron: "00 11 * * *"
   extra_refs:

--- a/prow/scripts/cluster-integration/kyma-gardener-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gardener-integration.sh
@@ -133,7 +133,7 @@ date
 
 (
 set -x
-yes | kyma install --non-interactive --source latest --timeout 45m #--domain "${DOMAIN}" --tlsCert "${TLS_CERT}" --tlsKey "${TLS_KEY}"
+yes | kyma install --non-interactive --source latest --timeout 60m #--domain "${DOMAIN}" --tlsCert "${TLS_CERT}" --tlsKey "${TLS_KEY}"
 )
 
 shout "Checking the versions"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Recent jobs on for [nightly gardener job](https://status.build.kyma-project.io/job-history/kyma-prow-logs/logs/kyma-gardener-azure-integration) are failing because of kyma installation timeout. It works locally for me, but just takes ages. Let's increase it and check if we have a general problem with gardener or if everything is just slow

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
maybe related to these issues:
https://github.com/kyma-project/kyma/issues/6950
https://github.com/kyma-project/kyma/issues/6876