### PR TITLE
Correct order in which resources are restored in backup test

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-backup-test.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-backup-test.sh
@@ -326,11 +326,11 @@ function restoreKyma() {
     done
     
 
-    shout "Restore Kyma CRDs"
+    shout "Restore Kyma CRDs, Services and Endpoints"
     date
-    velero restore create --from-backup "${BACKUP_NAME}" --include-resources customresourcedefinitions.apiextensions.k8s.io --wait
+    velero restore create --from-backup "${BACKUP_NAME}" --include-resources customresourcedefinitions.apiextensions.k8s.io,services,endpoints --wait
 
-    sleep 15
+    sleep 30
 
     shout "Patch Velero Deployment"
 
@@ -354,16 +354,16 @@ function restoreKyma() {
       }
     }
     '
+    
+    sleep 15
 
-    sleep 30
-
-    shout "Restore Kyma"
+    shout "Restore the rest of Kyma"
     date
 
     attempts=3
     for ((i=1; i<=attempts; i++)); do
         
-        velero restore create --from-backup "${BACKUP_NAME}" --restore-volumes --include-cluster-resources --wait
+        velero restore create --from-backup "${BACKUP_NAME}" --exclude-resources customresourcedefinitions.apiextensions.k8s.io,services,endpoints --restore-volumes --wait
 
         sleep 60
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- introduce order of restoring resources (taken from backup chart) in order to satisfy our need in Rafter to restore clusterassetgroups and assetgroups custom resources as last ones

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

See also https://github.com/kyma-project/kyma/issues/6539