### PR TITLE
Make integration job on minikube NOT optional (revert)

### DIFF
--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -17,7 +17,6 @@ k8s_1-14: &k8s_1-14
 vm_job_template: &vm_job_template
   skip_report: false # from documentation: SkipReport skips commenting and setting status on GitHub.
   decorate: true
-  optional: true
   path_alias: github.com/kyma-project/kyma
   max_concurrency: 10
   spec:

--- a/templates/templates/kyma-integration.yaml
+++ b/templates/templates/kyma-integration.yaml
@@ -15,7 +15,6 @@ k8s_1-14: &k8s_1-14
 vm_job_template: &vm_job_template
   skip_report: false # from documentation: SkipReport skips commenting and setting status on GitHub.
   decorate: true
-  optional: true
   path_alias: github.com/kyma-project/kyma
   max_concurrency: 10
   spec:


### PR DESCRIPTION
**Description**

Since https://github.com/kyma-project/kyma/issues/7132 is solved we can revert the workaround. 

Changes proposed in this pull request:

-  minikube integration test is mandatory again
- ...
- ...

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/7132