### PR TITLE
Service Account and Slack fixes for reporting

### DIFF
--- a/development/container-vulnerabilities.sh
+++ b/development/container-vulnerabilities.sh
@@ -8,8 +8,15 @@ set -o pipefail
 
 readonly DEVELOPMENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ -z "$SAP_SLACK_BOT_TOKEN" ] ; then
-    echo "ERROR: \$SAP_SLACK_BOT_TOKEN is not set"
+discoverUnsetVar=false
+
+for var in GOOGLE_APPLICATION_CREDENTIALS SLACK_CHANNEL SAP_SLACK_BOT_TOKEN; do
+    if [ -z "${!var}" ] ; then
+        echo "ERROR: $var is not set"
+        discoverUnsetVar=true
+    fi
+done
+if [ "${discoverUnsetVar}" = true ] ; then
     exit 1
 fi
 

--- a/development/tools/cmd/vulnerabilitycollector/main.go
+++ b/development/tools/cmd/vulnerabilitycollector/main.go
@@ -86,6 +86,6 @@ func main() {
 
 	slackErr := vulnerabilitycollector.WriteToSlack(!*dryRun, fmt.Sprintf("Checked %d containers and found a total of %d vulnerabilities", len(imageList), totalNumberOfIssues), totalHighSeverityIssues, totalNumberOfIssues)
 	if slackErr != nil {
-		log.Errorf("Error occured sending slack message: %w", slackErr)
+		log.Errorf("Error occured sending slack message: %s", slackErr)
 	}
 }

--- a/development/tools/cmd/vulnerabilitycollector/main.go
+++ b/development/tools/cmd/vulnerabilitycollector/main.go
@@ -84,6 +84,8 @@ func main() {
 
 	log.Infof("%sFound %d vulnerabilities for specified project when checking %d containers", changePrefix, totalNumberOfIssues, len(imageList))
 
-	vulnerabilitycollector.WriteToSlack(!*dryRun, fmt.Sprintf("Checked %d containers and found a total of %d vulnerabilities", len(imageList), totalNumberOfIssues), totalHighSeverityIssues, totalNumberOfIssues)
-
+	slackErr := vulnerabilitycollector.WriteToSlack(!*dryRun, fmt.Sprintf("Checked %d containers and found a total of %d vulnerabilities", len(imageList), totalNumberOfIssues), totalHighSeverityIssues, totalNumberOfIssues)
+	if slackErr != nil {
+		log.Errorf("Error occured sending slack message: %w", slackErr)
+	}
 }

--- a/development/tools/pkg/vulnerabilitycollector/vulnerabilitycollector.go
+++ b/development/tools/pkg/vulnerabilitycollector/vulnerabilitycollector.go
@@ -141,12 +141,21 @@ func FindVulnerabilityOccurrencesForImage(ctx context.Context, projectID string,
 }
 
 //WriteToSlack writes output to slack
-func WriteToSlack(doChanges bool, message string, high int, total int) {
+func WriteToSlack(doChanges bool, message string, high int, total int) error {
+	token := os.Getenv("SAP_SLACK_BOT_TOKEN")
+	if token == "" {
+		return fmt.Errorf("Slack token not set in environment variable 'SAP_SLACK_BOT_TOKEN'")
+	}
+	channel := os.Getenv("SLACK_CHANNEL")
+	if channel == "" {
+		return fmt.Errorf("Slack channel not set in environment variable 'SLACK_CHANNEL'")
+	}
+
 	changePrefix := ""
 	if !doChanges {
 		changePrefix = "[DRYRUN] "
 	}
-	api := slack.New(os.Getenv("SLACKKEY"))
+	api := slack.New(token)
 	var highc string
 	var countt string
 	if high > 0 {
@@ -182,11 +191,11 @@ func WriteToSlack(doChanges bool, message string, high int, total int) {
 	var channelID, timestamp string
 	if doChanges {
 		var errSlackPost error
-		channelID, timestamp, errSlackPost = api.PostMessage(os.Getenv("SLACKCHANNEL"), slack.MsgOptionText(message, false), slack.MsgOptionAttachments(attachment...))
+		channelID, timestamp, errSlackPost = api.PostMessage(channel, slack.MsgOptionText(message, false), slack.MsgOptionAttachments(attachment...))
 		if errSlackPost != nil {
-			log.Printf("%s\n", errSlackPost)
-			return
+			return fmt.Errorf("Posting message to slack channel failed: %w", errSlackPost)
 		}
 	}
 	log.Infof("%sMessage successfully sent to channel %s at %s", changePrefix, channelID, timestamp)
+	return nil
 }

--- a/development/tools/pkg/vulnerabilitycollector/vulnerabilitycollector.go
+++ b/development/tools/pkg/vulnerabilitycollector/vulnerabilitycollector.go
@@ -150,6 +150,10 @@ func WriteToSlack(doChanges bool, message string, high int, total int) error {
 	if channel == "" {
 		return fmt.Errorf("Slack channel not set in environment variable 'SLACK_CHANNEL'")
 	}
+	buildId := os.Getenv("BUILD_ID") // prow variable for build id
+	if buildId == "" {
+		buildId = "NOT_FOUND"
+	}
 
 	changePrefix := ""
 	if !doChanges {
@@ -183,7 +187,7 @@ func WriteToSlack(doChanges bool, message string, high int, total int) error {
 				slack.AttachmentAction{
 					Type: "button",
 					Text: "Browse logs",
-					URL:  "https://gcsweb.build.kyma-project.io/gcs/kyma-prow-logs/logs/kyma-gcp-container-vulnerability-collector", // TODO: Find out if we can get this URL programmatically.
+					URL:  fmt.Sprintf("https://gcsweb.build.kyma-project.io/gcs/kyma-prow-logs/logs/kyma-gcp-container-vulnerability-collector/%s", buildId), // TODO: Find out if we can get this URL programmatically.
 				},
 			},
 		},
@@ -193,7 +197,7 @@ func WriteToSlack(doChanges bool, message string, high int, total int) error {
 		var errSlackPost error
 		channelID, timestamp, errSlackPost = api.PostMessage(channel, slack.MsgOptionText(message, false), slack.MsgOptionAttachments(attachment...))
 		if errSlackPost != nil {
-			return fmt.Errorf("Posting message to slack channel failed: %w", errSlackPost)
+			return fmt.Errorf("Posting message to slack channel failed: %s", errSlackPost)
 		}
 	}
 	log.Infof("%sMessage successfully sent to channel %s at %s", changePrefix, channelID, timestamp)

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -298,6 +298,19 @@ presets:
           name: kyma-snyk-token
           key: secret
   - labels:
+      preset-sa-gke-kyma-integration-gcp-vulnerability-scanner: "true"
+    env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/credentials/sa-gke-kyma-integration/service-account.json
+    volumes:
+      - name: sa-gke-kyma-integration
+        secret:
+          secretName: sa-gke-kyma-integration
+    volumeMounts:
+      - name: sa-gke-kyma-integration
+        mountPath: /etc/credentials/sa-gke-kyma-integration
+        readOnly: true
+  - labels:
       preset-sap-slack-bot-token: "true"
     env:
     - name: SAP_SLACK_BOT_TOKEN

--- a/prow/jobs/kyma/kyma-vulnerability-scanner.yaml
+++ b/prow/jobs/kyma/kyma-vulnerability-scanner.yaml
@@ -41,6 +41,7 @@ periodics:
   labels:
     preset-sap-slack-bot-token: "true"
     preset-kyma-slack-channel: "true"
+    preset-sa-gke-kyma-integration-gcp-vulnerability-scanner: "true" # service account with Occurence Viewer permission
   extra_refs:
     - <<: *test_infra_ref
       base_ref: master

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -296,6 +296,19 @@ presets:
           name: kyma-snyk-token
           key: secret
   - labels:
+      preset-sa-gke-kyma-integration-gcp-vulnerability-scanner: "true"
+    env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/credentials/sa-gke-kyma-integration/service-account.json
+    volumes:
+      - name: sa-gke-kyma-integration
+        secret:
+          secretName: sa-gke-kyma-integration
+    volumeMounts:
+      - name: sa-gke-kyma-integration
+        mountPath: /etc/credentials/sa-gke-kyma-integration
+        readOnly: true
+  - labels:
       preset-sap-slack-bot-token: "true"
     env:
     - name: SAP_SLACK_BOT_TOKEN


### PR DESCRIPTION
**Description**
Job was missing service account with enough permissions to read vulnerabilities, as well as the Slack messaging would never have worked with the way how it was setup.

Changes proposed in this pull request:
- fix slack messaging
- add service account

**Related issue(s)**
#2019 
