### PR TITLE
Change VM type for AKS to Standard_F8s_v2

### DIFF
--- a/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
@@ -51,7 +51,7 @@ readonly REPO_NAME="kyma"
 readonly CURRENT_TIMESTAMP=$(date +%Y%m%d)
 
 export CLUSTER_NAME="${STANDARIZED_NAME}"
-export CLUSTER_SIZE="Standard_D4_v3"
+export CLUSTER_SIZE="Standard_F8s_v2"
 # set cluster version as MAJOR.MINOR without PATCH part (e.g. 1.10, 1.11)
 export DEFAULT_CLUSTER_VERSION="1.15"
 if [ -z "${CLUSTER_VERSION}" ]; then


### PR DESCRIPTION
**Description**

Kyma installation on `kyma-aks-nightly` fails with
```
message: '0/3 nodes are available: 3 Insufficient cpu.'
    reason: Unschedulable
    status: "False"
```
in `application-registry-66786bffff-hslc2`

Cluster state:
[describe-nodes.txt](https://github.com/kyma-project/test-infra/files/4203679/describe-nodes.txt)


Changes proposed in this pull request:

- VM type has changed

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
