### PR TITLE
use newly created service account

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -298,17 +298,17 @@ presets:
           name: kyma-snyk-token
           key: secret
   - labels:
-      preset-sa-gke-kyma-integration-gcp-vulnerability-scanner: "true"
+      preset-sa-prow-gcp-vulnerability-chk: "true"
     env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/credentials/sa-gke-kyma-integration/service-account.json
+        value: /etc/credentials/sa-prow-gcp-vulnerability-chk/service-account.json
     volumes:
-      - name: sa-gke-kyma-integration
+      - name: sa-prow-gcp-vulnerability-chk
         secret:
-          secretName: sa-gke-kyma-integration
+          secretName: sa-prow-gcp-vulnerability-chk
     volumeMounts:
-      - name: sa-gke-kyma-integration
-        mountPath: /etc/credentials/sa-gke-kyma-integration
+      - name: sa-prow-gcp-vulnerability-chk
+        mountPath: /etc/credentials/sa-prow-gcp-vulnerability-chk
         readOnly: true
   - labels:
       preset-sap-slack-bot-token: "true"

--- a/prow/jobs/kyma/kyma-vulnerability-scanner.yaml
+++ b/prow/jobs/kyma/kyma-vulnerability-scanner.yaml
@@ -41,7 +41,7 @@ periodics:
   labels:
     preset-sap-slack-bot-token: "true"
     preset-kyma-slack-channel: "true"
-    preset-sa-gke-kyma-integration-gcp-vulnerability-scanner: "true" # service account with Occurence Viewer permission
+    preset-sa-prow-gcp-vulnerability-chk: "true" # service account with Occurence Viewer permission
   extra_refs:
     - <<: *test_infra_ref
       base_ref: master

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -296,17 +296,17 @@ presets:
           name: kyma-snyk-token
           key: secret
   - labels:
-      preset-sa-gke-kyma-integration-gcp-vulnerability-scanner: "true"
+      preset-sa-prow-gcp-vulnerability-chk: "true"
     env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/credentials/sa-gke-kyma-integration/service-account.json
+        value: /etc/credentials/sa-prow-gcp-vulnerability-chk/service-account.json
     volumes:
-      - name: sa-gke-kyma-integration
+      - name: sa-prow-gcp-vulnerability-chk
         secret:
-          secretName: sa-gke-kyma-integration
+          secretName: sa-prow-gcp-vulnerability-chk
     volumeMounts:
-      - name: sa-gke-kyma-integration
-        mountPath: /etc/credentials/sa-gke-kyma-integration
+      - name: sa-prow-gcp-vulnerability-chk
+        mountPath: /etc/credentials/sa-prow-gcp-vulnerability-chk
         readOnly: true
   - labels:
       preset-sap-slack-bot-token: "true"


### PR DESCRIPTION
**Description**
Created a new service account for gcp-vulnerability scan on kyma-project to be used in kyma-prow.

Changes proposed in this pull request:
- moving away from gke-integration account for scanner job to separate scanning account

**Related issue(s)**
#2019 