### PR TITLE
ability to optionally define bucket region in config

### DIFF
--- a/development/prow-installer/cmd/installer/main.go
+++ b/development/prow-installer/cmd/installer/main.go
@@ -70,7 +70,7 @@ func main() {
 		log.Fatalf("An error occurred during storage client configuration: %v", err)
 	}
 	for _, bucket := range readConfig.Buckets {
-		if err := storageClient.CreateBucket(ctx, bucket); err != nil {
+		if err := storageClient.CreateBucket(ctx, bucket.Name, bucket.Location); err != nil {
 			log.Fatalf("Failed to create bucket: %s, %s", bucket, err)
 		}
 	}

--- a/development/prow-installer/cmd/storage/main.go
+++ b/development/prow-installer/cmd/storage/main.go
@@ -15,8 +15,8 @@ import (
 var (
 	projectID  = flag.String("proj", "", "ProjectID of the GCP project [Required]")
 	bucketName = flag.String("bucket", "", "Name of the storage bucket that contains the key [Required]")
-	locationID = flag.String("loc", "global", "Location of the keyring used for encryption/decryption [Optional]")
 	prefix     = flag.String("prefix", "", "Prefix for naming resources [Optional]")
+	location   = flag.String("location", "", "Location of a bucket. Default US [Optional]")
 )
 
 func main() {
@@ -40,9 +40,8 @@ func main() {
 	}
 
 	wrappedAPI := &storage.APIWrapper{
-		ProjectID:  *projectID,
-		LocationID: *locationID,
-		GCSClient:  gcsClient,
+		ProjectID: *projectID,
+		GCSClient: gcsClient,
 	}
 
 	clientOpts := storage.Option{}
@@ -55,7 +54,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = client.CreateBucket(ctx, *bucketName)
+	err = client.CreateBucket(ctx, *bucketName, *location)
 	if err != nil {
 		log.Fatalf("Creating bucket failed: %v", err)
 	}

--- a/development/prow-installer/config/prow-installer-config.yaml
+++ b/development/prow-installer/config/prow-installer-config.yaml
@@ -2,8 +2,9 @@ oauth: testoauth999
 project: sap-kyma-neighbors-dev
 region: europe-west3
 buckets:
-  - test-prow-bucket
-  - test-prow-bucket-2
+  - name: test-prow-bucket-eu
+    location: eu # Optional, might be either multi-region (eu, us) or region (ex. europe-west3)
+  - name: test-prow-bucket-us
 keyring_name: test-prow-keyring
 encryption_key_name: test-prow-key
 kubeconfig: ""

--- a/development/prow-installer/pkg/config/config.go
+++ b/development/prow-installer/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"github.com/kyma-project/test-infra/development/prow-installer/pkg/cluster"
+	"github.com/kyma-project/test-infra/development/prow-installer/pkg/storage"
 	"io/ioutil"
 
 	log "github.com/sirupsen/logrus"
@@ -16,7 +17,7 @@ type Config struct {
 	Project           string            `yaml:"project"`
 	Zone              string            `yaml:"zone"`
 	Region            string            `yaml:"region"`
-	Buckets           []string          `yaml:"buckets"`
+	Buckets           []storage.Bucket  `yaml:"buckets"`
 	KeyringName       string            `yaml:"keyring_name"`
 	EncryptionKeyName string            `yaml:"encryption_key_name"`
 	Kubeconfig        string            `yaml:"kubeconfig,omitempty"`

--- a/development/prow-installer/pkg/storage/automock/api.go
+++ b/development/prow-installer/pkg/storage/automock/api.go
@@ -13,13 +13,13 @@ type API struct {
 	mock.Mock
 }
 
-// CreateBucket provides a mock function with given fields: ctx, name
-func (_m *API) CreateBucket(ctx context.Context, name string) error {
-	ret := _m.Called(ctx, name)
+// CreateBucket provides a mock function with given fields: ctx, name, location
+func (_m *API) CreateBucket(ctx context.Context, name string, location string) error {
+	ret := _m.Called(ctx, name, location)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = rf(ctx, name)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, name, location)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/development/prow-installer/pkg/storage/storage.go
+++ b/development/prow-installer/pkg/storage/storage.go
@@ -21,9 +21,15 @@ type Client struct {
 	api API
 }
 
+// Struct that defines each bucket to create
+type Bucket struct {
+	Name     string `yaml:"name"`
+	Location string `yaml:"location,omitempty"`
+}
+
 // API provides a mockable interface for the GCP api. Find the implementation of the GCP wrapped API in wrapped.go
 type API interface {
-	CreateBucket(ctx context.Context, name string) error
+	CreateBucket(ctx context.Context, name string, location string) error
 	DeleteBucket(ctx context.Context, name string) error
 	Read(ctx context.Context, bucket, storageObject string) ([]byte, error)
 	Write(ctx context.Context, data []byte, bucket, storageObject string) error
@@ -46,14 +52,14 @@ func New(opts Option, api API) (*Client, error) {
 
 // TODO bucket region selection instead of fixed one (US)
 // CreateBucket attempts to create a storage bucket
-func (sc *Client) CreateBucket(ctx context.Context, name string) error {
+func (sc *Client) CreateBucket(ctx context.Context, name string, location string) error {
 	if name == "" {
 		return fmt.Errorf("name cannot be empty")
 	}
 	if sc.Prefix != "" {
 		name = fmt.Sprintf("%s-%s", sc.Prefix, name)
 	}
-	return sc.api.CreateBucket(ctx, name)
+	return sc.api.CreateBucket(ctx, name, location)
 }
 
 // DeleteBucket attempts to delete a storage bucket

--- a/development/prow-installer/pkg/storage/storage.go
+++ b/development/prow-installer/pkg/storage/storage.go
@@ -50,7 +50,6 @@ func New(opts Option, api API) (*Client, error) {
 	return &Client{Option: opts, api: api}, nil
 }
 
-// TODO bucket region selection instead of fixed one (US)
 // CreateBucket attempts to create a storage bucket
 func (sc *Client) CreateBucket(ctx context.Context, name string, location string) error {
 	if name == "" {

--- a/development/prow-installer/pkg/storage/storage_test.go
+++ b/development/prow-installer/pkg/storage/storage_test.go
@@ -15,6 +15,7 @@ var (
 	testGCSBucket        = "gcs-test-bucket"
 	testGCSStorageObject = "gcs-test-storage-object"
 	testBucketContent    = "gcs-test-bucket-content"
+	testBucketLocation   = "test-location"
 )
 
 func TestClient_Read(t *testing.T) {
@@ -286,7 +287,7 @@ func TestClient_CreateBucket(t *testing.T) {
 		ctx := context.Background()
 		opts := Option{}
 		opts = opts.WithPrefix(testGCSPrefix).WithProjectID(testGCSProj).WithServiceAccount("not-empty-gcp-will-validate")
-		mockAPI.On("CreateBucket", ctx, fmt.Sprintf("%s-%s", testGCSPrefix, testGCSBucket)).Return(nil) // we need to check if the prefixed name is created
+		mockAPI.On("CreateBucket", ctx, fmt.Sprintf("%s-%s", testGCSPrefix, testGCSBucket), testBucketLocation).Return(nil) // we need to check if the prefixed name is created
 
 		mockClient, err := New(opts, mockAPI)
 		if err != nil {
@@ -294,7 +295,7 @@ func TestClient_CreateBucket(t *testing.T) {
 			t.Fail()
 		}
 
-		err = mockClient.CreateBucket(ctx, testGCSBucket)
+		err = mockClient.CreateBucket(ctx, testGCSBucket, testBucketLocation)
 		if err != nil {
 			t.Errorf("Client.CreateBucket() error = %v", err)
 		}
@@ -312,7 +313,7 @@ func TestClient_CreateBucket(t *testing.T) {
 			t.Errorf("failed before running a test")
 		}
 
-		err = mockClient.CreateBucket(ctx, "")
+		err = mockClient.CreateBucket(ctx, "", testBucketLocation)
 		if err == nil {
 			t.Errorf("Client.CreateBucket() should throw an error")
 		}

--- a/development/prow-installer/pkg/storage/wrapped.go
+++ b/development/prow-installer/pkg/storage/wrapped.go
@@ -11,9 +11,8 @@ import (
 
 // APIWrapper wraps the GCP api
 type APIWrapper struct {
-	ProjectID  string
-	LocationID string
-	GCSClient  *gcs.Client
+	ProjectID string
+	GCSClient *gcs.Client
 }
 
 func NewClient(ctx context.Context, opts Option, credentials string) (*Client, error) {
@@ -35,9 +34,10 @@ func NewClient(ctx context.Context, opts Option, credentials string) (*Client, e
 }
 
 // CreateBucket attempts to create a storage bucket
-func (caw *APIWrapper) CreateBucket(ctx context.Context, name string) error {
+func (caw *APIWrapper) CreateBucket(ctx context.Context, name string, location string) error {
 	attrs := &gcs.BucketAttrs{
-		Name: name,
+		Location: location,
+		Name:     name,
 	}
 
 	err := caw.GCSClient.Bucket(name).Create(ctx, caw.ProjectID, attrs)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Buckets were creating in the us region by default. This PR adds ability to create storage in defined region.
Changes proposed in this pull request:

- added ability to optionally define bucket region in config

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
