### PR TITLE
add secret to workload cluster

### DIFF
--- a/prow/workload-cluster/required-secrets.yaml
+++ b/prow/workload-cluster/required-secrets.yaml
@@ -7,6 +7,7 @@ serviceAccounts:
   - prefix: sa-stability-fluentd-storage-writer
   - prefix: sa-kyma-backup-restore
   - prefix: sa-kyma-release-candidate
+  - prefix: sa-prow-gcp-vulnerability-chk
 
 generics:
   - prefix: kyma-bot-npm-token


### PR DESCRIPTION
**Description**
workload cluster has no reference of vulnerability service account

Changes proposed in this pull request:
- add sa from #2044 to workload-cluster
