### PR TITLE
Add minimal tide config

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -639,3 +639,10 @@ sinker:
 push_gateway:
   endpoint: pushgateway
   interval: 10s
+
+tide:
+  sync_period: 2m
+  queries:
+  - orgs:
+    - kyma-project
+    - kyma-incubator

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -613,3 +613,10 @@ sinker:
 push_gateway:
   endpoint: pushgateway
   interval: 10s
+
+tide:
+  sync_period: 2m
+  queries:
+  - orgs:
+    - kyma-project
+    - kyma-incubator


### PR DESCRIPTION
**Description**
If not configured, tide will query all of GitHub with this query to check for open PRs: `"query":"is:pr state:open sort:updated-asc "`. This minimal config should limit the query to `kyma-project` and `kyma-incubator` organisations and avoid filling tide logs with errors.

Changes proposed in this pull request:
- limit tide query to our own organisations
