### PR TITLE
Gather list of images from long running clusters

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -263,6 +263,15 @@ shout "Install stackdriver-prometheus collector"
 date
 installStackdriverPrometheusCollector
 
+shout "Collect list of images"
+date
+if [ -z "$ARTIFACTS" ] ; then
+    ARTIFACTS:=/tmp/artifacts
+fi
+
+IMAGES_LIST=$(kubectl get pods --all-namespaces -o go-template --template='{{range .items}}{{range .status.containerStatuses}}{{.name}},{{.image}},{{.imageID}}{{printf "\n"}}{{end}}{{end}}' | uniq | sort)
+echo "${IMAGES_LIST}" > "${ARTIFACTS}/kyma-images-${CLUSTER_NAME}.csv"
+
 shout "Install stability-checker"
 date
 (
@@ -270,3 +279,5 @@ export TEST_INFRA_SOURCES_DIR KYMA_SCRIPTS_DIR TEST_INFRA_CLUSTER_INTEGRATION_SC
         CLUSTER_NAME SLACK_CLIENT_WEBHOOK_URL STABILITY_SLACK_CLIENT_CHANNEL_ID SLACK_CLIENT_TOKEN TEST_RESULT_WINDOW_TIME
 "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/install-stability-checker.sh"
 )
+
+shout "Success"

--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -260,15 +260,14 @@ if [ -n "$(kubectl get  service -n kyma-system apiserver-proxy-ssl --ignore-not-
     IP_ADDRESS=${APISERVER_IP_ADDRESS} DNS_FULL_NAME=${APISERVER_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
 fi
 
-shout "Collect container labels"
+shout "Collect list of images"
 date
 if [ -z "$ARTIFACTS" ] ; then
     ARTIFACTS:=/tmp/artifacts
 fi
 
-IMAGES_LIST=$(kubectl get pods --all-namespaces -o jsonpath="{..image}" | tr -s '[:space:]' '\n' | sort | uniq)
-
-echo "${IMAGES_LIST}" > "${ARTIFACTS}/${RELEASE_VERSION}.txt" # should write all the images to a text file under the artifacts folder
+IMAGES_LIST=$(kubectl get pods --all-namespaces -o go-template --template='{{range .items}}{{range .status.containerStatuses}}{{.name}},{{.image}},{{.imageID}}{{printf "\n"}}{{end}}{{end}}' | uniq | sort)
+echo "${IMAGES_LIST}" > "${ARTIFACTS}/kyma-images-release-${RELEASE_VERSION}.csv"
 
 shout "Success"
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- list of images is now saved in csv file for rc, weekly and nightly clusters


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
