### PR TITLE
restrict to only one repository

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -641,8 +641,17 @@ push_gateway:
   interval: 10s
 
 tide:
-  sync_period: 2m
+  sync_period: 5m
   queries:
-  - orgs:
-    - kyma-project
-    - kyma-incubator
+  - repos:
+    - kyma-incubator/terraform-provider-kind
+    labels:
+    - lgtm
+    - approved
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/blocked-paths
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - needs-rebase

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -615,8 +615,17 @@ push_gateway:
   interval: 10s
 
 tide:
-  sync_period: 2m
+  sync_period: 5m
   queries:
-  - orgs:
-    - kyma-project
-    - kyma-incubator
+  - repos:
+    - kyma-incubator/terraform-provider-kind
+    labels:
+    - lgtm
+    - approved
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/blocked-paths
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - needs-rebase


### PR DESCRIPTION
**Description**
Without maintaining a list of excludes, we might have to remove the tide deployment completely. For now we can restrict it to a repo with not a lot of movement.


Changes proposed in this pull request:
- restrict tide to a single repo, to not produce merge fail logs, due to merge strategy.
