### PR TITLE
add new buildpack to use as baseimage for whitesource

### DIFF
--- a/prow/images/buildpack-java-node/Dockerfile
+++ b/prow/images/buildpack-java-node/Dockerfile
@@ -1,0 +1,27 @@
+# Basic node buildpack
+
+FROM eu.gcr.io/kyma-project/test-infra/buildpack-java:v20190729-5052901
+
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libfontconfig \
+    procps \
+    nodejs \
+    yarn \
+    && apt-get clean
+
+RUN npm install -g eslint-config-react-app@^3.0.4 \
+    babel-eslint@^9.0.0 \
+    eslint@^5.6.1 \
+    eslint-plugin-flowtype@^2.50.3 \
+    eslint-plugin-import@^2.14.0 \
+    eslint-plugin-jsx-a11y@^6.1.2 \
+    eslint-plugin-react@^7.11.1 \
+    tslint@^5.11.0 \
+    tslint-angular@^1.1.2 \
+    tslint-config-prettier@^1.15.0 \
+    typescript@^3.1.3 \
+    prettier@^1.14.3

--- a/prow/images/buildpack-java-node/Makefile
+++ b/prow/images/buildpack-java-node/Makefile
@@ -1,0 +1,12 @@
+IMG_NAME = buildpack-java-node
+IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(IMG_NAME)
+TAG = $(DOCKER_TAG)
+
+ci-pr: build-image push-image
+ci-release: build-image push-image
+
+build-image:
+	docker build -t $(IMG_NAME) .
+push-image:
+	docker tag $(IMG_NAME) $(IMG):$(TAG)
+	docker push $(IMG):$(TAG) 

--- a/prow/images/buildpack-java-node/README.md
+++ b/prow/images/buildpack-java-node/README.md
@@ -1,0 +1,18 @@
+# Buildpack Node.js Docker Image
+
+## Overview
+
+This folder contains the Buildpack for Java & Node.js image that is based on the Bootstrap image. This image is used for whitesource scans.
+
+The image consists of:
+
+- buildpack-java
+- additional instructions from buildpack-node
+
+## Installation
+
+To build the Docker image, run this command:
+
+```bash
+docker build buildpack-java-node .
+```

--- a/prow/images/buildpack-java-node/README.md
+++ b/prow/images/buildpack-java-node/README.md
@@ -1,13 +1,13 @@
-# Buildpack Node.js Docker Image
+# Node.js Docker Image Buildpack
 
 ## Overview
 
-This folder contains the Buildpack for Java & Node.js image that is based on the Bootstrap image. This image is used for whitesource scans.
+This folder contains the Buildpack for Java and Node.js image that is based on the Bootstrap image. This image is used for whitesource scans.
 
 The image consists of:
 
-- buildpack-java
-- additional instructions from buildpack-node
+- `buildpack-java`
+- Additional instructions reused from the `buildpack-node` image
 
 ## Installation
 

--- a/prow/jobs/test-infra/buildpack.yaml
+++ b/prow/jobs/test-infra/buildpack.yaml
@@ -318,7 +318,7 @@ presubmits: # runs on PRs
         preset-build-pr: "true"
         <<: *job_labels_template
       <<: *buildpack_java_job_template
-      - name: pre-test-infra-buildpack-java-node
+    - name: pre-test-infra-buildpack-java-node
       labels:
         preset-build-pr: "true"
         <<: *job_labels_template

--- a/prow/jobs/test-infra/buildpack.yaml
+++ b/prow/jobs/test-infra/buildpack.yaml
@@ -318,6 +318,11 @@ presubmits: # runs on PRs
         preset-build-pr: "true"
         <<: *job_labels_template
       <<: *buildpack_java_job_template
+      - name: pre-test-infra-buildpack-java-node
+      labels:
+        preset-build-pr: "true"
+        <<: *job_labels_template
+      <<: *buildpack_java_job_template
     - name: pre-test-infra-cleaner
       labels:
         preset-build-pr: "true"


### PR DESCRIPTION
**Description**
This will enable us to rebuild the wssagent image with this image as base-image.

Changes proposed in this pull request:
- create a new image for nodejs and java so whitesource can use npm

**Related issue(s)**
#2061 
