### PR TITLE
Make pre-master-gke-compass-integration job optional

### DIFF
--- a/development/tools/jobs/kyma/kyma_compass_integration_test.go
+++ b/development/tools/jobs/kyma/kyma_compass_integration_test.go
@@ -18,6 +18,7 @@ func TestKymaGKECompassIntegrationPresubmit(t *testing.T) {
 	require.NotNil(t, actualJob)
 
 	// then
+	assert.True(t, actualJob.Optional)
 	assert.True(t, actualJob.Decorate)
 	assert.Equal(t, "^((resources\\S+|installation\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))", actualJob.RunIfChanged)
 	assert.Equal(t, "github.com/kyma-project/kyma", actualJob.PathAlias)

--- a/prow/jobs/kyma/kyma-compass-integration.yaml
+++ b/prow/jobs/kyma/kyma-compass-integration.yaml
@@ -38,6 +38,7 @@ presubmits: # runs on PRs
     path_alias: github.com/kyma-project/kyma
     skip_report: false
     max_concurrency: 10
+    optional: true
     spec:
       containers:
         - <<: *base_image


### PR DESCRIPTION
**Description**

Currently we're facing problems with stability of Compass-related tests. That's why we decided to make the pipeline optional (temporarily, of course).

Changes proposed in this pull request:

- Make pre-master-gke-compass-integration job optional
