### PR TITLE
Reduce gardener cluster name length

### DIFF
--- a/prow/scripts/cluster-integration/kyma-integration-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-integration-gardener-azure.sh
@@ -108,9 +108,9 @@ cleanup() {
 
 trap cleanup EXIT INT
 
-RANDOM_NAME_SUFFIX=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c6)
+RANDOM_NAME_SUFFIX=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c4)
 readonly COMMON_NAME_PREFIX="grdnr"
-COMMON_NAME=$(echo "${COMMON_NAME_PREFIX}-${RANDOM_NAME_SUFFIX}" | tr "[:upper:]" "[:lower:]")
+COMMON_NAME=$(echo "${COMMON_NAME_PREFIX}${RANDOM_NAME_SUFFIX}" | tr "[:upper:]" "[:lower:]")
 
 ### Cluster name must be less than 20 characters!
 export CLUSTER_NAME="${COMMON_NAME}"

--- a/prow/scripts/cluster-integration/kyma-integration-gardener-gcp.sh
+++ b/prow/scripts/cluster-integration/kyma-integration-gardener-gcp.sh
@@ -91,9 +91,9 @@ cleanup() {
 
 trap cleanup EXIT INT
 
-RANDOM_NAME_SUFFIX=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c6)
+RANDOM_NAME_SUFFIX=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c4)
 readonly COMMON_NAME_PREFIX="grdnr"
-COMMON_NAME=$(echo "${COMMON_NAME_PREFIX}-${RANDOM_NAME_SUFFIX}" | tr "[:upper:]" "[:lower:]")
+COMMON_NAME=$(echo "${COMMON_NAME_PREFIX}${RANDOM_NAME_SUFFIX}" | tr "[:upper:]" "[:lower:]")
 
 ### Cluster name must be less than 20 characters!
 export CLUSTER_NAME="${COMMON_NAME}"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Reduce the cluster name length so that the full domain fits in 64 chars.
Otherwise API server certificate creation fails with the following error:
```
the Common Name is limited to 64 characters (X.509 ASN.1 specification), but first given domain <my-long-gardener-domain> has 67 characters
```

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/7068
