### PR TITLE
Add jq to alpine-kubectl image

### DIFF
--- a/prow/images/alpine-kubectl/Dockerfile
+++ b/prow/images/alpine-kubectl/Dockerfile
@@ -6,7 +6,7 @@ ENV HELM_VERSION="v2.16.1"
 ENV KUBECTL_VERSION="v1.16.3"
 
 RUN apk update &&\
-    apk add --no-cache openssl coreutils curl bash  &&\
+    apk add --no-cache openssl coreutils curl bash jq &&\
 	wget https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl &&\
 	chmod +x /usr/local/bin/kubectl &&\
 	wget https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm &&\


### PR DESCRIPTION
**Description**

We need to provide a common image with kubectl and some helper commands for all kyma components.
Unfortunately compas entrypoints require jq: 
https://github.com/kyma-project/kyma/blob/master/resources/compass/templates/agent-configuration-job.yaml
That makes [this](https://github.com/kyma-project/kyma/pull/7511/files) PR hard to merge :/


Changes proposed in this pull request:

- added jq to the image
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
