### PR TITLE
Fix prowjobs count grafana chart 1563

### DIFF
--- a/development/update-jobs.sh
+++ b/development/update-jobs.sh
@@ -13,9 +13,9 @@ if [[ -z "${JOBS_PATH}" ]]; then
 fi
 
 readonly UPLOADER="${DEVELOPMENT_DIR}/tools/cmd/configuploader/main.go"
-if [[ ! -d "${DEVELOPMENT_DIR}/tools/vendor/github.com" ]]; then
-    (cd "${DEVELOPMENT_DIR}/tools" && dep ensure -v -vendor-only)
-fi
+#if [[ ! -d "${DEVELOPMENT_DIR}/tools/vendor/github.com" ]]; then
+#    (cd "${DEVELOPMENT_DIR}/tools" && dep ensure -v -vendor-only)
+#fi
 
 readonly CONFIG="${HOME}/.kube/config"
 

--- a/development/update-jobs.sh
+++ b/development/update-jobs.sh
@@ -13,9 +13,9 @@ if [[ -z "${JOBS_PATH}" ]]; then
 fi
 
 readonly UPLOADER="${DEVELOPMENT_DIR}/tools/cmd/configuploader/main.go"
-#if [[ ! -d "${DEVELOPMENT_DIR}/tools/vendor/github.com" ]]; then
-#    (cd "${DEVELOPMENT_DIR}/tools" && dep ensure -v -vendor-only)
-#fi
+if [[ ! -d "${DEVELOPMENT_DIR}/tools/vendor/github.com" ]]; then
+    (cd "${DEVELOPMENT_DIR}/tools" && dep ensure -v -vendor-only)
+fi
 
 readonly CONFIG="${HOME}/.kube/config"
 

--- a/prow/cluster/resources/monitoring/templates/prow_prometheusrules.yaml
+++ b/prow/cluster/resources/monitoring/templates/prow_prometheusrules.yaml
@@ -161,7 +161,7 @@ spec:
                     description: Ingress-nginx service doesn't have any endpoints assigned.
               # In progress prowjobs count
               - alert: ProwjobsCountLimit
-                expr: prowjobs{state=~"pending|triggered"} > 69
+                expr: sum(prowjobs{state=~"pending|triggered"}) > 69
                 for: 30s
                 labels:
                   app: prow

--- a/prow/cluster/resources/monitoring/templates/prow_prometheusrules.yaml
+++ b/prow/cluster/resources/monitoring/templates/prow_prometheusrules.yaml
@@ -6,7 +6,7 @@ metadata:
       app: prometheus-operator
       chart: monitoring
       role: alert-rules
-      #Thie lable is requried as it's define which prometheus server should include this rules.
+      #Thie label is requried as it define which prometheus server should include this rules.
       prometheus: monitoring-prometheus-oper-prometheus
       release: monitoring
     name: monitoring-prometheus-oper-prow-custom-rules
@@ -159,3 +159,13 @@ spec:
                 annotations:
                     summary: No endpoints assigned.
                     description: Ingress-nginx service doesn't have any endpoints assigned.
+              # In progress prowjobs count
+              - alert: ProwjobsCountLimit
+                expr: prowjobs{state=~"pending|triggered"} > 69
+                for: 30s
+                labels:
+                  app: prow
+                  severity: critical
+                annotations:
+                  summary: Prowjobs count limit exceeded.
+                  description: Number of running concurrent prowjobs reached maximum limit. Check plank config max_concurrency option.

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -639,3 +639,4 @@ sinker:
 push_gateway:
   endpoint: pushgateway
   interval: 10s
+  serve_metrics: true

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -639,4 +639,3 @@ sinker:
 push_gateway:
   endpoint: pushgateway
   interval: 10s
-  serve_metrics: true

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -613,3 +613,4 @@ sinker:
 push_gateway:
   endpoint: pushgateway
   interval: 10s
+  serve_metrics: true


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Added missing plank config option to enable plank push metrics to pushgateway.
- Defined alert rule for number of running prowjobs.

**Related issue(s)**
Resolves #1563 
