### PR TITLE
Display "Copying license..." message only if --verbose flag is set

### DIFF
--- a/prow/scripts/license-puller.sh
+++ b/prow/scripts/license-puller.sh
@@ -21,6 +21,10 @@ function read_arguments() {
               local dirs_to_pulling=($( echo "${arg#*=}" | tr "," "\n" ))
               shift # remove --dirs-to-pulling=
             ;;
+            --verbose)
+              VERBOSE=true
+              shift # remove this --verbose
+            ;;
             *)
               # unknown option
             ;;

--- a/prow/scripts/license-puller.sh
+++ b/prow/scripts/license-puller.sh
@@ -12,6 +12,7 @@ readonly LICENSES_DIR_NAME="licenses"
 readonly LICENSES_DIR="./${LICENSES_DIR_NAME}"
 
 DIRS_TO_PULLING=()
+VERBOSE=false
 function read_arguments() {
     for arg in "${ARGS[@]}"
     do
@@ -132,7 +133,10 @@ function pullNodeLicensesByDir() {
             fi
 
             local outputDir="${LICENSES_DIR}/${key}"
-            echo "Copying '${licenseFile}' to '${outputDir}'"
+            if [ "$VERBOSE" = true ] ; then
+                echo "Copying '${licenseFile}' to '${outputDir}'"
+            fi
+           
             mkdir -p "${outputDir}"
             cp "${licenseFile}" "${outputDir}/"
         done


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
We've been struggling with extremely long job logs in Console for ages. Around 1000 of the 3000 lines were `Copying license xxx to yyy...` which gives absolutely no benefit.
This PR removes these echos by default but also introduces the `--verbose` flag which brings them back, just in case anyone finds them useful.

Here are the logs from my `make` command that uses the script following way:
```bash
bash $(LICENSE_PULLER_PATH) --dirs-to-pulling="../,../common,../components/react,../components/shared"
```
executed with a command:
`LICENSE_PULLER_PATH=/Users/parostatkiem/test-infra/prow/scripts/license-puller.sh make ci-pr`

- [without `--verbose` flag ](https://github.com/kyma-project/test-infra/files/4343406/non-verbose.log)
- [with `--verbose` flag](https://github.com/kyma-project/test-infra/files/4343420/verbose.log)

both processes ended with pushing a docker image (which means all previous steps succeeded), only the number of lines is different by 1098 🏆 

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
