### PR TITLE
Fix a broken Prow webhook link

### DIFF
--- a/docs/prow/prow-installation-on-forks.md
+++ b/docs/prow/prow-installation-on-forks.md
@@ -151,7 +151,7 @@ Verify if the Prow installation was successful.
 
 ## Configure the webhook
 
-After Prow installs successfully, you must [configure the webhook](https://support.hockeyapp.net/kb/third-party-bug-trackers-services-and-webhooks/how-to-set-up-a-webhook-in-github) to enable the GitHub repository to send events to Prow.
+After Prow installs successfully, you must [configure the webhook](https://github.com/kyma-project/community/blob/master/guidelines/repository-guidelines/01-new-repository-settings.md#add-webhooks) to enable the GitHub repository to send events to Prow.
 
 ## Configure Prow
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix a broken link to a guide on how to set up a Prow webhook in GitHub.

**Related issue(s)**
[Build log](https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/logs/test-infra-governance-nightly/1240443004662059009)
