### PR TITLE
Enabled ha for aks master nodes.

### DIFF
--- a/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
@@ -167,7 +167,8 @@ function installCluster() {
 	  --enable-addons "${CLUSTER_ADDONS}" \
 	  --service-principal "${AZURE_SUBSCRIPTION_APP_ID}" \
 	  --client-secret "${AZURE_SUBSCRIPTION_SECRET}" \
-	  --generate-ssh-keys
+	  --generate-ssh-keys \
+	  --zones 1 2 3
 }
 
 function azureAuthenticating() {


### PR DESCRIPTION
**Description**

AKS nighlty job is failing on kyma installation with timeouts in connections to k8s master. Increasing master nodes capacity and enabling ha.

Changes proposed in this pull request:

- Enabled deploying ask master nodes in three zones.

