### PR TITLE
Copy tools from prow-tools image to kyma-integration image

### DIFF
--- a/prow/images/kyma-integration/Dockerfile
+++ b/prow/images/kyma-integration/Dockerfile
@@ -134,4 +134,4 @@ RUN curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor |
 ########################## Prow Tools ###########################
 #################################################################
 
-COPY --from=eu.gcr.io/kyma-project/test-infra/prow-tools:v20200403-12d3f0c5 /prow-tools /prow-tools
+COPY --from=eu.gcr.io/kyma-project/test-infra/pr/prow-tools:PR-2208 /prow-tools /prow-tools

--- a/prow/images/kyma-integration/Dockerfile
+++ b/prow/images/kyma-integration/Dockerfile
@@ -129,3 +129,9 @@ RUN curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor |
     tee /etc/apt/sources.list.d/azure-cli.list && \
     apt-get update && \
     apt-get install -y azure-cli=${AZURE_CLI_VERSION}
+
+#################################################################
+########################## Prow Tools ###########################
+#################################################################
+
+COPY --from=eu.gcr.io/kyma-project/test-infra/prow-tools:v20200403-12d3f0c5 /prow-tools /prow-tools

--- a/prow/images/kyma-integration/Dockerfile
+++ b/prow/images/kyma-integration/Dockerfile
@@ -134,4 +134,4 @@ RUN curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor |
 ########################## Prow Tools ###########################
 #################################################################
 
-COPY --from=eu.gcr.io/kyma-project/test-infra/pr/prow-tools:PR-2209 /prow-tools /prow-tools
+COPY --from=eu.gcr.io/kyma-project/test-infra/prow-tools:v20200403-ebf5f81e /prow-tools /prow-tools

--- a/prow/images/kyma-integration/Dockerfile
+++ b/prow/images/kyma-integration/Dockerfile
@@ -134,4 +134,4 @@ RUN curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor |
 ########################## Prow Tools ###########################
 #################################################################
 
-COPY --from=eu.gcr.io/kyma-project/test-infra/pr/prow-tools:PR-2208 /prow-tools /prow-tools
+COPY --from=eu.gcr.io/kyma-project/test-infra/pr/prow-tools:PR-2209 /prow-tools /prow-tools


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Added copying prebuilt tools from prow-tools image as described in #2189. The tools will be needed by integration jobs so it's mandatory that the integration image includes all precompiled tools.

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
