### PR TITLE
Changed base images from alpine-based to debian-based in prow-tools image

### DIFF
--- a/development/tools/Dockerfile
+++ b/development/tools/Dockerfile
@@ -1,13 +1,14 @@
-FROM golang:1.14.1-alpine3.11 AS builder
+FROM golang:1.14.1-buster AS builder
 
 WORKDIR /go/src/github.com/kyma-project/test-infra
 COPY . development/tools
 
-RUN apk --update --no-cache add bash upx dep git && \
+RUN apt-get update && apt-get install -y git upx && \
+    curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh && \
     development/tools/build-cleaners.sh
 
-FROM alpine:latest
+FROM debian:10
 
-RUN apk --update --no-cache add ca-certificates bash
+RUN apt-get update && apt-get upgrade -y
 COPY --from=builder /go/src/github.com/kyma-project/test-infra/development/tools/bin /prow-tools
 WORKDIR /prow-tools


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Basically the binaries compiled in alpine-based image do not work on Debian-based image. This changes base image to debian based for compatibility with Kyma-integration image.

Changes proposed in this pull request:

- change golang1.14.1-alpine3.11 to golang1.14.1-buster
- change alpine:latest to debian:10

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
