### PR TITLE
Use string values for stringData in knative-eventing-kafka overrides

### DIFF
--- a/prow/scripts/cluster-integration/helpers/create-azure-event-hubs-secret.sh
+++ b/prow/scripts/cluster-integration/helpers/create-azure-event-hubs-secret.sh
@@ -196,13 +196,13 @@ metadata:
     component: knative-eventing-channel-kafka
     kyma-project.io/installation: ""
 stringData:
-  kafka.brokers.hostname: ${K8S_SECRET_BROKER_HOSTNAME}
+  kafka.brokers.hostname: "${K8S_SECRET_BROKER_HOSTNAME}"
   kafka.brokers.port: "${K8S_SECRET_BROKER_PORT}"
-  kafka.namespace: ${EVENTHUB_NAMESPACE_NAME}
-  kafka.password: ${K8S_SECRET_PASSWORD}
-  kafka.username: ${K8S_SECRET_USERNAME}
-  kafka.secretName: knative-kafka
-  environment.kafkaProvider: azure
+  kafka.namespace: "${EVENTHUB_NAMESPACE_NAME}"
+  kafka.password: "${K8S_SECRET_PASSWORD}"
+  kafka.username: "${K8S_SECRET_USERNAME}"
+  kafka.secretName: "knative-kafka"
+  environment.kafkaProvider: "azure"
 EOF
 )
   echo "${kafkaSecret}" > "${EVENTHUB_SECRET_OVERRIDE_FILE}"

--- a/prow/scripts/cluster-integration/helpers/create-azure-event-hubs-secret.sh
+++ b/prow/scripts/cluster-integration/helpers/create-azure-event-hubs-secret.sh
@@ -193,7 +193,7 @@ metadata:
   labels:
     knativekafka.kyma-project.io/kafka-secret: "true"
     installer: overrides
-    component: knative-eventing-channel-kafka
+    component: knative-eventing-kafka
     kyma-project.io/installation: ""
 stringData:
   kafka.brokers.hostname: "${K8S_SECRET_BROKER_HOSTNAME}"

--- a/prow/scripts/cluster-integration/helpers/create-azure-event-hubs-secret.sh
+++ b/prow/scripts/cluster-integration/helpers/create-azure-event-hubs-secret.sh
@@ -197,7 +197,7 @@ metadata:
     kyma-project.io/installation: ""
 stringData:
   kafka.brokers.hostname: ${K8S_SECRET_BROKER_HOSTNAME}
-  kafka.brokers.port: ${K8S_SECRET_BROKER_PORT}
+  kafka.brokers.port: "${K8S_SECRET_BROKER_PORT}"
   kafka.namespace: ${EVENTHUB_NAMESPACE_NAME}
   kafka.password: ${K8S_SECRET_PASSWORD}
   kafka.username: ${K8S_SECRET_USERNAME}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Make kafka.brokers.port value a string
- Problem: stringData is only accepting strings as values, see https://kubernetes.io/docs/concepts/configuration/secret/#creating-a-secret-manually

Some context on the problem:

If you run `createK8SSecretFileBroken` and `createK8SSecretFileFixed` and check the created overrides, you will see the following diff:

broken:
```
stringData:
  kafka.brokers.port: 9093
```
When you try to create the file with `kubectl apply`, you will get the error message mentioned in the ticket.

fixed:
```
 kafka.brokers.port: "9093"
```

```bash
primaryConnectionString="Endpoint=sb://azure-gardener.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=somekey="
K8S_SECRET_BROKER_PORT="9093"


createK8SSecretFileBroken() {

  echo "Creating a Kubernetes Secret override file for the New EventHub Namespace..."

kafkaSecret=$(cat << EOF
apiVersion: v1
kind: Secret
type: Opaque
metadata:
  name: "test"
  namespace: "default"
  labels:
    knativekafka.kyma-project.io/kafka-secret: "true"
    installer: overrides
    component: knative-eventing-channel-kafka
    kyma-project.io/installation: ""
stringData:
  kafka.brokers.hostname: ${K8S_SECRET_BROKER_HOSTNAME}
  kafka.brokers.port: ${K8S_SECRET_BROKER_PORT}
  kafka.secretName: knative-kafka
  environment.kafkaProvider: azure
EOF
)
  echo "${kafkaSecret}" > test-broken.yaml
}

createK8SSecretFileFixed() {

  echo "Creating a Kubernetes Secret override file for the New EventHub Namespace..."

kafkaSecret=$(cat << EOF
apiVersion: v1
kind: Secret
type: Opaque
metadata:
  name: "test"
  namespace: "default"
  labels:
    knativekafka.kyma-project.io/kafka-secret: "true"
    installer: overrides
    component: knative-eventing-channel-kafka
    kyma-project.io/installation: ""
stringData:
  kafka.brokers.hostname: ${K8S_SECRET_BROKER_HOSTNAME}
  kafka.brokers.port: "${K8S_SECRET_BROKER_PORT}"
  kafka.secretName: knative-kafka
  environment.kafkaProvider: azure
EOF
)
  echo "${kafkaSecret}" > test-fixed.yaml
}
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes #https://github.com/kyma-project/kyma/issues/7960
