### PR TITLE
GitHub-release job optimisation 

### DIFF
--- a/development/github-release.sh
+++ b/development/github-release.sh
@@ -22,14 +22,7 @@ echo "--------------------------------------------------------------------------
 echo "Creating the Github release for Kyma...  "
 echo "--------------------------------------------------------------------------------"
 
-if [ ! -d "${DEVELOPMENT_DIR}/tools/vendor" ]; then
-    echo "Vendoring 'tools'"
-    pushd "${DEVELOPMENT_DIR}/tools"
-    dep ensure -v -vendor-only
-    popd
-fi
-
-go run "${DEVELOPMENT_DIR}/tools/cmd/githubrelease/main.go" "$@"
+/prow-tools/githubrelease "$@"
 status=$?
 
 if [ ${status} -ne 0 ]

--- a/development/tools/jobs/kyma/kyma_github-release_test.go
+++ b/development/tools/jobs/kyma/kyma_github-release_test.go
@@ -22,7 +22,7 @@ func TestKymaGithubReleaseJobPostsubmit(t *testing.T) {
 			assert.True(t, actualPostsubmit.Decorate)
 			tester.AssertThatHasExtraRefTestInfra(t, actualPostsubmit.JobBase.UtilityConfig, currentRelease.Branch())
 			tester.AssertThatHasPresets(t, actualPostsubmit.JobBase, "preset-sa-kyma-artifacts", "preset-bot-github-token")
-			assert.Equal(t, tester.ImageGolangBuildpackLatest, actualPostsubmit.Spec.Containers[0].Image)
+			assert.Equal(t, tester.ImageProwToolsLatest, actualPostsubmit.Spec.Containers[0].Image)
 			assert.Equal(t, []string{"-c", "/home/prow/go/src/github.com/kyma-project/test-infra/development/github-release.sh -targetCommit=${RELEASE_TARGET_COMMIT} -githubRepoOwner=${REPO_OWNER} -githubRepoName=${REPO_NAME} -githubAccessToken=${BOT_GITHUB_TOKEN} -releaseVersionFilePath=/home/prow/go/src/github.com/kyma-project/test-infra/prow/RELEASE_VERSION"}, actualPostsubmit.Spec.Containers[0].Args)
 		})
 	}

--- a/prow/jobs/kyma/kyma-github-release.yaml
+++ b/prow/jobs/kyma/kyma-github-release.yaml
@@ -12,7 +12,7 @@ job_template: &job_template
   run_if_changed: ^common/|^components/|^installation/|^resources/|^tests/|^tools/
   spec:
     containers:
-    - image: eu.gcr.io/kyma-project/prow/test-infra/buildpack-golang:v20181119-afd3fbd
+    - image: eu.gcr.io/kyma-project/test-infra/prow-tools:v20200403-ebf5f81e
       securityContext:
         privileged: true
       command:
@@ -22,7 +22,7 @@ job_template: &job_template
       - "/home/prow/go/src/github.com/kyma-project/test-infra/development/github-release.sh -targetCommit=${RELEASE_TARGET_COMMIT} -githubRepoOwner=${REPO_OWNER} -githubRepoName=${REPO_NAME} -githubAccessToken=${BOT_GITHUB_TOKEN} -releaseVersionFilePath=/home/prow/go/src/github.com/kyma-project/test-infra/prow/RELEASE_VERSION"
       resources:
         requests:
-          memory: 1Gi
+          memory: 200Mi
           cpu: 0.2
 
 job_labels_template: &job_labels_template

--- a/templates/templates/kyma-github-release.yaml
+++ b/templates/templates/kyma-github-release.yaml
@@ -20,7 +20,7 @@ job_template: &job_template
       - "/home/prow/go/src/github.com/kyma-project/test-infra/development/github-release.sh -targetCommit=${RELEASE_TARGET_COMMIT} -githubRepoOwner=${REPO_OWNER} -githubRepoName=${REPO_NAME} -githubAccessToken=${BOT_GITHUB_TOKEN} -releaseVersionFilePath=/home/prow/go/src/github.com/kyma-project/test-infra/prow/RELEASE_VERSION"
       resources:
         requests:
-          memory: 1Gi
+          memory: 200Mi
           cpu: 0.2
 
 job_labels_template: &job_labels_template

--- a/templates/templates/kyma-github-release.yaml
+++ b/templates/templates/kyma-github-release.yaml
@@ -10,7 +10,7 @@ job_template: &job_template
   run_if_changed: ^common/|^components/|^installation/|^resources/|^tests/|^tools/
   spec:
     containers:
-    - image: eu.gcr.io/kyma-project/prow/test-infra/buildpack-golang:v20181119-afd3fbd
+    - image: eu.gcr.io/kyma-project/test-infra/prow-tools:v20200403-ebf5f81e
       securityContext:
         privileged: true
       command:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Edited `GitHub-release` job to use pre-built binary without the need to build it on every run.
Changes proposed in this pull request:

- edited GitHub-release.sh to run a binary instead of build source.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
