### PR TITLE
Fix prow-tools build job regexp

### DIFF
--- a/prow/jobs/test-infra/buildpack.yaml
+++ b/prow/jobs/test-infra/buildpack.yaml
@@ -301,7 +301,7 @@ prow_clonerefs_job_template: &prow_clonerefs_job_template
           cpu: 0.8
 
 prow_tools_job_template: &prow_tools_job_template
-  run_if_changed: '^development/tools/(.*\.go|.*\.toml|.*\.sh|go\.mod|Dockerfile|Makefile)$'
+  run_if_changed: '^development/tools/((cmd|pkg)/.*\.go|.*\.toml|go\.mod|Dockerfile|Makefile)$'
   <<: *common_job_template
   spec:
     containers:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Edited prow-tools build job regexp to run only when go files from cmd/pkg are modified.
https://regex101.com/r/2iLu9X/1

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Closes #2232 