### PR TITLE
Moved prow-addons-ctrl to golang 1.13 image.

### DIFF
--- a/development/prow-addons-ctrl-manager/Makefile
+++ b/development/prow-addons-ctrl-manager/Makefile
@@ -57,9 +57,10 @@ docker-push:
 ### Custom targets
 # Resolve dependencies
 resolve:
-	@echo 'prow-addons-ctrl-manager was migrated to go mod'
+	dep ensure -v -vendor-only
 
 validate: fmt vet
+	dep status
 
 # CI specified targets
 ci-pr: docker-build docker-push

--- a/development/prow-addons-ctrl-manager/Makefile
+++ b/development/prow-addons-ctrl-manager/Makefile
@@ -57,10 +57,9 @@ docker-push:
 ### Custom targets
 # Resolve dependencies
 resolve:
-	dep ensure -v -vendor-only
+	@echo 'prow-addons-ctrl-manager was migrated to go mod'
 
 validate: fmt vet
-	dep status
 
 # CI specified targets
 ci-pr: docker-build docker-push

--- a/development/tools/jobs/testinfra/prow_addons_ctrl_manager_test.go
+++ b/development/tools/jobs/testinfra/prow_addons_ctrl_manager_test.go
@@ -26,7 +26,7 @@ func TestProwAddonsCtrlManagerJobsPresubmit(t *testing.T) {
 	assert.Equal(t, "github.com/kyma-project/test-infra", actualPresubmit.PathAlias)
 	tester.AssertThatHasPresets(t, actualPresubmit.JobBase, preset.DindEnabled, preset.DockerPushRepoTestInfra, preset.GcrPush, preset.BuildPr)
 	assert.Equal(t, "^development/prow-addons-ctrl-manager/", actualPresubmit.RunIfChanged)
-	assert.Equal(t, tester.ImageGolangKubebuilderBuildpackLatest, actualPresubmit.Spec.Containers[0].Image)
+	assert.Equal(t, "eu.gcr.io/kyma-project/test-infra/buildpack-golang-kubebuilder2:v20200124-69faeef6", actualPresubmit.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPresubmit.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/development/prow-addons-ctrl-manager"}, actualPresubmit.Spec.Containers[0].Args)
 }
@@ -46,7 +46,7 @@ func TestProwAddonsCtrlManagerJobPostsubmit(t *testing.T) {
 	assert.Equal(t, "github.com/kyma-project/test-infra", actualPostsubmit.PathAlias)
 	tester.AssertThatHasPresets(t, actualPostsubmit.JobBase, preset.DindEnabled, preset.DockerPushRepoTestInfra, preset.GcrPush, preset.BuildMaster)
 	assert.Equal(t, "^development/prow-addons-ctrl-manager/", actualPostsubmit.RunIfChanged)
-	assert.Equal(t, tester.ImageGolangKubebuilderBuildpackLatest, actualPostsubmit.Spec.Containers[0].Image)
+	assert.Equal(t, "eu.gcr.io/kyma-project/test-infra/buildpack-golang-kubebuilder2:v20200124-69faeef6", actualPostsubmit.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build.sh"}, actualPostsubmit.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/development/prow-addons-ctrl-manager"}, actualPostsubmit.Spec.Containers[0].Args)
 }

--- a/prow/jobs/test-infra/prow-addons-ctrl-manager.yaml
+++ b/prow/jobs/test-infra/prow-addons-ctrl-manager.yaml
@@ -5,7 +5,7 @@ job_template: &job_template
   max_concurrency: 10
   spec:
     containers:
-    - image:  eu.gcr.io/kyma-project/test-infra/buildpack-golang-kubebuilder:v20190208-813daef
+    - image:  eu.gcr.io/kyma-project/test-infra/buildpack-golang-kubebuilder2:v20200124-69faeef6
       securityContext:
         privileged: true
       command:


### PR DESCRIPTION
Upgraded prow-addons-ctrl-manager build image.
Disabled dep checks from Makefile.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
