### PR TITLE
Whitelist the hook link

### DIFF
--- a/milv.config.yaml
+++ b/milv.config.yaml
@@ -15,3 +15,6 @@ files:
   - path: "./test-infra/docs/prow/prow-k8s-testgrid.md"
     config:
       white-list-external: ["https://github.com/kyma-project/test-infra/blob/60493dd61d77da363b8758b7e4c94f25d4b36501/prow/jobs/test-infra/test-infra-kind.yaml#L80-L83"]
+  - path: "./test-infra/docs/prow/prow-architecture.md"
+    config:
+      white-list-external: ["https://status.build.kyma-project.io/hook"]


### PR DESCRIPTION
**Description**

The `https://status.build.kyma-project.io/hook` hook link requires an HTTP method different than GET. As a result, it caused the pipeline job to fail. 

Changes proposed in this pull request:

- Whitelist the `https://status.build.kyma-project.io/hook` hook link.

