### PR TITLE
removed sa-gcs-credentials arg and mount from deck deployment.

### DIFF
--- a/prow/cluster/components/15-deck_deployment.yaml
+++ b/prow/cluster/components/15-deck_deployment.yaml
@@ -36,7 +36,6 @@ spec:
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
             - --github-token-path=/etc/github/oauth
-            - --gcs-credentials-file=/etc/gcs-credentials/service-account.json
             - --build-cluster=/etc/cluster/cluster.yaml
             - --redirect-http-to=status.build.kyma-project.io
           ports:
@@ -57,9 +56,6 @@ spec:
               readOnly: true
             - name: branding
               mountPath: /static/extensions
-              readOnly: true
-            - mountPath: /etc/gcs-credentials
-              name: gcs-credentials
               readOnly: true
             - mountPath: /etc/cluster
               name: cluster
@@ -94,10 +90,6 @@ spec:
           configMap:
             defaultMode: 420
             name: branding
-        - name: gcs-credentials
-          secret:
-            defaultMode: 420
-            secretName: sa-gcs-plank
         - name: cluster
           secret:
             defaultMode: 420


### PR DESCRIPTION
sa-gcs-credentials mount was added as part of prow upgrade as it was needed on upgrade instance to correctly dispaly logs stored in a bucket. In prod instance this appears not needed as everything seems working fine, whereas the secret needed for mount doesn't exist. moreover, serviceaccount which credentials were suppose to store within a secrete doesn't have any permissions assigned in GCP IAM.
