### PR TITLE
Use latest published master on periodic clusters

### DIFF
--- a/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
@@ -279,7 +279,7 @@ function installKyma() {
 
   kyma install \
 			--ci \
-			--source latest \
+			--source latest-published \
 			-o "${KYMA_RESOURCES_DIR}"/installer-config-production.yaml.tpl \
 			--domain "${DOMAIN}" \
 			--tlsCert "${TLS_CERT}" \

--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -164,7 +164,7 @@ function installKyma() {
 
 	kyma install \
 			--ci \
-			--source latest \
+			--source latest-published \
 			-o "${KYMA_RESOURCES_DIR}"/installer-config-production.yaml.tpl \
 			--domain "${DOMAIN}" \
 			--tlsCert "${TLS_CERT}" \

--- a/prow/scripts/cluster-integration/kyma-integration-gardener-aws.sh
+++ b/prow/scripts/cluster-integration/kyma-integration-gardener-aws.sh
@@ -162,7 +162,7 @@ curl -L --silent --fail --show-error "https://raw.githubusercontent.com/kyma-pro
 set -x
 kyma install \
     --ci \
-    --source latest \
+    --source latest-published \
     -o installer-config-production.yaml.tpl \
     --timeout 90m
 )

--- a/prow/scripts/cluster-integration/kyma-integration-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-integration-gardener-azure.sh
@@ -197,7 +197,7 @@ cat "${EVENTHUB_SECRET_OVERRIDE_FILE}" >> installer-config-azure-eventhubs.yaml.
 set -x
 kyma install \
     --ci \
-    --source latest \
+    --source latest-published \
     -o installer-cr-gardener-azure.yaml.tpl \
     -o installer-config-production.yaml.tpl \
     -o installer-config-azure-eventhubs.yaml.tpl \

--- a/prow/scripts/cluster-integration/kyma-integration-gardener-gcp.sh
+++ b/prow/scripts/cluster-integration/kyma-integration-gardener-gcp.sh
@@ -162,7 +162,7 @@ curl -L --silent --fail --show-error "https://raw.githubusercontent.com/kyma-pro
 set -x
 kyma install \
     --ci \
-    --source latest \
+    --source latest-published \
     -o installer-config-production.yaml.tpl \
     --timeout 90m
 )


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Use latest published master on periodic clusters to avoid pull backoff errors when artifacts are not there for the most recent commit.
