### PR TITLE
Wait for tiller rollout status

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-rel2rel-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-rel2rel-upgrade.sh
@@ -392,7 +392,10 @@ upgradeKyma() {
     shout "Install Tiller from version ${TARGET_VERSION}"
     date
     kubectl apply -f /tmp/kyma-gke-upgradeability/upgraded-tiller.yaml
-
+    
+    # Wait untill tiller is correctly rolled out
+    kubectl -n kube-system rollout status deployment/tiller-deploy
+    
     shout "Use release artifacts from version ${TARGET_VERSION}"
     date
     kubectl apply -f /tmp/kyma-gke-upgradeability/upgraded-release-installer.yaml

--- a/prow/scripts/cluster-integration/kyma-gke-upgrade-xip.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-upgrade-xip.sh
@@ -325,6 +325,9 @@ function upgradeKyma() {
         shout "Update tiller"
         kubectl apply -f /tmp/kyma-gke-upgradeability/new-tiller.yaml
 
+        # Wait untill tiller is correctly rolled out
+        kubectl -n kube-system rollout status deployment/tiller-deploy
+
         shout "Update kyma installer"
         kubectl apply -f /tmp/kyma-gke-upgradeability/new-release-kyma-installer.yaml
     else

--- a/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
@@ -392,6 +392,9 @@ function upgradeKyma() {
 
         shout "Update tiller"
         kubectl apply -f /tmp/kyma-gke-upgradeability/new-tiller.yaml
+        
+        # Wait untill tiller is correctly rolled out
+        kubectl -n kube-system rollout status deployment/tiller-deploy
 
         shout "Update kyma installer"
         kubectl apply -f /tmp/kyma-gke-upgradeability/new-release-kyma-installer.yaml


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Added waiting for tiller upgrade rollout status

**Context:**

In the below issue, there was a need to upgrade tiller,however, I have discovered that upgrade jobs are not waiting for tiller upgrade to finish.

Now there can be a situation, that happened on my PR, that there was old tiller pod running, installer pod connected to it then k8s terminated old pod once new was running and `connection closed` error occurred (expected in such case). 
To make sure that we will not go further (apply new deployment)  until rollout completes (at least new pod will be in status RUNNING) I have additional command.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/7725