### PR TITLE
go vanity import path support

### DIFF
--- a/prow/images/buildpack-golang-toolbox/Dockerfile
+++ b/prow/images/buildpack-golang-toolbox/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN go get golang.org/x/tools/cmd/goimports  \
     golang.org/x/lint/golint \
     github.com/vektra/mockery \
+    github.com/ericchiang/pup\
     github.com/kisielk/errcheck && \
     GO111MODULE="on" go get sigs.k8s.io/kind@v0.5.1
 

--- a/prow/images/buildpack-golang-toolbox/license-puller.sh
+++ b/prow/images/buildpack-golang-toolbox/license-puller.sh
@@ -71,7 +71,7 @@ function downloadLicense() {
 
     # laymans vanity-import support
     local repository
-    repository=$(curl -L "${importPath}?go-get=1" | pup 'meta[name="go-import"] attr{content}' | paste -sd "," - | awk '{print $3}' | sed 's/.git$// ; s%^[^:]\+://%%')
+    repository=$(curl -L "${importPath}?go-get=1" | pup 'meta[name="go-import"] attr{content}' | paste -sd " " - | awk '{print $3}' | sed 's/.git$// ; s%^[^:]\+://%%')
     local url="https://${repository/github.com/raw.githubusercontent.com}/master"
 
     echo "Downloading license from '${repository}' to '${output}''"

--- a/prow/images/buildpack-golang-toolbox/license-puller.sh
+++ b/prow/images/buildpack-golang-toolbox/license-puller.sh
@@ -17,7 +17,7 @@ function read_arguments() {
         case $arg in
             --dirs-to-pulling=*)
 	      local dirs_to_pulling=()
-	      IFS=" " read -r -a dirs_to_pulling <<< "${arg#*=}"
+	      IFS="," read -r -a dirs_to_pulling <<< "${arg#*=}"
               shift # remove --dirs-to-pulling=
             ;;
             *)

--- a/prow/images/buildpack-golang-toolbox/license-puller.sh
+++ b/prow/images/buildpack-golang-toolbox/license-puller.sh
@@ -125,3 +125,5 @@ function main() {
 }
 
 main
+
+# vim: set expandtab:

--- a/prow/images/buildpack-golang-toolbox/license-puller.sh
+++ b/prow/images/buildpack-golang-toolbox/license-puller.sh
@@ -71,6 +71,15 @@ function downloadLicense() {
 
     # laymans vanity-import support
     local repository
+    # the gist of the line below:
+    # 1. go get queries ${importpath} and appends ?go-get=1 to this call
+    #    so we do the same, and the server responds the same way it does for go get. 
+    # 2. the web page returned has to contain a meta tag similar to this:
+    # <meta name="go-import" content="knative.dev/serving git https://github.com/knative/serving">
+    # 3. pup (a html parser) extracts the content attribute from this meta-tag
+    # 4. in some cases the output is multiline (github.com does this). paste joins these lines into one
+    # 5. extract 3rd element from the line (this is the repository
+    # 6. clean it up
     repository=$(curl -L "${importPath}?go-get=1" | pup 'meta[name="go-import"] attr{content}' | paste -sd " " - | awk '{print $3}' | sed 's/.git$// ; s%^[^:]\+://%%')
     local url="https://${repository/github.com/raw.githubusercontent.com}/master"
 

--- a/prow/images/buildpack-golang-toolbox/license-puller.sh
+++ b/prow/images/buildpack-golang-toolbox/license-puller.sh
@@ -16,8 +16,8 @@ function read_arguments() {
     do
         case $arg in
             --dirs-to-pulling=*)
-	      local dirs_to_pulling=()
-	      IFS="," read -r -a dirs_to_pulling <<< "${arg#*=}"
+              local dirs_to_pulling=()
+              IFS="," read -r -a dirs_to_pulling <<< "${arg#*=}"
               shift # remove --dirs-to-pulling=
             ;;
             *)

--- a/prow/images/buildpack-golang-toolbox/license-puller.sh
+++ b/prow/images/buildpack-golang-toolbox/license-puller.sh
@@ -16,7 +16,8 @@ function read_arguments() {
     do
         case $arg in
             --dirs-to-pulling=*)
-              local dirs_to_pulling=($( echo "${arg#*=}" | tr "," "\n" ))
+	      local dirs_to_pulling=()
+	      IFS=" " read -r -a dirs_to_pulling <<< "${arg#*=}"
               shift # remove --dirs-to-pulling=
             ;;
             *)
@@ -27,7 +28,7 @@ function read_arguments() {
 
     if [ "${#dirs_to_pulling[@]}" -ne 0 ]; then
         for d in "${dirs_to_pulling[@]}"; do
-            DIRS_TO_PULLING+=($( cd "${CWD}/${d}" && pwd ))
+            DIRS_TO_PULLING+=( "$( cd "${CWD}/${d}" && pwd )" )
         done
     fi
     readonly DIRS_TO_PULLING
@@ -69,7 +70,8 @@ function downloadLicense() {
     local importPath=${2}
 
     # laymans vanity-import support
-    local repository=$(curl -L ${importPath}?go-get=1 | pup 'meta[name="go-import"] attr{content}' | paste -sd "," - | awk '{print $3}' | sed 's/.git$// ; s%^[^:]\+://%%')
+    local repository
+    repository=$(curl -L "${importPath}?go-get=1" | pup 'meta[name="go-import"] attr{content}' | paste -sd "," - | awk '{print $3}' | sed 's/.git$// ; s%^[^:]\+://%%')
     local url="https://${repository/github.com/raw.githubusercontent.com}/master"
 
     echo "Downloading license from '${repository}' to '${output}''"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

the license puller was not able to download licenses for import paths using go's vanity import paths

using pup and a bit of other shell commands this can be implemented

>***NOTE:*** `go help importpath` to the rescue

1. append ?go-get=1 to the importpath when curling it
2. extract the meta tag with name=go-import
3. extract the repository url

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

kyma-project/kyma#7992