### PR TITLE
Update buildpack-golang to go 1.14

### DIFF
--- a/prow/images/buildpack-golang/Dockerfile
+++ b/prow/images/buildpack-golang/Dockerfile
@@ -4,7 +4,7 @@ FROM eu.gcr.io/kyma-project/test-infra/bootstrap:v20200124-900eb728
 
 # Versions
 
-ENV GO_VERSION 1.13.4
+ENV GO_VERSION 1.14.2
 ENV DEP_RELEASE_TAG v0.5.4
 
 # Install Go

--- a/prow/images/buildpack-golang/Makefile
+++ b/prow/images/buildpack-golang/Makefile
@@ -11,5 +11,5 @@ push-image:
 	docker tag $(IMG_NAME) $(IMG):$(TAG)
 	docker push $(IMG):$(TAG)
 push-image-release: push-image
-	docker tag $(IMG_NAME) $(IMG):go1.13
-	docker push $(IMG):go1.13
+	docker tag $(IMG_NAME) $(IMG):go1.14
+	docker push $(IMG):go1.14

--- a/prow/images/buildpack-golang/README.md
+++ b/prow/images/buildpack-golang/README.md
@@ -6,7 +6,7 @@ This folder contains the Buildpack Golang image that is based on the Bootstrap i
 
 The image consists of:
 
-- golang 1.13.4
+- golang 1.14.2
 - dep 0.5.4
 
 ## Installation


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Go 1.14.2

**Related issue(s)**

