### PR TITLE
Change VM type on integration-gardener-azure

### DIFF
--- a/prow/scripts/cluster-integration/kyma-integration-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-integration-gardener-azure.sh
@@ -157,7 +157,7 @@ install::kyma_cli
 shout "Provision cluster: \"${CLUSTER_NAME}\""
 
 if [ -z "$MACHINE_TYPE" ]; then
-      export MACHINE_TYPE="Standard_D4_v3"
+      export MACHINE_TYPE="Standard_D8_v3"
 fi
 
 CLEANUP_CLUSTER="true"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project
/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
According to the documentation on azure we should use "Standard_D8_v3"

![Screenshot 2020-04-24 at 16 41 02](https://user-images.githubusercontent.com/8530211/80351639-f9fd5580-8872-11ea-8c15-ed7fe05b599b.png)
https://kyma-project.io/docs/root/kyma#installation-install-kyma-on-a-cluster
Changes proposed in this pull request:

- updated default vm size


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
