### PR TITLE
Enable project plugin

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -3,9 +3,11 @@ plugins:
   kyma-project:
     - cat
     - trigger
+    - project
   kyma-incubator:
     - cat
     - trigger
+    - project
   kyma-project/test-infra:
     - config-updater
 
@@ -27,3 +29,10 @@ triggers:
   only_org_members: true
   ignore_ok_to_test: true
   elide_skipped_contexts: false
+
+project_config:
+  project_org_configs:
+    kyma-project:
+      org_default_column_map:
+        Wookiee:
+          Inbox


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Enabled plugin
- Defined default column for the Wookiee project

As a team, we would like to work with GitHub projects. For everyone that is outside of our team, the project will be read-only. The only way for people that have read-only access to assign an Issue/PR to it will be by the command `/project Wookiee`.
