### PR TITLE
bump golang to version 1.14.2 in kyma-integration image

### DIFF
--- a/prow/images/kyma-integration/Dockerfile
+++ b/prow/images/kyma-integration/Dockerfile
@@ -79,7 +79,7 @@ RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \
 
 # Versions
 
-ENV GO_VERSION 1.13.4
+ENV GO_VERSION 1.14.2
 ENV DEP_RELEASE_TAG v0.5.4
 
 # Install Go
@@ -135,3 +135,5 @@ RUN curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor |
 #################################################################
 
 COPY --from=eu.gcr.io/kyma-project/test-infra/prow-tools:v20200423-7436dd60 /prow-tools /prow-tools
+# for better access to prow-tools
+ENV PATH=$PATH:/prow-tools


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
As most of the images use Go in version 1.14.2 it's good to bump the version of Go in kyma-integration image from 1.13.4 to 1.14.2.
Changes proposed in this pull request:

- bumped Go version to 1.14.2
- added /prow-tools to PATH

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
