### PR TITLE
report: false to jobs that should not report to slack

### DIFF
--- a/prow/jobs/incubator/compass/components/metris/metris-generic.yaml
+++ b/prow/jobs/incubator/compass/components/metris/metris-generic.yaml
@@ -10,6 +10,7 @@ job_template: &job_template
   decorate: true
   path_alias: github.com/kyma-incubator/compass
   max_concurrency: 10
+  report: false
   reporter_config:
     slack:
       channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/kyma/components/api-gateway-migrator/api-gateway-migrator-generic.yaml
+++ b/prow/jobs/kyma/components/api-gateway-migrator/api-gateway-migrator-generic.yaml
@@ -10,6 +10,7 @@ job_template: &job_template
   decorate: true
   path_alias: github.com/kyma-project/kyma
   max_concurrency: 10
+  report: false
   reporter_config:
     slack:
       channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/kyma/components/nats-init/nats-init-generic.yaml
+++ b/prow/jobs/kyma/components/nats-init/nats-init-generic.yaml
@@ -10,6 +10,7 @@ job_template: &job_template
   decorate: true
   path_alias: github.com/kyma-project/kyma
   max_concurrency: 10
+  report: false
   reporter_config:
     slack:
       channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/kyma/tests/function-controller/function-controller-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/function-controller/function-controller-tests-generic.yaml
@@ -10,6 +10,7 @@ job_template: &job_template
   decorate: true
   path_alias: github.com/kyma-project/kyma
   max_concurrency: 10
+  report: false
   reporter_config:
     slack:
       channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/kyma/tools/event-subscriber/event-subscriber-generic.yaml
+++ b/prow/jobs/kyma/tools/event-subscriber/event-subscriber-generic.yaml
@@ -10,6 +10,7 @@ job_template: &job_template
   decorate: true
   path_alias: github.com/kyma-project/kyma
   max_concurrency: 10
+  report: false
   reporter_config:
     slack:
       channel: '' # empty channel overrides slack reporting in crier

--- a/templates/templates/component.yaml
+++ b/templates/templates/component.yaml
@@ -137,6 +137,7 @@ postsubmits:
           base_ref: master
 {{- end }}
 {{- if or .Values.optional .Values.skipSlackReport }}
+      report: false
       reporter_config:
         slack:
           channel: '' # empty channel overrides slack reporting in crier

--- a/templates/templates/generic-component.yaml
+++ b/templates/templates/generic-component.yaml
@@ -38,6 +38,7 @@ job_template: &job_template
   path_alias: {{ .Values.repository }}
   max_concurrency: 10
 {{- if or .Values.optional .Values.skipSlackReport }}
+  report: false
   reporter_config:
     slack:
       channel: '' # empty channel overrides slack reporting in crier

--- a/templates/templates/knative-kafka-component.yaml
+++ b/templates/templates/knative-kafka-component.yaml
@@ -138,6 +138,7 @@ postsubmits:
           base_ref: master
 {{- end }}
 {{- if or .Values.optional .Values.skipSlackReport }}
+      report: false
       reporter_config:
         slack:
           channel: '' # empty channel overrides slack reporting in crier


### PR DESCRIPTION
**Description**
It seems that just adding the empty channel doesnt work so we'll explicitly set the report to false.

Changes proposed in this pull request:
- set `report: false` on jobs that set the empty channel

**Related issue(s)**
#2311
