### PR TITLE
GitHub quota monitoring #1162

### DIFF
--- a/prow/cluster/resources/monitoring/dashboards/grafana-prow.json
+++ b/prow/cluster/resources/monitoring/dashboards/grafana-prow.json
@@ -371,7 +371,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "fill": 2,
+      "fill": 10,
       "gridPos": {
         "h": 10,
         "w": 24,
@@ -484,13 +484,13 @@
     },
     {
       "aliasColors": {},
-      "bars": true,
+      "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
       "decimals": 0,
       "description": "Show number of prow services present on a kubernetes cluster.",
-      "fill": 1,
+      "fill": 10,
       "gridPos": {
         "h": 9,
         "w": 12,
@@ -507,7 +507,7 @@
         "total": false,
         "values": true
       },
-      "lines": false,
+      "lines": true,
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
@@ -747,6 +747,19 @@
       }
     },
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 23,
+      "panels": [],
+      "title": "Github",
+      "type": "row"
+    },
+    {
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": true,
@@ -768,9 +781,9 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 25
+        "y": 26
       },
-      "id": 23,
+      "id": 24,
       "interval": null,
       "links": [],
       "mappingType": 1,

--- a/prow/cluster/resources/monitoring/dashboards/grafana-prow.json
+++ b/prow/cluster/resources/monitoring/dashboards/grafana-prow.json
@@ -371,7 +371,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "fill": 10,
+      "fill": 2,
       "gridPos": {
         "h": 10,
         "w": 24,
@@ -381,7 +381,7 @@
       "id": 2,
       "legend": {
         "avg": false,
-        "current": false,
+        "current": true,
         "max": false,
         "min": false,
         "show": true,
@@ -745,6 +745,88 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#d44a3a",
+        "rgba(237, 129, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "Prometheus",
+      "format": "none",
+      "gauge": {
+        "maxValue": 5000,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": true,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "id": 23,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "#052b51",
+        "full": true,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "github_token_usage{token_hash=~\"^a6.*$\"}",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "200,500",
+      "title": "Github token usage",
+      "transparent": false,
+      "type": "singlestat",
+      "valueFontSize": "50%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
     }
   ],
   "refresh": "10s",
@@ -752,7 +834,7 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+  "list": []
   },
   "time": {
     "from": "now-1h",

--- a/prow/cluster/resources/monitoring/dashboards/grafana-prow.json
+++ b/prow/cluster/resources/monitoring/dashboards/grafana-prow.json
@@ -428,7 +428,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
+      "timeFrom": "12h",
       "timeShift": null,
       "title": "Queue",
       "tooltip": {
@@ -566,7 +566,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
+      "timeFrom": "12h",
       "timeShift": null,
       "title": "Prow service availability",
       "tooltip": {
@@ -685,7 +685,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
+      "timeFrom": "12h",
       "timeShift": null,
       "title": "Prow endpoints count",
       "tooltip": {
@@ -810,7 +810,7 @@
       "thresholds": "200,500",
       "timeFrom": "12h",
       "timeShift": null,
-      "title": "Github token usage",
+      "title": "Github token quota usage",
       "transparent": false,
       "type": "singlestat",
       "valueFontSize": "50%",
@@ -892,7 +892,7 @@
         }
       ],
       "thresholds": "",
-      "title": "Time to next Github token quota reset.",
+      "title": "Time to Github token quota reset.",
       "transparent": true,
       "type": "singlestat",
       "valueFontSize": "50%",

--- a/prow/cluster/resources/monitoring/dashboards/grafana-prow.json
+++ b/prow/cluster/resources/monitoring/dashboards/grafana-prow.json
@@ -381,7 +381,7 @@
       "id": 2,
       "legend": {
         "avg": false,
-        "current": true,
+        "current": false,
         "max": false,
         "min": false,
         "show": true,
@@ -500,7 +500,7 @@
       "id": 21,
       "legend": {
         "avg": false,
-        "current": true,
+        "current": false,
         "max": false,
         "min": false,
         "show": true,

--- a/prow/cluster/resources/monitoring/dashboards/grafana-prow.json
+++ b/prow/cluster/resources/monitoring/dashboards/grafana-prow.json
@@ -558,20 +558,6 @@
           "refId": "E"
         },
         {
-          "expr": "kube_service_info{service=\"tide\", namespace=\"default\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "tide",
-          "refId": "F"
-        },
-        {
-          "expr": "kube_service_info{service=\"prow-addons-controller-manager-service\", namespace=\"default\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "prow-addons-controller-manager-service",
-          "refId": "G"
-        },
-        {
           "expr": "kube_service_info{service=\"ingress-nginx\", namespace=\"ingress-nginx\"}",
           "format": "time_series",
           "intervalFactor": 1,
@@ -689,13 +675,6 @@
           "intervalFactor": 1,
           "legendFormat": "pushgateway_endpoints",
           "refId": "E"
-        },
-        {
-          "expr": "kube_endpoint_address_available{endpoint=\"tide\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "tide_endpoints",
-          "refId": "F"
         },
         {
           "expr": "kube_endpoint_address_available{endpoint=\"ingress-nginx\"}",

--- a/prow/cluster/resources/monitoring/dashboards/grafana-prow.json
+++ b/prow/cluster/resources/monitoring/dashboards/grafana-prow.json
@@ -762,6 +762,7 @@
         "x": 0,
         "y": 26
       },
+      "hideTimeOverride": false,
       "id": 24,
       "interval": null,
       "links": [],
@@ -807,8 +808,92 @@
         }
       ],
       "thresholds": "200,500",
+      "timeFrom": "12h",
+      "timeShift": null,
       "title": "Github token usage",
       "transparent": false,
+      "type": "singlestat",
+      "valueFontSize": "50%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(237, 129, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "Prometheus",
+      "format": "dthms",
+      "gauge": {
+        "maxValue": 3600,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": false,
+        "thresholdMarkers": false
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "id": 25,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "#052b51",
+        "full": true,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "github_token_reset{token_hash=~\"^a6.*$\"} / 1000000000",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Time to next Github token quota reset.",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "50%",
       "valueMaps": [
@@ -857,9 +942,8 @@
       "30d"
     ]
   },
-
   "timezone": "",
   "title": "Prow",
   "uid": "rzdkVLPik",
-  "version": 3
+  "version": 1
 }

--- a/prow/cluster/resources/monitoring/dashboards/grafana-prow.json
+++ b/prow/cluster/resources/monitoring/dashboards/grafana-prow.json
@@ -625,7 +625,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "fill": 1,
+      "fill": 10,
       "gridPos": {
         "h": 9,
         "w": 12,

--- a/prow/cluster/resources/monitoring/dashboards/grafana-prow.json
+++ b/prow/cluster/resources/monitoring/dashboards/grafana-prow.json
@@ -826,7 +826,7 @@
   "style": "dark",
   "tags": [],
   "templating": {
-  "list": []
+    "list": []
   },
   "time": {
     "from": "now-1h",

--- a/prow/cluster/resources/monitoring/templates/prow_prometheusrules.yaml
+++ b/prow/cluster/resources/monitoring/templates/prow_prometheusrules.yaml
@@ -189,8 +189,9 @@ spec:
                   severity: warning
                 annotations:
                   summary: Github API token usage is high for current time window.
-                  description: |-
+                  description: |
                     Github API token quota usage reached warning treshold. Current value: {{"{{"}} $value {{"}}"}}
+                    See time to token quota rest: https://monitoring.build.kyma-project.io/d/rzdkVLPik/prow?refresh=10s&panelId=25&fullscreen&orgId=1
               - alert: GithubAPITokenExhausted
                 expr: github_token_usage{token_hash=~"^a.*"} < 1
                 for: 30s
@@ -199,4 +200,6 @@ spec:
                   severity: critical
                 annotations:
                   summary: Github API token quota exhausted for current time window.
-                  description: "Github API token quota exhausted for current time window."
+                  description: |
+                    Github API token quota exhausted for current time window.
+                    See time to token quota rest: https://monitoring.build.kyma-project.io/d/rzdkVLPik/prow?refresh=10s&panelId=25&fullscreen&orgId=1

--- a/prow/cluster/resources/monitoring/templates/prow_prometheusrules.yaml
+++ b/prow/cluster/resources/monitoring/templates/prow_prometheusrules.yaml
@@ -168,7 +168,8 @@ spec:
                   severity: critical
                 annotations:
                   summary: Prowjobs count limit exceeded.
-                  description: "Number of running concurrent prowjobs reached maximum limit. Current value: {{ $value }}"
+                  description: |-
+                    Number of running concurrent prowjobs reached maximum limit. Current value: {{"{{"}} $value {{"}}"}}
               - alert: ProwjobsCountLimit
                 expr: sum(prowjobs{state=~"pending|triggered"}) > 89
                 for: 30s
@@ -176,10 +177,11 @@ spec:
                   app: prow
                   severity: warning
                 annotations:
-                  description: "Number of running concurrent prowjobs reached warning treshold. Current value: {{ $value }}"
+                  description: |-
+                    Number of running concurrent prowjobs reached warning treshold. Current value: {{"{{"}} $value {{"}}"}}
                   summary: Prowjobs count is high.
               # Github API token usage
-              - alert: GithubAPITokenUsage
+              - alert: GithubAPITokenUsageWarning
                 expr: github_token_usage{token_hash=~"^a.*"} < 500
                 for: 30s
                 labels:
@@ -187,9 +189,10 @@ spec:
                   severity: warning
                 annotations:
                   summary: Github API token usage is high for current time window.
-                  description: "Github API token quota usage reached warning treshold. Current value: {{ $value }}"
-              - alert: GithubAPITokenUsage
-                expr: github_token_usage{token_hash=~"^a.*"} = 0
+                  description: |-
+                    Github API token quota usage reached warning treshold. Current value: {{"{{"}} $value {{"}}"}}
+              - alert: GithubAPITokenExhausted
+                expr: github_token_usage{token_hash=~"^a.*"} < 1
                 for: 30s
                 labels:
                   app: prow

--- a/prow/cluster/resources/monitoring/templates/prow_prometheusrules.yaml
+++ b/prow/cluster/resources/monitoring/templates/prow_prometheusrules.yaml
@@ -168,7 +168,7 @@ spec:
                   severity: critical
                 annotations:
                   summary: Prowjobs count limit exceeded.
-                  description: Number of running concurrent prowjobs reached maximum limit. Check plank config max_concurrency option.
+                  description: "Number of running concurrent prowjobs reached maximum limit. Current value: {{ $value }}"
               - alert: ProwjobsCountLimit
                 expr: sum(prowjobs{state=~"pending|triggered"}) > 89
                 for: 30s
@@ -176,5 +176,24 @@ spec:
                   app: prow
                   severity: warning
                 annotations:
-                  description: Number of running concurrent prowjobs reached warning treshold.
+                  description: "Number of running concurrent prowjobs reached warning treshold. Current value: {{ $value }}"
                   summary: Prowjobs count is high.
+              # Github API token usage
+              - alert: GithubAPITokenUsage
+                expr: github_token_usage{token_hash=~"^a.*"} < 500
+                for: 30s
+                labels:
+                  app: prow
+                  severity: warning
+                annotations:
+                  summary: Github API token usage is high for current time window.
+                  description: "Github API token quota usage reached warning treshold. Current value: {{ $value }}"
+              - alert: GithubAPITokenUsage
+                expr: github_token_usage{token_hash=~"^a.*"} = 0
+                for: 30s
+                labels:
+                  app: prow
+                  severity: critical
+                annotations:
+                  summary: Github API token quota exhausted for current time window.
+                  description: "Github API token quota exhausted for current time window."


### PR DESCRIPTION
**Description**

Enabled github token usage monitoring and alerting.
Removed tide and prow-addons-ctrl-manager from endpoint and services graphs.
Aligned graphs formating.
**Related issue(s)**
See #1162 
