### PR TITLE
report: false for all jobs that set empty channel

### DIFF
--- a/prow/jobs/helm-broker/helm-broker.yaml
+++ b/prow/jobs/helm-broker/helm-broker.yaml
@@ -84,9 +84,6 @@ postsubmits:
         preset-build-master: "true"
         preset-bot-github-token: "true"
       report: false
-      reporter_config:
-        slack:
-          channel: '' # empty channel overrides slack reporting in crier
     - name: post-release-helm-broker
       # Prow resolves git tags as branches, so that regexp triggers build after tagging the repository.
       branches:
@@ -97,9 +94,6 @@ postsubmits:
         preset-bot-github-token: "true"
         preset-kind-volume-mounts: "true"
       report: false
-      reporter_config:
-        slack:
-          channel: '' # empty channel overrides slack reporting in crier
       skip_report: false
       decorate: true
       optional: false

--- a/prow/jobs/helm-broker/helm-broker.yaml
+++ b/prow/jobs/helm-broker/helm-broker.yaml
@@ -83,6 +83,7 @@ postsubmits:
         <<: *job_labels_template
         preset-build-master: "true"
         preset-bot-github-token: "true"
+      report: false
       reporter_config:
         slack:
           channel: '' # empty channel overrides slack reporting in crier
@@ -95,6 +96,7 @@ postsubmits:
         preset-build-release: "true"
         preset-bot-github-token: "true"
         preset-kind-volume-mounts: "true"
+      report: false
       reporter_config:
         slack:
           channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/api-gateway/api-gateway.yaml
+++ b/prow/jobs/incubator/api-gateway/api-gateway.yaml
@@ -48,6 +48,3 @@ postsubmits:
       <<: *job_labels_template
       preset-build-master: "true"
     report: false
-    reporter_config:
-      slack:
-        channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/api-gateway/api-gateway.yaml
+++ b/prow/jobs/incubator/api-gateway/api-gateway.yaml
@@ -47,6 +47,7 @@ postsubmits:
     labels:
       <<: *job_labels_template
       preset-build-master: "true"
+    report: false
     reporter_config:
       slack:
         channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/compass/components/metris/metris-generic.yaml
+++ b/prow/jobs/incubator/compass/components/metris/metris-generic.yaml
@@ -11,9 +11,6 @@ job_template: &job_template
   path_alias: github.com/kyma-incubator/compass
   max_concurrency: 10
   report: false
-  reporter_config:
-    slack:
-      channel: '' # empty channel overrides slack reporting in crier
   labels:
     preset-dind-enabled: "true"
     preset-sa-gcr-push: "true"

--- a/prow/jobs/incubator/dex/dex.yaml
+++ b/prow/jobs/incubator/dex/dex.yaml
@@ -46,6 +46,3 @@ postsubmits:
       <<: *job_labels_template
       preset-build-master: "true"
     report: false
-    reporter_config:
-      slack:
-        channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/dex/dex.yaml
+++ b/prow/jobs/incubator/dex/dex.yaml
@@ -45,6 +45,7 @@ postsubmits:
     labels:
       <<: *job_labels_template
       preset-build-master: "true"
+    report: false
     reporter_config:
       slack:
         channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/gcp-service-broker/gcp-service-broker.yaml
+++ b/prow/jobs/incubator/gcp-service-broker/gcp-service-broker.yaml
@@ -48,6 +48,3 @@ postsubmits:
         <<: *job_labels_template
         preset-build-master: "true"
       report: false
-      reporter_config:
-        slack:
-          channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/gcp-service-broker/gcp-service-broker.yaml
+++ b/prow/jobs/incubator/gcp-service-broker/gcp-service-broker.yaml
@@ -47,6 +47,7 @@ postsubmits:
       labels:
         <<: *job_labels_template
         preset-build-master: "true"
+      report: false
       reporter_config:
         slack:
           channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/github-slack-connectors/github-connector/github-connector.yaml
+++ b/prow/jobs/incubator/github-slack-connectors/github-connector/github-connector.yaml
@@ -49,6 +49,3 @@ postsubmits:
         <<: *job_labels_template
         preset-build-master: "true"
       report: false
-      reporter_config:
-        slack:
-          channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/github-slack-connectors/github-connector/github-connector.yaml
+++ b/prow/jobs/incubator/github-slack-connectors/github-connector/github-connector.yaml
@@ -48,6 +48,7 @@ postsubmits:
       labels:
         <<: *job_labels_template
         preset-build-master: "true"
+      report: false
       reporter_config:
         slack:
           channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/github-slack-connectors/slack-connector/slack-connector.yaml
+++ b/prow/jobs/incubator/github-slack-connectors/slack-connector/slack-connector.yaml
@@ -48,6 +48,3 @@ postsubmits:
         <<: *job_labels_template
         preset-build-master: "true"
       report: false
-      reporter_config:
-        slack:
-          channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/github-slack-connectors/slack-connector/slack-connector.yaml
+++ b/prow/jobs/incubator/github-slack-connectors/slack-connector/slack-connector.yaml
@@ -47,6 +47,7 @@ postsubmits:
       labels:
         <<: *job_labels_template
         preset-build-master: "true"
+      report: false
       reporter_config:
         slack:
           channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/hydroform/hydroform.yaml
+++ b/prow/jobs/incubator/hydroform/hydroform.yaml
@@ -56,6 +56,7 @@ postsubmits:
       labels:
         <<: *job_labels_template
         preset-build-master: "true"
+      report: false
       reporter_config:
         slack:
           channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/hydroform/hydroform.yaml
+++ b/prow/jobs/incubator/hydroform/hydroform.yaml
@@ -57,6 +57,3 @@ postsubmits:
         <<: *job_labels_template
         preset-build-master: "true"
       report: false
-      reporter_config:
-        slack:
-          channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/marketplaces/marketplaces.yaml
+++ b/prow/jobs/incubator/marketplaces/marketplaces.yaml
@@ -85,6 +85,7 @@ postsubmits: # runs on merges
     labels:
       <<: *job_labels_template
       preset-build-master: "true"
+    report: false
     reporter_config:
       slack:
         channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/marketplaces/marketplaces.yaml
+++ b/prow/jobs/incubator/marketplaces/marketplaces.yaml
@@ -86,9 +86,6 @@ postsubmits: # runs on merges
       <<: *job_labels_template
       preset-build-master: "true"
     report: false
-    reporter_config:
-      slack:
-        channel: '' # empty channel overrides slack reporting in crier
   - name: rel-marketplaces
     <<: *job_template
     branches:

--- a/prow/jobs/incubator/octopus/octopus.yaml
+++ b/prow/jobs/incubator/octopus/octopus.yaml
@@ -50,6 +50,7 @@ postsubmits:
     labels:
       <<: *job_labels_template
       preset-build-master: "true"
+    report: false
     reporter_config:
       slack:
         channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/octopus/octopus.yaml
+++ b/prow/jobs/incubator/octopus/octopus.yaml
@@ -51,6 +51,3 @@ postsubmits:
       <<: *job_labels_template
       preset-build-master: "true"
     report: false
-    reporter_config:
-      slack:
-        channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/podpreset-crd/podpreset-crd.yaml
+++ b/prow/jobs/incubator/podpreset-crd/podpreset-crd.yaml
@@ -49,6 +49,3 @@ postsubmits:
         <<: *job_labels_template
         preset-build-master: "true"
       report: false
-      reporter_config:
-        slack:
-          channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/podpreset-crd/podpreset-crd.yaml
+++ b/prow/jobs/incubator/podpreset-crd/podpreset-crd.yaml
@@ -48,6 +48,7 @@ postsubmits:
       labels:
         <<: *job_labels_template
         preset-build-master: "true"
+      report: false
       reporter_config:
         slack:
           channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/service-catalog-tester/service-catalog-tester.yaml
+++ b/prow/jobs/incubator/service-catalog-tester/service-catalog-tester.yaml
@@ -48,6 +48,3 @@ postsubmits:
         <<: *job_labels_template
         preset-build-master: "true"
       report: false
-      reporter_config:
-        slack:
-          channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/service-catalog-tester/service-catalog-tester.yaml
+++ b/prow/jobs/incubator/service-catalog-tester/service-catalog-tester.yaml
@@ -47,6 +47,7 @@ postsubmits:
       labels:
         <<: *job_labels_template
         preset-build-master: "true"
+      report: false
       reporter_config:
         slack:
           channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/terraform-provider-gardener/terraform-provider-gardener.yaml
+++ b/prow/jobs/incubator/terraform-provider-gardener/terraform-provider-gardener.yaml
@@ -49,6 +49,3 @@ postsubmits:
         <<: *job_labels_template
         preset-build-master: "true"
       report: false
-      reporter_config:
-        slack:
-          channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/terraform-provider-gardener/terraform-provider-gardener.yaml
+++ b/prow/jobs/incubator/terraform-provider-gardener/terraform-provider-gardener.yaml
@@ -48,6 +48,7 @@ postsubmits:
       labels:
         <<: *job_labels_template
         preset-build-master: "true"
+      report: false
       reporter_config:
         slack:
           channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/third-party-images/docker-registry/registry.yaml
+++ b/prow/jobs/incubator/third-party-images/docker-registry/registry.yaml
@@ -47,6 +47,3 @@ postsubmits:
       <<: *job_labels_template
       preset-build-master: "true"
     report: false
-    reporter_config:
-      slack:
-        channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/third-party-images/docker-registry/registry.yaml
+++ b/prow/jobs/incubator/third-party-images/docker-registry/registry.yaml
@@ -46,6 +46,7 @@ postsubmits:
     labels:
       <<: *job_labels_template
       preset-build-master: "true"
+    report: false
     reporter_config:
       slack:
         channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/third-party-images/fluent-bit/fluent-bit.yaml
+++ b/prow/jobs/incubator/third-party-images/fluent-bit/fluent-bit.yaml
@@ -46,6 +46,3 @@ postsubmits:
       <<: *job_labels_template
       preset-build-master: "true"
     report: false
-    reporter_config:
-      slack:
-        channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/third-party-images/fluent-bit/fluent-bit.yaml
+++ b/prow/jobs/incubator/third-party-images/fluent-bit/fluent-bit.yaml
@@ -45,6 +45,7 @@ postsubmits:
     labels:
       <<: *job_labels_template
       preset-build-master: "true"
+    report: false
     reporter_config:
       slack:
         channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/third-party-images/jaeger-operator/jaeger-operator.yaml
+++ b/prow/jobs/incubator/third-party-images/jaeger-operator/jaeger-operator.yaml
@@ -46,6 +46,3 @@ postsubmits:
       <<: *job_labels_template
       preset-build-master: "true"
     report: false
-    reporter_config:
-      slack:
-        channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/third-party-images/jaeger-operator/jaeger-operator.yaml
+++ b/prow/jobs/incubator/third-party-images/jaeger-operator/jaeger-operator.yaml
@@ -45,6 +45,7 @@ postsubmits:
     labels:
       <<: *job_labels_template
       preset-build-master: "true"
+    report: false
     reporter_config:
       slack:
         channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/third-party-images/kiali-operator/kiali-operator.yaml
+++ b/prow/jobs/incubator/third-party-images/kiali-operator/kiali-operator.yaml
@@ -46,6 +46,3 @@ postsubmits:
       <<: *job_labels_template
       preset-build-master: "true"
     report: false
-    reporter_config:
-      slack:
-        channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/third-party-images/kiali-operator/kiali-operator.yaml
+++ b/prow/jobs/incubator/third-party-images/kiali-operator/kiali-operator.yaml
@@ -45,6 +45,7 @@ postsubmits:
     labels:
       <<: *job_labels_template
       preset-build-master: "true"
+    report: false
     reporter_config:
       slack:
         channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/third-party-images/kiali/kiali.yaml
+++ b/prow/jobs/incubator/third-party-images/kiali/kiali.yaml
@@ -46,6 +46,3 @@ postsubmits:
       <<: *job_labels_template
       preset-build-master: "true"
     report: false
-    reporter_config:
-      slack:
-        channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/third-party-images/kiali/kiali.yaml
+++ b/prow/jobs/incubator/third-party-images/kiali/kiali.yaml
@@ -45,6 +45,7 @@ postsubmits:
     labels:
       <<: *job_labels_template
       preset-build-master: "true"
+    report: false
     reporter_config:
       slack:
         channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/third-party-images/minio-mc/minio-mc.yaml
+++ b/prow/jobs/incubator/third-party-images/minio-mc/minio-mc.yaml
@@ -47,6 +47,3 @@ postsubmits:
       <<: *job_labels_template
       preset-build-master: "true"
     report: false
-    reporter_config:
-      slack:
-        channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/third-party-images/minio-mc/minio-mc.yaml
+++ b/prow/jobs/incubator/third-party-images/minio-mc/minio-mc.yaml
@@ -46,6 +46,7 @@ postsubmits:
     labels:
       <<: *job_labels_template
       preset-build-master: "true"
+    report: false
     reporter_config:
       slack:
         channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/third-party-images/minio/minio.yaml
+++ b/prow/jobs/incubator/third-party-images/minio/minio.yaml
@@ -47,6 +47,3 @@ postsubmits:
       <<: *job_labels_template
       preset-build-master: "true"
     report: false
-    reporter_config:
-      slack:
-        channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/third-party-images/minio/minio.yaml
+++ b/prow/jobs/incubator/third-party-images/minio/minio.yaml
@@ -46,6 +46,7 @@ postsubmits:
     labels:
       <<: *job_labels_template
       preset-build-master: "true"
+    report: false
     reporter_config:
       slack:
         channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/third-party-images/prometheus-node-exporter/prometheus-node-exporter.yaml
+++ b/prow/jobs/incubator/third-party-images/prometheus-node-exporter/prometheus-node-exporter.yaml
@@ -46,6 +46,3 @@ postsubmits:
       <<: *job_labels_template
       preset-build-master: "true"
     report: false
-    reporter_config:
-      slack:
-        channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/third-party-images/prometheus-node-exporter/prometheus-node-exporter.yaml
+++ b/prow/jobs/incubator/third-party-images/prometheus-node-exporter/prometheus-node-exporter.yaml
@@ -45,6 +45,7 @@ postsubmits:
     labels:
       <<: *job_labels_template
       preset-build-master: "true"
+    report: false
     reporter_config:
       slack:
         channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/varkes/varkes.yaml
+++ b/prow/jobs/incubator/varkes/varkes.yaml
@@ -48,9 +48,6 @@ postsubmits:
         <<: *job_labels_template
         preset-build-master: "true"
       report: false
-      reporter_config:
-        slack:
-          channel: '' # empty channel overrides slack reporting in crier
     - name: post-release-varkes #publishes to npm
       branches:
         - release
@@ -60,6 +57,3 @@ postsubmits:
         preset-build-release: "true"
         preset-bot-npm-token: "true"
       report: false
-      reporter_config:
-        slack:
-          channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/varkes/varkes.yaml
+++ b/prow/jobs/incubator/varkes/varkes.yaml
@@ -47,6 +47,7 @@ postsubmits:
       labels:
         <<: *job_labels_template
         preset-build-master: "true"
+      report: false
       reporter_config:
         slack:
           channel: '' # empty channel overrides slack reporting in crier
@@ -58,6 +59,7 @@ postsubmits:
         <<: *job_labels_template
         preset-build-release: "true"
         preset-bot-npm-token: "true"
+      report: false
       reporter_config:
         slack:
           channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/vstudio-extension/vstudio-extension.yaml
+++ b/prow/jobs/incubator/vstudio-extension/vstudio-extension.yaml
@@ -39,6 +39,3 @@ postsubmits:
       labels:
         preset-build-master: "true"
       report: false
-      reporter_config:
-        slack:
-          channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/incubator/vstudio-extension/vstudio-extension.yaml
+++ b/prow/jobs/incubator/vstudio-extension/vstudio-extension.yaml
@@ -38,6 +38,7 @@ postsubmits:
       <<: *job_template
       labels:
         preset-build-master: "true"
+      report: false
       reporter_config:
         slack:
           channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/kyma/components/api-gateway-migrator/api-gateway-migrator-generic.yaml
+++ b/prow/jobs/kyma/components/api-gateway-migrator/api-gateway-migrator-generic.yaml
@@ -11,9 +11,6 @@ job_template: &job_template
   path_alias: github.com/kyma-project/kyma
   max_concurrency: 10
   report: false
-  reporter_config:
-    slack:
-      channel: '' # empty channel overrides slack reporting in crier
   labels:
     preset-dind-enabled: "true"
     preset-sa-gcr-push: "true"

--- a/prow/jobs/kyma/components/nats-init/nats-init-generic.yaml
+++ b/prow/jobs/kyma/components/nats-init/nats-init-generic.yaml
@@ -11,9 +11,6 @@ job_template: &job_template
   path_alias: github.com/kyma-project/kyma
   max_concurrency: 10
   report: false
-  reporter_config:
-    slack:
-      channel: '' # empty channel overrides slack reporting in crier
   labels:
     preset-dind-enabled: "true"
     preset-sa-gcr-push: "true"

--- a/prow/jobs/kyma/kyma-compass-provisioner-tests.yaml
+++ b/prow/jobs/kyma/kyma-compass-provisioner-tests.yaml
@@ -61,6 +61,7 @@ presubmits: # runs on PRs
     branches:
       - ^master$
     run_if_changed: "resources/compass/charts/provisioner"
+    report: false
     reporter_config:
       slack:
         channel: '' # empty channel overrides slack reporting in crier
@@ -104,6 +105,7 @@ postsubmits:
               cpu: 80m
     branches:
       - ^master$
+    report: false
     reporter_config:
       slack:
         channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/kyma/kyma-compass-provisioner-tests.yaml
+++ b/prow/jobs/kyma/kyma-compass-provisioner-tests.yaml
@@ -62,9 +62,6 @@ presubmits: # runs on PRs
       - ^master$
     run_if_changed: "resources/compass/charts/provisioner"
     report: false
-    reporter_config:
-      slack:
-        channel: '' # empty channel overrides slack reporting in crier
     labels:
       preset-build-pr: "true"
       <<: *gke_integration_job_labels_template
@@ -106,9 +103,6 @@ postsubmits:
     branches:
       - ^master$
     report: false
-    reporter_config:
-      slack:
-        channel: '' # empty channel overrides slack reporting in crier
     labels:
       preset-build-master: "true"
       <<: *gke_integration_job_labels_template

--- a/prow/jobs/kyma/kyma-gke-compass-integration.yaml
+++ b/prow/jobs/kyma/kyma-gke-compass-integration.yaml
@@ -68,9 +68,6 @@ presubmits: # runs on PRs
       # following regexp won't start build if only Markdown files were changed
       run_if_changed: "^((resources\\S+|installation\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       report: false
-      reporter_config:
-        slack:
-          channel: '' # empty channel overrides slack reporting in crier
       labels:
         preset-build-pr: "true"
         <<: *gke_integration_job_labels_template
@@ -100,9 +97,6 @@ postsubmits:
         # testgrid-alert-email: email-here@sap.com
         testgrid-num-failures-to-alert: '1'
       report: false
-      reporter_config:
-        slack:
-          channel: '' # empty channel overrides slack reporting in crier
       labels:
         preset-build-master: "true"
         <<: *gke_integration_job_labels_template

--- a/prow/jobs/kyma/kyma-gke-compass-integration.yaml
+++ b/prow/jobs/kyma/kyma-gke-compass-integration.yaml
@@ -67,6 +67,7 @@ presubmits: # runs on PRs
       <<: *gke_integration_job_template_k15
       # following regexp won't start build if only Markdown files were changed
       run_if_changed: "^((resources\\S+|installation\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
+      report: false
       reporter_config:
         slack:
           channel: '' # empty channel overrides slack reporting in crier
@@ -98,6 +99,7 @@ postsubmits:
         testgrid-dashboards: kyma-cleaners
         # testgrid-alert-email: email-here@sap.com
         testgrid-num-failures-to-alert: '1'
+      report: false
       reporter_config:
         slack:
           channel: '' # empty channel overrides slack reporting in crier

--- a/prow/jobs/kyma/tests/function-controller/function-controller-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/function-controller/function-controller-tests-generic.yaml
@@ -11,9 +11,6 @@ job_template: &job_template
   path_alias: github.com/kyma-project/kyma
   max_concurrency: 10
   report: false
-  reporter_config:
-    slack:
-      channel: '' # empty channel overrides slack reporting in crier
   labels:
     preset-dind-enabled: "true"
     preset-sa-gcr-push: "true"

--- a/prow/jobs/kyma/tools/event-subscriber/event-subscriber-generic.yaml
+++ b/prow/jobs/kyma/tools/event-subscriber/event-subscriber-generic.yaml
@@ -11,9 +11,6 @@ job_template: &job_template
   path_alias: github.com/kyma-project/kyma
   max_concurrency: 10
   report: false
-  reporter_config:
-    slack:
-      channel: '' # empty channel overrides slack reporting in crier
   labels:
     preset-dind-enabled: "true"
     preset-sa-gcr-push: "true"

--- a/templates/templates/component.yaml
+++ b/templates/templates/component.yaml
@@ -138,9 +138,6 @@ postsubmits:
 {{- end }}
 {{- if or .Values.optional .Values.skipSlackReport }}
       report: false
-      reporter_config:
-        slack:
-          channel: '' # empty channel overrides slack reporting in crier
 {{- end}}
       labels:
         <<: *job_labels_template

--- a/templates/templates/generic-component.yaml
+++ b/templates/templates/generic-component.yaml
@@ -39,9 +39,6 @@ job_template: &job_template
   max_concurrency: 10
 {{- if or .Values.optional .Values.skipSlackReport }}
   report: false
-  reporter_config:
-    slack:
-      channel: '' # empty channel overrides slack reporting in crier
 {{- end}}
   labels:
     preset-dind-enabled: "true"

--- a/templates/templates/knative-kafka-component.yaml
+++ b/templates/templates/knative-kafka-component.yaml
@@ -139,9 +139,6 @@ postsubmits:
 {{- end }}
 {{- if or .Values.optional .Values.skipSlackReport }}
       report: false
-      reporter_config:
-        slack:
-          channel: '' # empty channel overrides slack reporting in crier
 {{- end}}
       labels:
         <<: *job_labels_template

--- a/templates/templates/kyma-gke-compass-integration.yaml
+++ b/templates/templates/kyma-gke-compass-integration.yaml
@@ -66,9 +66,6 @@ presubmits: # runs on PRs
       # following regexp won't start build if only Markdown files were changed
       run_if_changed: "^((resources\\S+|installation\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       report: false
-      reporter_config:
-        slack:
-          channel: '' # empty channel overrides slack reporting in crier
       labels:
         preset-build-pr: "true"
         <<: *gke_integration_job_labels_template
@@ -101,9 +98,6 @@ postsubmits:
         # testgrid-alert-email: email-here@sap.com
         testgrid-num-failures-to-alert: '1'
       report: false
-      reporter_config:
-        slack:
-          channel: '' # empty channel overrides slack reporting in crier
       labels:
         preset-build-master: "true"
         <<: *gke_integration_job_labels_template

--- a/templates/templates/kyma-gke-compass-integration.yaml
+++ b/templates/templates/kyma-gke-compass-integration.yaml
@@ -65,6 +65,7 @@ presubmits: # runs on PRs
       <<: *gke_integration_job_template_k15
       # following regexp won't start build if only Markdown files were changed
       run_if_changed: "^((resources\\S+|installation\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
+      report: false
       reporter_config:
         slack:
           channel: '' # empty channel overrides slack reporting in crier
@@ -99,6 +100,7 @@ postsubmits:
         testgrid-dashboards: kyma-cleaners
         # testgrid-alert-email: email-here@sap.com
         testgrid-num-failures-to-alert: '1'
+      report: false
       reporter_config:
         slack:
           channel: '' # empty channel overrides slack reporting in crier


### PR DESCRIPTION
**Description**
Setting `report: false` for all jobs that have `channel: ''` set to the empty channel.


**Related issue(s)**
https://github.com/kyma-project/test-infra/pull/2312
https://github.com/kyma-project/test-infra/pull/2346
https://github.com/kyma-project/test-infra/issues/2311
