### PR TITLE
enable docker in docker for cli release

### DIFF
--- a/prow/jobs/cli/cli.yaml
+++ b/prow/jobs/cli/cli.yaml
@@ -47,6 +47,7 @@ postsubmits: # runs on merges
     labels:
       preset-build-release: "true"
       preset-bot-github-token: "true"
+      preset-dind-enabled: "true"
   - name: stable-kyma-cli
     branches:
     - "^stable$" # stable tag


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- setting the `preset-dind-enabled` label to be `true` in order to allow for running docker inside a docker during the CLI release

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#465