### PR TITLE
Quick fix for kyma-metadata-schema-governance job

### DIFF
--- a/prow/jobs/kyma/kyma-metadata-governance.yaml
+++ b/prow/jobs/kyma/kyma-metadata-governance.yaml
@@ -15,6 +15,7 @@ presubmits: # runs on PRs
         - org: kyma-project
           repo: test-infra
           base_ref: master
+          base_sha: 070ff576c1601ebab0e6fc2ee2ed5496eab8c2dc
           path_alias: github.com/kyma-project/test-infra
       spec:
         containers:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Job is failing because it was not migrated to go modules. This PR is only a quick fix.

Logs:
```
Initializing
Docker in Docker enabled, initializing...
================================================================================
Starting Docker: docker.
================================================================================
/root/.docker/config.json configured to use this credential helper for GCR registries
Done setting up docker in docker.
Vendoring 'tools'
/home/prow/go/src/github.com/kyma-project/test-infra/development/tools /home/prow/go/src/github.com/kyma-project/kyma
could not find project Gopkg.toml, use dep init to initiate a manifest
```
