### PR TITLE
Move dependencies resolving to go modules

### DIFF
--- a/development/tools/jobs/kyma/metadata_governance_test.go
+++ b/development/tools/jobs/kyma/metadata_governance_test.go
@@ -31,7 +31,7 @@ func TestMetadataGovernanceJobPresubmit(t *testing.T) {
 	tester.AssertThatHasPresets(t, actualPresubmit.JobBase, preset.BuildPr, preset.DindEnabled)
 	assert.Equal(t, "^resources/.*/values.schema.json$", actualPresubmit.RunIfChanged)
 	assert.True(t, tester.IfPresubmitShouldRunAgainstChanges(*actualPresubmit, true, "resources/test/values.schema.json"))
-	assert.Equal(t, tester.ImageGolangBuildpackLatest, actualPresubmit.Spec.Containers[0].Image)
+	assert.Equal(t, tester.ImageGolangBuildpack1_14, actualPresubmit.Spec.Containers[0].Image)
 	assert.Equal(t, []string{tester.MetadataGovernanceScriptDir}, actualPresubmit.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"--repository", "kyma", "--validator", "/home/prow/go/src/github.com/kyma-project/test-infra/development/tools/pkg/metadata/jsonmetadatavalidator.go"}, actualPresubmit.Spec.Containers[0].Args)
 }

--- a/development/update-config.sh
+++ b/development/update-config.sh
@@ -12,11 +12,8 @@ if [[ -z "${CONFIG_PATH}" ]]; then
     usage
 fi
 
-readonly UPLOADER="${DEVELOPMENT_DIR}/tools/cmd/configuploader/main.go"
-if [[ ! -d "${DEVELOPMENT_DIR}/tools/vendor/github.com" ]]; then
-    (cd "${DEVELOPMENT_DIR}/tools" && dep ensure -v -vendor-only)
-fi
-
+readonly UPLOADER="cmd/configuploader/main.go"
 readonly CONFIG="${HOME}/.kube/config"
 
+cd "${DEVELOPMENT_DIR}/tools" || exit 1
 go run "${UPLOADER}" --kubeconfig "${CONFIG}" --config-path "${CONFIG_PATH}"

--- a/development/update-jobs.sh
+++ b/development/update-jobs.sh
@@ -12,11 +12,8 @@ if [[ -z "${JOBS_PATH}" ]]; then
     usage
 fi
 
-readonly UPLOADER="${DEVELOPMENT_DIR}/tools/cmd/configuploader/main.go"
-if [[ ! -d "${DEVELOPMENT_DIR}/tools/vendor/github.com" ]]; then
-    (cd "${DEVELOPMENT_DIR}/tools" && dep ensure -v -vendor-only)
-fi
-
+readonly UPLOADER="cmd/configuploader/main.go"
 readonly CONFIG="${HOME}/.kube/config"
 
+cd "${DEVELOPMENT_DIR}/tools" || exit 1
 go run "${UPLOADER}" --kubeconfig "${CONFIG}" --jobs-config-path "${JOBS_PATH}"

--- a/development/update-plugins.sh
+++ b/development/update-plugins.sh
@@ -12,11 +12,8 @@ if [[ -z "${PLUGINS_PATH}" ]]; then
     usage
 fi
 
-readonly UPLOADER="${DEVELOPMENT_DIR}/tools/cmd/configuploader/main.go"
-if [[ ! -d "${DEVELOPMENT_DIR}/tools/vendor/github.com" ]]; then
-    (cd "${DEVELOPMENT_DIR}/tools" && dep ensure -v -vendor-only)
-fi
-
+readonly UPLOADER="cmd/configuploader/main.go"
 readonly CONFIG="${HOME}/.kube/config"
 
+cd "${DEVELOPMENT_DIR}/tools" || exit 1
 go run "${UPLOADER}" --kubeconfig "${CONFIG}" --plugins-config-path "${PLUGINS_PATH}"

--- a/prow/jobs/kyma/kyma-metadata-governance.yaml
+++ b/prow/jobs/kyma/kyma-metadata-governance.yaml
@@ -18,7 +18,7 @@ presubmits: # runs on PRs
           path_alias: github.com/kyma-project/test-infra
       spec:
         containers:
-          - image: eu.gcr.io/kyma-project/prow/test-infra/buildpack-golang:go1.14
+          - image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.14
             securityContext:
               privileged: true
             command:

--- a/prow/jobs/kyma/kyma-metadata-governance.yaml
+++ b/prow/jobs/kyma/kyma-metadata-governance.yaml
@@ -15,7 +15,6 @@ presubmits: # runs on PRs
         - org: kyma-project
           repo: test-infra
           base_ref: master
-          base_sha: 070ff576c1601ebab0e6fc2ee2ed5496eab8c2dc
           path_alias: github.com/kyma-project/test-infra
       spec:
         containers:

--- a/prow/jobs/kyma/kyma-metadata-governance.yaml
+++ b/prow/jobs/kyma/kyma-metadata-governance.yaml
@@ -18,7 +18,7 @@ presubmits: # runs on PRs
           path_alias: github.com/kyma-project/test-infra
       spec:
         containers:
-          - image: eu.gcr.io/kyma-project/prow/test-infra/buildpack-golang:v20181119-afd3fbd
+          - image: eu.gcr.io/kyma-project/prow/test-infra/buildpack-golang:go1.14
             securityContext:
               privileged: true
             command:

--- a/prow/scripts/cluster-integration/helpers/aks-library.sh
+++ b/prow/scripts/cluster-integration/helpers/aks-library.sh
@@ -45,11 +45,15 @@ function createPublicIPandDNS() {
 function addGithubDexConnector() {
     shout "Add Github Dex Connector"
     date
-    pushd "${KYMA_PROJECT_DIR}/test-infra/development/tools"
-    dep ensure -v -vendor-only
-    popd
+    pushd "${KYMA_PROJECT_DIR}/test-infra/development/tools" || exit 1
     export DEX_CALLBACK_URL="https://dex.${CLUSTER_NAME}.build.kyma-project.io/callback"
-    go run "${KYMA_PROJECT_DIR}/test-infra/development/tools/cmd/enablegithubauth/main.go"
+    if [ -x /prow-tools/enablegithubauth ];
+    then
+      /prow-tools/enablegithubauth
+    else
+      go run "${KYMA_PROJECT_DIR}/test-infra/development/tools/cmd/enablegithubauth/main.go"
+    fi
+    popd || exit 1
 }
 
 function createGroup() {

--- a/prow/scripts/cluster-integration/helpers/aks-library.sh
+++ b/prow/scripts/cluster-integration/helpers/aks-library.sh
@@ -51,7 +51,7 @@ function addGithubDexConnector() {
     then
       /prow-tools/enablegithubauth
     else
-      go run "${KYMA_PROJECT_DIR}/test-infra/development/tools/cmd/enablegithubauth/main.go"
+      go run "cmd/enablegithubauth/main.go"
     fi
     popd || exit 1
 }

--- a/prow/scripts/metadata-governance.sh
+++ b/prow/scripts/metadata-governance.sh
@@ -85,7 +85,7 @@ function copy_files() {
 
 function run_metadata_validation() {
     set +e
-    pushd "development/tools"
+    pushd "${SCRIPT_DIR}/../../development/tools"
     go run "${VALIDATOR}" "${@}"
     local result=$?
     if [[ ${result} -ne 0 ]]; then

--- a/prow/scripts/metadata-governance.sh
+++ b/prow/scripts/metadata-governance.sh
@@ -85,13 +85,13 @@ function copy_files() {
 
 function run_metadata_validation() {
     set +e
-    # shellcheck disable=SC2068
-    go run "${VALIDATOR}" ${@}
-
+    pushd "development/tools"
+    go run "${VALIDATOR}" "${@}"
     local result=$?
     if [[ ${result} -ne 0 ]]; then
         OUTPUT=1
     fi
+    popd
     set -e
 }
 
@@ -131,13 +131,6 @@ function validate_metadata_schema_on_pr() {
 function main() {
     read_arguments "${ARGS[@]}"
     init
-
-    if [ ! -d "${SCRIPT_DIR}/../../development/tools/vendor" ]; then
-        echo "Vendoring 'tools'"
-        pushd "${SCRIPT_DIR}/../../development/tools"
-        dep ensure -v -vendor-only
-        popd
-    fi
 
     shout "Validate changed json schema files"
     validate_metadata_schema_on_pr

--- a/prow/scripts/metadata-governance.sh
+++ b/prow/scripts/metadata-governance.sh
@@ -86,7 +86,8 @@ function copy_files() {
 function run_metadata_validation() {
     set +e
     pushd "${SCRIPT_DIR}/../../development/tools"
-    go run "${VALIDATOR}" "${@}"
+    # shellcheck disable=SC2068
+    go run "${VALIDATOR}" ${@}
     local result=$?
     if [[ ${result} -ne 0 ]]; then
         OUTPUT=1


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Fix in #2412 for `kyma-metadata-schema-governance` job intended to use previous revision of a repository before using modules. This rewrites scripts to fetch dependencies using go modules with latest revision of test-infra repo.

Also addresses multiple usages of `dep` in other scripts in a repository.

Changes proposed in this pull request:

- revert #2412 
- remove fetching dependencies using dep
- use `enablegithubauth` binary in aks-library.sh

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
