### PR TITLE
GitHub token monitoring dashboard changes

### DIFF
--- a/prow/cluster/resources/monitoring/dashboards/grafana-prow.json
+++ b/prow/cluster/resources/monitoring/dashboards/grafana-prow.json
@@ -428,7 +428,6 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": "12h",
       "timeShift": null,
       "title": "Queue",
       "tooltip": {
@@ -566,7 +565,6 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": "12h",
       "timeShift": null,
       "title": "Prow service availability",
       "tooltip": {
@@ -685,7 +683,6 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": "12h",
       "timeShift": null,
       "title": "Prow endpoints count",
       "tooltip": {
@@ -808,7 +805,6 @@
         }
       ],
       "thresholds": "200,500",
-      "timeFrom": "12h",
       "timeShift": null,
       "title": "Github token quota usage",
       "transparent": false,

--- a/prow/cluster/resources/monitoring/dashboards/grafana-prow.json
+++ b/prow/cluster/resources/monitoring/dashboards/grafana-prow.json
@@ -900,6 +900,93 @@
         }
       ],
       "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "decimals": 0,
+      "description": "GitHub token usage metrics over time period",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "id": 26,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "github_token_usage{token_hash=~\"^a6.*$\"}",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "Token usage",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeShift": null,
+      "title": "Github token usage over time",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": false,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": "5000",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": "10s",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Removed timeFrom override from Grafana dashboard panels in order to restore ability to access metrics from different time ranges
Changes proposed in this pull request:

- removed timeFrom override from dashboard's panels
- added GitHub token usage time series for monitoring usage over time

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
