### PR TITLE
Make pre-test-infra-validate-configs required again

### DIFF
--- a/prow/jobs/test-infra/validation.yaml
+++ b/prow/jobs/test-infra/validation.yaml
@@ -5,7 +5,6 @@ presubmits:
     - name: pre-test-infra-validate-scripts
       run_if_changed: "^(development/.*.sh$|prow/.*.sh$)"
       decorate: true
-      skip_report: false
       spec:
         containers:
           - image: eu.gcr.io/kyma-project/prow/test-infra/bootstrap:v20181121-f3ea5ce
@@ -18,8 +17,6 @@ presubmits:
     - name: pre-test-infra-validate-configs
       run_if_changed: "^prow/((plugins|config).yaml|jobs/)"
       decorate: true
-      optional: true
-      skip_report: false
       spec:
         containers:
           - image: *buildpack_golang_image


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Job `pre-test-infra-validate-configs` was set to optional because of an issue after switching to go modules. This PR restores the job to be required again.

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
