### PR TITLE
Use consistent timeout for gardener azure job

### DIFF
--- a/prow/jobs/kyma/kyma-integration-gardener.yaml
+++ b/prow/jobs/kyma/kyma-integration-gardener.yaml
@@ -112,6 +112,9 @@ presubmits:
   kyma-project/kyma:
     - name: pre-master-kyma-gardener-azure-integration
       <<: *gardener_azure_job_template
+      decoration_config:
+        timeout: 14400000000000 # 4h
+        grace_period: 600000000000 # 10min
       optional: true
       branches:
         - ^master$

--- a/templates/templates/kyma-integration-gardener.yaml
+++ b/templates/templates/kyma-integration-gardener.yaml
@@ -110,6 +110,9 @@ presubmits:
   kyma-project/kyma:
     - name: pre-master-kyma-gardener-azure-integration
       <<: *gardener_azure_job_template
+      decoration_config:
+        timeout: 14400000000000 # 4h
+        grace_period: 600000000000 # 10min
       optional: {{ .Values.optional }}
       branches:
         - ^master$


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- periodic [kyma-integration-gardener-azure](https://github.com/kyma-project/test-infra/blob/56ae24e5b3b64058fdf927b11e916dbb4d699b2a/prow/jobs/kyma/kyma-integration-gardener.yaml#L179) job uses 4h timeout, because cluster provisioning has timeout of 90m and kyma installation adds another 90m. That hopefully leaves enough time for cleanup. Default timeout value seems to be [2h](https://github.com/kyma-project/test-infra/blob/master/prow/config.yaml#L487) which is too low.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Hopefully improves/fixes #8700