### PR TITLE
Enable start-wssagent.sh to use mounted keys.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2,6 +2,22 @@
 
 presets:
   - labels:
+      preset-wssagent-keys: "true"
+    volumes:
+      - name: whitesource-apikey
+        secret:
+          secretName: whitesource-apikey
+      - name: whitesource-userkey
+        secret:
+          secretName: whitesource-userkey
+    volumeMounts:
+      - name: whitesource-apikey
+        mountPath: /etc/credentials/whitesource-apikey
+        readOnly: true
+      - name: whitesource-userkey
+        mountPath: /etc/credentials/whitesource-userkey
+        readOnly: true
+  - labels:
       preset-sa-prow-job-resource-cleaner: "true"
     env:
       - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/prow/jobs/incubator/compass/tests/provisioner-tests/provisioner-whitesource.yaml
+++ b/prow/jobs/incubator/compass/tests/provisioner-tests/provisioner-whitesource.yaml
@@ -48,6 +48,7 @@ presubmits: # runs on PRs
         preset-docker-push-repository-kyma: "true"
         preset-build-pr: "true"
         preset-kyma-wssagent-config: "true"
+        preset-wssagent-keys: "true"
         preset-kyma-keyring: "true"
         preset-kyma-encryption-key: "true"
         preset-kms-gc-project-env: "true"

--- a/prow/jobs/scans/whitesource-periodics.yaml
+++ b/prow/jobs/scans/whitesource-periodics.yaml
@@ -13,6 +13,7 @@ periodics:
     cron: "0 4 * * *" # At 04:00 am every day
     labels:
         preset-kyma-wssagent-config: "true"
+        preset-wssagent-keys: "true"
         preset-kyma-keyring: "true"
         preset-kyma-encryption-key: "true"
         preset-kms-gc-project-env: "true"
@@ -51,6 +52,7 @@ periodics:
     cron: "0 4 * * *" # At 04:00 am every day
     labels:
         preset-kyma-wssagent-config: "true"
+        preset-wssagent-keys: "true"
         preset-kyma-keyring: "true"
         preset-kyma-encryption-key: "true"
         preset-kms-gc-project-env: "true"
@@ -89,6 +91,7 @@ periodics:
     cron: "0 4 * * *" # At 04:00 am every day
     labels:
         preset-kyma-wssagent-config: "true"
+        preset-wssagent-keys: "true"
         preset-kyma-keyring: "true"
         preset-kyma-encryption-key: "true"
         preset-kms-gc-project-env: "true"
@@ -127,6 +130,7 @@ periodics:
     cron: "0 4 * * *" # At 04:00 am every day
     labels:
         preset-kyma-wssagent-config: "true"
+        preset-wssagent-keys: "true"
         preset-kyma-keyring: "true"
         preset-kyma-encryption-key: "true"
         preset-kms-gc-project-env: "true"
@@ -165,6 +169,7 @@ periodics:
     cron: "0 4 * * *" # At 04:00 am every day
     labels:
         preset-kyma-wssagent-config: "true"
+        preset-wssagent-keys: "true"
         preset-kyma-keyring: "true"
         preset-kyma-encryption-key: "true"
         preset-kms-gc-project-env: "true"
@@ -203,6 +208,7 @@ periodics:
     cron: "0 4 * * *" # At 04:00 am every day
     labels:
         preset-kyma-wssagent-config: "true"
+        preset-wssagent-keys: "true"
         preset-kyma-keyring: "true"
         preset-kyma-encryption-key: "true"
         preset-kms-gc-project-env: "true"
@@ -241,6 +247,7 @@ periodics:
     cron: "0 4 * * *" # At 04:00 am every day
     labels:
         preset-kyma-wssagent-config: "true"
+        preset-wssagent-keys: "true"
         preset-kyma-keyring: "true"
         preset-kyma-encryption-key: "true"
         preset-kms-gc-project-env: "true"
@@ -279,6 +286,7 @@ periodics:
     cron: "0 4 * * *" # At 04:00 am every day
     labels:
         preset-kyma-wssagent-config: "true"
+        preset-wssagent-keys: "true"
         preset-kyma-keyring: "true"
         preset-kyma-encryption-key: "true"
         preset-kms-gc-project-env: "true"
@@ -317,6 +325,7 @@ periodics:
     cron: "0 4 * * *" # At 04:00 am every day
     labels:
         preset-kyma-wssagent-config: "true"
+        preset-wssagent-keys: "true"
         preset-kyma-keyring: "true"
         preset-kyma-encryption-key: "true"
         preset-kms-gc-project-env: "true"
@@ -355,6 +364,7 @@ periodics:
     cron: "0 4 * * *" # At 04:00 am every day
     labels:
         preset-kyma-wssagent-config: "true"
+        preset-wssagent-keys: "true"
         preset-kyma-keyring: "true"
         preset-kyma-encryption-key: "true"
         preset-kms-gc-project-env: "true"

--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -26,14 +26,9 @@ init
 
 export TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS="${TEST_INFRA_SOURCES_DIR}/prow/scripts/cluster-integration/helpers"
 
-gsutil cp "gs://kyma-prow-secrets/whitesource-userkey.encrypted" "." 
-gsutil cp "gs://kyma-prow-secrets/whitesource-apikey.encrypted" "." 
+USERKEY=$(cat /etc/credentials/whitesource-userkey/userKey)
 
-"${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/decrypt.sh" "whitesource-userkey" "whitesource-userkey.encrypted"
-USERKEY=$(cat "whitesource-userkey")
-
-"${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/decrypt.sh" "whitesource-apikey" "whitesource-apikey.encrypted"
-APIKEY=$(cat "whitesource-apikey")
+APIKEY=$(cat /etc/credentials/whitesource-apikey/apiKey)
 
 
 case "${SCAN_LANGUAGE}" in

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -1,5 +1,21 @@
 presets:
   - labels:
+      preset-wssagent-keys: "true"
+    volumes:
+      - name: whitesource-apikey
+        secret:
+          secretName: whitesource-apikey
+      - name: whitesource-userkey
+        secret:
+          secretName: whitesource-userkey
+    volumeMounts:
+      - name: whitesource-apikey
+        mountPath: /etc/credentials/whitesource-apikey
+        readOnly: true
+      - name: whitesource-userkey
+        mountPath: /etc/credentials/whitesource-userkey
+        readOnly: true
+  - labels:
       preset-sa-prow-job-resource-cleaner: "true"
     env:
       - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/templates/templates/whitesource-periodics.yaml
+++ b/templates/templates/whitesource-periodics.yaml
@@ -11,6 +11,7 @@ periodics:
     cron: "0 4 * * *" # At 04:00 am every day
     labels:
         preset-kyma-wssagent-config: "true"
+        preset-wssagent-keys: "true"
         preset-kyma-keyring: "true"
         preset-kyma-encryption-key: "true"
         preset-kms-gc-project-env: "true"


### PR DESCRIPTION
**Description**

Created preset to mount wssagent api and user keys.
Enabled whitesource scans prowjobs to use new preset.
Enabled start-wssagent.sh to use mounted keys.

**Related issue(s)**
See #2399
