### PR TITLE
Fix typo in file name.

### DIFF
--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -26,9 +26,9 @@ init
 
 export TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS="${TEST_INFRA_SOURCES_DIR}/prow/scripts/cluster-integration/helpers"
 
-USERKEY=$(cat /etc/credentials/whitesource-userkey/userKey)
+USERKEY=$(cat /etc/credentials/whitesource-userkey/userkey)
 
-APIKEY=$(cat /etc/credentials/whitesource-apikey/apiKey)
+APIKEY=$(cat /etc/credentials/whitesource-apikey/apikey)
 
 
 case "${SCAN_LANGUAGE}" in


### PR DESCRIPTION
Whitesource scans failing due to no access to user and api keys because of typo in file name.