### PR TITLE
Skip the new E2E upgrade job by default

### DIFF
--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -442,6 +442,7 @@ presubmits: # runs on PRs
 
     - name: pre-master-kyma-gke-upgrade-e2e
       optional: true
+      always_run: false
       branches:
         - ^master$
       <<: *gke_upgrade_e2e_job_template
@@ -605,6 +606,7 @@ postsubmits:
 
     - name: post-master-kyma-gke-upgrade-e2e
       optional: true
+      always_run: false
       <<: *gke_upgrade_e2e_job_template
       annotations:
         testgrid-dashboards: kyma-postsubmit

--- a/templates/templates/kyma-integration.yaml
+++ b/templates/templates/kyma-integration.yaml
@@ -486,6 +486,7 @@ presubmits: # runs on PRs
 
     - name: pre-master-kyma-gke-upgrade-e2e
       optional: true
+      always_run: false
       branches:
         - ^master$
       <<: *gke_upgrade_e2e_job_template
@@ -672,6 +673,7 @@ postsubmits:
 
     - name: post-master-kyma-gke-upgrade-e2e
       optional: true
+      always_run: false
       <<: *gke_upgrade_e2e_job_template
       annotations:
         testgrid-dashboards: kyma-postsubmit


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Skip the new E2E upgrade job by default.

**Related issue(s)**

https://github.com/kyma-project/kyma/issues/7512.