### PR TITLE
Make validate-prow-jobs and prow-tools required

### DIFF
--- a/prow/jobs/test-infra/validation.yaml
+++ b/prow/jobs/test-infra/validation.yaml
@@ -33,7 +33,6 @@ presubmits:
                 cpu: 0.8
     - name: pre-master-test-infra-validate-prow-tools
       run_if_changed: "^development/tools/(cmd/.*|pkg/.*|Makefile|.*.sh)"
-      optional: true
       branches:
         - ^master$
       max_concurrency: 10
@@ -56,7 +55,6 @@ presubmits:
                 cpu: 0.8
     - name: pre-master-test-infra-validate-prow-jobs
       run_if_changed: "^(development/tools/jobs|prow)" # Also for any changes in prow directory
-      optional: true
       branches:
         - ^master$
       max_concurrency: 10


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The jobs were optional because there were code formatting errors that made the job fail. Right now these errors are fixed so the jobs can be required.
This PR sets the `pre-master-test-infra-validate-prow-jobs` and `pre-master-test-infra-validate-prow-tools` required to merge.

Changes proposed in this pull request:

- remove `optional: true` setting from `pre-master-test-infra-validate-prow-jobs` and `pre-master-test-infra-validate-prow-tools` jobs.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#2407 