### PR TITLE
Added case with no docker authentication.

### DIFF
--- a/prow/scripts/library.sh
+++ b/prow/scripts/library.sh
@@ -45,11 +45,13 @@ function authenticateDocker() {
     if [[ -n "${GCR_PUSH_GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
       client_email=$(jq -r '.client_email' < "${GCR_PUSH_GOOGLE_APPLICATION_CREDENTIALS}")
       echo "Authenticating in regsitry ${DOCKER_PUSH_REPOSITORY%%/*} as $client_email"
-      docker login -u _json_key --password-stdin https://"${DOCKER_PUSH_REPOSITORY%%/*}" < "${GCR_PUSH_GOOGLE_APPLICATION_CREDENTIALS}"
-    else
+      docker login -u _json_key --password-stdin https://"${DOCKER_PUSH_REPOSITORY%%/*}" < "${GCR_PUSH_GOOGLE_APPLICATION_CREDENTIALS}" || exit 1
+    elif [[ -n "${GOOGLE_APPLICATION_CREDENTIALS}" ]];then
       client_email=$(jq -r '.client_email' < "${GOOGLE_APPLICATION_CREDENTIALS}")
       echo "Authenticating in regsitry ${DOCKER_PUSH_REPOSITORY%%/*} as $client_email"
-      docker login -u _json_key --password-stdin https://"${DOCKER_PUSH_REPOSITORY%%/*}" < "${GOOGLE_APPLICATION_CREDENTIALS}"
+      docker login -u _json_key --password-stdin https://"${DOCKER_PUSH_REPOSITORY%%/*}" < "${GOOGLE_APPLICATION_CREDENTIALS}" || exit 1
+    else
+      echo "Skipping docker authnetication in registry. No credentials provided."
     fi
 
 }


### PR DESCRIPTION
**Description**
Some scripts doesn't need authenticate docker in gcr whereas still use DinD.
Changes proposed in this pull request:

- Added support for no docker authentication in gcr.

**Related issue(s)**
See #2399 
