### PR TITLE
disable cleanup of azure eventhub resource group

### DIFF
--- a/prow/scripts/cluster-integration/kyma-integration-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-integration-gardener-azure.sh
@@ -135,9 +135,10 @@ cleanup() {
         # Delete the Azure Event Hubs namespace which was created
         az eventhubs namespace delete -n "${EVENTHUB_NAMESPACE_NAME}" -g "${RS_GROUP}"
 
-        shout "Deleting Azure Resource Group: \"${RS_GROUP}\""
-        # Delete the Azure Resource Group
-        az group delete -n "${RS_GROUP}" -y
+        # TODO(k15r): think about one resource group per test run
+        #shout "Deleting Azure Resource Group: \"${RS_GROUP}\""
+        ## Delete the Azure Resource Group
+        #az group delete -n "${RS_GROUP}" -y
     fi
 
     if [ -n "${CLEANUP_DOCKER_IMAGE}" ]; then


### PR DESCRIPTION
this had side effects on other simultaneously running tests

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- do not remove the resource group as this kills all eventhubs (even the ones that are not used by the current test)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
