### PR TITLE
Enable Agent preconfiguration for Kyma Compass integration

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
@@ -244,6 +244,7 @@ function applyCompassOverrides() {
   fi
 
   "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --namespace "${NAMESPACE}" --name "compass-gateway-overrides" \
+    --data "global.agentPreconfiguration=true" \
     --data "global.istio.gateway.name=kyma-gateway" \
     --data "global.istio.gateway.namespace=kyma-system" \
     --data "global.connector.secrets.ca.name=connector-service-app-ca" \


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Enable Agent preconfiguration for Kyma Compass integration

Explanation: Default value for the Compass Agent preconfiguration is changed  to `false`.