### PR TITLE
Enable Agent preconfiguration for Kyma Compass integration (#2645)

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
@@ -244,6 +244,7 @@ function applyCompassOverrides() {
   fi
 
   "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --namespace "${NAMESPACE}" --name "compass-gateway-overrides" \
+    --data "global.agentPreconfiguration=true" \
     --data "global.istio.gateway.name=kyma-gateway" \
     --data "global.istio.gateway.namespace=kyma-system" \
     --data "global.connector.secrets.ca.name=connector-service-app-ca" \


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The Compass chart is installed from the `master` branch. Recent changes to the Compass chart caused job to need an additional override. For the release job to work properly we need to cherry-pick the change to release branch.

Change in Compass: https://github.com/kyma-incubator/compass/pull/1505/files
Adjustment in Test Infra: https://github.com/kyma-project/test-infra/pull/2645

Changes proposed in this pull request:

- Cherry-pick fix to Compass Integration job

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
