### PR TITLE
Fix logging overrides for kyma-upgrade-gardener-azure job

### DIFF
--- a/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
@@ -313,6 +313,7 @@ createTestResources() {
 }
 
 function upgradeKyma() {
+    # TODO(nachtmaar): ticket xxxx: comment as soon as Kyma 1.15 is out
     prepare_stackdriver_logging "${INSTALLATION_OVERRIDE_STACKDRIVER}"
     if [[ "$?" -ne 0 ]]; then
         return 1

--- a/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
@@ -183,12 +183,6 @@ function installKyma() {
     "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/create-azure-event-hubs-secret.sh
     cat "${EVENTHUB_SECRET_OVERRIDE_FILE}" >> installer-config-azure-eventhubs.yaml.tpl
 
-    # TODO(nachtmaar): ticket xxxx: uncomment as soon as Kyma 1.15 is out
-    # prepare_stackdriver_logging "${INSTALLATION_OVERRIDE_STACKDRIVER}"
-    # if [[ "$?" -ne 0 ]]; then
-    #     return 1
-    # fi
-
     (
     set -x
     kyma install \
@@ -197,8 +191,6 @@ function installKyma() {
         -o installer-config-production.yaml.tpl \
         -o installer-config-azure-eventhubs.yaml.tpl \
         --timeout 90m
-        # TODO(nachtmaar): ticket xxxx: uncomment as soon as Kyma 1.15 is out
-        # -o "${INSTALLATION_OVERRIDE_STACKDRIVER}" \
     )
 }
 
@@ -313,7 +305,6 @@ createTestResources() {
 }
 
 function upgradeKyma() {
-    # TODO(nachtmaar): ticket xxxx: comment as soon as Kyma 1.15 is out
     prepare_stackdriver_logging "${INSTALLATION_OVERRIDE_STACKDRIVER}"
     if [[ "$?" -ne 0 ]]; then
         return 1

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,2 +1,0 @@
-pjNames:
-  - pjName: "kyma-upgrade-gardener-azure"

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,2 @@
+pjNames:
+  - pjName: "kyma-upgrade-gardener-azure"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Problem: This [PR](https://github.com/kyma-project/kyma/pull/9165) did not make it into Kyma 1.14, hence we need to disable stackdriver installation overrides  in upgrade test until Kyma 1.15 is out
- There is a reminder to re-enable once Kyma 1.15 is out: https://github.com/kyma-project/test-infra/issues/2674
- Job can't be fully tested with pjtester, because https://github.com/kyma-project/kyma/issues/9210 is failing the upgrade

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/8783