### PR TITLE
Fix prepare data stage for eventmesh upgrade in kyma-upgrade-gardener-azure job

### DIFF
--- a/development/tools/jobs/kyma/kyma_upgrade_gardener_test.go
+++ b/development/tools/jobs/kyma/kyma_upgrade_gardener_test.go
@@ -33,6 +33,5 @@ func TestKymaGardenerAzureUpgradeJobPeriodics(t *testing.T) {
 	tester.AssertThatContainerHasEnv(t, job.Spec.Containers[0], "GARDENER_ZONES", "1")
 	tester.AssertThatContainerHasEnv(t, job.Spec.Containers[0], "KYMA_PROJECT_DIR", "/home/prow/go/src/github.com/kyma-project")
 	tester.AssertThatContainerHasEnv(t, job.Spec.Containers[0], "REGION", "northeurope")
-	tester.AssertThatContainerHasEnv(t, job.Spec.Containers[0], "RS_GROUP", "kyma-gardener-upgrade-azure")
 	tester.AssertThatSpecifiesResourceRequests(t, job.JobBase)
 }

--- a/prow/jobs/kyma/kyma-upgrade-gardener.yaml
+++ b/prow/jobs/kyma/kyma-upgrade-gardener.yaml
@@ -35,12 +35,8 @@ gardener_azure_job_template: &gardener_azure_job_template
           - "-c"
           - "${KYMA_PROJECT_DIR}/test-infra/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh"
         env:
-          - name: RS_GROUP
-            value: "kyma-gardener-upgrade-azure"
           - name: REGION
             value: "northeurope"
-          - name: EVENTHUB_NAMESPACE_NAME
-            value: "kyma-gardener-upgrade-azure"
           - name: KYMA_PROJECT_DIR
             value: "/home/prow/go/src/github.com/kyma-project"
           - name: GARDENER_REGION

--- a/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
@@ -27,9 +27,7 @@ VARIABLES=(
     GARDENER_KYMA_PROW_KUBECONFIG
     GARDENER_KYMA_PROW_PROJECT_NAME
     GARDENER_KYMA_PROW_PROVIDER_SECRET_NAME
-    RS_GROUP
     REGION
-    EVENTHUB_NAMESPACE_NAME
     AZURE_SUBSCRIPTION_ID
     AZURE_SUBSCRIPTION_APP_ID
     AZURE_SUBSCRIPTION_SECRET
@@ -49,9 +47,7 @@ fi
 readonly GARDENER_CLUSTER_VERSION="1.16"
 
 #Exported variables
-export RS_GROUP \
-    EVENTHUB_NAMESPACE_NAME \
-    REGION \
+export REGION \
     AZURE_SUBSCRIPTION_ID \
     AZURE_SUBSCRIPTION_APP_ID \
     AZURE_SUBSCRIPTION_SECRET \
@@ -83,6 +79,11 @@ source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/cluster-integration/helpers/kyma-
 # shellcheck disable=SC1090
 source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/cluster-integration/helpers/fluent-bit-stackdriver-logging.sh"
 
+RANDOM_NAME_SUFFIX=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c6)
+RS_GROUP="kyma-grdnr-upgrade-${RANDOM_NAME_SUFFIX}"
+EVENTHUB_NAMESPACE_NAME="kyma-grdnr-upgrade-${RANDOM_NAME_SUFFIX}"
+export RS_GROUP \
+    EVENTHUB_NAMESPACE_NAME
 #!Put cleanup code in this function! Function is executed at exit from the script and on interuption.
 cleanup() {
     #!!! Must be at the beginning of this function !!!

--- a/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
@@ -180,6 +180,10 @@ function installKyma() {
 
     shout "Generate Azure Event Hubs overrides"
     date
+
+    # create-azure-event-hubs-secret.sh creates an override secret file, eventhubs-secret-overrides.yaml for Azure EventHub in current working directory.
+    # The override is later used in the Kyma installation to configure the kafka-knative channel.
+
     # shellcheck disable=SC1090
     "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/create-azure-event-hubs-secret.sh
 

--- a/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
@@ -167,7 +167,7 @@ function installKyma() {
 
     shout "Downloading Kyma installer CR"
     curl -L --silent --fail --show-error "https://raw.githubusercontent.com/kyma-project/kyma/master/installation/resources/installer-cr-azure-eventhubs.yaml.tpl" \
-        --output installer-cr-gardener-azure.yaml.tpl
+        --output installer-cr-azure-eventhubs.yaml.tpl
 
     echo "Downlading production profile"
     curl -L --silent --fail --show-error "https://raw.githubusercontent.com/kyma-project/kyma/master/installation/resources/installer-config-production.yaml.tpl" \
@@ -181,15 +181,16 @@ function installKyma() {
     date
     # shellcheck disable=SC1090
     "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/create-azure-event-hubs-secret.sh
-    cat "${EVENTHUB_SECRET_OVERRIDE_FILE}" >> installer-config-azure-eventhubs.yaml.tpl
 
     (
     set -x
     kyma install \
         --ci \
         --source "${LAST_RELEASE_VERSION}" \
+        -c installer-cr-azure-eventhubs.yaml.tpl \
         -o installer-config-production.yaml.tpl \
         -o installer-config-azure-eventhubs.yaml.tpl \
+        -o "${EVENTHUB_SECRET_OVERRIDE_FILE}" \
         --timeout 90m
     )
 }

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,3 @@
+pjNames:
+  - pjName: "kyma-upgrade-gardener-azure"
+    pjPath: "test-infra/prow/jobs/kyma/kyma-upgrade-gardener.yaml"

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,3 +1,0 @@
-pjNames:
-  - pjName: "kyma-upgrade-gardener-azure"
-    pjPath: "test-infra/prow/jobs/kyma/kyma-upgrade-gardener.yaml"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- The reason it failed was the knative-kafka chart was not installed whereas the default webhook config was using KafkaChannels. Hence the channels were never ready.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See https://github.com/kyma-project/kyma/issues/9210