### PR TITLE
add generation of image list in json

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -340,6 +340,10 @@ fi
 IMAGES_LIST=$(kubectl get pods --all-namespaces -o go-template --template='{{range .items}}{{range .status.containerStatuses}}{{.name}},{{.image}},{{.imageID}}{{printf "\n"}}{{end}}{{range .status.initContainerStatuses}}{{.name}},{{.image}},{{.imageID}}{{printf "\n"}}{{end}}{{end}}' | uniq | sort)
 echo "${IMAGES_LIST}" > "${ARTIFACTS}/kyma-images-${CLUSTER_NAME}.csv"
 
+# also generate image list in json
+IMAGES_LIST=$(kubectl get pods --all-namespaces -o json | jq '[.items[] | .metadata.ownerReferences[0].name as $owner | (.status.containerStatuses + .status.initContainerStatuses)[] | { owner_ref: $owner, image: .image, image_id: .imageID }] | unique' )
+echo "${IMAGES_LIST}" > "${ARTIFACTS}/kyma-images-${CLUSTER_NAME}.json"
+
 shout "Install stability-checker"
 date
 (

--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -341,7 +341,9 @@ IMAGES_LIST=$(kubectl get pods --all-namespaces -o go-template --template='{{ran
 echo "${IMAGES_LIST}" > "${ARTIFACTS}/kyma-images-${CLUSTER_NAME}.csv"
 
 # also generate image list in json
-IMAGES_LIST=$(kubectl get pods --all-namespaces -o json | jq '[.items[] | .metadata.ownerReferences[0].name as $owner | (.status.containerStatuses + .status.initContainerStatuses)[] | { owner_ref: $owner, image: .image, image_id: .imageID }] | unique' )
+## this is false-positive as we need to use single-quotes for jq
+# shellcheck disable=SC2016
+IMAGES_LIST=$(kubectl get pods --all-namespaces -o json | jq '{ images: [.items[] | .metadata.ownerReferences[0].name as $owner | (.status.containerStatuses + .status.initContainerStatuses)[] | { name: .imageID, custom_fields: {owner: $owner, image: .image, name: .name }}] | unique | group_by(.name) | map({name: .[0].name, custom_fields: {owner: map(.custom_fields.owner) | unique | join(","), name: map(.custom_fields.name) | unique | join(","), image: .[0].custom_fields.image}})}' )
 echo "${IMAGES_LIST}" > "${ARTIFACTS}/kyma-images-${CLUSTER_NAME}.json"
 
 shout "Install stability-checker"

--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -263,6 +263,10 @@ fi
 IMAGES_LIST=$(kubectl get pods --all-namespaces -o go-template --template='{{range .items}}{{range .status.containerStatuses}}{{.name}},{{.image}},{{.imageID}}{{printf "\n"}}{{end}}{{range .status.initContainerStatuses}}{{.name}},{{.image}},{{.imageID}}{{printf "\n"}}{{end}}{{end}}' | uniq | sort)
 echo "${IMAGES_LIST}" > "${ARTIFACTS}/kyma-images-release-${RELEASE_VERSION}.csv"
 
+# also generate image list in json
+IMAGES_LIST=$(kubectl get pods --all-namespaces -o json | jq '[.items[] | .metadata.ownerReferences[0].name as $owner | (.status.containerStatuses + .status.initContainerStatuses)[] | { owner_ref: $owner, image: .image, image_id: .imageID }] | unique' )
+echo "${IMAGES_LIST}" > "${ARTIFACTS}/kyma-images-release-${RELEASE_VERSION}.json"
+
 shout "Success"
 
 #!!! Must be at the end of the script !!!


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The list will be a JSON array with objects defined as below:
```json
[
  {
      "owner_ref": "tiller-deploy-548dd6998b",
      "image": "eu.gcr.io/kyma-project/alpine-net:2fbe4fd3",
      "image_id": "docker-pullable://eu.gcr.io/kyma-project/alpine-net@sha256:01f3cd28bb37d8d88686745f532cb4d3f827bf028e19775ecd76799e0806f67c"
  },
...
]
```
The `unique` command should filter all the direct duplicates of objects, e.g. those which "owner_ref", "image" and "image_id" are exactly the same.

Changes proposed in this pull request:

- add additional creation of json list with images

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
