### PR TITLE
Add go and dep to the whitesource scanner image.

### DIFF
--- a/prow/images/whitesource-scanner/Dockerfile
+++ b/prow/images/whitesource-scanner/Dockerfile
@@ -1,18 +1,36 @@
 FROM eu.gcr.io/kyma-project/test-infra/buildpack-java-node:v20200226-b9357193
 
 # Commit details
-
 ARG commit
 ENV IMAGE_COMMIT=$commit
 LABEL io.kyma-project.test-infra.commit=$commit
 
+ENV UA_VERSION v20.8.2
+ENV GO_VERSION 1.14.2
+ENV DEP_RELEASE_TAG v0.5.4
+
+# Install Go
+ENV GOPATH /workspace/go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+RUN wget -q https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
+    tar xzf go${GO_VERSION}.linux-amd64.tar.gz && \
+    rm go${GO_VERSION}.linux-amd64.tar.gz && \
+    mv go /usr/local && \
+
+    mkdir -p ${GOPATH}/bin && \
+    mkdir -p ${GOPATH}/src
+
+
+
+# Install Dep
+RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+
 # install unified agent
-RUN curl -LJO https://github.com/whitesource/unified-agent-distribution/releases/download/v20.4.2.1/wss-unified-agent.jar
-RUN mkdir -p /wss
-RUN mv wss-unified-agent.jar /wss/wss-unified-agent.jar
+RUN curl -LJO https://github.com/whitesource/unified-agent-distribution/releases/download/"${UA_VERSION}"/wss-unified-agent.jar && \
+    mkdir -p /wss && \
+    mv wss-unified-agent.jar /wss/wss-unified-agent.jar
 
 # Prow Tools
-
 COPY --from=eu.gcr.io/kyma-project/test-infra/prow-tools:v20200827-b59d2d67 /prow-tools /prow-tools
 # for better access to prow-tools
 ENV PATH=$PATH:/prow-tools


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
As stated in #2728 the whitesource unified agent was having an issue resolving the dependency graph due to missing go and dep binaries. This PR adds the missing binaries to the image and updates whitesource unified agent to the latest version available.
Changes proposed in this pull request:

- add go 1.14.2
- add dep 0.5.4
- update Unified Agent to v20.8.2

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#2728 