### PR TITLE
Add pre-master-kyma-gke* jobs which use new GKE K8s version.

### DIFF
--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -63,9 +63,9 @@ presets:
   - labels:
       preset-gke-ver1_17_9: "true"
     env:
-      - name: GKE_K8S_VERSION
+      - name: CLUSTER_VERSION
         value: 1.17.9-gke.1504
-      - name: GKE_RELEASE_CHANNEL
+      - name: RELEASE_CHANNEL
         value: rapid
 
 gke_job_template: &gke_job_template

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -65,6 +65,13 @@ presets:
     env:
       - name: RELEASE_CHANNEL
         value: rapid
+  - labels:
+      preset-gke-ver1_17_9: "true"
+    env:
+      - name: CLUSTER_VERSION
+        value: 1.17.9-gke.1504
+      - name: RELEASE_CHANNEL
+        value: regular
 
 gke_job_template: &gke_job_template
   decorate: true
@@ -343,7 +350,7 @@ presubmits: # runs on PRs
           repo: test-infra
           path_alias: github.com/kyma-project/test-infra
           base_ref: release-1.14
-    - name: pre-master-kyma-gke_rapid_default-integration
+    - name: pre-master-kyma-gke1_17_9-integration
       optional: true
       cluster: untrusted-workload
       branches:
@@ -352,7 +359,7 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         <<: *gke_job_labels_template
-        preset-gke-ver_rapid_default: "true"
+        preset-gke-ver1_17_9: "true"
       extra_refs:
         - <<: *test_infra_ref
           base_ref: master
@@ -406,7 +413,7 @@ presubmits: # runs on PRs
       extra_refs:
         - <<: *test_infra_ref
           base_ref: release-1.14
-    - name: pre-master-kyma-gke_rapid_default-upgrade
+    - name: pre-master-kyma-gke1_17_9-upgrade
       optional: true
       cluster: untrusted-workload
       branches:
@@ -416,7 +423,7 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources\\S+|installation\\S+|tests/end-to-end/upgrade/chart/upgrade/\\S+|tests/end-to-end/external-solution-integration/chart/external-solution/\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         preset-build-pr: "true"
-        preset-gke-ver_rapid_default: "true"
+        preset-gke-ver1_17_9: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -471,7 +478,7 @@ presubmits: # runs on PRs
       extra_refs:
         - <<: *test_infra_ref
           base_ref: release-1.14
-    - name: pre-master-kyma-gke_rapid_default-central-connector
+    - name: pre-master-kyma-gke1_17_9-central-connector
       optional: true
       cluster: untrusted-workload
       branches:
@@ -482,7 +489,7 @@ presubmits: # runs on PRs
       labels:
         preset-build-pr: "true"
         <<: *gke_job_labels_template
-        preset-gke-ver_rapid_default: "true"
+        preset-gke-ver1_17_9: "true"
       extra_refs:
         - <<: *test_infra_ref
           base_ref: master
@@ -550,6 +557,98 @@ postsubmits:
       labels:
         preset-log-collector-slack-token: "true"
         preset-build-master: "true"
+        <<: *gke_job_labels_template
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: master
+    - name: post-master-kyma-gke-ver_rapid_default-integration
+      cluster: trusted-workload
+      <<: *gke_job_template
+      annotations:
+        testgrid-create-test-group: "false"
+      branches:
+        - ^master$
+      labels:
+        preset-log-collector-slack-token: "true"
+        preset-build-master: "true"
+        preset-gke-ver_rapid_default: "true"
+        <<: *gke_job_labels_template
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: master
+
+    - name: post-master-kyma-gke-ver_rapid_default-central-connector
+      cluster: trusted-workload
+      <<: *gke_central_job_template
+      annotations:
+        testgrid-create-test-group: "false"
+      branches:
+        - ^master$
+      labels:
+        preset-build-master: "true"
+        preset-gke-ver_rapid_default: "true"
+        <<: *gke_job_labels_template
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: master
+
+    - name: post-master-kyma-gke-ver_rapid_default-upgrade
+      cluster: trusted-workload
+      <<: *gke_upgrade_job_template
+      annotations:
+        testgrid-create-test-group: "false"
+      branches:
+        - ^master$
+      labels:
+        preset-log-collector-slack-token: "true"
+        preset-build-master: "true"
+        preset-gke-ver_rapid_default: "true"
+        <<: *gke_job_labels_template
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: master
+    - name: post-master-kyma-gke-ver1_17_9-integration
+      cluster: trusted-workload
+      <<: *gke_job_template
+      annotations:
+        testgrid-create-test-group: "false"
+      branches:
+        - ^master$
+      labels:
+        preset-log-collector-slack-token: "true"
+        preset-build-master: "true"
+        preset-gke-ver1_17_9: "true"
+        <<: *gke_job_labels_template
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: master
+
+    - name: post-master-kyma-gke-ver1_17_9-central-connector
+      cluster: trusted-workload
+      <<: *gke_central_job_template
+      annotations:
+        testgrid-create-test-group: "false"
+      branches:
+        - ^master$
+      labels:
+        preset-build-master: "true"
+        preset-gke-ver1_17_9: "true"
+        <<: *gke_job_labels_template
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: master
+
+    - name: post-master-kyma-gke-ver1_17_9-upgrade
+      cluster: trusted-workload
+      <<: *gke_upgrade_job_template
+      annotations:
+        testgrid-create-test-group: "false"
+      branches:
+        - ^master$
+      labels:
+        preset-log-collector-slack-token: "true"
+        preset-build-master: "true"
+        preset-gke-ver1_17_9: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -61,13 +61,6 @@ presets:
       - name: AZURE_REGION
         value: westeurope
   - labels:
-      preset-gke-ver1_17_9: "true"
-    env:
-      - name: CLUSTER_VERSION
-        value: 1.17.9-gke.1504
-      - name: RELEASE_CHANNEL
-        value: rapid
-  - labels:
       preset-gke-ver1_18_6: "true"
     env:
       - name: CLUSTER_VERSION
@@ -352,19 +345,6 @@ presubmits: # runs on PRs
           repo: test-infra
           path_alias: github.com/kyma-project/test-infra
           base_ref: release-1.14
-    - name: pre-master-kyma-gke1_17_9-integration
-      optional: true
-      cluster: untrusted-workload
-      branches:
-        - ^master$
-      <<: *gke_job_template
-      run_if_changed: "^((resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
-      labels:
-        <<: *gke_job_labels_template
-        preset-gke-ver1_17_9: "true"
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
     - name: pre-master-kyma-gke1_18_6-integration
       optional: true
       cluster: untrusted-workload
@@ -428,21 +408,6 @@ presubmits: # runs on PRs
       extra_refs:
         - <<: *test_infra_ref
           base_ref: release-1.14
-    - name: pre-master-kyma-gke1_17_9-upgrade
-      optional: true
-      cluster: untrusted-workload
-      branches:
-        - ^master$
-      <<: *gke_upgrade_job_template
-      # following regexp won't start build if only Markdown files were changed
-      run_if_changed: "^((resources\\S+|installation\\S+|tests/end-to-end/upgrade/chart/upgrade/\\S+|tests/end-to-end/external-solution-integration/chart/external-solution/\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
-      labels:
-        preset-build-pr: "true"
-        preset-gke-ver1_17_9: "true"
-        <<: *gke_job_labels_template
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
     - name: pre-master-kyma-gke1_18_6-upgrade
       optional: true
       cluster: untrusted-workload
@@ -508,21 +473,6 @@ presubmits: # runs on PRs
       extra_refs:
         - <<: *test_infra_ref
           base_ref: release-1.14
-    - name: pre-master-kyma-gke1_17_9-central-connector
-      optional: true
-      cluster: untrusted-workload
-      branches:
-        - ^master$
-      <<: *gke_central_job_template
-      # following regexp won't start build if only Markdown files were changed
-      run_if_changed: "^((resources/core/templates/tests\\S+|resources/application-connector\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
-      labels:
-        preset-build-pr: "true"
-        <<: *gke_job_labels_template
-        preset-gke-ver1_17_9: "true"
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
     - name: pre-master-kyma-gke1_18_6-central-connector
       optional: true
       cluster: untrusted-workload

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -71,7 +71,7 @@ presets:
       preset-gke-ver1_18_6: "true"
     env:
       - name: CLUSTER_VERSION
-        value: 1.18.6-gke.3504
+        value: 1.18.6-gke.4801
       - name: RELEASE_CHANNEL
         value: rapid
 
@@ -353,6 +353,7 @@ presubmits: # runs on PRs
           path_alias: github.com/kyma-project/test-infra
           base_ref: release-1.14
     - name: pre-master-kyma-gke1_17_9-integration
+      optional: true
       cluster: untrusted-workload
       branches:
         - ^master$
@@ -365,6 +366,7 @@ presubmits: # runs on PRs
         - <<: *test_infra_ref
           base_ref: master
     - name: pre-master-kyma-gke1_18_6-integration
+      optional: true
       cluster: untrusted-workload
       branches:
         - ^master$
@@ -427,6 +429,7 @@ presubmits: # runs on PRs
         - <<: *test_infra_ref
           base_ref: release-1.14
     - name: pre-master-kyma-gke1_17_9-upgrade
+      optional: true
       cluster: untrusted-workload
       branches:
         - ^master$
@@ -441,6 +444,7 @@ presubmits: # runs on PRs
         - <<: *test_infra_ref
           base_ref: master
     - name: pre-master-kyma-gke1_18_6-upgrade
+      optional: true
       cluster: untrusted-workload
       branches:
         - ^master$
@@ -505,6 +509,7 @@ presubmits: # runs on PRs
         - <<: *test_infra_ref
           base_ref: release-1.14
     - name: pre-master-kyma-gke1_17_9-central-connector
+      optional: true
       cluster: untrusted-workload
       branches:
         - ^master$
@@ -519,6 +524,7 @@ presubmits: # runs on PRs
         - <<: *test_infra_ref
           base_ref: master
     - name: pre-master-kyma-gke1_18_6-central-connector
+      optional: true
       cluster: untrusted-workload
       branches:
         - ^master$

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -60,6 +60,13 @@ presets:
         value: kyma-minio-gateway
       - name: AZURE_REGION
         value: westeurope
+  - labels:
+      preset-gke-ver1_17_9: "true"
+    env:
+      - name: GKE_K8S_VERSION
+        value: 1.17.9-gke.1504
+      - name: GKE_RELEASE_CHANNEL
+        value: rapid
 
 gke_job_template: &gke_job_template
   decorate: true
@@ -338,6 +345,18 @@ presubmits: # runs on PRs
           repo: test-infra
           path_alias: github.com/kyma-project/test-infra
           base_ref: release-1.14
+    - name: pre-master-kyma-gke1_17_9-integration
+      cluster: untrusted-workload
+      branches:
+        - ^master$
+      <<: *gke_job_template
+      run_if_changed: "^((resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
+      labels:
+        <<: *gke_job_labels_template
+        preset-gke-ver1_17_9: "true"
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: master
 
     - name: pre-master-kyma-gke-upgrade
       cluster: untrusted-workload
@@ -388,6 +407,20 @@ presubmits: # runs on PRs
       extra_refs:
         - <<: *test_infra_ref
           base_ref: release-1.14
+    - name: pre-master-kyma-gke1_17_9-upgrade
+      cluster: untrusted-workload
+      branches:
+        - ^master$
+      <<: *gke_upgrade_job_template
+      # following regexp won't start build if only Markdown files were changed
+      run_if_changed: "^((resources\\S+|installation\\S+|tests/end-to-end/upgrade/chart/upgrade/\\S+|tests/end-to-end/external-solution-integration/chart/external-solution/\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
+      labels:
+        preset-build-pr: "true"
+        preset-gke-ver1_17_9: "true"
+        <<: *gke_job_labels_template
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: master
 
     - name: pre-master-kyma-gke-central-connector
       cluster: untrusted-workload
@@ -438,6 +471,20 @@ presubmits: # runs on PRs
       extra_refs:
         - <<: *test_infra_ref
           base_ref: release-1.14
+    - name: pre-master-kyma-gke1_17_9-central-connector
+      cluster: untrusted-workload
+      branches:
+        - ^master$
+      <<: *gke_central_job_template
+      # following regexp won't start build if only Markdown files were changed
+      run_if_changed: "^((resources/core/templates/tests\\S+|resources/application-connector\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
+      labels:
+        preset-build-pr: "true"
+        <<: *gke_job_labels_template
+        preset-gke-ver1_17_9: "true"
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: master
 
 postsubmits:
   kyma-project/kyma:

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -61,10 +61,8 @@ presets:
       - name: AZURE_REGION
         value: westeurope
   - labels:
-      preset-gke-ver1_18_6: "true"
+      preset-gke-ver_rapid_default: "true"
     env:
-      - name: CLUSTER_VERSION
-        value: 1.18.6-gke.4801
       - name: RELEASE_CHANNEL
         value: rapid
 
@@ -345,7 +343,7 @@ presubmits: # runs on PRs
           repo: test-infra
           path_alias: github.com/kyma-project/test-infra
           base_ref: release-1.14
-    - name: pre-master-kyma-gke1_18_6-integration
+    - name: pre-master-kyma-gke_rapid_default-integration
       optional: true
       cluster: untrusted-workload
       branches:
@@ -354,7 +352,7 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         <<: *gke_job_labels_template
-        preset-gke-ver1_18_6: "true"
+        preset-gke-ver_rapid_default: "true"
       extra_refs:
         - <<: *test_infra_ref
           base_ref: master
@@ -408,7 +406,7 @@ presubmits: # runs on PRs
       extra_refs:
         - <<: *test_infra_ref
           base_ref: release-1.14
-    - name: pre-master-kyma-gke1_18_6-upgrade
+    - name: pre-master-kyma-gke_rapid_default-upgrade
       optional: true
       cluster: untrusted-workload
       branches:
@@ -418,7 +416,7 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources\\S+|installation\\S+|tests/end-to-end/upgrade/chart/upgrade/\\S+|tests/end-to-end/external-solution-integration/chart/external-solution/\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         preset-build-pr: "true"
-        preset-gke-ver1_18_6: "true"
+        preset-gke-ver_rapid_default: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -473,7 +471,7 @@ presubmits: # runs on PRs
       extra_refs:
         - <<: *test_infra_ref
           base_ref: release-1.14
-    - name: pre-master-kyma-gke1_18_6-central-connector
+    - name: pre-master-kyma-gke_rapid_default-central-connector
       optional: true
       cluster: untrusted-workload
       branches:
@@ -484,7 +482,7 @@ presubmits: # runs on PRs
       labels:
         preset-build-pr: "true"
         <<: *gke_job_labels_template
-        preset-gke-ver1_18_6: "true"
+        preset-gke-ver_rapid_default: "true"
       extra_refs:
         - <<: *test_infra_ref
           base_ref: master

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -67,6 +67,13 @@ presets:
         value: 1.17.9-gke.1504
       - name: RELEASE_CHANNEL
         value: rapid
+  - labels:
+      preset-gke-ver1_18_6: "true"
+    env:
+      - name: CLUSTER_VERSION
+        value: 1.18.6-gke.3504
+      - name: RELEASE_CHANNEL
+        value: rapid
 
 gke_job_template: &gke_job_template
   decorate: true
@@ -357,6 +364,18 @@ presubmits: # runs on PRs
       extra_refs:
         - <<: *test_infra_ref
           base_ref: master
+    - name: pre-master-kyma-gke1_18_6-integration
+      cluster: untrusted-workload
+      branches:
+        - ^master$
+      <<: *gke_job_template
+      run_if_changed: "^((resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
+      labels:
+        <<: *gke_job_labels_template
+        preset-gke-ver1_18_6: "true"
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: master
 
     - name: pre-master-kyma-gke-upgrade
       cluster: untrusted-workload
@@ -417,6 +436,20 @@ presubmits: # runs on PRs
       labels:
         preset-build-pr: "true"
         preset-gke-ver1_17_9: "true"
+        <<: *gke_job_labels_template
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: master
+    - name: pre-master-kyma-gke1_18_6-upgrade
+      cluster: untrusted-workload
+      branches:
+        - ^master$
+      <<: *gke_upgrade_job_template
+      # following regexp won't start build if only Markdown files were changed
+      run_if_changed: "^((resources\\S+|installation\\S+|tests/end-to-end/upgrade/chart/upgrade/\\S+|tests/end-to-end/external-solution-integration/chart/external-solution/\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
+      labels:
+        preset-build-pr: "true"
+        preset-gke-ver1_18_6: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -482,6 +515,20 @@ presubmits: # runs on PRs
         preset-build-pr: "true"
         <<: *gke_job_labels_template
         preset-gke-ver1_17_9: "true"
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: master
+    - name: pre-master-kyma-gke1_18_6-central-connector
+      cluster: untrusted-workload
+      branches:
+        - ^master$
+      <<: *gke_central_job_template
+      # following regexp won't start build if only Markdown files were changed
+      run_if_changed: "^((resources/core/templates/tests\\S+|resources/application-connector\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
+      labels:
+        preset-build-pr: "true"
+        <<: *gke_job_labels_template
+        preset-gke-ver1_18_6: "true"
       extra_refs:
         - <<: *test_infra_ref
           base_ref: master

--- a/prow/scripts/cluster-integration/helpers/provision-gke-cluster.sh
+++ b/prow/scripts/cluster-integration/helpers/provision-gke-cluster.sh
@@ -50,6 +50,7 @@ CLEANER_LABELS_PARAM="created-at=${CURRENT_TIMESTAMP_PARAM},created-at-readable=
 
 GCLOUD_PARAMS+=("${CLUSTER_NAME}")
 if [ "${CLUSTER_VERSION}" ]; then GCLOUD_PARAMS+=("--cluster-version=${CLUSTER_VERSION}"); else GCLOUD_PARAMS+=("${CLUSTER_VERSION_PARAM}"); fi
+if [ "${RELEASE_CHANNEL}" ]; then GCLOUD_PARAMS+=("--release-channel=${RELEASE_CHANNEL}"); fi
 if [ "${MACHINE_TYPE}" ]; then GCLOUD_PARAMS+=("--machine-type=${MACHINE_TYPE}"); else GCLOUD_PARAMS+=("${MACHINE_TYPE_PARAM}"); fi
 if [ "${NUM_NODES}" ]; then GCLOUD_PARAMS+=("--num-nodes=${NUM_NODES}"); else GCLOUD_PARAMS+=("${NUM_NODES_PARAM}"); fi
 if [ "${GCLOUD_NETWORK_NAME}" ] && [ "${GCLOUD_SUBNET_NAME}" ]; then GCLOUD_PARAMS+=("--network=${GCLOUD_NETWORK_NAME}" "--subnetwork=${GCLOUD_SUBNET_NAME}"); else GCLOUD_PARAMS+=("${NETWORK_PARAM}"); fi

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -672,8 +672,6 @@ templates:
           <<: *cluster_default
           gkeVersions:
             - channel: rapid
-              version: 1.17.9-gke.1504
-            - channel: rapid
               version: 1.18.6-gke.4801
   - from: templates/kyma-integration-gardener.yaml
     render:

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -672,7 +672,7 @@ templates:
           <<: *cluster_default
           gkeVersions:
             - channel: rapid
-              version: 1.18.6-gke.4801
+              jobs: ["presubmit", "postsubmit"]
   - from: templates/kyma-integration-gardener.yaml
     render:
       - to: ../prow/jobs/kyma/kyma-integration-gardener.yaml

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -674,7 +674,7 @@ templates:
             - channel: rapid
               version: 1.17.9-gke.1504
             - channel: rapid
-              version: 1.18.6-gke.3504
+              version: 1.18.6-gke.4801
   - from: templates/kyma-integration-gardener.yaml
     render:
       - to: ../prow/jobs/kyma/kyma-integration-gardener.yaml

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -673,8 +673,8 @@ templates:
           gkeVersions:
             - channel: rapid
               version: 1.17.9-gke.1504
-#            - channel: rapid
-#              version: 1.18.6-gke.3504
+            - channel: rapid
+              version: 1.18.6-gke.3504
   - from: templates/kyma-integration-gardener.yaml
     render:
       - to: ../prow/jobs/kyma/kyma-integration-gardener.yaml

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -670,6 +670,11 @@ templates:
       - to: ../prow/jobs/kyma/kyma-integration.yaml
         values:
           <<: *cluster_default
+          gkeVersions:
+            - channel: rapid
+              version: 1.17.9-gke.1504
+#            - channel: rapid
+#              version: 1.18.6-gke.3504
   - from: templates/kyma-integration-gardener.yaml
     render:
       - to: ../prow/jobs/kyma/kyma-integration-gardener.yaml

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -672,6 +672,9 @@ templates:
           <<: *cluster_default
           gkeVersions:
             - channel: rapid
+              jobs: ["postsubmit"]
+            - channel: regular
+              version: 1.17.9-gke.1504
               jobs: ["presubmit", "postsubmit"]
   - from: templates/kyma-integration-gardener.yaml
     render:

--- a/templates/templates/kyma-integration.yaml
+++ b/templates/templates/kyma-integration.yaml
@@ -58,6 +58,15 @@ presets:
         value: kyma-minio-gateway
       - name: AZURE_REGION
         value: westeurope
+  {{- range .Values.gkeVersions }}
+  - labels:
+      preset-gke-ver{{ regexReplaceAllLiteral "-.*" .version "" | replace "." "_"}}: "true"
+    env:
+      - name: GKE_K8S_VERSION
+        value: {{ .version }}
+      - name: GKE_RELEASE_CHANNEL
+        value: {{ .channel }}
+  {{- end }}
 
 gke_job_template: &gke_job_template
   decorate: true
@@ -293,6 +302,21 @@ presubmits: # runs on PRs
           base_ref: release-{{ . }}
 {{- end }}
 
+{{- range .Values.gkeVersions }}
+    - name: pre-master-kyma-gke{{ regexReplaceAllLiteral "-.*" .version "" | replace "." "_"}}-integration
+      cluster: {{if $.Values.cluster.presubmit}}{{ $.Values.cluster.presubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
+      branches:
+        - ^master$
+      <<: *gke_job_template
+      run_if_changed: "^((resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
+      labels:
+        <<: *gke_job_labels_template
+        preset-gke-ver{{ regexReplaceAllLiteral "-.*" .version "" | replace "." "_"}}: "true"
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: master
+{{- end }}
+
     - name: pre-master-kyma-gke-upgrade
       cluster: {{if $.Values.cluster.presubmit}}{{ $.Values.cluster.presubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
       branches:
@@ -337,6 +361,23 @@ presubmits: # runs on PRs
           base_ref: release-{{ . }}
 {{- end }}
 
+{{- range .Values.gkeVersions }}
+    - name: pre-master-kyma-gke{{ regexReplaceAllLiteral "-.*" .version "" | replace "." "_"}}-upgrade
+      cluster: {{if $.Values.cluster.presubmit}}{{ $.Values.cluster.presubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
+      branches:
+        - ^master$
+      <<: *gke_upgrade_job_template
+      # following regexp won't start build if only Markdown files were changed
+      run_if_changed: "^((resources\\S+|installation\\S+|tests/end-to-end/upgrade/chart/upgrade/\\S+|tests/end-to-end/external-solution-integration/chart/external-solution/\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
+      labels:
+        preset-build-pr: "true"
+        preset-gke-ver{{ regexReplaceAllLiteral "-.*" .version "" | replace "." "_"}}: "true"
+        <<: *gke_job_labels_template
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: master
+{{- end }}
+
     - name: pre-master-kyma-gke-central-connector
       cluster: {{if $.Values.cluster.presubmit}}{{ $.Values.cluster.presubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
       branches:
@@ -379,6 +420,23 @@ presubmits: # runs on PRs
       extra_refs:
         - <<: *test_infra_ref
           base_ref: release-{{ . }}
+{{- end }}
+
+{{- range .Values.gkeVersions }}
+    - name: pre-master-kyma-gke{{ regexReplaceAllLiteral "-.*" .version "" | replace "." "_"}}-central-connector
+      cluster: {{if $.Values.cluster.presubmit}}{{ $.Values.cluster.presubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
+      branches:
+        - ^master$
+      <<: *gke_central_job_template
+      # following regexp won't start build if only Markdown files were changed
+      run_if_changed: "^((resources/core/templates/tests\\S+|resources/application-connector\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
+      labels:
+        preset-build-pr: "true"
+        <<: *gke_job_labels_template
+        preset-gke-ver{{ regexReplaceAllLiteral "-.*" .version "" | replace "." "_"}}: "true"
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: master
 {{- end }}
 
 {{- range (matchingReleases .Global.releases "1.11" "1.11") }}

--- a/templates/templates/kyma-integration.yaml
+++ b/templates/templates/kyma-integration.yaml
@@ -60,10 +60,15 @@ presets:
         value: westeurope
   {{- range .Values.gkeVersions }}
   - labels:
-      preset-gke-ver{{ regexReplaceAllLiteral "-.*" .version "" | replace "." "_"}}: "true"
+      {{- $ch := printf "_%v_default" .channel }}
+      {{- $ver := default  $ch .version }}
+      {{- $preset := regexReplaceAllLiteral "-.*" $ver "" | replace "." "_" }}
+      preset-gke-ver{{ $preset }}: "true"
     env:
+      {{- if .version }}
       - name: CLUSTER_VERSION
         value: {{ .version }}
+      {{- end }}
       - name: RELEASE_CHANNEL
         value: {{ .channel }}
   {{- end }}
@@ -303,7 +308,11 @@ presubmits: # runs on PRs
 {{- end }}
 
 {{- range .Values.gkeVersions }}
-    - name: pre-master-kyma-gke{{ regexReplaceAllLiteral "-.*" .version "" | replace "." "_"}}-integration
+  {{- if has "presubmit" .jobs }}
+  {{- $ch := printf "_%v_default" .channel }}
+  {{- $ver := default  $ch .version }}
+  {{- $preset := regexReplaceAllLiteral "-.*" $ver "" | replace "." "_" }}
+    - name: pre-master-kyma-gke{{ $preset }}-integration
       optional: true
       cluster: {{if $.Values.cluster.presubmit}}{{ $.Values.cluster.presubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
       branches:
@@ -312,10 +321,11 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         <<: *gke_job_labels_template
-        preset-gke-ver{{ regexReplaceAllLiteral "-.*" .version "" | replace "." "_"}}: "true"
+        preset-gke-ver{{ $preset }}: "true"
       extra_refs:
         - <<: *test_infra_ref
           base_ref: master
+  {{- end }}
 {{- end }}
 
     - name: pre-master-kyma-gke-upgrade
@@ -363,7 +373,11 @@ presubmits: # runs on PRs
 {{- end }}
 
 {{- range .Values.gkeVersions }}
-    - name: pre-master-kyma-gke{{ regexReplaceAllLiteral "-.*" .version "" | replace "." "_"}}-upgrade
+  {{- if has "presubmit" .jobs }}
+  {{- $ch := printf "_%v_default" .channel }}
+  {{- $ver := default  $ch .version }}
+  {{- $preset := regexReplaceAllLiteral "-.*" $ver "" | replace "." "_" }}
+    - name: pre-master-kyma-gke{{ $preset }}-upgrade
       optional: true
       cluster: {{if $.Values.cluster.presubmit}}{{ $.Values.cluster.presubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
       branches:
@@ -373,11 +387,12 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources\\S+|installation\\S+|tests/end-to-end/upgrade/chart/upgrade/\\S+|tests/end-to-end/external-solution-integration/chart/external-solution/\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         preset-build-pr: "true"
-        preset-gke-ver{{ regexReplaceAllLiteral "-.*" .version "" | replace "." "_"}}: "true"
+        preset-gke-ver{{ $preset }}: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
           base_ref: master
+  {{- end }}
 {{- end }}
 
     - name: pre-master-kyma-gke-central-connector
@@ -425,7 +440,11 @@ presubmits: # runs on PRs
 {{- end }}
 
 {{- range .Values.gkeVersions }}
-    - name: pre-master-kyma-gke{{ regexReplaceAllLiteral "-.*" .version "" | replace "." "_"}}-central-connector
+  {{- if has "presubmit" .jobs }}
+  {{- $ch := printf "_%v_default" .channel }}
+  {{- $ver := default  $ch .version }}
+  {{- $preset := regexReplaceAllLiteral "-.*" $ver "" | replace "." "_" }}
+    - name: pre-master-kyma-gke{{ $preset }}-central-connector
       optional: true
       cluster: {{if $.Values.cluster.presubmit}}{{ $.Values.cluster.presubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
       branches:
@@ -436,10 +455,11 @@ presubmits: # runs on PRs
       labels:
         preset-build-pr: "true"
         <<: *gke_job_labels_template
-        preset-gke-ver{{ regexReplaceAllLiteral "-.*" .version "" | replace "." "_"}}: "true"
+        preset-gke-ver{{ $preset }}: "true"
       extra_refs:
         - <<: *test_infra_ref
           base_ref: master
+  {{- end }}
 {{- end }}
 
 {{- range (matchingReleases .Global.releases "1.11" "1.11") }}

--- a/templates/templates/kyma-integration.yaml
+++ b/templates/templates/kyma-integration.yaml
@@ -62,9 +62,9 @@ presets:
   - labels:
       preset-gke-ver{{ regexReplaceAllLiteral "-.*" .version "" | replace "." "_"}}: "true"
     env:
-      - name: GKE_K8S_VERSION
+      - name: CLUSTER_VERSION
         value: {{ .version }}
-      - name: GKE_RELEASE_CHANNEL
+      - name: RELEASE_CHANNEL
         value: {{ .channel }}
   {{- end }}
 

--- a/templates/templates/kyma-integration.yaml
+++ b/templates/templates/kyma-integration.yaml
@@ -561,6 +561,59 @@ postsubmits:
       extra_refs:
         - <<: *test_infra_ref
           base_ref: master
+  {{- range .Values.gkeVersions }}
+  {{- if has "postsubmit" .jobs }}
+  {{- $ch := printf "_%v_default" .channel }}
+  {{- $ver := default  $ch .version }}
+  {{- $preset := regexReplaceAllLiteral "-.*" $ver "" | replace "." "_" }}
+    - name: post-master-kyma-gke-ver{{ $preset }}-integration
+      cluster: {{if $.Values.cluster.postsubmit}}{{ $.Values.cluster.postsubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
+      <<: *gke_job_template
+      annotations:
+        testgrid-create-test-group: "false"
+      branches:
+        - ^master$
+      labels:
+        preset-log-collector-slack-token: "true"
+        preset-build-master: "true"
+        preset-gke-ver{{ $preset }}: "true"
+        <<: *gke_job_labels_template
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: master
+
+    - name: post-master-kyma-gke-ver{{ $preset }}-central-connector
+      cluster: {{if $.Values.cluster.postsubmit}}{{ $.Values.cluster.postsubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
+      <<: *gke_central_job_template
+      annotations:
+        testgrid-create-test-group: "false"
+      branches:
+        - ^master$
+      labels:
+        preset-build-master: "true"
+        preset-gke-ver{{ $preset }}: "true"
+        <<: *gke_job_labels_template
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: master
+
+    - name: post-master-kyma-gke-ver{{ $preset }}-upgrade
+      cluster: {{if $.Values.cluster.postsubmit}}{{ $.Values.cluster.postsubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
+      <<: *gke_upgrade_job_template
+      annotations:
+        testgrid-create-test-group: "false"
+      branches:
+        - ^master$
+      labels:
+        preset-log-collector-slack-token: "true"
+        preset-build-master: "true"
+        preset-gke-ver{{ $preset }}: "true"
+        <<: *gke_job_labels_template
+      extra_refs:
+        - <<: *test_infra_ref
+          base_ref: master
+  {{- end }}
+  {{- end }}
 
 periodics:
   # kyma-integration-cleaner removes all sshPublic keys stored for service account "sa-vm-kyma-integration". Those keys refers to machines that in most cases were already removed.

--- a/templates/templates/kyma-integration.yaml
+++ b/templates/templates/kyma-integration.yaml
@@ -304,6 +304,7 @@ presubmits: # runs on PRs
 
 {{- range .Values.gkeVersions }}
     - name: pre-master-kyma-gke{{ regexReplaceAllLiteral "-.*" .version "" | replace "." "_"}}-integration
+      optional: true
       cluster: {{if $.Values.cluster.presubmit}}{{ $.Values.cluster.presubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
       branches:
         - ^master$
@@ -363,6 +364,7 @@ presubmits: # runs on PRs
 
 {{- range .Values.gkeVersions }}
     - name: pre-master-kyma-gke{{ regexReplaceAllLiteral "-.*" .version "" | replace "." "_"}}-upgrade
+      optional: true
       cluster: {{if $.Values.cluster.presubmit}}{{ $.Values.cluster.presubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
       branches:
         - ^master$
@@ -424,6 +426,7 @@ presubmits: # runs on PRs
 
 {{- range .Values.gkeVersions }}
     - name: pre-master-kyma-gke{{ regexReplaceAllLiteral "-.*" .version "" | replace "." "_"}}-central-connector
+      optional: true
       cluster: {{if $.Values.cluster.presubmit}}{{ $.Values.cluster.presubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
       branches:
         - ^master$

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,7 +1,0 @@
-pjNames:
-  - pjName: pre-master-kyma-gke1_18_6-integration
-  - pjName: pre-master-kyma-gke1_17_9-integration
-prConfigs:
-  kyma-project:
-    kyma:
-      prNumber: 9400

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,7 @@
+pjNames:
+  - pjName: pre-master-kyma-gke1_18_6-integration
+  - pjName: pre-master-kyma-gke1_17_9-integration
+prConfigs:
+  kyma-project:
+    kyma:
+      prNumber: 9400


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
It's needed to test Kyma GKE jobs on different cluster versions that are available on rapid channel. This PR adds the functionality of generating prowjobs that use specific version of GKE K8s from different release channels provided.

If you want to add a new release channel just add a new entry under `gkeVersions` struct in templates/config.yaml:
```yaml
gkeVersions:
# will generate only presubmit jobs with version of gke 1.18.6 from rapid channel
- version: 1.18.6-gke.4504
   channel: rapid
   jobs: ["presubmit"]
# will generate presubmit and postsubmit for default version of gke from stable channel
- channel: stable
   jobs: ["presubmit", "postsubmit"]
```
both `channel` and `jobs` are required.

If you want to add job for gke version generation please refer to the file in this PR.

Changes proposed in this pull request:

- add generation of prowjobs based on the release version
- add label generation for each of the release version
- make jobs optional
- define for which types the job should be generated
- omit version if it's not present (use default version for a release channel)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#2761 