### PR TITLE
Build and publish skr CLI to development artifacts

### DIFF
--- a/development/tools/jobs/control-plane/development_artifacts_test.go
+++ b/development/tools/jobs/control-plane/development_artifacts_test.go
@@ -28,7 +28,7 @@ func TestKCPPresubmitDevelopmentArtifacts(t *testing.T) {
 	tester.AssertThatHasPresets(t, job.JobBase, preset.DindEnabled, preset.DockerPushRepoKyma, "preset-kyma-development-artifacts-bucket", preset.GcrPush)
 	require.Len(t, job.Spec.Containers, 1)
 	cont := job.Spec.Containers[0]
-	assert.Equal(t, tester.ImageBootstrap20190604, cont.Image)
+	assert.Equal(t, tester.ImageGolangToolboxLatest, cont.Image)
 	require.Len(t, cont.Command, 1)
 	assert.Equal(t, "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-kcp-development-artifacts.sh", cont.Command[0])
 	require.Len(t, job.Spec.Volumes, 1)
@@ -53,7 +53,7 @@ func TestKCPPostsubmitDevelopmentArtifcts(t *testing.T) {
 	tester.AssertThatHasPresets(t, job.JobBase, preset.DindEnabled, preset.DockerPushRepoKyma, preset.BuildArtifactsMaster, "preset-kyma-development-artifacts-bucket", preset.GcrPush)
 	require.Len(t, job.Spec.Containers, 1)
 	cont := job.Spec.Containers[0]
-	assert.Equal(t, tester.ImageBootstrap20190604, cont.Image)
+	assert.Equal(t, tester.ImageGolangToolboxLatest, cont.Image)
 	require.Len(t, cont.Command, 1)
 	assert.Equal(t, "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-kcp-development-artifacts.sh", cont.Command[0])
 	require.Len(t, job.Spec.Volumes, 1)

--- a/development/tools/jobs/tester/tester.go
+++ b/development/tools/jobs/tester/tester.go
@@ -58,7 +58,7 @@ const (
 	// ImageBootstrapHelm20191227 represents verion of bootstrap-helm image
 	ImageBootstrapHelm20191227 = "eu.gcr.io/kyma-project/test-infra/bootstrap-helm:v20191227-cca719e8"
 	// ImageGolangToolboxLatest represents the latest version of the golang buildpack toolbox
-	ImageGolangToolboxLatest = "eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200423-1d9d6590"
+	ImageGolangToolboxLatest = "eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200831-e46c648b"
 	// ImageProwToolsLatest represents the latest version of the prow-tools image
 	ImageProwToolsLatest = "eu.gcr.io/kyma-project/test-infra/prow-tools:v20200608-2db047ac"
 	// KymaProjectDir means kyma project dir

--- a/prow/jobs/cli/cli.yaml
+++ b/prow/jobs/cli/cli.yaml
@@ -10,7 +10,7 @@ job_template: &job_template
       path_alias: github.com/kyma-project/test-infra
   spec:
     containers:
-      - image: eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200423-1d9d6590
+      - image: eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200831-e46c648b
         securityContext:
           privileged: true
         command:

--- a/prow/jobs/control-plane/kcp-development-artifacts.yaml
+++ b/prow/jobs/control-plane/kcp-development-artifacts.yaml
@@ -13,7 +13,7 @@ job_template: &job_template
   max_concurrency: 10
   spec:
     containers:
-    - image: eu.gcr.io/kyma-project/test-infra/bootstrap:v20190604-d08e7fe
+    - image: eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200831-e46c648b
       securityContext:
         privileged: true
       command:
@@ -40,7 +40,7 @@ job_labels_template: &job_labels_template
 presubmits: # runs on PRs
   kyma-project/control-plane:
   - name: pre-master-kcp-development-artifacts
-    run_if_changed: "^installation|^resources|^tools/kcp-installer"
+    run_if_changed: "^installation|^resources|^tools/kcp-installer|^components/kyma-environment-broker/cmd/cli"
     branches:
     - ^master$
     <<: *job_template

--- a/prow/scripts/build-kcp-development-artifacts.sh
+++ b/prow/scripts/build-kcp-development-artifacts.sh
@@ -34,19 +34,23 @@ function export_variables() {
    if [[ -n "${PULL_NUMBER}" ]]; then
         DOCKER_TAG="PR-${PULL_NUMBER}-${COMMIT_ID}"
         BUCKET_DIR="PR-${PULL_NUMBER}"
+        CLI_VERSION="PR-${PULL_NUMBER}-${COMMIT_ID}"
     else
         DOCKER_TAG="master-${COMMIT_ID}-${CURRENT_TIMESTAMP}"
         BUCKET_DIR="master-${COMMIT_ID}"
+        CLI_VERSION="master-${COMMIT_ID}"
     fi
 
    readonly DOCKER_TAG
    readonly KCP_INSTALLER_PUSH_DIR
    readonly BUCKET_DIR
    readonly KCP_INSTALLER_VERSION
+   readonly CLI_VERSION
 
    export DOCKER_TAG
    export KCP_INSTALLER_PUSH_DIR
    export BUCKET_DIR
+   export CLI_VERSION
 }
 
 init
@@ -61,6 +65,9 @@ buildTarget="release"
 
 shout "Build kcp-installer with target ${buildTarget}"
 make -C "${KCP_PATH}/tools/kcp-installer" ${buildTarget}
+
+shout "Build SKR CLI with target ${buildTarget}"
+make -C "${KCP_PATH}/components/kyma-environment-broker" -f Makefile.cli ${buildTarget}
 
 shout "Create development artifacts"
 # INPUTS:
@@ -88,14 +95,22 @@ gsutil cp  "${ARTIFACTS}/is-kyma-installed.sh" "${KCP_DEVELOPMENT_ARTIFACTS_BUCK
 gsutil cp  "${ARTIFACTS}/compass-installer.yaml" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/compass-installer.yaml"
 gsutil cp  "${ARTIFACTS}/is-compass-installed.sh" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/is-compass-installed.sh"
 
+gsutil cp "${ARTIFACTS}/skr.exe" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/skr.exe"
+gsutil cp "${ARTIFACTS}/skr-linux" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/skr-linux"
+gsutil cp "${ARTIFACTS}/skr-darwin" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/skr-darwin"
+
 if [[ "${BUILD_TYPE}" == "master" ]]; then
   shout "Copy artifacts to ${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master"
   gsutil cp "${ARTIFACTS}/kcp-installer.yaml" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/kcp-installer.yaml"
   gsutil cp  "${KCP_PATH}/installation/scripts/is-installed.sh" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/is-installed.sh"
-  
+
   gsutil cp  "${ARTIFACTS}/kyma-installer.yaml" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/kyma-installer.yaml"
   gsutil cp  "${ARTIFACTS}/is-kyma-installed.sh" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/is-kyma-installed.sh"
 
   gsutil cp "${ARTIFACTS}/compass-installer.yaml" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/compass-installer.yaml"
   gsutil cp  "${ARTIFACTS}/is-compass-installed.sh" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/is-compass-installed.sh"
+
+  gsutil cp "${ARTIFACTS}/skr.exe" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/skr.exe"
+  gsutil cp "${ARTIFACTS}/skr-linux" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/skr-linux"
+  gsutil cp "${ARTIFACTS}/skr-darwin" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/skr-darwin"
 fi


### PR DESCRIPTION
**Description**
New skr CLI tool is being developed in control-plane repo. 
Dependent PR for Makefile:
https://github.com/kyma-project/control-plane/pull/227

Changes proposed in this pull request:

- Add building and uploading skr CLI binaries to kyma-development-artifacts bucket as part of kcp-development-artifacts job


**Related issue(s)**
https://github.com/kyma-project/control-plane/issues/212