### PR TITLE
Workaround for assigning LoadBalancer IP in nightly and weekly clusters.

### DIFF
--- a/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
@@ -345,7 +345,7 @@ EOF
 cat << EOF > istio-ingressgateway-patch-yq.yaml
 - command: update
   path: spec.components.ingressGateways[0].k8s.service
-  values:
+  value:
     loadBalancerIP: ${GATEWAY_IP_ADDRESS}
     type: LoadBalancer
 EOF

--- a/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
@@ -295,18 +295,18 @@ metadata:
 data:
   global.alertTools.credentials.slack.channel: "${KYMA_ALERTS_CHANNEL}"
   global.alertTools.credentials.slack.apiurl: "${KYMA_ALERTS_SLACK_API_URL}"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: "istio-overrides"
-  namespace: "kyma-installer"
-  labels:
-    installer: overrides
-    kyma-project.io/installation: ""
-    component: istio
-data:
-  gateways.istio-ingressgateway.loadBalancerIP: "${GATEWAY_IP_ADDRESS}"
+#---
+#apiVersion: v1
+#kind: ConfigMap
+#metadata:
+#  name: "istio-overrides"
+#  namespace: "kyma-installer"
+#  labels:
+#    installer: overrides
+#    kyma-project.io/installation: ""
+#    component: istio
+#data:
+#  gateways.istio-ingressgateway.loadBalancerIP: "${GATEWAY_IP_ADDRESS}"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -333,6 +333,10 @@ EOF
   echo "${componentOverrides}" > "${componentOverridesFile}"
 
 	KYMA_RESOURCES_DIR="${KYMA_SOURCES_DIR}/installation/resources"
+
+  # WORKAROUND: add gateway ip address do IstioOperator in installer-config-production.yaml.tpl (see: https://github.com/kyma-project/test-infra/issues/2792)
+  echo "#### WORKAROUND: add gateway ip address do IstioOperator in installer-config-production.yaml.tpl (see: https://github.com/kyma-project/test-infra/issues/2792)"
+  sed -i "/k8s:/a\            service:\n              loadBalancerIP: ${GATEWAY_IP_ADDRESS}\n              type: LoadBalancer" "${KYMA_RESOURCES_DIR}"/installer-config-production.yaml.tpl
 
 	log::info "Apply Azure crb for healthz"
 	kubectl apply -f "${KYMA_RESOURCES_DIR}"/azure-crb-for-healthz.yaml

--- a/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
@@ -336,7 +336,20 @@ EOF
 
   # WORKAROUND: add gateway ip address do IstioOperator in installer-config-production.yaml.tpl (see: https://github.com/kyma-project/test-infra/issues/2792)
   echo "#### WORKAROUND: add gateway ip address do IstioOperator in installer-config-production.yaml.tpl (see: https://github.com/kyma-project/test-infra/issues/2792)"
-  sed -i "/k8s:/a\            service:\n              loadBalancerIP: ${GATEWAY_IP_ADDRESS}\n              type: LoadBalancer" "${KYMA_RESOURCES_DIR}"/installer-config-production.yaml.tpl
+  # install if yq does not exist
+  if [[ ! -x $(command -v yq) ]];
+  then
+    yq_rel_latest=$(curl --silent "https://api.github.com/repos/mikefarah/yq/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')
+    curl -sSLo /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${yq_rel_latest}/yq_linux_amd64" && chmod +x /usr/local/bin/yq
+  fi
+cat << EOF > istio-ingressgateway-patch-yq.yaml
+- command: update
+  path: spec.components.ingressGateways[0].k8s.service
+  values:
+    loadBalancerIP: ${GATEWAY_IP_ADDRESS}
+    type: LoadBalancer
+EOF
+  yq w -i -d1 "${KYMA_RESOURCES_DIR}"/installer-config-production.yaml.tpl 'data.kyma_istio_operator' "$(yq r -d1 "${KYMA_RESOURCES_DIR}"/installer-config-production.yaml.tpl 'data.kyma_istio_operator' | yq w - -s istio-ingressgateway-patch-yq.yaml)"
 
 	log::info "Apply Azure crb for healthz"
 	kubectl apply -f "${KYMA_RESOURCES_DIR}"/azure-crb-for-healthz.yaml

--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -180,18 +180,18 @@ metadata:
 data:
   global.alertTools.credentials.slack.channel: "${KYMA_ALERTS_CHANNEL}"
   global.alertTools.credentials.slack.apiurl: "${KYMA_ALERTS_SLACK_API_URL}"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: "istio-overrides"
-  namespace: "kyma-installer"
-  labels:
-    installer: overrides
-    kyma-project.io/installation: ""
-    component: istio
-data:
-  gateways.istio-ingressgateway.loadBalancerIP: "${GATEWAY_IP_ADDRESS}"
+#---
+#apiVersion: v1
+#kind: ConfigMap
+#metadata:
+#  name: "istio-overrides"
+#  namespace: "kyma-installer"
+#  labels:
+#    installer: overrides
+#    kyma-project.io/installation: ""
+#    component: istio
+#data:
+#  gateways.istio-ingressgateway.loadBalancerIP: "${GATEWAY_IP_ADDRESS}"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -225,6 +225,10 @@ EOF
 	date
 
 	KYMA_RESOURCES_DIR="${KYMA_SOURCES_DIR}/installation/resources"
+
+  # WORKAROUND: add gateway ip address do IstioOperator in installer-config-production.yaml.tpl (see: https://github.com/kyma-project/test-infra/issues/2792)
+  echo "#### WORKAROUND: add gateway ip address do IstioOperator in installer-config-production.yaml.tpl (see: https://github.com/kyma-project/test-infra/issues/2792)"
+  sed -i "/k8s:/a\            service:\n              loadBalancerIP: ${GATEWAY_IP_ADDRESS}\n              type: LoadBalancer" "${KYMA_RESOURCES_DIR}"/installer-config-production.yaml.tpl
 
 	kyma install \
 			--ci \

--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -233,7 +233,7 @@ EOF
 cat << EOF > istio-ingressgateway-patch-yq.yaml
 - command: update
   path: spec.components.ingressGateways[0].k8s.service
-  values:
+  value:
     loadBalancerIP: ${GATEWAY_IP_ADDRESS}
     type: LoadBalancer
 EOF


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Right now the clusters fail to provision because of the `kcproxy` pod cannot access address "https://dex.nightly.a.build.kyma-project.io/.well-known/openid-configuration" (or similar). Due to changes in [this file](https://github.com/kyma-project/kyma/commit/19e240cd79041e8f82b5f3c90e39bc64406f7b08#diff-36ea24c083a451c0d26fd76a526e7566) helm-like overrides do not work anymore so the override value `gateways.istio-ingressgateway.loadBalancerIP: "${GATEWAY_IP_ADDRESS}"` is not used. That leads to GKE/AKS loadbalancer to assign random IP address instead of the pre-generated one. This leads to host not reachable when using DNS entry. New format requires yaml file to be passed as a configuration. Additionally currently kyma installer, which we are using, does not have functionality of merging two YAML files. 

In this case we use `yq` to edit ConfigMap on-the-fly with needed override as a workaround.

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#2792 