### PR TITLE
Fix istio installation error

### DIFF
--- a/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
@@ -167,15 +167,15 @@ function installKyma() {
     date
 
     shout "Downloading Kyma installer CR"
-    curl -L --silent --fail --show-error "https://raw.githubusercontent.com/kyma-project/kyma/master/installation/resources/installer-cr-azure-eventhubs.yaml.tpl" \
+    curl -L --silent --fail --show-error "https://raw.githubusercontent.com/kyma-project/kyma/${LAST_RELEASE_VERSION}/installation/resources/installer-cr-azure-eventhubs.yaml.tpl" \
         --output installer-cr-azure-eventhubs.yaml.tpl
 
     echo "Downlading production profile"
-    curl -L --silent --fail --show-error "https://raw.githubusercontent.com/kyma-project/kyma/master/installation/resources/installer-config-production.yaml.tpl" \
+    curl -L --silent --fail --show-error "https://raw.githubusercontent.com/kyma-project/kyma/${LAST_RELEASE_VERSION}/installation/resources/installer-config-production.yaml.tpl" \
         --output installer-config-production.yaml.tpl
 
     shout "Downloading Azure EventHubs config"
-    curl -L --silent --fail --show-error "https://raw.githubusercontent.com/kyma-project/kyma/master/installation/resources/installer-config-azure-eventhubs.yaml.tpl" \
+    curl -L --silent --fail --show-error "https://raw.githubusercontent.com/kyma-project/kyma/${LAST_RELEASE_VERSION}/installation/resources/installer-config-azure-eventhubs.yaml.tpl" \
         --output installer-config-azure-eventhubs.yaml.tpl
 
     shout "Generate Azure Event Hubs overrides"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Problem: Upgrade job has to install installation overrides/configuration from the kyma version which gets installed
- However, the version from master is always taken. This worked for some while until a change in the config file was introduced with the [Istio 1.5 introduction](https://github.com/kyma-project/kyma/pulls?page=2&q=is%3Apr+istio+is%3Aclosed)

A proof that the problem is fixed can be seen in [this PR](https://github.com/kyma-project/test-infra/pull/2722/files). It has the same code change. A pipeline was triggered with the pjtester tool: <https://storage.googleapis.com/kyma-prow-logs/pr-logs/pull/kyma-project_test-infra/2722/nachtmaar_test_of_prowjob_pre-master-kyma-upgrade-gardener-azure/1311738848375476224/build-log.txt>

Now the installation fails because of this [issue](https://github.com/kyma-project/kyma/issues/9604)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes https://github.com/kyma-project/kyma/issues/9594