### PR TITLE
Remove --cluster-version param from provision gke scripts

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -467,6 +467,14 @@ presets:
     env:
       - name: PRODUCTNAME
         value: "OOSS - KYMA"
+  # stable release version of gke
+  - labels:
+      preset-gke-ver-stable: "true"
+    env:
+      - name: CLUSTER_VERSION
+        value: "1.16"
+      - name: RELEASE_CHANNEL
+        value: regular
   # volume mounts for kind
   - labels:
       preset-kind-volume-mounts: "true"

--- a/prow/jobs/cli/cli-integration.yaml
+++ b/prow/jobs/cli/cli-integration.yaml
@@ -64,6 +64,7 @@ periodics:
       preset-gc-compute-envs: "true"
       preset-gc-project-env: "true"
       preset-cluster-use-ssd: "true"
+      preset-gke-ver-stable: "true"
     extra_refs:
     - <<: *test_infra_ref
       base_ref: master

--- a/prow/jobs/control-plane/control-plane-gke-integration.yaml
+++ b/prow/jobs/control-plane/control-plane-gke-integration.yaml
@@ -52,6 +52,7 @@ gke_integration_job_labels_template: &gke_integration_job_labels_template
   preset-kyma-artifacts-bucket: "true"
   preset-gardener-azure-kyma-integration: "true"
   preset-kyma-development-artifacts-bucket: "true"
+  preset-gke-ver-stable: "true"
 
 presubmits: # runs on PRs
   kyma-project/control-plane:

--- a/prow/jobs/incubator/compass/compass-gke-integration.yaml
+++ b/prow/jobs/incubator/compass/compass-gke-integration.yaml
@@ -54,6 +54,7 @@ gke_integration_job_labels_template: &gke_integration_job_labels_template
   preset-kyma-artifacts-bucket: "true"
   preset-gardener-azure-kyma-integration: "true"
   preset-kyma-development-artifacts-bucket: "true"
+  preset-gke-ver-stable: "true"
 
 presubmits: # runs on PRs
   kyma-incubator/compass:

--- a/prow/jobs/kyma/kyma-gke-compass-integration.yaml
+++ b/prow/jobs/kyma/kyma-gke-compass-integration.yaml
@@ -59,6 +59,7 @@ gke_integration_job_labels_template: &gke_integration_job_labels_template
   preset-kyma-artifacts-bucket: "true"
   preset-gardener-azure-kyma-integration: "true"
   preset-kyma-development-artifacts-bucket: "true"
+  preset-gke-ver-stable: "true"
 
 presubmits: # runs on PRs
   kyma-project/kyma:

--- a/prow/jobs/kyma/kyma-gke-external-registry.yaml
+++ b/prow/jobs/kyma/kyma-gke-external-registry.yaml
@@ -42,6 +42,7 @@ gke_job_labels_template: &gke_job_labels_template
   preset-dind-enabled: "true"
   preset-kyma-artifacts-bucket: "true"
   preset-cluster-use-ssd: "true"
+  preset-gke-ver-stable: "true"
 
 presubmits: # runs on PRs
   kyma-project/kyma:

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -326,6 +326,7 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         preset-build-pr: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -341,6 +342,7 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         preset-build-pr: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -353,6 +355,7 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - org: kyma-project
@@ -367,6 +370,7 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - org: kyma-project
@@ -381,6 +385,7 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - org: kyma-project
@@ -410,6 +415,7 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources\\S+|installation\\S+|tests/end-to-end/upgrade/chart/upgrade/\\S+|tests/end-to-end/external-solution-integration/chart/external-solution/\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         preset-build-pr: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -422,6 +428,7 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -434,6 +441,7 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -446,6 +454,7 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -475,6 +484,7 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources/core/templates/tests\\S+|resources/application-connector\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         preset-build-pr: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -487,6 +497,7 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -499,6 +510,7 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -511,6 +523,7 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -561,6 +574,7 @@ postsubmits:
       labels:
         preset-log-collector-slack-token: "true"
         preset-build-master: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -577,6 +591,7 @@ postsubmits:
         - ^master$
       labels:
         preset-build-master: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -594,6 +609,7 @@ postsubmits:
       labels:
         preset-log-collector-slack-token: "true"
         preset-build-master: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -948,6 +964,7 @@ periodics:
       preset-nightly-github-integration: "true"
       preset-kms-gc-project-env: "true"
       preset-certificates-bucket: "true"
+      preset-gke-ver-stable: "true"
       <<: *gke_job_labels_template
     decorate: true
     extra_refs:
@@ -1020,6 +1037,7 @@ periodics:
       preset-weekly-github-integration: "true"
       preset-kms-gc-project-env: "true"
       preset-certificates-bucket: "true"
+      preset-gke-ver-stable: "true"
       <<: *gke_job_labels_template
     decorate: true
     extra_refs:

--- a/prow/scripts/cluster-integration/helpers/provision-gke-cluster.sh
+++ b/prow/scripts/cluster-integration/helpers/provision-gke-cluster.sh
@@ -41,7 +41,6 @@ readonly CURRENT_TIMESTAMP_PARAM=$(date +%s)
 declare -a GCLOUD_PARAMS
 
 TTL_HOURS_PARAM="3"
-CLUSTER_VERSION_PARAM="--cluster-version=1.16"
 MACHINE_TYPE_PARAM="--machine-type=n1-standard-4"
 NUM_NODES_PARAM="--num-nodes=3"
 NETWORK_PARAM="--network=default"
@@ -49,7 +48,7 @@ if [ "${TTL_HOURS}" ]; then TTL_HOURS_PARAM="${TTL_HOURS}"; fi
 CLEANER_LABELS_PARAM="created-at=${CURRENT_TIMESTAMP_PARAM},created-at-readable=${CURRENT_TIMESTAMP_READABLE_PARAM},ttl=${TTL_HOURS_PARAM}"
 
 GCLOUD_PARAMS+=("${CLUSTER_NAME}")
-if [ "${CLUSTER_VERSION}" ]; then GCLOUD_PARAMS+=("--cluster-version=${CLUSTER_VERSION}"); else GCLOUD_PARAMS+=("${CLUSTER_VERSION_PARAM}"); fi
+if [ "${CLUSTER_VERSION}" ]; then GCLOUD_PARAMS+=("--cluster-version=${CLUSTER_VERSION}"); fi
 if [ "${RELEASE_CHANNEL}" ]; then GCLOUD_PARAMS+=("--release-channel=${RELEASE_CHANNEL}"); fi
 if [ "${MACHINE_TYPE}" ]; then GCLOUD_PARAMS+=("--machine-type=${MACHINE_TYPE}"); else GCLOUD_PARAMS+=("${MACHINE_TYPE_PARAM}"); fi
 if [ "${NUM_NODES}" ]; then GCLOUD_PARAMS+=("--num-nodes=${NUM_NODES}"); else GCLOUD_PARAMS+=("${NUM_NODES_PARAM}"); fi

--- a/templates/templates/compass-gke-integration.yaml
+++ b/templates/templates/compass-gke-integration.yaml
@@ -52,6 +52,7 @@ gke_integration_job_labels_template: &gke_integration_job_labels_template
   preset-kyma-artifacts-bucket: "true"
   preset-gardener-azure-kyma-integration: "true"
   preset-kyma-development-artifacts-bucket: "true"
+  preset-gke-ver-stable: "true"
 
 presubmits: # runs on PRs
   kyma-incubator/compass:

--- a/templates/templates/kyma-gke-compass-integration.yaml
+++ b/templates/templates/kyma-gke-compass-integration.yaml
@@ -57,6 +57,7 @@ gke_integration_job_labels_template: &gke_integration_job_labels_template
   preset-kyma-artifacts-bucket: "true"
   preset-gardener-azure-kyma-integration: "true"
   preset-kyma-development-artifacts-bucket: "true"
+  preset-gke-ver-stable: "true"
 
 presubmits: # runs on PRs
   kyma-project/kyma:

--- a/templates/templates/kyma-gke-external-registry.yaml
+++ b/templates/templates/kyma-gke-external-registry.yaml
@@ -40,6 +40,7 @@ gke_job_labels_template: &gke_job_labels_template
   preset-dind-enabled: "true"
   preset-kyma-artifacts-bucket: "true"
   preset-cluster-use-ssd: "true"
+  preset-gke-ver-stable: "true"
 
 presubmits: # runs on PRs
   kyma-project/kyma:

--- a/templates/templates/kyma-integration.yaml
+++ b/templates/templates/kyma-integration.yaml
@@ -307,6 +307,7 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         preset-build-pr: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -322,6 +323,7 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         preset-build-pr: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -336,6 +338,7 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - org: kyma-project
@@ -374,6 +377,7 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources\\S+|installation\\S+|tests/end-to-end/upgrade/chart/upgrade/\\S+|tests/end-to-end/external-solution-integration/chart/external-solution/\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         preset-build-pr: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -388,6 +392,7 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -403,6 +408,7 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -441,6 +447,7 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources/core/templates/tests\\S+|resources/application-connector\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         preset-build-pr: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -455,6 +462,7 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -470,6 +478,7 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -509,6 +518,7 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_backup_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -525,6 +535,7 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_backup_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -561,6 +572,7 @@ postsubmits:
       labels:
         preset-log-collector-slack-token: "true"
         preset-build-master: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -577,6 +589,7 @@ postsubmits:
         - ^master$
       labels:
         preset-build-master: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -594,6 +607,7 @@ postsubmits:
       labels:
         preset-log-collector-slack-token: "true"
         preset-build-master: "true"
+        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -909,6 +923,7 @@ periodics:
       preset-nightly-github-integration: "true"
       preset-kms-gc-project-env: "true"
       preset-certificates-bucket: "true"
+      preset-gke-ver-stable: "true"
       <<: *gke_job_labels_template
     decorate: true
     extra_refs:
@@ -981,6 +996,7 @@ periodics:
       preset-weekly-github-integration: "true"
       preset-kms-gc-project-env: "true"
       preset-certificates-bucket: "true"
+      preset-gke-ver-stable: "true"
       <<: *gke_job_labels_template
     decorate: true
     extra_refs:

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -465,6 +465,14 @@ presets:
     env:
       - name: PRODUCTNAME
         value: "OOSS - KYMA"
+  # stable release version of gke
+  - labels:
+      preset-gke-ver-stable: "true"
+    env:
+      - name: CLUSTER_VERSION
+        value: "1.16"
+      - name: RELEASE_CHANNEL
+        value: regular
   # volume mounts for kind
   - labels:
       preset-kind-volume-mounts: "true"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
GKE 1.16 is the default value on regular channel. I think it's safe to use default version from channel.
```yaml
- channel: REGULAR
  defaultVersion: 1.16.13-gke.401
  validVersions:
  - 1.17.9-gke.1504
  - 1.16.13-gke.401
```

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
