### PR TITLE
Remove CLUSTER_VERSION env from the kyma-integration Dockerfile.

### DIFF
--- a/prow/images/kyma-integration/Dockerfile
+++ b/prow/images/kyma-integration/Dockerfile
@@ -135,8 +135,7 @@ ENV PATH=$PATH:/prow-tools
 
 ENV CLOUD_SDK_VERSION=299.0.0 \
     PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
-    CLOUDSDK_CORE_DISABLE_PROMPTS=1 \
-    CLUSTER_VERSION=$K8S_VERSION
+    CLOUDSDK_CORE_DISABLE_PROMPTS=1
 
 RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
     tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz -C / && \
@@ -148,4 +147,4 @@ RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cl
     --usage-reporting=false && \
     gcloud components install alpha beta kubectl docker-credential-gcr && \
     gcloud info | tee /workspace/gcloud-info.txt && \
-    mv /google-cloud-sdk/bin/kubectl.${CLUSTER_VERSION} /google-cloud-sdk/bin/kubectl
+    mv /google-cloud-sdk/bin/kubectl.${K8S_VERSION} /google-cloud-sdk/bin/kubectl


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
It is causing unwanted setting of `CLUSTER_VERSION` env variable in the scripts.

Changes proposed in this pull request:

* Remove CLUSTER_VERSION mentions in the Kyma-Integration image

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
