### PR TITLE
Edit image for kyma-cli-integration-gke to use kyma-integration image.

### DIFF
--- a/development/tools/jobs/cli/cli_integration_test.go
+++ b/development/tools/jobs/cli/cli_integration_test.go
@@ -72,7 +72,7 @@ func TestKymaCliIntegrationGKEPeriodic(t *testing.T) {
 	assert.Equal(t, "00 00 * * *", actualPeriodic.Cron)
 	tester.AssertThatHasExtraRepoRef(t, actualPeriodic.JobBase.UtilityConfig, []string{"test-infra", "cli"})
 	tester.AssertThatHasPresets(t, actualPeriodic.JobBase, preset.SaGKEKymaIntegration, preset.GCProjectEnv, "preset-gc-compute-envs", "preset-cluster-use-ssd")
-	assert.Equal(t, tester.ImageGolangKubebuilder2BuildpackLatest, actualPeriodic.Spec.Containers[0].Image)
+	assert.Equal(t, tester.ImageKymaIntegrationLatest, actualPeriodic.Spec.Containers[0].Image)
 	tester.AssertThatSpecifiesResourceRequests(t, actualPeriodic.JobBase)
 	tester.AssertThatContainerHasEnv(t, actualPeriodic.Spec.Containers[0], "CLOUDSDK_COMPUTE_ZONE", "europe-west4-a")
 	tester.AssertThatContainerHasEnv(t, actualPeriodic.Spec.Containers[0], "GO111MODULE", "on")

--- a/prow/jobs/cli/cli-integration.yaml
+++ b/prow/jobs/cli/cli-integration.yaml
@@ -72,7 +72,7 @@ periodics:
       base_ref: master
     spec:
       containers:
-      - image: eu.gcr.io/kyma-project/test-infra/buildpack-golang-kubebuilder2:v20200124-69faeef6
+      - image: eu.gcr.io/kyma-project/test-infra/kyma-integration:v20200817-1.14.0-rc1-75-g625c1054-k8s1.16
         securityContext:
           privileged: true
         command:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
After adding a new preset the job started to fail due to outdated `gcloud` CLI in `buildpack-golang-kubebuilder2:v20200124-69faeef6` image. This changes the job's image to the latest zkyma-integration`. Test run https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/logs/kyma-cli-integration-gke/1313065980812857344
Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
