### PR TITLE
Set domain in helm install command for `kyma-upgrade-gardener-azure` test

### DIFF
--- a/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
@@ -258,7 +258,8 @@ function installTestChartOrFail() {
   local namespace=$3
 
   # get server IP for HTTPS protocol and split away wildcard ".*" from it using sed
-  local domain=$(kubectl get gateways.networking.istio.io --namespace kyma-system kyma-gateway -o jsonpath='{.spec.servers[?(@.port.protocol=="HTTPS")].hosts[0]}' | sed s/\*\.//g)
+  local domain
+  domain=$(kubectl get gateways.networking.istio.io --namespace kyma-system kyma-gateway -o jsonpath='{.spec.servers[?(@.port.protocol=="HTTPS")].hosts[0]}' | sed s/\*\.//g)
 
   shout "Create ${name} resources"
   date

--- a/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
@@ -257,6 +257,9 @@ function installTestChartOrFail() {
   local name=$2
   local namespace=$3
 
+  # get server IP for HTTPS protocol and split away wildcard ".*" from it using sed
+  local domain=$(kubectl get gateways.networking.istio.io --namespace kyma-system kyma-gateway -o jsonpath='{.spec.servers[?(@.port.protocol=="HTTPS")].hosts[0]}' | sed s/\*\.//g)
+
   shout "Create ${name} resources"
   date
 
@@ -265,7 +268,7 @@ function installTestChartOrFail() {
       --create-namespace \
       "${path}" \
       --timeout "${HELM_TIMEOUT_SEC}" \
-      --set domain="${DOMAIN}" \
+      --set domain="${domain}" \
       --wait
 
   prepareResult=$?


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Set correct domain in core-test-external-solution test for `kyma-upgrade-gardener-azure` test

See this [PR with pjtester](https://github.com/kyma-project/test-infra/pull/2722/files) for a proof that the provided solution works

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes https://github.com/kyma-project/kyma/issues/9604
