### PR TITLE
Reenable stackdriver logging for upgrade job now that Kyma 1.15.1 is …

### DIFF
--- a/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
@@ -390,6 +390,10 @@ fi
 createTestResources
 
 upgradeKyma
+if [[ "$?" -ne 0 ]]; then
+    return 1
+fi
+
 remove_addons_if_necessary
 
 testKyma

--- a/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
@@ -187,6 +187,11 @@ function installKyma() {
     # shellcheck disable=SC1090
     "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/create-azure-event-hubs-secret.sh
 
+    prepare_stackdriver_logging "${INSTALLATION_OVERRIDE_STACKDRIVER}"
+    if [[ "$?" -ne 0 ]]; then
+        return 1
+    fi
+
     (
     set -x
     kyma install \
@@ -196,6 +201,7 @@ function installKyma() {
         -o installer-config-production.yaml.tpl \
         -o installer-config-azure-eventhubs.yaml.tpl \
         -o "${EVENTHUB_SECRET_OVERRIDE_FILE}" \
+        -o "${INSTALLATION_OVERRIDE_STACKDRIVER}" \
         --timeout 90m
     )
 }
@@ -390,10 +396,6 @@ fi
 createTestResources
 
 upgradeKyma
-if [[ "$?" -ne 0 ]]; then
-    return 1
-fi
-
 remove_addons_if_necessary
 
 testKyma

--- a/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
@@ -321,12 +321,6 @@ createTestResources() {
 }
 
 function upgradeKyma() {
-    prepare_stackdriver_logging "${INSTALLATION_OVERRIDE_STACKDRIVER}"
-    if [[ "$?" -ne 0 ]]; then
-        return 1
-    fi
-    kubectk apply -f "${INSTALLATION_OVERRIDE_STACKDRIVER}"
-
     shout "Delete the kyma-installation CR and kyma-installer deployment"
     # Remove the finalizer form kyma-installation the merge type is used because strategic is not supported on CRD.
     # More info about merge strategy can be found here: https://tools.ietf.org/html/rfc7386


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Use stackdriver logging integration which is only supported since Kyma 1.15.1 (see issue for more description)

A proof that it works can be found in this [PR with pjtester](https://github.com/kyma-project/test-infra/pull/2722/files)
Also see the job lobs in the screenshot for this pipeline: https://status.build.kyma-project.io/log?job=nachtmaar_test_of_prowjob_pre-master-kyma-upgrade-gardener-azure&id=1313069757024440320

<img width="1207" alt="Screenshot 2020-10-05 at 16 15 11" src="https://user-images.githubusercontent.com/8013145/95090774-f45f4200-0725-11eb-90b6-338cf99c6fc2.png">



**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/test-infra/issues/2674