### PR TITLE
Revert multiple gke tests

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -467,14 +467,6 @@ presets:
     env:
       - name: PRODUCTNAME
         value: "OOSS - KYMA"
-  # stable release version of gke
-  - labels:
-      preset-gke-ver-stable: "true"
-    env:
-      - name: CLUSTER_VERSION
-        value: "1.16"
-      - name: RELEASE_CHANNEL
-        value: regular
   # volume mounts for kind
   - labels:
       preset-kind-volume-mounts: "true"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -473,6 +473,8 @@ presets:
     env:
       - name: CLUSTER_VERSION
         value: "1.16"
+      - name: RELEASE_CHANNEL
+        value: regular
   # volume mounts for kind
   - labels:
       preset-kind-volume-mounts: "true"

--- a/prow/jobs/cli/cli-integration.yaml
+++ b/prow/jobs/cli/cli-integration.yaml
@@ -64,7 +64,6 @@ periodics:
       preset-gc-compute-envs: "true"
       preset-gc-project-env: "true"
       preset-cluster-use-ssd: "true"
-      preset-gke-ver-stable: "true"
     extra_refs:
     - <<: *test_infra_ref
       base_ref: master

--- a/prow/jobs/control-plane/control-plane-gke-integration.yaml
+++ b/prow/jobs/control-plane/control-plane-gke-integration.yaml
@@ -52,7 +52,6 @@ gke_integration_job_labels_template: &gke_integration_job_labels_template
   preset-kyma-artifacts-bucket: "true"
   preset-gardener-azure-kyma-integration: "true"
   preset-kyma-development-artifacts-bucket: "true"
-  preset-gke-ver-stable: "true"
 
 presubmits: # runs on PRs
   kyma-project/control-plane:

--- a/prow/jobs/incubator/compass/compass-gke-integration.yaml
+++ b/prow/jobs/incubator/compass/compass-gke-integration.yaml
@@ -54,7 +54,6 @@ gke_integration_job_labels_template: &gke_integration_job_labels_template
   preset-kyma-artifacts-bucket: "true"
   preset-gardener-azure-kyma-integration: "true"
   preset-kyma-development-artifacts-bucket: "true"
-  preset-gke-ver-stable: "true"
 
 presubmits: # runs on PRs
   kyma-incubator/compass:

--- a/prow/jobs/kyma/kyma-gke-compass-integration.yaml
+++ b/prow/jobs/kyma/kyma-gke-compass-integration.yaml
@@ -59,7 +59,6 @@ gke_integration_job_labels_template: &gke_integration_job_labels_template
   preset-kyma-artifacts-bucket: "true"
   preset-gardener-azure-kyma-integration: "true"
   preset-kyma-development-artifacts-bucket: "true"
-  preset-gke-ver-stable: "true"
 
 presubmits: # runs on PRs
   kyma-project/kyma:

--- a/prow/jobs/kyma/kyma-gke-external-registry.yaml
+++ b/prow/jobs/kyma/kyma-gke-external-registry.yaml
@@ -42,7 +42,6 @@ gke_job_labels_template: &gke_job_labels_template
   preset-dind-enabled: "true"
   preset-kyma-artifacts-bucket: "true"
   preset-cluster-use-ssd: "true"
-  preset-gke-ver-stable: "true"
 
 presubmits: # runs on PRs
   kyma-project/kyma:

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -60,18 +60,6 @@ presets:
         value: kyma-minio-gateway
       - name: AZURE_REGION
         value: westeurope
-  - labels:
-      preset-gke-ver_rapid_default: "true"
-    env:
-      - name: RELEASE_CHANNEL
-        value: rapid
-  - labels:
-      preset-gke-ver1_17_9: "true"
-    env:
-      - name: CLUSTER_VERSION
-        value: 1.17.9-gke.1504
-      - name: RELEASE_CHANNEL
-        value: regular
 
 gke_job_template: &gke_job_template
   decorate: true
@@ -387,19 +375,6 @@ presubmits: # runs on PRs
           repo: test-infra
           path_alias: github.com/kyma-project/test-infra
           base_ref: release-1.14
-    - name: pre-master-kyma-gke1_17_9-integration
-      optional: true
-      cluster: untrusted-workload
-      branches:
-        - ^master$
-      <<: *gke_job_template
-      run_if_changed: "^((resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
-      labels:
-        <<: *gke_job_labels_template
-        preset-gke-ver1_17_9: "true"
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
 
     - name: pre-master-kyma-gke-upgrade
       cluster: untrusted-workload
@@ -450,21 +425,6 @@ presubmits: # runs on PRs
       extra_refs:
         - <<: *test_infra_ref
           base_ref: release-1.14
-    - name: pre-master-kyma-gke1_17_9-upgrade
-      optional: true
-      cluster: untrusted-workload
-      branches:
-        - ^master$
-      <<: *gke_upgrade_job_template
-      # following regexp won't start build if only Markdown files were changed
-      run_if_changed: "^((resources\\S+|installation\\S+|tests/end-to-end/upgrade/chart/upgrade/\\S+|tests/end-to-end/external-solution-integration/chart/external-solution/\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
-      labels:
-        preset-build-pr: "true"
-        preset-gke-ver1_17_9: "true"
-        <<: *gke_job_labels_template
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
 
     - name: pre-master-kyma-gke-central-connector
       cluster: untrusted-workload
@@ -515,21 +475,6 @@ presubmits: # runs on PRs
       extra_refs:
         - <<: *test_infra_ref
           base_ref: release-1.14
-    - name: pre-master-kyma-gke1_17_9-central-connector
-      optional: true
-      cluster: untrusted-workload
-      branches:
-        - ^master$
-      <<: *gke_central_job_template
-      # following regexp won't start build if only Markdown files were changed
-      run_if_changed: "^((resources/core/templates/tests\\S+|resources/application-connector\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
-      labels:
-        preset-build-pr: "true"
-        <<: *gke_job_labels_template
-        preset-gke-ver1_17_9: "true"
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
 
 postsubmits:
   kyma-project/kyma:
@@ -594,98 +539,6 @@ postsubmits:
       labels:
         preset-log-collector-slack-token: "true"
         preset-build-master: "true"
-        <<: *gke_job_labels_template
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
-    - name: post-master-kyma-gke-ver_rapid_default-integration
-      cluster: trusted-workload
-      <<: *gke_job_template
-      annotations:
-        testgrid-create-test-group: "false"
-      branches:
-        - ^master$
-      labels:
-        preset-log-collector-slack-token: "true"
-        preset-build-master: "true"
-        preset-gke-ver_rapid_default: "true"
-        <<: *gke_job_labels_template
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
-
-    - name: post-master-kyma-gke-ver_rapid_default-central-connector
-      cluster: trusted-workload
-      <<: *gke_central_job_template
-      annotations:
-        testgrid-create-test-group: "false"
-      branches:
-        - ^master$
-      labels:
-        preset-build-master: "true"
-        preset-gke-ver_rapid_default: "true"
-        <<: *gke_job_labels_template
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
-
-    - name: post-master-kyma-gke-ver_rapid_default-upgrade
-      cluster: trusted-workload
-      <<: *gke_upgrade_job_template
-      annotations:
-        testgrid-create-test-group: "false"
-      branches:
-        - ^master$
-      labels:
-        preset-log-collector-slack-token: "true"
-        preset-build-master: "true"
-        preset-gke-ver_rapid_default: "true"
-        <<: *gke_job_labels_template
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
-    - name: post-master-kyma-gke-ver1_17_9-integration
-      cluster: trusted-workload
-      <<: *gke_job_template
-      annotations:
-        testgrid-create-test-group: "false"
-      branches:
-        - ^master$
-      labels:
-        preset-log-collector-slack-token: "true"
-        preset-build-master: "true"
-        preset-gke-ver1_17_9: "true"
-        <<: *gke_job_labels_template
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
-
-    - name: post-master-kyma-gke-ver1_17_9-central-connector
-      cluster: trusted-workload
-      <<: *gke_central_job_template
-      annotations:
-        testgrid-create-test-group: "false"
-      branches:
-        - ^master$
-      labels:
-        preset-build-master: "true"
-        preset-gke-ver1_17_9: "true"
-        <<: *gke_job_labels_template
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
-
-    - name: post-master-kyma-gke-ver1_17_9-upgrade
-      cluster: trusted-workload
-      <<: *gke_upgrade_job_template
-      annotations:
-        testgrid-create-test-group: "false"
-      branches:
-        - ^master$
-      labels:
-        preset-log-collector-slack-token: "true"
-        preset-build-master: "true"
-        preset-gke-ver1_17_9: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -326,7 +326,6 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         preset-build-pr: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -342,7 +341,6 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         preset-build-pr: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -355,7 +353,6 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - org: kyma-project
@@ -370,7 +367,6 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - org: kyma-project
@@ -385,7 +381,6 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - org: kyma-project
@@ -415,7 +410,6 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources\\S+|installation\\S+|tests/end-to-end/upgrade/chart/upgrade/\\S+|tests/end-to-end/external-solution-integration/chart/external-solution/\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         preset-build-pr: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -428,7 +422,6 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -441,7 +434,6 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -454,7 +446,6 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -484,7 +475,6 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources/core/templates/tests\\S+|resources/application-connector\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         preset-build-pr: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -497,7 +487,6 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -510,7 +499,6 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -523,7 +511,6 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -574,7 +561,6 @@ postsubmits:
       labels:
         preset-log-collector-slack-token: "true"
         preset-build-master: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -591,7 +577,6 @@ postsubmits:
         - ^master$
       labels:
         preset-build-master: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -609,7 +594,6 @@ postsubmits:
       labels:
         preset-log-collector-slack-token: "true"
         preset-build-master: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -964,7 +948,6 @@ periodics:
       preset-nightly-github-integration: "true"
       preset-kms-gc-project-env: "true"
       preset-certificates-bucket: "true"
-      preset-gke-ver-stable: "true"
       <<: *gke_job_labels_template
     decorate: true
     extra_refs:
@@ -1037,7 +1020,6 @@ periodics:
       preset-weekly-github-integration: "true"
       preset-kms-gc-project-env: "true"
       preset-certificates-bucket: "true"
-      preset-gke-ver-stable: "true"
       <<: *gke_job_labels_template
     decorate: true
     extra_refs:

--- a/prow/scripts/cluster-integration/helpers/provision-gke-cluster.sh
+++ b/prow/scripts/cluster-integration/helpers/provision-gke-cluster.sh
@@ -50,7 +50,6 @@ CLEANER_LABELS_PARAM="created-at=${CURRENT_TIMESTAMP_PARAM},created-at-readable=
 
 GCLOUD_PARAMS+=("${CLUSTER_NAME}")
 if [ "${CLUSTER_VERSION}" ]; then GCLOUD_PARAMS+=("--cluster-version=${CLUSTER_VERSION}"); else GCLOUD_PARAMS+=("${CLUSTER_VERSION_PARAM}"); fi
-if [ "${RELEASE_CHANNEL}" ]; then GCLOUD_PARAMS+=("--release-channel=${RELEASE_CHANNEL}"); fi
 if [ "${MACHINE_TYPE}" ]; then GCLOUD_PARAMS+=("--machine-type=${MACHINE_TYPE}"); else GCLOUD_PARAMS+=("${MACHINE_TYPE_PARAM}"); fi
 if [ "${NUM_NODES}" ]; then GCLOUD_PARAMS+=("--num-nodes=${NUM_NODES}"); else GCLOUD_PARAMS+=("${NUM_NODES_PARAM}"); fi
 if [ "${GCLOUD_NETWORK_NAME}" ] && [ "${GCLOUD_SUBNET_NAME}" ]; then GCLOUD_PARAMS+=("--network=${GCLOUD_NETWORK_NAME}" "--subnetwork=${GCLOUD_SUBNET_NAME}"); else GCLOUD_PARAMS+=("${NETWORK_PARAM}"); fi

--- a/prow/scripts/cluster-integration/helpers/provision-gke-cluster.sh
+++ b/prow/scripts/cluster-integration/helpers/provision-gke-cluster.sh
@@ -41,6 +41,7 @@ readonly CURRENT_TIMESTAMP_PARAM=$(date +%s)
 declare -a GCLOUD_PARAMS
 
 TTL_HOURS_PARAM="3"
+CLUSTER_VERSION_PARAM="--cluster-version=1.16"
 MACHINE_TYPE_PARAM="--machine-type=n1-standard-4"
 NUM_NODES_PARAM="--num-nodes=3"
 NETWORK_PARAM="--network=default"
@@ -48,7 +49,7 @@ if [ "${TTL_HOURS}" ]; then TTL_HOURS_PARAM="${TTL_HOURS}"; fi
 CLEANER_LABELS_PARAM="created-at=${CURRENT_TIMESTAMP_PARAM},created-at-readable=${CURRENT_TIMESTAMP_READABLE_PARAM},ttl=${TTL_HOURS_PARAM}"
 
 GCLOUD_PARAMS+=("${CLUSTER_NAME}")
-if [ "${CLUSTER_VERSION}" ]; then GCLOUD_PARAMS+=("--cluster-version=${CLUSTER_VERSION}"); fi
+if [ "${CLUSTER_VERSION}" ]; then GCLOUD_PARAMS+=("--cluster-version=${CLUSTER_VERSION}"); else GCLOUD_PARAMS+=("${CLUSTER_VERSION_PARAM}"); fi
 if [ "${RELEASE_CHANNEL}" ]; then GCLOUD_PARAMS+=("--release-channel=${RELEASE_CHANNEL}"); fi
 if [ "${MACHINE_TYPE}" ]; then GCLOUD_PARAMS+=("--machine-type=${MACHINE_TYPE}"); else GCLOUD_PARAMS+=("${MACHINE_TYPE_PARAM}"); fi
 if [ "${NUM_NODES}" ]; then GCLOUD_PARAMS+=("--num-nodes=${NUM_NODES}"); else GCLOUD_PARAMS+=("${NUM_NODES_PARAM}"); fi

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -693,12 +693,6 @@ templates:
       - to: ../prow/jobs/kyma/kyma-integration.yaml
         values:
           <<: *cluster_default
-          gkeVersions:
-            - channel: rapid
-              jobs: ["postsubmit"]
-            - channel: regular
-              version: 1.17.9-gke.1504
-              jobs: ["presubmit", "postsubmit"]
   - from: templates/kyma-integration-gardener.yaml
     render:
       - to: ../prow/jobs/kyma/kyma-integration-gardener.yaml

--- a/templates/templates/compass-gke-integration.yaml
+++ b/templates/templates/compass-gke-integration.yaml
@@ -52,7 +52,6 @@ gke_integration_job_labels_template: &gke_integration_job_labels_template
   preset-kyma-artifacts-bucket: "true"
   preset-gardener-azure-kyma-integration: "true"
   preset-kyma-development-artifacts-bucket: "true"
-  preset-gke-ver-stable: "true"
 
 presubmits: # runs on PRs
   kyma-incubator/compass:

--- a/templates/templates/kyma-gke-compass-integration.yaml
+++ b/templates/templates/kyma-gke-compass-integration.yaml
@@ -57,7 +57,6 @@ gke_integration_job_labels_template: &gke_integration_job_labels_template
   preset-kyma-artifacts-bucket: "true"
   preset-gardener-azure-kyma-integration: "true"
   preset-kyma-development-artifacts-bucket: "true"
-  preset-gke-ver-stable: "true"
 
 presubmits: # runs on PRs
   kyma-project/kyma:

--- a/templates/templates/kyma-gke-external-registry.yaml
+++ b/templates/templates/kyma-gke-external-registry.yaml
@@ -40,7 +40,6 @@ gke_job_labels_template: &gke_job_labels_template
   preset-dind-enabled: "true"
   preset-kyma-artifacts-bucket: "true"
   preset-cluster-use-ssd: "true"
-  preset-gke-ver-stable: "true"
 
 presubmits: # runs on PRs
   kyma-project/kyma:

--- a/templates/templates/kyma-integration.yaml
+++ b/templates/templates/kyma-integration.yaml
@@ -307,7 +307,6 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         preset-build-pr: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -323,7 +322,6 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         preset-build-pr: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -338,7 +336,6 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - org: kyma-project
@@ -377,7 +374,6 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources\\S+|installation\\S+|tests/end-to-end/upgrade/chart/upgrade/\\S+|tests/end-to-end/external-solution-integration/chart/external-solution/\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         preset-build-pr: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -392,7 +388,6 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -408,7 +403,6 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -447,7 +441,6 @@ presubmits: # runs on PRs
       run_if_changed: "^((resources/core/templates/tests\\S+|resources/application-connector\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         preset-build-pr: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -462,7 +455,6 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -478,7 +470,6 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -518,7 +509,6 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_backup_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -535,7 +525,6 @@ presubmits: # runs on PRs
       always_run: false
       labels:
         preset-build-release: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_backup_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -572,7 +561,6 @@ postsubmits:
       labels:
         preset-log-collector-slack-token: "true"
         preset-build-master: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -589,7 +577,6 @@ postsubmits:
         - ^master$
       labels:
         preset-build-master: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -607,7 +594,6 @@ postsubmits:
       labels:
         preset-log-collector-slack-token: "true"
         preset-build-master: "true"
-        preset-gke-ver-stable: "true"
         <<: *gke_job_labels_template
       extra_refs:
         - <<: *test_infra_ref
@@ -923,7 +909,6 @@ periodics:
       preset-nightly-github-integration: "true"
       preset-kms-gc-project-env: "true"
       preset-certificates-bucket: "true"
-      preset-gke-ver-stable: "true"
       <<: *gke_job_labels_template
     decorate: true
     extra_refs:
@@ -996,7 +981,6 @@ periodics:
       preset-weekly-github-integration: "true"
       preset-kms-gc-project-env: "true"
       preset-certificates-bucket: "true"
-      preset-gke-ver-stable: "true"
       <<: *gke_job_labels_template
     decorate: true
     extra_refs:

--- a/templates/templates/kyma-integration.yaml
+++ b/templates/templates/kyma-integration.yaml
@@ -58,20 +58,6 @@ presets:
         value: kyma-minio-gateway
       - name: AZURE_REGION
         value: westeurope
-  {{- range .Values.gkeVersions }}
-  - labels:
-      {{- $ch := printf "_%v_default" .channel }}
-      {{- $ver := default  $ch .version }}
-      {{- $preset := regexReplaceAllLiteral "-.*" $ver "" | replace "." "_" }}
-      preset-gke-ver{{ $preset }}: "true"
-    env:
-      {{- if .version }}
-      - name: CLUSTER_VERSION
-        value: {{ .version }}
-      {{- end }}
-      - name: RELEASE_CHANNEL
-        value: {{ .channel }}
-  {{- end }}
 
 gke_job_template: &gke_job_template
   decorate: true
@@ -344,27 +330,6 @@ presubmits: # runs on PRs
           base_ref: release-{{ . }}
 {{- end }}
 
-{{- range .Values.gkeVersions }}
-  {{- if has "presubmit" .jobs }}
-  {{- $ch := printf "_%v_default" .channel }}
-  {{- $ver := default  $ch .version }}
-  {{- $preset := regexReplaceAllLiteral "-.*" $ver "" | replace "." "_" }}
-    - name: pre-master-kyma-gke{{ $preset }}-integration
-      optional: true
-      cluster: {{if $.Values.cluster.presubmit}}{{ $.Values.cluster.presubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
-      branches:
-        - ^master$
-      <<: *gke_job_template
-      run_if_changed: "^((resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
-      labels:
-        <<: *gke_job_labels_template
-        preset-gke-ver{{ $preset }}: "true"
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
-  {{- end }}
-{{- end }}
-
     - name: pre-master-kyma-gke-upgrade
       cluster: {{if $.Values.cluster.presubmit}}{{ $.Values.cluster.presubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
       branches:
@@ -409,29 +374,6 @@ presubmits: # runs on PRs
           base_ref: release-{{ . }}
 {{- end }}
 
-{{- range .Values.gkeVersions }}
-  {{- if has "presubmit" .jobs }}
-  {{- $ch := printf "_%v_default" .channel }}
-  {{- $ver := default  $ch .version }}
-  {{- $preset := regexReplaceAllLiteral "-.*" $ver "" | replace "." "_" }}
-    - name: pre-master-kyma-gke{{ $preset }}-upgrade
-      optional: true
-      cluster: {{if $.Values.cluster.presubmit}}{{ $.Values.cluster.presubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
-      branches:
-        - ^master$
-      <<: *gke_upgrade_job_template
-      # following regexp won't start build if only Markdown files were changed
-      run_if_changed: "^((resources\\S+|installation\\S+|tests/end-to-end/upgrade/chart/upgrade/\\S+|tests/end-to-end/external-solution-integration/chart/external-solution/\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
-      labels:
-        preset-build-pr: "true"
-        preset-gke-ver{{ $preset }}: "true"
-        <<: *gke_job_labels_template
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
-  {{- end }}
-{{- end }}
-
     - name: pre-master-kyma-gke-central-connector
       cluster: {{if $.Values.cluster.presubmit}}{{ $.Values.cluster.presubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
       branches:
@@ -474,29 +416,6 @@ presubmits: # runs on PRs
       extra_refs:
         - <<: *test_infra_ref
           base_ref: release-{{ . }}
-{{- end }}
-
-{{- range .Values.gkeVersions }}
-  {{- if has "presubmit" .jobs }}
-  {{- $ch := printf "_%v_default" .channel }}
-  {{- $ver := default  $ch .version }}
-  {{- $preset := regexReplaceAllLiteral "-.*" $ver "" | replace "." "_" }}
-    - name: pre-master-kyma-gke{{ $preset }}-central-connector
-      optional: true
-      cluster: {{if $.Values.cluster.presubmit}}{{ $.Values.cluster.presubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
-      branches:
-        - ^master$
-      <<: *gke_central_job_template
-      # following regexp won't start build if only Markdown files were changed
-      run_if_changed: "^((resources/core/templates/tests\\S+|resources/application-connector\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
-      labels:
-        preset-build-pr: "true"
-        <<: *gke_job_labels_template
-        preset-gke-ver{{ $preset }}: "true"
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
-  {{- end }}
 {{- end }}
 
 {{- range (matchingReleases .Global.releases "1.11" "1.11") }}
@@ -598,59 +517,6 @@ postsubmits:
       extra_refs:
         - <<: *test_infra_ref
           base_ref: master
-  {{- range .Values.gkeVersions }}
-  {{- if has "postsubmit" .jobs }}
-  {{- $ch := printf "_%v_default" .channel }}
-  {{- $ver := default  $ch .version }}
-  {{- $preset := regexReplaceAllLiteral "-.*" $ver "" | replace "." "_" }}
-    - name: post-master-kyma-gke-ver{{ $preset }}-integration
-      cluster: {{if $.Values.cluster.postsubmit}}{{ $.Values.cluster.postsubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
-      <<: *gke_job_template
-      annotations:
-        testgrid-create-test-group: "false"
-      branches:
-        - ^master$
-      labels:
-        preset-log-collector-slack-token: "true"
-        preset-build-master: "true"
-        preset-gke-ver{{ $preset }}: "true"
-        <<: *gke_job_labels_template
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
-
-    - name: post-master-kyma-gke-ver{{ $preset }}-central-connector
-      cluster: {{if $.Values.cluster.postsubmit}}{{ $.Values.cluster.postsubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
-      <<: *gke_central_job_template
-      annotations:
-        testgrid-create-test-group: "false"
-      branches:
-        - ^master$
-      labels:
-        preset-build-master: "true"
-        preset-gke-ver{{ $preset }}: "true"
-        <<: *gke_job_labels_template
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
-
-    - name: post-master-kyma-gke-ver{{ $preset }}-upgrade
-      cluster: {{if $.Values.cluster.postsubmit}}{{ $.Values.cluster.postsubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
-      <<: *gke_upgrade_job_template
-      annotations:
-        testgrid-create-test-group: "false"
-      branches:
-        - ^master$
-      labels:
-        preset-log-collector-slack-token: "true"
-        preset-build-master: "true"
-        preset-gke-ver{{ $preset }}: "true"
-        <<: *gke_job_labels_template
-      extra_refs:
-        - <<: *test_infra_ref
-          base_ref: master
-  {{- end }}
-  {{- end }}
 
 periodics:
   # kyma-integration-cleaner removes all sshPublic keys stored for service account "sa-vm-kyma-integration". Those keys refers to machines that in most cases were already removed.

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -471,6 +471,8 @@ presets:
     env:
       - name: CLUSTER_VERSION
         value: "1.16"
+      - name: RELEASE_CHANNEL
+        value: regular
   # volume mounts for kind
   - labels:
       preset-kind-volume-mounts: "true"

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -465,14 +465,6 @@ presets:
     env:
       - name: PRODUCTNAME
         value: "OOSS - KYMA"
-  # stable release version of gke
-  - labels:
-      preset-gke-ver-stable: "true"
-    env:
-      - name: CLUSTER_VERSION
-        value: "1.16"
-      - name: RELEASE_CHANNEL
-        value: regular
   # volume mounts for kind
   - labels:
       preset-kind-volume-mounts: "true"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The multiple gke jobs caused a lot of errors on the prow instances. The integration is not yet stable to use it in production.
* GKE Integration jobs fail because there are several different pipelines that build installer image under the same image tag. This causes the image to be tagged improperly. We should consider using Kyma CLI for the install job.
* we cannot use default version of the GKE release channel because our images have CLUSTER_RELEASE hardly defined in the image along with the kubectl command. Additionally the scripts are not flexible enough to use them with different versions of GKE.

Changes proposed in this pull request:

- revert https://github.com/kyma-project/test-infra/commit/319ff3f0f5a286c061c8345d0d88cada5cab26dd
- revert https://github.com/kyma-project/test-infra/commit/59746bdc093f511afad897dbb60116826d0aa4bc
- revert https://github.com/kyma-project/test-infra/commit/84440a7743c3124918fe5d7f249d512b4ea2f048

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#2761 