### PR TITLE
exclude go.mod based folders in godep scan and vice versa

### DIFF
--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -38,7 +38,7 @@ case "${SCAN_LANGUAGE}" in
         sed -i.bak "s|go.dependencyManager=|go.dependencyManager=dep|g" $CONFIG_PATH
         sed -i.bak '/^excludes=/d' $CONFIG_PATH
         # exclude gomod based folders
-        filterFolders go.mod $KYMA_SRC >> $CONFIG_PATH
+        filterFolders go.mod "${KYMA_SRC}" >> ${CONFIG_PATH}
         ;;
 
     golang-mod)
@@ -48,7 +48,7 @@ case "${SCAN_LANGUAGE}" in
         sed -i.bak "s|go.dependencyManager=|go.dependencyManager=modules|g" $CONFIG_PATH
         sed -i.bak '/^excludes=/d' $CONFIG_PATH
         # exclude godep based folders
-        filterFolders gopkg.toml $KYMA_SRC >> $CONFIG_PATH
+        filterFolders gopkg.toml "${KYMA_SRC}" >> ${CONFIG_PATH}
         ;;
         
     javascript)
@@ -81,9 +81,9 @@ function filterFolders() {
         local FOLDER_TO_SCAN
         FOLDER_TO_SCAN=$2
         local EXCLUDES
-        EXCLUDES=$( { cd $FOLDER_TO_SCAN && find . -iname go.mod ; } | grep -v vendor | grep -v tests | xargs -n 1 dirname | sed 's/$/\/**/' | sed 's/^.\//**\//' | paste -s -d" " - )
+        EXCLUDES=$( { cd "${FOLDER_TO_SCAN}" && find . -iname ${DEPENDENCY_FILE_TO_EXCLUDE} ; } | grep -v vendor | grep -v tests | xargs -n 1 dirname | sed 's/$/\/**/' | sed 's/^.\//**\//' | paste -s -d" " - )
         EXCLUDES="excludes=**/tests/** ${EXCLUDES}"
-        echo $EXCLUDES
+        echo "$EXCLUDES"
 }
 
 

--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -50,6 +50,7 @@ case "${SCAN_LANGUAGE}" in
         CONFIG_PATH=$GO_CONFIG_PATH
         sed -i.bak "s|go.dependencyManager=|go.dependencyManager=dep|g" $CONFIG_PATH
         sed -i.bak '/^excludes=/d' $CONFIG_PATH
+        echo "log.level=debug" >> $CONFIG_PATH
         # exclude gomod based folders
         filterFolders go.mod "${KYMA_SRC}" >> ${CONFIG_PATH}
         ;;

--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -48,14 +48,14 @@ function prepareDependencies() {
   FOLDER_TO_SCAN=$2
 
   if [[ ${DEPENDENCY_FILE,,} == "gopkg.toml" ]]; then
-    for COMPFOLDER in $({ cd "${FOLDER_TO_SCAN}" && find . -iname "${DEPENDENCY_FILE}"; } | grep -v vendor | grep -v tests | xargs -n 1 dirname); do
+    for COMPFOLDER in $({ find "${FOLDER_TO_SCAN}" -iname "${DEPENDENCY_FILE}"; } | grep -v vendor | grep -v tests | xargs -n 1 dirname); do
       {
         cd "$COMPFOLDER"
         dep ensure -vendor-only
       }
     done
   elif [[ ${DEPENDENCY_FILE,,} == "go.mod" ]]; then
-    for COMPFOLDER in $({ cd "${FOLDER_TO_SCAN}" && find . -iname "${DEPENDENCY_FILE}"; } | grep -v vendor | grep -v tests | xargs -n 1 dirname); do
+    for COMPFOLDER in $({ find "${FOLDER_TO_SCAN}" -iname "${DEPENDENCY_FILE}"; } | grep -v vendor | grep -v tests | xargs -n 1 dirname); do
       {
         cd "$COMPFOLDER"
         go mod download

--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -81,7 +81,7 @@ function filterFolders() {
         local FOLDER_TO_SCAN
         FOLDER_TO_SCAN=$2
         local EXCLUDES
-        EXCLUDES=$( { cd "${FOLDER_TO_SCAN}" && find . -iname ${DEPENDENCY_FILE_TO_EXCLUDE} ; } | grep -v vendor | grep -v tests | xargs -n 1 dirname | sed 's/$/\/**/' | sed 's/^.\//**\//' | paste -s -d" " - )
+        EXCLUDES=$( { cd "${FOLDER_TO_SCAN}" && find . -iname "${DEPENDENCY_FILE_TO_EXCLUDE}" ; } | grep -v vendor | grep -v tests | xargs -n 1 dirname | sed 's/$/\/**/' | sed 's/^.\//**\//' | paste -s -d" " - )
         EXCLUDES="excludes=**/tests/** ${EXCLUDES}"
         echo "$EXCLUDES"
 }

--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -65,7 +65,8 @@ golang)
   CONFIG_PATH=$GO_CONFIG_PATH
   sed -i.bak "s|go.dependencyManager=|go.dependencyManager=dep|g" $CONFIG_PATH
   sed -i.bak '/^excludes=/d' $CONFIG_PATH
-  echo "log.level=debug" >>$CONFIG_PATH
+  echo "log.level=debug" >> $CONFIG_PATH
+  echo "scanComment=$(date)" >> $CONFIG_PATH
   # exclude gomod based folders
   filterFolders go.mod "${KYMA_SRC}" >>${CONFIG_PATH}
   prepareDependencies gopkg.toml "${KYMA_SRC}"
@@ -78,6 +79,7 @@ golang-mod)
   sed -i.bak "s|go.dependencyManager=|go.dependencyManager=modules|g" $CONFIG_PATH
   sed -i.bak "s|go.collectDependenciesAtRuntime=true|go.collectDependenciesAtRuntime=false|g" $CONFIG_PATH
   sed -i.bak '/^excludes=/d' $CONFIG_PATH
+  echo "scanComment=$(date)" >> $CONFIG_PATH
   # exclude godep based folders
   filterFolders gopkg.toml "${KYMA_SRC}" >>${CONFIG_PATH}
   prepareDependencies go.mod "${KYMA_SRC}"
@@ -86,6 +88,7 @@ golang-mod)
 javascript)
   echo "SCAN: javascript"
   CONFIG_PATH=$JAVASCRIPT_CONFIG_PATH
+  echo "scanComment=$(date)" >> $CONFIG_PATH
   ;;
 
 *)

--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
-
-#Description: runs wss-unified-agent 
+#Description: runs wss-unified-agent
 #The purpose is to run the wss-unified-agent
 
-#Expected vars: 
+#Expected vars:
 # - APIKEY- Key provided by SAP Whitesource Team
 # - PRODUCTNAME - Product inside whitesource
 # - USERKEY - Users specified key(should be a service account)
@@ -32,103 +31,125 @@ APIKEY=$(cat "${WHITESOURCE_APIKEY}")
 
 #exclude components based on dependency management
 function filterFolders() {
-        local DEPENDENCY_FILE_TO_EXCLUDE
-        DEPENDENCY_FILE_TO_EXCLUDE=$1
-        local FOLDER_TO_SCAN
-        FOLDER_TO_SCAN=$2
-        local EXCLUDES
-        EXCLUDES=$( { cd "${FOLDER_TO_SCAN}" && find . -iname "${DEPENDENCY_FILE_TO_EXCLUDE}" ; } | grep -v vendor | grep -v tests | xargs -n 1 dirname | sed 's/$/\/**/' | sed 's/^.\//**\//' | paste -s -d" " - )
-        EXCLUDES="excludes=**/tests/** ${EXCLUDES}"
-        echo "$EXCLUDES"
+  local DEPENDENCY_FILE_TO_EXCLUDE
+  DEPENDENCY_FILE_TO_EXCLUDE=$1
+  local FOLDER_TO_SCAN
+  FOLDER_TO_SCAN=$2
+  local EXCLUDES
+  EXCLUDES=$({ cd "${FOLDER_TO_SCAN}" && find . -iname "${DEPENDENCY_FILE_TO_EXCLUDE}"; } | grep -v vendor | grep -v tests | xargs -n 1 dirname | sed 's/$/\/**/' | sed 's/^.\//**\//' | paste -s -d" " -)
+  EXCLUDES="excludes=**/tests/** ${EXCLUDES}"
+  echo "$EXCLUDES"
+}
+
+function prepareDependencies() {
+  local DEPENDENCY_FILE
+  DEPENDENCY_FILE=$1
+  local FOLDER_TO_SCAN
+  FOLDER_TO_SCAN=$2
+
+  if [[ ${DEPENDENCY_FILE,,} == "gopkg.toml" ]]; then
+    for COMPFOLDER in $({ cd "${FOLDER_TO_SCAN}" && find . -iname "${DEPENDENCY_FILE}"; } | grep -v vendor | grep -v tests | xargs -n 1 dirname); do
+      {
+        cd "$COMPFOLDER"
+        dep ensure -vendor-only
+      }
+    done
+  elif [[ ${DEPENDENCY_FILE,,} == "go.mod" ]]; then
+    for COMPFOLDER in $({ cd "${FOLDER_TO_SCAN}" && find . -iname "${DEPENDENCY_FILE}"; } | grep -v vendor | grep -v tests | xargs -n 1 dirname); do
+      {
+        cd "$COMPFOLDER"
+        go mod download
+      }
+    done
+  fi
 }
 
 KYMA_SRC="${GITHUB_ORG_DIR}/${PROJECTNAME}"
 
 case "${SCAN_LANGUAGE}" in
-    golang)
-        echo "SCAN: golang (dep)"
-        CONFIG_PATH=$GO_CONFIG_PATH
-        sed -i.bak "s|go.dependencyManager=|go.dependencyManager=dep|g" $CONFIG_PATH
-        sed -i.bak '/^excludes=/d' $CONFIG_PATH
-        echo "log.level=debug" >> $CONFIG_PATH
-        # exclude gomod based folders
-        filterFolders go.mod "${KYMA_SRC}" >> ${CONFIG_PATH}
-        ;;
+golang)
+  echo "SCAN: golang (dep)"
+  CONFIG_PATH=$GO_CONFIG_PATH
+  sed -i.bak "s|go.dependencyManager=|go.dependencyManager=dep|g" $CONFIG_PATH
+  sed -i.bak '/^excludes=/d' $CONFIG_PATH
+  echo "log.level=debug" >>$CONFIG_PATH
+  # exclude gomod based folders
+  filterFolders go.mod "${KYMA_SRC}" >>${CONFIG_PATH}
+  prepareDependencies gopkg.toml "${KYMA_SRC}"
+  ;;
 
-    golang-mod)
-        echo "SCAN: golang-mod"
-        CONFIG_PATH=$GO_CONFIG_PATH
-        export GO111MODULE=on
-        sed -i.bak "s|go.dependencyManager=|go.dependencyManager=modules|g" $CONFIG_PATH
-        sed -i.bak '/^excludes=/d' $CONFIG_PATH
-        # exclude godep based folders
-        filterFolders gopkg.toml "${KYMA_SRC}" >> ${CONFIG_PATH}
-        ;;
-        
-    javascript)
-        echo "SCAN: javascript"
-        CONFIG_PATH=$JAVASCRIPT_CONFIG_PATH
-        ;;
-        
-    *)
-        echo "can only be golang or javascript"
-        exit 1
+golang-mod)
+  echo "SCAN: golang-mod"
+  CONFIG_PATH=$GO_CONFIG_PATH
+  export GO111MODULE=on
+  sed -i.bak "s|go.dependencyManager=|go.dependencyManager=modules|g" $CONFIG_PATH
+  sed -i.bak '/^excludes=/d' $CONFIG_PATH
+  # exclude godep based folders
+  filterFolders gopkg.toml "${KYMA_SRC}" >>${CONFIG_PATH}
+  prepareDependencies go.mod "${KYMA_SRC}"
+  ;;
+
+javascript)
+  echo "SCAN: javascript"
+  CONFIG_PATH=$JAVASCRIPT_CONFIG_PATH
+  ;;
+
+*)
+  echo "can only be golang or javascript"
+  exit 1
+  ;;
 esac
 
 echo "***********************************"
 echo "***********Starting Scan***********"
 echo "***********************************"
 
-
 # resolve deps for console repository
 #if [ "${PROJECTNAME}" == "console" ]; then
 #    cd "$KYMA_SRC"
 #    make resolve
-#fi    
-
-
+#fi
 
 
 function scanFolder() { # expects to get the fqdn of folder passed to scan
-    if [[ $1 == "" ]]; then
-        echo "path cannot be empty"
-        exit 1
-    fi
-    FOLDER=$1
-    if [[ $2 == "" ]]; then
-        echo "component name cannot be empty"
-        exit 1
-    fi
-    cd "${FOLDER}" # change to passed parameter
-    PROJNAME=$2
+  if [[ $1 == "" ]]; then
+    echo "path cannot be empty"
+    exit 1
+  fi
+  FOLDER=$1
+  if [[ $2 == "" ]]; then
+    echo "component name cannot be empty"
+    exit 1
+  fi
+  cd "${FOLDER}" # change to passed parameter
+  PROJNAME=$2
 
-    if [[ $CUSTOM_PROJECTNAME == "" ]]; then 
+  if [[ $CUSTOM_PROJECTNAME == "" ]]; then
     # use custom projectname for kyma-mod scans in order not to override kyma (dep) scan results
-        sed -i.bak "s|apiKey=|apiKey=${APIKEY}|g; s|productName=|productName=${PRODUCTNAME}|g; s|userKey=|userKey=${USERKEY}|g; s|projectName=|projectName=${PROJNAME}|g" $CONFIG_PATH
+    sed -i.bak "s|apiKey=|apiKey=${APIKEY}|g; s|productName=|productName=${PRODUCTNAME}|g; s|userKey=|userKey=${USERKEY}|g; s|projectName=|projectName=${PROJNAME}|g" $CONFIG_PATH
+  else
+    sed -i.bak "s|apiKey=|apiKey=${APIKEY}|g; s|productName=|productName=${PRODUCTNAME}|g; s|userKey=|userKey=${USERKEY}|g; s|projectName=|projectName=${CUSTOM_PROJECTNAME}|g" $CONFIG_PATH
+  fi
+
+  echo "Product name - $PRODUCTNAME"
+  echo "Project name - $PROJNAME"
+  echo "Java Options - '$JAVA_OPTS'"
+
+  if [ "${DRYRUN}" = false ]; then
+    echo "***********************************"
+    echo "******** Scanning $FOLDER ***"
+    echo "***********************************"
+    if [ -z "$JAVA_OPTS" ]; then
+      echo "no additional java_opts set"
+      java -jar /wss/wss-unified-agent.jar -c $CONFIG_PATH
     else
-        sed -i.bak "s|apiKey=|apiKey=${APIKEY}|g; s|productName=|productName=${PRODUCTNAME}|g; s|userKey=|userKey=${USERKEY}|g; s|projectName=|projectName=${CUSTOM_PROJECTNAME}|g" $CONFIG_PATH
+      java "${JAVA_OPTS}" -jar /wss/wss-unified-agent.jar -c $CONFIG_PATH
     fi
-
-    echo "Product name - $PRODUCTNAME"
-    echo "Project name - $PROJNAME"
-    echo "Java Options - '$JAVA_OPTS'"
-
-
-    if [ "${DRYRUN}" = false ];then
-        echo "***********************************"
-        echo "******** Scanning $FOLDER ***"
-        echo "***********************************"
-        if [ -z "$JAVA_OPTS" ]; then
-            echo "no additional java_opts set"
-            java -jar /wss/wss-unified-agent.jar -c $CONFIG_PATH
-        else
-            java "${JAVA_OPTS}" -jar /wss/wss-unified-agent.jar -c $CONFIG_PATH
-        fi
-    else 
-        echo "***********************************"
-        echo "******** DRYRUN Successful for $FOLDER ***"  
-        echo "***********************************"
-    fi
+  else
+    echo "***********************************"
+    echo "******** DRYRUN Successful for $FOLDER ***"
+    echo "***********************************"
+  fi
 }
 
 scanFolder "${KYMA_SRC}" "${PROJECTNAME}"

--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -81,8 +81,8 @@ function filterFolders() {
         local FOLDER_TO_SCAN
         FOLDER_TO_SCAN=$2
         local EXCLUDES
-        EXCLUDES=$({cd $FOLDER_TO_SCAN && find . -iname go.mod }| grep -v vendor | grep -v tests | xargs -n 1 dirname | sed 's/$/\/**/' | sed 's/^.\//**\//' | paste -s -d" " -)
-        EXCLUDES="excludes=**/tests/** $EXCLUDES"
+        EXCLUDES=$( { cd $FOLDER_TO_SCAN && find . -iname go.mod ; } | grep -v vendor | grep -v tests | xargs -n 1 dirname | sed 's/$/\/**/' | sed 's/^.\//**\//' | paste -s -d" " - )
+        EXCLUDES="excludes=**/tests/** ${EXCLUDES}"
         echo $EXCLUDES
 }
 

--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -65,7 +65,6 @@ golang)
   CONFIG_PATH=$GO_CONFIG_PATH
   sed -i.bak "s|go.dependencyManager=|go.dependencyManager=dep|g" $CONFIG_PATH
   sed -i.bak '/^excludes=/d' $CONFIG_PATH
-  echo "log.level=debug" >> $CONFIG_PATH
   echo "scanComment=$(date)" >> $CONFIG_PATH
   # exclude gomod based folders
   filterFolders go.mod "${KYMA_SRC}" >>${CONFIG_PATH}

--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -30,6 +30,18 @@ USERKEY=$(cat "${WHITESOURCE_USERKEY}")
 
 APIKEY=$(cat "${WHITESOURCE_APIKEY}")
 
+#exclude components based on dependency management
+function filterFolders() {
+        local DEPENDENCY_FILE_TO_EXCLUDE
+        DEPENDENCY_FILE_TO_EXCLUDE=$1
+        local FOLDER_TO_SCAN
+        FOLDER_TO_SCAN=$2
+        local EXCLUDES
+        EXCLUDES=$( { cd "${FOLDER_TO_SCAN}" && find . -iname "${DEPENDENCY_FILE_TO_EXCLUDE}" ; } | grep -v vendor | grep -v tests | xargs -n 1 dirname | sed 's/$/\/**/' | sed 's/^.\//**\//' | paste -s -d" " - )
+        EXCLUDES="excludes=**/tests/** ${EXCLUDES}"
+        echo "$EXCLUDES"
+}
+
 
 case "${SCAN_LANGUAGE}" in
     golang)
@@ -74,17 +86,6 @@ KYMA_SRC="${GITHUB_ORG_DIR}/${PROJECTNAME}"
 #fi    
 
 
-#exclude components based on dependency management
-function filterFolders() {
-        local DEPENDENCY_FILE_TO_EXCLUDE
-        DEPENDENCY_FILE_TO_EXCLUDE=$1
-        local FOLDER_TO_SCAN
-        FOLDER_TO_SCAN=$2
-        local EXCLUDES
-        EXCLUDES=$( { cd "${FOLDER_TO_SCAN}" && find . -iname "${DEPENDENCY_FILE_TO_EXCLUDE}" ; } | grep -v vendor | grep -v tests | xargs -n 1 dirname | sed 's/$/\/**/' | sed 's/^.\//**\//' | paste -s -d" " - )
-        EXCLUDES="excludes=**/tests/** ${EXCLUDES}"
-        echo "$EXCLUDES"
-}
 
 
 function scanFolder() { # expects to get the fqdn of folder passed to scan

--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -49,7 +49,6 @@ case "${SCAN_LANGUAGE}" in
         echo "SCAN: golang (dep)"
         CONFIG_PATH=$GO_CONFIG_PATH
         sed -i.bak "s|go.dependencyManager=|go.dependencyManager=dep|g" $CONFIG_PATH
-        sed -i.bak "s|go.collectDependenciesAtRuntime=true|go.collectDependenciesAtRuntime=false|g" $CONFIG_PATH
         sed -i.bak '/^excludes=/d' $CONFIG_PATH
         # exclude gomod based folders
         filterFolders go.mod "${KYMA_SRC}" >> ${CONFIG_PATH}

--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -50,8 +50,9 @@ function prepareDependencies() {
   if [[ ${DEPENDENCY_FILE,,} == "gopkg.toml" ]]; then
     for COMPFOLDER in $({ find "${FOLDER_TO_SCAN}" -iname "${DEPENDENCY_FILE}"; } | grep -v vendor | grep -v tests | xargs -n 1 dirname); do
       {
+        echo "$COMPFOLDER"
         cd "$COMPFOLDER"
-        dep ensure -vendor-only
+        mkdir -p vendor
       }
     done
   elif [[ ${DEPENDENCY_FILE,,} == "go.mod" ]]; then

--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -42,6 +42,7 @@ function filterFolders() {
         echo "$EXCLUDES"
 }
 
+KYMA_SRC="${GITHUB_ORG_DIR}/${PROJECTNAME}"
 
 case "${SCAN_LANGUAGE}" in
     golang)
@@ -77,7 +78,6 @@ echo "***********************************"
 echo "***********Starting Scan***********"
 echo "***********************************"
 
-KYMA_SRC="${GITHUB_ORG_DIR}/${PROJECTNAME}"
 
 # resolve deps for console repository
 #if [ "${PROJECTNAME}" == "console" ]; then

--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -49,6 +49,7 @@ case "${SCAN_LANGUAGE}" in
         echo "SCAN: golang (dep)"
         CONFIG_PATH=$GO_CONFIG_PATH
         sed -i.bak "s|go.dependencyManager=|go.dependencyManager=dep|g" $CONFIG_PATH
+        sed -i.bak "s|go.collectDependenciesAtRuntime=true|go.collectDependenciesAtRuntime=false|g" $CONFIG_PATH
         sed -i.bak '/^excludes=/d' $CONFIG_PATH
         # exclude gomod based folders
         filterFolders go.mod "${KYMA_SRC}" >> ${CONFIG_PATH}

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,2 +1,3 @@
 pjNames:
   - pjName: "kyma-whitesource-scan"
+  - pjName: "kyma-mod-whitesource-scan"

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,3 +1,0 @@
-pjNames:
-  - pjName: "kyma-whitesource-scan"
-  - pjName: "kyma-mod-whitesource-scan"

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,2 @@
+pjNames:
+  - pjName: "kyma-whitesource-scan"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

currently whitesource tries to scan godep based subfolders in the gomod scan and vice versa, in the log this results in the following message:
```
[INFO] [2020-10-07 04:02:31,333 +0000] - Trying to resolve GO dependencies
[INFO] [2020-10-07 04:02:31,559 +0000] - topFolder = /home/prow/go/src/github.com/kyma-project/kyma/components/event-service
[INFO] [2020-10-07 04:02:31,563 +0000] - Resolve dependencies - START - modules
[WARN] [2020-10-07 04:05:03,574 +0000] - CommandLineProcess - executeProcessCommand - error in execute command 'go build', Exit Status 1
[WARN] [2020-10-07 04:05:33,950 +0000] - CommandLineProcess - executeProcessCommand - error in execute command 'go mod vendor', Exit Status 1
[WARN] [2020-10-07 04:05:33,950 +0000] - There was an error in running 'go build' command, please fix your code/imports for maximum results.
[WARN] [2020-10-07 04:05:33,950 +0000] - go.collectDependenciesAtRuntime = true but pre-step failed
[WARN] [2020-10-07 04:05:33,999 +0000] - The 'vendor' folder is missing and 'modules' package manager pre-step failed. The UA will extract dependencies as a flat tree.
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
