### PR TITLE
Revert old istio overrides format

### DIFF
--- a/prow/scripts/cluster-integration/control-plane-gke-integration.sh
+++ b/prow/scripts/cluster-integration/control-plane-gke-integration.sh
@@ -213,24 +213,9 @@ function applyKymaOverrides() {
     --data "pushgateway.enabled=true" \
     --label "component=monitoring"
 
-  cat << EOF > "$PWD/kyma_istio_operator"
-apiVersion: install.istio.io/v1alpha1
-kind: IstioOperator
-metadata:
-  namespace: istio-system
-spec:
-  components:
-    ingressGateways:
-      - name: istio-ingressgateway
-        k8s:
-          service:
-            loadBalancerIP: ${GATEWAY_IP_ADDRESS}
-            type: LoadBalancer
-EOF
-
-  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map-file.sh" --name "istio-overrides" \
-    --label "component=istio" \
-    --file "$PWD/kyma_istio_operator"
+  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "istio-overrides" \
+    --data "gateways.istio-ingressgateway.loadBalancerIP=${GATEWAY_IP_ADDRESS}" \
+    --label "component=istio"
 
   "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "api-gateway-overrides" \
     --data "tests.env.gatewayName=compass-istio-gateway" \


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- use old format of istio overrides as kyma 1.16 is not yet released


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
