### PR TITLE
Disable reports to ci-force for compatibility jobs

### DIFF
--- a/prow/jobs/cli/cli-compatibility.yaml
+++ b/prow/jobs/cli/cli-compatibility.yaml
@@ -17,7 +17,7 @@ job_template: &job_template
     preset-gc-project-env: "true"
   optional: false
   always_run: true
-  skip_report: false
+  report: false # Temporarily do not report to ci-force, until compatibility is stable.
   decorate: true
   path_alias: github.com/kyma-project/cli
   max_concurrency: 10


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Disable reporting to `ci-force` for compatibility jobs since they have false negatives.

**Related issue(s)**
https://github.com/kyma-project/cli/issues/584