### PR TITLE
Disabled pr tag for prow-tools image.

### DIFF
--- a/prow/images/prow-tools/Makefile
+++ b/prow/images/prow-tools/Makefile
@@ -23,9 +23,6 @@ tag-image: build-image
 .PHONY: tag-image
 tag-image:
 	docker tag $(IMG):$(DOCKER_TAG) $(IMG):current
-ifdef DOCKER_POST_PR_TAG
-	docker tag $(IMG):$(DOCKER_TAG) $(IMG):$(DOCKER_POST_PR_TAG)
-endif
 
 
 # build image and tag it with commit ID or PR number


### PR DESCRIPTION
Disabled pr tag to let prow-tools image rebuild with fixed prtagbulder tool