### PR TITLE
Enable using 1.16.0 as Kyma version in control-plane

### DIFF
--- a/prow/scripts/build-kcp-development-artifacts.sh
+++ b/prow/scripts/build-kcp-development-artifacts.sh
@@ -69,6 +69,10 @@ make -C "${KCP_PATH}/tools/kcp-installer" ${buildTarget}
 shout "Build SKR CLI with target ${buildTarget}"
 make -C "${KCP_PATH}/components/kyma-environment-broker" -f Makefile.cli ${buildTarget}
 
+shout "Switch to a different service account to pull/push to GCS bucket"
+export GOOGLE_APPLICATION_CREDENTIALS=/etc/credentials/sa-kyma-artifacts/service-account.json
+authenticate
+
 shout "Create development artifacts"
 # INPUTS:
 # - KCP_INSTALLER_PUSH_DIR
@@ -79,11 +83,6 @@ env KCP_INSTALLER_VERSION="${DOCKER_TAG}" ARTIFACTS_DIR="${ARTIFACTS}" "${KCP_PA
 
 shout "Content of the local artifacts directory"
 ls -la "${ARTIFACTS}"
-
-shout "Switch to a different service account to push to GCS bucket"
-
-export GOOGLE_APPLICATION_CREDENTIALS=/etc/credentials/sa-kyma-artifacts/service-account.json
-authenticate
 
 shout "Copy artifacts to ${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}"
 gsutil cp  "${ARTIFACTS}/kcp-installer.yaml" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/kcp-installer.yaml"

--- a/prow/scripts/cluster-integration/control-plane-gke-integration.sh
+++ b/prow/scripts/cluster-integration/control-plane-gke-integration.sh
@@ -213,9 +213,24 @@ function applyKymaOverrides() {
     --data "pushgateway.enabled=true" \
     --label "component=monitoring"
 
-  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "istio-overrides" \
-    --data "gateways.istio-ingressgateway.loadBalancerIP=${GATEWAY_IP_ADDRESS}" \
-    --label "component=istio"
+  cat << EOF > "$PWD/kyma_istio_operator"
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: istio-system
+spec:
+  components:
+    ingressGateways:
+      - name: istio-ingressgateway
+        k8s:
+          service:
+            loadBalancerIP: ${GATEWAY_IP_ADDRESS}
+            type: LoadBalancer
+EOF
+
+  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map-file.sh" --name "istio-overrides" \
+    --label "component=istio" \
+    --file "$PWD/kyma_istio_operator"
 
   "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "api-gateway-overrides" \
     --data "tests.env.gatewayName=compass-istio-gateway" \
@@ -410,7 +425,7 @@ function installControlPlane() {
   | sed -e "s/__VERSION__/0.0.1/g" \
   | sed -e "s/__.*__//g" \
   | kubectl apply -f-
-  
+
   shout "Installation triggered"
   date
   "${KCP_SCRIPTS_DIR}"/is-installed.sh --timeout 30m


### PR DESCRIPTION
**Description**

Enable using 1.16.0 as Kyma version in control-plane

Changes proposed in this pull request:

- authenticate with GCS bucket SA before generating KCP installer artifacts since the script might download from gs//kyma-prow-artifacts
- Define istio overrides in `IstioOperator` format

- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
