### PR TITLE
Rewrite kyma-gke-integration.sh to use kyma-cli

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-integration.sh
@@ -255,7 +255,7 @@ date
 
 cat << EOF > "$PWD/kyma-installer-overrides.yaml"
 apiVersion: v1
-kind ConfigMap
+kind: ConfigMap
 metadata:
   name: "installation-config-overrides"
   namespace: "kyma-installer"

--- a/prow/scripts/cluster-integration/kyma-gke-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-integration.sh
@@ -212,7 +212,7 @@ date
 GATEWAY_IP_ADDRESS_NAME="${COMMON_NAME}"
 GATEWAY_IP_ADDRESS=$(IP_ADDRESS_NAME=${GATEWAY_IP_ADDRESS_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/reserve-ip-address.sh")
 CLEANUP_GATEWAY_IP_ADDRESS="true"
-log::success "Created IP Address for Ingressgateway: ${GATEWAY_IP_ADDRESS}"
+log::info "Created IP Address for Ingressgateway: ${GATEWAY_IP_ADDRESS}"
 
 
 log::info "Create DNS Record for Ingressgateway IP"

--- a/prow/scripts/cluster-integration/kyma-gke-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-integration.sh
@@ -62,6 +62,8 @@ export TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS="${TEST_INFRA_SOURCES_DIR}/prow/sc
 source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/common.sh"
 # shellcheck disable=SC1090
 source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/kyma-cli.sh"
+# shellcheck disable=SC1090
+source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/log.sh"
 
 #!Put cleanup code in this function! Function is executed at exit from the script and on interruption.
 # TODO (@Ressetkk): I think we can safely source this method from external file to use it with other GKE scripts.

--- a/prow/scripts/cluster-integration/kyma-gke-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-integration.sh
@@ -263,8 +263,8 @@ metadata:
     installer: overrides
     kyma-project.io/installation: ""
 data:
-  global.domainName: ${DOMAIN}
-  global.loadBalancerIP: ${GATEWAY_IP_ADDRESS}
+  global.domainName: "${DOMAIN}"
+  global.loadBalancerIP: "${GATEWAY_IP_ADDRESS}"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -274,10 +274,9 @@ metadata:
   labels:
     installer: overrides
     kyma-project.io/installation: ""
-    labels:
-      component: core
+    component: core
 data:
-  test.acceptance.ui.logging.enabled: true
+  test.acceptance.ui.logging.enabled: "true"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -287,10 +286,9 @@ metadata:
   labels:
     installer: overrides
     kyma-project.io/installation: ""
-    labels:
-      component: application-connector
+    component: application-connector
 data:
-  application-registry.deployment.args.detailedErrorResponse: true
+  application-registry.deployment.args.detailedErrorResponse: "true"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/prow/scripts/cluster-integration/kyma-gke-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-integration.sh
@@ -175,9 +175,9 @@ elif [[ "$BUILD_TYPE" == "release" ]]; then
 else
     # Otherwise (master), operate on triggering commit id
     readonly COMMON_NAME_PREFIX="gkeint-commit"
-    readonly COMMIT_ID=$(cd "$KYMA_SOURCES_DIR" && git rev-parse --short HEAD)
+    readonly COMMIT_ID="${PULL_BASE_SHA::8}"
     COMMON_NAME=$(echo "${COMMON_NAME_PREFIX}-${COMMIT_ID}-${RANDOM_NAME_SUFFIX}" | tr "[:upper:]" "[:lower:]")
-    KYMA_SOURCE="master-${COMMIT_ID}"
+    KYMA_SOURCE="${COMMIT_ID}"
     export KYMA_INSTALLER_IMAGE
 fi
 

--- a/prow/scripts/cluster-integration/kyma-gke-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-integration.sh
@@ -201,7 +201,7 @@ ERROR_LOGGING_GUARD="true"
 shout "Authenticate"
 date
 init
-install::kyma_cli
+INSTALL_DIR=$(mktemp -d) install::kyma_cli
 
 DNS_DOMAIN="$(gcloud dns managed-zones describe "${CLOUDSDK_DNS_ZONE_NAME}" --format="value(dnsName)")"
 
@@ -332,7 +332,7 @@ yes | kyma install \
 if [ -n "$(kubectl get  service -n kyma-system apiserver-proxy-ssl --ignore-not-found)" ]; then
     shout "Create DNS Record for Apiserver proxy IP"
     date
-    APISERVER_IP_ADDRESS=$(kubectl get  service -n kyma-system apiserver-proxy-ssl -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    APISERVER_IP_ADDRESS=$(kubectl get service -n kyma-system apiserver-proxy-ssl -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     APISERVER_DNS_FULL_NAME="apiserver.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
     CLEANUP_APISERVER_DNS_RECORD="true"
     IP_ADDRESS=${APISERVER_IP_ADDRESS} DNS_FULL_NAME=${APISERVER_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"

--- a/prow/scripts/kyma-testing.sh
+++ b/prow/scripts/kyma-testing.sh
@@ -113,7 +113,10 @@ function main() {
   echo "----------------------------"
 
   export INSTALL_DIR=${TMP_DIR}
-  install::kyma_cli
+  if ! [[ -x "$(command -v kyma)" ]];
+  then
+    install::kyma_cli
+  fi
 
   cts::check_crd_exist
 

--- a/prow/scripts/lib/kyma-cli.sh
+++ b/prow/scripts/lib/kyma-cli.sh
@@ -11,17 +11,14 @@ install::kyma_cli() {
 
     pushd "${INSTALL_DIR}/bin" || exit
 
-    log::info "- Install kyma CLI ${os} locally to a tempdir..."
+    echo "--> Install kyma CLI ${os} locally to ${INSTALL_DIR}/bin"
 
     curl -sSLo kyma "https://storage.googleapis.com/kyma-cli-stable/kyma-${os}?alt=media"
     chmod +x kyma
     kyma_version=$(kyma version --client)
-    log::info "Kyma CLI version: ${kyma_version}"
-
-    log::success "OK"
-
+    echo "--> Kyma CLI version: ${kyma_version}"
+    echo "OK"
     popd || exit
-
     eval "${settings}"
 }
 
@@ -35,7 +32,7 @@ host::os() {
       host_os=linux
       ;;
     *)
-      log::error "Unsupported host OS. Must be Linux or Mac OS X."
+      echo "Unsupported host OS. Must be Linux or Mac OS X."
       exit 1
       ;;
   esac

--- a/prow/scripts/lib/kyma-cli.sh
+++ b/prow/scripts/lib/kyma-cli.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+install::kyma_cli() {
+    local settings
+    local kyma_version
+    settings="$(set +o); set -$-"
+    set -u
+    mkdir -p "${INSTALL_DIR}/bin"
+    export PATH="${INSTALL_DIR}/bin:${PATH}"
+    os=$(host::os)
+
+    pushd "${INSTALL_DIR}/bin" || exit
+
+    log::info "- Install kyma CLI ${os} locally to a tempdir..."
+
+    curl -sSLo kyma "https://storage.googleapis.com/kyma-cli-stable/kyma-${os}?alt=media"
+    chmod +x kyma
+    kyma_version=$(kyma version --client)
+    log::info "Kyma CLI version: ${kyma_version}"
+
+    log::success "OK"
+
+    popd || exit
+
+    eval "${settings}"
+}
+
+host::os() {
+  local host_os
+  case "$(uname -s)" in
+    Darwin)
+      host_os=darwin
+      ;;
+    Linux)
+      host_os=linux
+      ;;
+    *)
+      log::error "Unsupported host OS. Must be Linux or Mac OS X."
+      exit 1
+      ;;
+  esac
+  echo "${host_os}"
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The kyma-gke-* jobs were using the old method of installing Kyma cluster in their scripts - they were building Kyma-installer image and pushing it to a registry. If there was multiple jobs doing the same thing on a commit it generated the problems where the image was improperly tagged, resulting the job to fail. 

This PR targets the rewrite of installation process of Kyma using Kyma-cli and its flag `-s` which allows to define the source of Kyma - PR, master commit or release version built by separate prowjob.

It additionally targets the deprecation of `library.sh` and sources needed scripts from `prow/scripts/lib/` directory.

Changes proposed in this pull request:

- rewrite kyma-gke-integration.sh to utilise Kyma-cli for installing Kyma on GKE cluster
- remove usage of `library.sh` in favour of sourcing needed scripts from `prow/scripts/lib/` directory
- use log.sh commands in logging prowjob steps
- generate multidocument yaml that is accepted by Kyma-cli `-o` flag with overrides and show a file
- add `kyma-cli.sh` file as a library script that installs Kyma-cli from stable channel (temporary copy from `cluster-integration/` directory)

**Attachments**
https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/logs/post-master-kyma-gke-integration/1316349153428639744
https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/pr-logs/pull/kyma-project_kyma/9400/pre-master-kyma-gke-integration/1316349153432834048

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#2822 