### PR TITLE
Rename SKR CLI to KCP CLI

### DIFF
--- a/prow/scripts/build-kcp-development-artifacts.sh
+++ b/prow/scripts/build-kcp-development-artifacts.sh
@@ -66,7 +66,7 @@ buildTarget="release"
 shout "Build kcp-installer with target ${buildTarget}"
 make -C "${KCP_PATH}/tools/kcp-installer" ${buildTarget}
 
-shout "Build SKR CLI with target ${buildTarget}"
+shout "Build KCP CLI with target ${buildTarget}"
 make -C "${KCP_PATH}/components/kyma-environment-broker" -f Makefile.cli ${buildTarget}
 
 shout "Create development artifacts"
@@ -95,9 +95,9 @@ gsutil cp  "${ARTIFACTS}/is-kyma-installed.sh" "${KCP_DEVELOPMENT_ARTIFACTS_BUCK
 gsutil cp  "${ARTIFACTS}/compass-installer.yaml" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/compass-installer.yaml"
 gsutil cp  "${ARTIFACTS}/is-compass-installed.sh" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/is-compass-installed.sh"
 
-gsutil cp "${ARTIFACTS}/skr.exe" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/skr.exe"
-gsutil cp "${ARTIFACTS}/skr-linux" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/skr-linux"
-gsutil cp "${ARTIFACTS}/skr-darwin" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/skr-darwin"
+gsutil cp "${ARTIFACTS}/kcp.exe" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/kcp.exe"
+gsutil cp "${ARTIFACTS}/kcp-linux" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/kcp-linux"
+gsutil cp "${ARTIFACTS}/kcp-darwin" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/kcp-darwin"
 
 if [[ "${BUILD_TYPE}" == "master" ]]; then
   shout "Copy artifacts to ${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master"
@@ -110,7 +110,7 @@ if [[ "${BUILD_TYPE}" == "master" ]]; then
   gsutil cp "${ARTIFACTS}/compass-installer.yaml" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/compass-installer.yaml"
   gsutil cp  "${ARTIFACTS}/is-compass-installed.sh" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/is-compass-installed.sh"
 
-  gsutil cp "${ARTIFACTS}/skr.exe" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/skr.exe"
-  gsutil cp "${ARTIFACTS}/skr-linux" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/skr-linux"
-  gsutil cp "${ARTIFACTS}/skr-darwin" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/skr-darwin"
+  gsutil cp "${ARTIFACTS}/kcp.exe" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/kcp.exe"
+  gsutil cp "${ARTIFACTS}/kcp-linux" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/kcp-linux"
+  gsutil cp "${ARTIFACTS}/kcp-darwin" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/kcp-darwin"
 fi


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Rename control plane CLI to `kcp`

**Related issue(s)**
https://github.com/kyma-project/control-plane/pull/270