### PR TITLE
Remove `allow-http` annotation from stalebot chart

### DIFF
--- a/prow/cluster/resources/probot-stale/values.yaml
+++ b/prow/cluster/resources/probot-stale/values.yaml
@@ -24,7 +24,6 @@ ingress:
     kubernetes.io/tls-acme: "true"
     certmanager.k8s.io/cluster-issuer: letsencrypt-prod
     certmanager.k8s.io/acme-http01-edit-in-place: "true"
-    kubernetes.io/ingress.allow-http: "false"
   path: /*
   host: stale.build.kyma-project.io
   tls:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
`cert-manager` couldn't refresh SSL certificate for our stalebot deployment. We have been cutting all traffic from HTTP in the ingress configuration so HTTP URL for stalebot was returning 404, instead of 200 thus resulting in broken HTTP challenge.

Changes proposed in this pull request:

- remove `allow-http: false` annotation from ingress deployment in stalebot chart.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
