### PR TITLE
Rewrite kyma-gke-central.sh to use pre-built artifacts and Kyma CLI.

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-central.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-central.sh
@@ -34,7 +34,7 @@ discoverUnsetVar=false
 
 for var in REPO_OWNER REPO_NAME DOCKER_PUSH_REPOSITORY KYMA_PROJECT_DIR CLOUDSDK_CORE_PROJECT CLOUDSDK_COMPUTE_REGION CLOUDSDK_DNS_ZONE_NAME GOOGLE_APPLICATION_CREDENTIALS KYMA_ARTIFACTS_BUCKET GCR_PUSH_GOOGLE_APPLICATION_CREDENTIALS; do
     if [ -z "${!var}" ] ; then
-        echo "ERROR: $var is not set"
+        echo "$var is not set"
         discoverUnsetVar=true
     fi
 done
@@ -46,25 +46,30 @@ fi
 export TEST_INFRA_SOURCES_DIR="${KYMA_PROJECT_DIR}/test-infra"
 export KYMA_SOURCES_DIR="${KYMA_PROJECT_DIR}/kyma"
 export TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS="${TEST_INFRA_SOURCES_DIR}/prow/scripts/cluster-integration/helpers"
-# shellcheck disable=SC1090
-source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/library.sh"
+
+# shellcheck source=prow/scripts/lib/common.sh
+source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/common.sh"
+# shellcheck source=prow/scripts/lib/kyma-cli.sh
+source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/kyma-cli.sh"
+# shellcheck source=prow/scripts/lib/log.sh
+source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/log.sh"
 
 #!Put cleanup code in this function!
 cleanup() {
     #!!! Must be at the beginning of this function !!!
     EXIT_STATUS=$?
 
+    log::banner "CLEANUP"
+
     if [ "${ERROR_LOGGING_GUARD}" = "true" ]; then
-        shout "AN ERROR OCCURED! Take a look at preceding log entries."
-        echo
+        log::error "AN ERROR OCCURED! Take a look at preceding log entries."
     fi
 
     #Turn off exit-on-error so that next step is executed even if previous one fails.
     set +e
 
     if [ -n "${CLEANUP_CLUSTER}" ]; then
-        shout "Deprovision cluster: \"${CLUSTER_NAME}\""
-        date
+        log::info "Deprovision cluster: \"${CLUSTER_NAME}\""
 
         #save disk names while the cluster still exists to remove them later
         DISKS=$(kubectl get pvc --all-namespaces -o jsonpath="{.items[*].spec.volumeName}" | xargs -n1 echo)
@@ -74,40 +79,34 @@ cleanup() {
         "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/deprovision-gke-cluster.sh"
 
         #Delete orphaned disks
-        shout "Delete orphaned PVC disks..."
-        date
+        log::info "Delete orphaned PVC disks..."
         "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/delete-disks.sh"
     fi
 
     if [ -n "${CLEANUP_GATEWAY_DNS_RECORD}" ]; then
-        shout "Delete Gateway DNS Record"
-        date
+        log::info "Delete Gateway DNS Record"
         "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/delete-dns-record.sh --project="${CLOUDSDK_CORE_PROJECT}" --zone="${CLOUDSDK_DNS_ZONE_NAME}" --name="${GATEWAY_DNS_FULL_NAME}" --address="${GATEWAY_IP_ADDRESS}" --dryRun=false
     fi
 
     if [ -n "${CLEANUP_GATEWAY_IP_ADDRESS}" ]; then
-        shout "Release Gateway IP Address"
-        date
+        log::info "Release Gateway IP Address"
         "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/release-ip-address.sh --project="${CLOUDSDK_CORE_PROJECT}" --ipname="${GATEWAY_IP_ADDRESS_NAME}" --region="${CLOUDSDK_COMPUTE_REGION}" --dryRun=false
     fi
 
     if [ -n "${CLEANUP_DOCKER_IMAGE}" ]; then
-        shout "Delete temporary Kyma-Installer Docker image"
-        date
+        log::info "Delete temporary Kyma-Installer Docker image"
         "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/delete-image.sh"
     fi
 
     if [ -n "${CLEANUP_APISERVER_DNS_RECORD}" ]; then
-        shout "Delete Apiserver proxy DNS Record"
-        date
+        log::info "Delete Apiserver proxy DNS Record"
         "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/delete-dns-record.sh --project="${CLOUDSDK_CORE_PROJECT}" --zone="${CLOUDSDK_DNS_ZONE_NAME}" --name="${APISERVER_DNS_FULL_NAME}" --address="${APISERVER_IP_ADDRESS}" --dryRun=false
     fi
 
 
     MSG=""
     if [[ ${EXIT_STATUS} -ne 0 ]]; then MSG="(exit status: ${EXIT_STATUS})"; fi
-    shout "Job is finished ${MSG}"
-    date
+    log::info "Job is finished ${MSG}"
     set -e
 
     exit "${EXIT_STATUS}"
@@ -116,7 +115,7 @@ cleanup() {
 trap cleanup EXIT INT
 
 if [[ "${BUILD_TYPE}" == "pr" ]]; then
-    shout "Execute Job Guard"
+    log::info "Execute Job Guard"
     "${TEST_INFRA_SOURCES_DIR}/development/jobguard/scripts/run.sh"
 fi
 
@@ -132,21 +131,20 @@ if [[ "$BUILD_TYPE" == "pr" ]]; then
     # In case of PR, operate on PR number
     readonly COMMON_NAME_PREFIX="gke-central-pr"
     COMMON_NAME=$(echo "${COMMON_NAME_PREFIX}-${PULL_NUMBER}-${RANDOM_NAME_SUFFIX}" | tr "[:upper:]" "[:lower:]")
-    KYMA_INSTALLER_IMAGE="${DOCKER_PUSH_REPOSITORY}${DOCKER_PUSH_DIRECTORY}/gke-central-connector/${REPO_OWNER}/${REPO_NAME}:PR-${PULL_NUMBER}"
-    export KYMA_INSTALLER_IMAGE
+    KYMA_SOURCE="PR-${PULL_NUMBER}"
 elif [[ "$BUILD_TYPE" == "release" ]]; then
     readonly COMMON_NAME_PREFIX="gke-central-rel"
     readonly SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
     readonly RELEASE_VERSION=$(cat "${SCRIPT_DIR}/../../RELEASE_VERSION")
-    shout "Reading release version from RELEASE_VERSION file, got: ${RELEASE_VERSION}"
+    log::info "Reading release version from RELEASE_VERSION file, got: ${RELEASE_VERSION}"
+    KYMA_SOURCE="${RELEASE_VERSION}"
     COMMON_NAME=$(echo "${COMMON_NAME_PREFIX}-${RANDOM_NAME_SUFFIX}" | tr "[:upper:]" "[:lower:]")
 else
     # Otherwise (master), operate on triggering commit id
     readonly COMMON_NAME_PREFIX="gke-central-commit"
-    readonly COMMIT_ID=$(cd "$KYMA_SOURCES_DIR" && git rev-parse --short HEAD)
+    readonly COMMIT_ID="${PULL_BASE_SHA::8}"
     COMMON_NAME=$(echo "${COMMON_NAME_PREFIX}-${COMMIT_ID}-${RANDOM_NAME_SUFFIX}" | tr "[:upper:]" "[:lower:]")
-    KYMA_INSTALLER_IMAGE="${DOCKER_PUSH_REPOSITORY}${DOCKER_PUSH_DIRECTORY}/gke-central-connector/${REPO_OWNER}/${REPO_NAME}:COMMIT-${COMMIT_ID}"
-    export KYMA_INSTALLER_IMAGE
+    KYMA_SOURCE="${COMMIT_ID}"
 fi
 
 
@@ -162,37 +160,24 @@ export GCLOUD_COMPUTE_ZONE="${CLOUDSDK_COMPUTE_ZONE}"
 
 #Local variables
 DNS_SUBDOMAIN="${COMMON_NAME}"
-KYMA_SCRIPTS_DIR="${KYMA_SOURCES_DIR}/installation/scripts"
-KYMA_RESOURCES_DIR="${KYMA_SOURCES_DIR}/installation/resources"
-
-INSTALLER_YAML="${KYMA_RESOURCES_DIR}/installer.yaml"
-INSTALLER_CR="${KYMA_RESOURCES_DIR}/installer-cr-cluster.yaml.tpl"
 
 #Used to detect errors for logging purposes
 ERROR_LOGGING_GUARD="true"
 
-shout "Authenticate"
-date
-init
+log::info "Authenticate"
+common::init
+INSTALL_DIR=$(mktemp -d) install::kyma_cli
+
 DNS_DOMAIN="$(gcloud dns managed-zones describe "${CLOUDSDK_DNS_ZONE_NAME}" --format="value(dnsName)")"
 
-if [[ "$BUILD_TYPE" != "release" ]]; then
-    shout "Build Kyma-Installer Docker image"
-    date
-    CLEANUP_DOCKER_IMAGE="true"
-    "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-image.sh"
-fi
-
-shout "Reserve IP Address for Ingressgateway"
-date
+log::info "Reserve IP Address for Ingressgateway"
 GATEWAY_IP_ADDRESS_NAME="${COMMON_NAME}"
 GATEWAY_IP_ADDRESS=$(IP_ADDRESS_NAME=${GATEWAY_IP_ADDRESS_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/reserve-ip-address.sh")
 CLEANUP_GATEWAY_IP_ADDRESS="true"
-echo "Created IP Address for Ingressgateway: ${GATEWAY_IP_ADDRESS}"
+log::info "Created IP Address for Ingressgateway: ${GATEWAY_IP_ADDRESS}"
 
 
-shout "Create DNS Record for Ingressgateway IP"
-date
+log::info "Create DNS Record for Ingressgateway IP"
 GATEWAY_DNS_FULL_NAME="*.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
 CLEANUP_GATEWAY_DNS_RECORD="true"
 IP_ADDRESS=${GATEWAY_IP_ADDRESS} DNS_FULL_NAME=${GATEWAY_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
@@ -200,16 +185,14 @@ IP_ADDRESS=${GATEWAY_IP_ADDRESS} DNS_FULL_NAME=${GATEWAY_DNS_FULL_NAME} "${TEST_
 
 NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
 if [ "$NETWORK_EXISTS" -gt 0 ]; then
-    shout "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
-    date
+    log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
     "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-network-with-subnet.sh"
 else
-    shout "Network ${GCLOUD_NETWORK_NAME} exists"
+    log::warn "Network ${GCLOUD_NETWORK_NAME} exists"
 fi
 
 
-shout "Provision cluster: \"${CLUSTER_NAME}\""
-date
+log::info "Provision cluster: \"${CLUSTER_NAME}\""
 export GCLOUD_SERVICE_KEY_PATH="${GOOGLE_APPLICATION_CREDENTIALS}"
 if [ -z "$MACHINE_TYPE" ]; then
       export MACHINE_TYPE="${DEFAULT_MACHINE_TYPE}"
@@ -220,88 +203,104 @@ fi
 CLEANUP_CLUSTER="true"
 "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/provision-gke-cluster.sh"
 
-shout "Generate self-signed certificate"
-date
+log::info "Generate self-signed certificate"
 DOMAIN="${DNS_SUBDOMAIN}.${DNS_DOMAIN%?}"
 export DOMAIN
 CERT_KEY=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/generate-self-signed-cert.sh")
 TLS_CERT=$(echo "${CERT_KEY}" | head -1)
 TLS_KEY=$(echo "${CERT_KEY}" | tail -1)
 
-shout "Apply Kyma config"
-date
+log::info "Create Kyma CLI overrides"
 
-kubectl create namespace "kyma-installer"
-
-"${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "cluster-certificate-overrides" \
-    --data "global.tlsCrt=${TLS_CERT}" \
-    --data "global.tlsKey=${TLS_KEY}"
-
-cat << EOF > "$PWD/kyma_istio_operator"
-apiVersion: install.istio.io/v1alpha1
-kind: IstioOperator
+cat << EOF > "$PWD/kyma-installer-central-override.yaml"
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  namespace: istio-system
-spec:
-  components:
-    ingressGateways:
-      - name: istio-ingressgateway
-        k8s:
-          service:
-            loadBalancerIP: ${GATEWAY_IP_ADDRESS}
-            type: LoadBalancer
+  name: "installation-config-overrides"
+  namespace: "kyma-installer"
+  labels:
+    installer: overrides
+    kyma-project.io/installation: ""
+data:
+  global.domainName: "${DOMAIN}"
+  global.loadBalancerIP: "${GATEWAY_IP_ADDRESS}"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "core-test-ui-acceptance-overrides"
+  namespace: "kyma-installer"
+  labels:
+    installer: overrides
+    kyma-project.io/installation: ""
+    component: core
+data:
+  test.acceptance.ui.logging.enabled: "true"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "istio-overrides"
+  namespace: "kyma-installer"
+  labels:
+    installer: overrides
+    kyma-project.io/installation: ""
+    component: istio
+data:
+  kyma_istio_operator: |
+    apiVersion: install.istio.io/v1alpha1
+    kind: IstioOperator
+    metadata:
+      namespace: istio-system
+    spec:
+      components:
+        ingressGateways:
+          - name: istio-ingressgateway
+            k8s:
+              service:
+                loadBalancerIP: ${GATEWAY_IP_ADDRESS}
+                type: LoadBalancer
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "connector-service-central-overrides"
+  namespace: "kyma-installer"
+  labels:
+    installer: overrides
+    kyma-project.io/installation: ""
+data:
+  tests.application_connector_tests.connector_service.central: "true"
+  connector-service.deployment.args.central: "true"
+  connector-service.tests.central: "true"
+  connection-token-handler.tests.central: "true"
 EOF
 
-"${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map-file.sh" --name "istio-overrides" \
-    --label "component=istio" \
-    --file "$PWD/kyma_istio_operator"
+cat "$PWD/kyma-installer-central-override.yaml"
 
-"${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "installation-config-overrides" \
-    --data "global.domainName=${DOMAIN}" \
-    --data "global.loadBalancerIP=${GATEWAY_IP_ADDRESS}"
+log::info "Installation triggered"
 
-"${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "core-test-ui-acceptance-overrides" \
-    --data "test.acceptance.ui.logging.enabled=true" \
-    --label "component=core"
-
-shout "Apply override for central connector-service"
-"${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "connector-service-central-overrides" \
-    --data "tests.application_connector_tests.connector_service.central=true" \
-    --data "connector-service.deployment.args.central=true" \
-    --data "connector-service.tests.central=true" \
-    --data "connection-token-handler.tests.central=true"
-
-if [[ "$BUILD_TYPE" == "release" ]]; then
-    echo "Use released artifacts"
-    gsutil cp "${KYMA_ARTIFACTS_BUCKET}/${RELEASE_VERSION}/kyma-installer-cluster.yaml" /tmp/kyma-gke-central/downloaded-installer.yaml
-    kubectl apply -f /tmp/kyma-gke-central/downloaded-installer.yaml
-else
-    echo "Manual concatenating yamls"
-    "${KYMA_SCRIPTS_DIR}"/concat-yamls.sh "${INSTALLER_YAML}" "${INSTALLER_CR}" \
-    | sed -e 's;image: eu.gcr.io/kyma-project/.*/installer:.*$;'"image: ${KYMA_INSTALLER_IMAGE};" \
-    | sed -e "s/__VERSION__/0.0.1/g" \
-    | sed -e "s/__.*__//g" \
-    | kubectl apply -f-
-fi
-
-shout "Installation triggered"
-date
-"${KYMA_SCRIPTS_DIR}"/is-installed.sh --timeout 30m
+yes | kyma install \
+  --ci \
+  -s "${KYMA_SOURCE}" \
+  -o "$PWD/kyma-installer-central-override.yaml" \
+  --domain "${DOMAIN}" \
+  --tlsCert="${TLS_CERT}" \
+  --tlsKey="${TLS_KEY}" \
+  --timeout 30m
 
 if [ -n "$(kubectl get  service -n kyma-system apiserver-proxy-ssl --ignore-not-found)" ]; then
-    shout "Create DNS Record for Apiserver proxy IP"
-    date
+    log::info "Create DNS Record for Apiserver proxy IP"
     APISERVER_IP_ADDRESS=$(kubectl get  service -n kyma-system apiserver-proxy-ssl -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     APISERVER_DNS_FULL_NAME="apiserver.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
     CLEANUP_APISERVER_DNS_RECORD="true"
     IP_ADDRESS=${APISERVER_IP_ADDRESS} DNS_FULL_NAME=${APISERVER_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
 fi
 
-shout "Test Kyma"
-date
+log::info "Test Kyma"
 "${TEST_INFRA_SOURCES_DIR}"/prow/scripts/kyma-testing.sh
 
-shout "Success"
+log::success "Success"
 
 #!!! Must be at the end of the script !!!
 ERROR_LOGGING_GUARD="false"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Next part of GKE integration scripts rewrite. This one addresses rewriting the kyma-gke-cental-connector jobs. As kyma-gke-integration jobs it uses Kyma CLI and externally prebuilt artifacts for given PR/master/release to install and test Kyma.

Changes proposed in this pull request:

- Rewrite kyma-gke-central.sh to use pre-built artifacts and Kyma CLI
- remove usage of deprecated `library.sh`
- use internal log.sh library for logging

**Successful runs**
https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/pr-logs/pull/kyma-project_kyma/9400/pre-master-kyma-gke-central-connector/1318880113407823872

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#2822 #2761 