### PR TITLE
Rewrite provision-vm-and-start-kyma.sh to fix fetching JUnit report

### DIFF
--- a/prow/scripts/provision-vm-and-start-kyma.sh
+++ b/prow/scripts/provision-vm-and-start-kyma.sh
@@ -10,108 +10,108 @@ readonly TEST_INFRA_SOURCES_DIR="$(cd "${SCRIPT_DIR}/../../" && pwd)"
 readonly TMP_DIR=$(mktemp -d)
 readonly JUNIT_REPORT_PATH="${ARTIFACTS:-${TMP_DIR}}/junit_kyma_octopus-test-suite.xml"
 
-# shellcheck disable=SC1090
-source "${SCRIPT_DIR}/library.sh"
+# shellcheck source=prow/scripts/lib/gcloud.sh
+source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/gcloud.sh"
+# shellcheck source=prow/scripts/lib/log.sh
+source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/log.sh"
 
 if [[ "${BUILD_TYPE}" == "pr" ]]; then
-    shout "Execute Job Guard"
-    "${TEST_INFRA_SOURCES_DIR}/development/jobguard/scripts/run.sh"
+  log::info "Execute Job Guard"
+  "${TEST_INFRA_SOURCES_DIR}/development/jobguard/scripts/run.sh"
 fi
 
 cleanup() {
-    ARG=$?
-    shout "Removing instance kyma-integration-test-${RANDOM_ID}"
-    gcloud compute instances delete --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}" || true ### Workaround: not failing the job regardless of the vm deletion result
-    exit $ARG
+  log::info "Fetch JUnit test results and store them in job artifacts"
+  gcloud compute scp --quiet --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}:junit_kyma_octopus-test-suite.xml" "${JUNIT_REPORT_PATH}"
+  ARG=$?
+  log::info "Removing instance kyma-integration-test-${RANDOM_ID}"
+  gcloud compute instances delete --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}" || true ### Workaround: not failing the job regardless of the vm deletion result
+  exit $ARG
 }
 
 function testCustomImage() {
-    CUSTOM_IMAGE="$1"
-    IMAGE_EXISTS=$(gcloud compute images list --filter "name:${CUSTOM_IMAGE}" | tail -n +2 | awk '{print $1}')
-    if [[ -z "$IMAGE_EXISTS" ]]; then
-        shout "${CUSTOM_IMAGE} is invalid, it is not available in GCP images list, the script will terminate ..." && exit 1
-    fi
+  CUSTOM_IMAGE="$1"
+  IMAGE_EXISTS=$(gcloud compute images list --filter "name:${CUSTOM_IMAGE}" | tail -n +2 | awk '{print $1}')
+  if [[ -z "$IMAGE_EXISTS" ]]; then
+    log::error "${CUSTOM_IMAGE} is invalid, it is not available in GCP images list, the script will terminate ..." && exit 1
+  fi
 }
 
-authenticate
+gcloud::authenticate
 
 RANDOM_ID=$(openssl rand -hex 4)
 
 LABELS=""
 if [[ -z "${PULL_NUMBER}" ]]; then
-    LABELS=(--labels "branch=$PULL_BASE_REF,job-name=kyma-integration")
+  LABELS=(--labels "branch=$PULL_BASE_REF,job-name=kyma-integration")
 else
-    LABELS=(--labels "pull-number=$PULL_NUMBER,job-name=kyma-integration")
+  LABELS=(--labels "pull-number=$PULL_NUMBER,job-name=kyma-integration")
 fi
 
 POSITIONAL=()
 while [[ $# -gt 0 ]]
 do
+  key="$1"
 
-    key="$1"
-
-    case ${key} in
-        --image)
-            IMAGE="$2"
-            testCustomImage "${IMAGE}"
-            shift
-            shift
-            ;;
-        --*)
-            echo "Unknown flag ${1}"
-            exit 1
-            ;;
-        *)    # unknown option
-            POSITIONAL+=("$1") # save it in an array for later
-            shift # past argument
-            ;;
-    esac
+  case ${key} in
+    --image)
+      IMAGE="$2"
+      testCustomImage "${IMAGE}"
+      shift
+      shift
+      ;;
+    --*)
+      echo "Unknown flag ${1}"
+      exit 1
+      ;;
+    *)    # unknown option
+      POSITIONAL+=("$1") # save it in an array for later
+      shift # past argument
+      ;;
+  esac
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
 
 if [[ -z "$IMAGE" ]]; then
-    shout "Provisioning vm using the latest default custom image ..."   
-    
-    IMAGE=$(gcloud compute images list --sort-by "~creationTimestamp" \
-         --filter "family:custom images AND labels.default:yes" --limit=1 | tail -n +2 | awk '{print $1}')
-    
-    if [[ -z "$IMAGE" ]]; then
-       shout "There are no default custom images, the script will exit ..." && exit 1 
-    fi   
+  log::info "Provisioning vm using the latest default custom image ..."
+
+  IMAGE=$(gcloud compute images list --sort-by "~creationTimestamp" \
+       --filter "family:custom images AND labels.default:yes" --limit=1 | tail -n +2 | awk '{print $1}')
+
+  if [[ -z "$IMAGE" ]]; then
+   log::error "There are no default custom images, the script will exit ..." && exit 1
+  fi
  fi
 
 ZONE_LIMIT=${ZONE_LIMIT:-5}
 EU_ZONES=$(gcloud compute zones list --filter="name~europe" --limit="${ZONE_LIMIT}" | tail -n +2 | awk '{print $1}')
 STARTTIME=$(date +%s)
 for ZONE in ${EU_ZONES}; do
-    shout "Attempting to create a new instance named kyma-integration-test-${RANDOM_ID} in zone ${ZONE} using image ${IMAGE}"
-    gcloud compute instances create "kyma-integration-test-${RANDOM_ID}" \
-        --metadata enable-oslogin=TRUE \
-        --image "${IMAGE}" \
-        --machine-type n1-standard-4 \
-        --zone "${ZONE}" \
-        --boot-disk-size 30 "${LABELS[@]}" &&\
-    shout "Created kyma-integration-test-${RANDOM_ID} in zone ${ZONE}" && break
-    shout "Could not create machine in zone ${ZONE}"
+  log::info "Attempting to create a new instance named kyma-integration-test-${RANDOM_ID} in zone ${ZONE} using image ${IMAGE}"
+  gcloud compute instances create "kyma-integration-test-${RANDOM_ID}" \
+      --metadata enable-oslogin=TRUE \
+      --image "${IMAGE}" \
+      --machine-type n1-standard-4 \
+      --zone "${ZONE}" \
+      --boot-disk-size 30 "${LABELS[@]}" &&\
+  log::info "Created kyma-integration-test-${RANDOM_ID} in zone ${ZONE}" && break
+  log::error "Could not create machine in zone ${ZONE}"
 done || exit 1
 ENDTIME=$(date +%s)
 echo "VM creation time: $((ENDTIME - STARTTIME)) seconds."
 
 trap cleanup exit INT
 
-shout "Copying Kyma to the instance"
+log::info "Copying Kyma to the instance"
 
 for i in $(seq 1 5); do
-    [[ ${i} -gt 1 ]] && echo 'Retrying in 15 seconds..' && sleep 15;
-    gcloud compute scp --quiet --recurse --zone="${ZONE}" /home/prow/go/src/github.com/kyma-project/kyma "kyma-integration-test-${RANDOM_ID}":~/kyma && break;
-    [[ ${i} -ge 5 ]] && echo "Failed after $i attempts." && exit 1
+  [[ ${i} -gt 1 ]] && log::info 'Retrying in 15 seconds..' && sleep 15;
+  gcloud compute scp --quiet --recurse --zone="${ZONE}" /home/prow/go/src/github.com/kyma-project/kyma "kyma-integration-test-${RANDOM_ID}":~/kyma && break;
+  [[ ${i} -ge 5 ]] && log::error "Failed after $i attempts." && exit 1
 done;
 
-shout "Triggering the installation"
+log::info "Triggering the installation"
 gcloud compute ssh --quiet --zone="${ZONE}" --command="sudo bash" --ssh-flag="-o ServerAliveInterval=30" "kyma-integration-test-${RANDOM_ID}" < "${SCRIPT_DIR}/cluster-integration/kyma-integration-minikube.sh"
 
-shout "Fetch JUnit test results and store them in job artifacts"
-gcloud compute scp --quiet --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}:junit_kyma_octopus-test-suite.xml" "${JUNIT_REPORT_PATH}"
-
-shout "all done"
+log::success "all done"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
This PR addresses #2882 by fetching JUnit report in trap function. We make sure the fetching happens everytime the script fails or not. Additionally remove usage of deprecated `library.sh` from the script in favour of scripts from `lib/` directory.
Changes proposed in this pull request:

- move fetching JUnit report to cleanup function
- remove usage of deprecated `library.sh`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes #2882 