### PR TITLE
Add installing image-guard to nightly and weekly cluster

### DIFF
--- a/development/image-guard/image-guard/values.yaml
+++ b/development/image-guard/image-guard/values.yaml
@@ -2,7 +2,7 @@ service:
   port: 443
 
 deployment:
-  image: eu.gcr.io/kyma-prow/test-infra/image-guard:current
+  image: eu.gcr.io/kyma-project/test-infra/image-guard:current
   replicas: 1
   imagePullPolicy: Always
   resources:

--- a/development/image-guard/image-guard/values.yaml
+++ b/development/image-guard/image-guard/values.yaml
@@ -2,7 +2,7 @@ service:
   port: 443
 
 deployment:
-  image: eu.gcr.io/kyma-prow/test-infra/image-guard
+  image: eu.gcr.io/kyma-prow/test-infra/image-guard:current
   replicas: 1
   imagePullPolicy: Always
   resources:

--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -322,6 +322,9 @@ shout "Create new cluster"
 date
 createCluster
 
+log::info "install image-guard"
+helm install image-guard "$TEST_INFRA_SOURCES_DIR/development/image-guard/image-guard"
+
 export INSTALL_DIR=${TMP_DIR}
 install::kyma_cli
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Add helm command to `kyma-gke-long-lasting.sh` script to install image-guard in nightly and weekly clusters.

Changes proposed in this pull request:

- Add installing image-guard to nightly and weekly cluster

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#2599