### PR TITLE
Require branches to be up to date before merging into Compass master

### DIFF
--- a/prow/branchprotector-config.yaml
+++ b/prow/branchprotector-config.yaml
@@ -88,6 +88,8 @@ branch-protection:
           branches:
             master:
               protect: true
+              required_status_checks:
+                strict: true
         marketplaces:
           protect: true
         documentation-component:

--- a/templates/templates/branchprotector-config.yaml
+++ b/templates/templates/branchprotector-config.yaml
@@ -66,6 +66,8 @@ branch-protection:
           branches:
             master:
               protect: true
+              required_status_checks:
+                strict: true
         marketplaces:
           protect: true
         documentation-component:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

We want to require branches to be up to date before merging into master for the Compass repository.
Currently our manual setting gets overridden by Prow constantly so this change tries to fix that by configuring Prow with our desired branch protection.

Reference GitHub API link (Properties of the **required_status_checks** object -> **strict** should be `true` in our case): https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#update-branch-protection 

Changes proposed in this pull request:

- configure `branchprotector-config.yaml` template file
- regenerate actual `prow/branchprotector-config.yaml` file
