### PR TITLE
Add flags to prtagbuilder

### DIFF
--- a/development/tools/cmd/prtagbuilder/main.go
+++ b/development/tools/cmd/prtagbuilder/main.go
@@ -18,20 +18,15 @@ var (
 		Use:   "prtagbuilder [-o, --org string], [-r, --repo string], [-b --baseref string], [-O --numberOnly]",
 		Short: "prtagbuilder will find pull request number for commit or branch head.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Flags().NFlag() == 1 {
-				if !cmd.Flags().Changed("numberOnly") {
-					err := checkFlags(cmd.Flags())
-					if err != nil {
-						logrus.WithError(err).Fatalf("Required flag is empty")
-					}
-				}
-			} else if cmd.Flags().NFlag() > 2 {
+			numFlags := cmd.Flags().NFlag()
+			if numFlags == 1 && !cmd.Flags().Changed("numberOnly") || numFlags > 2 {
 				err := checkFlags(cmd.Flags())
 				if err != nil {
 					logrus.WithError(err).Fatalf("Required flag is empty")
 				}
-				// set prtagbuilder to use data from flags
-				fromFlags = true
+				if numFlags > 2 {
+					fromFlags = true
+				}
 			}
 			prNumber, err := prtagbuilder.BuildPrTag(jobSpec, fromFlags, numberOnly)
 			if err != nil {

--- a/development/tools/cmd/prtagbuilder/main.go
+++ b/development/tools/cmd/prtagbuilder/main.go
@@ -19,10 +19,10 @@ var (
 		Short: "prtagbuilder will find pull request number for commit or branch head.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			numFlags := cmd.Flags().NFlag()
-			if numFlags == 1 && !cmd.Flags().Changed("numberOnly") || numFlags > 2 {
+			if numFlags == 1 && !cmd.Flags().Changed("numberOnly") || numFlags > 1 {
 				err := checkFlags(cmd.Flags())
 				if err != nil {
-					logrus.WithError(err).Fatalf("Required flag is empty")
+					return fmt.Errorf("required flag is empty, got error: %w", err)
 				}
 				if numFlags > 2 {
 					fromFlags = true

--- a/development/tools/cmd/prtagbuilder/main.go
+++ b/development/tools/cmd/prtagbuilder/main.go
@@ -33,9 +33,9 @@ var (
 				// set prtagbuilder to use data from flags
 				fromFlags = true
 			}
-			err, prNumber := prtagbuilder.BuildPrTag(jobSpec, fromFlags, numberOnly)
+			prNumber, err := prtagbuilder.BuildPrTag(jobSpec, fromFlags, numberOnly)
 			if err != nil {
-				return fmt.Errorf("failed build prtag, got error %w:", err)
+				return fmt.Errorf("failed build prtag, got error: %w", err)
 			}
 			fmt.Printf(prNumber)
 			return nil

--- a/development/tools/cmd/prtagbuilder/main.go
+++ b/development/tools/cmd/prtagbuilder/main.go
@@ -1,18 +1,48 @@
 package main
 
 import (
-	"os"
-
+	"fmt"
+	"github.com/jamiealquiza/envy"
 	"github.com/kyma-project/test-infra/development/tools/pkg/prtagbuilder"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/pod-utils/downwardapi"
+	"os"
 )
 
 var (
-	log = logrus.New()
+	log     = logrus.New()
+	rootCmd = &cobra.Command{
+		Use:   "prtagbuilder",
+		Short: "short description",
+		Long:  "long description",
+		Run: func(cmd *cobra.Command, args []string) {
+			prtagbuilder.BuildPrTag(jobSpec, fromFlags)
+		},
+	}
+	jobSpec   *downwardapi.JobSpec
+	fromFlags bool = false
 )
 
 func main() {
 	log.SetOutput(os.Stdout)
 	log.SetLevel(logrus.InfoLevel)
-	prtagbuilder.BuildPrTag()
+	jobSpec = &downwardapi.JobSpec{Refs: &v1.Refs{}}
+	rootCmd.PersistentFlags().StringVarP(&jobSpec.Refs.Org, "org", "o", "", "Github organisation which owns repo.")
+	rootCmd.PersistentFlags().StringVarP(&jobSpec.Refs.Repo, "repo", "r", "", "Github repository.")
+	rootCmd.PersistentFlags().StringVarP(&jobSpec.Refs.BaseRef, "baseref", "b", "", "Base branch name.")
+	rootCmd.MarkPersistentFlagRequired("org")
+	rootCmd.MarkPersistentFlagRequired("repo")
+	rootCmd.MarkPersistentFlagRequired("baseref")
+	envy.ParseCobra(rootCmd, envy.CobraConfig{Prefix: "TAGBUILDER", Persistent: true, Recursive: false})
+	fmt.Println(pflag.NFlag())
+	if pflag.NFlag() > 0 {
+		fromFlags = true
+	}
+	fmt.Printf("%v", jobSpec)
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }

--- a/development/tools/cmd/prtagbuilder/main.go
+++ b/development/tools/cmd/prtagbuilder/main.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/kyma-project/test-infra/development/tools/pkg/prtagbuilder"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"k8s.io/test-infra/prow/apis/prowjobs/v1"
+	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
-	"os"
 )
 
 var (

--- a/development/tools/pkg/prtagbuilder/prtagbuilder.go
+++ b/development/tools/pkg/prtagbuilder/prtagbuilder.go
@@ -13,16 +13,16 @@ import (
 )
 
 // findPRNumber match commit message with regex to extract pull request number. By default github add pr number to the commit message.
-func findPRNumber(commit *github.RepositoryCommit) (error, string) {
+func findPRNumber(commit *github.RepositoryCommit) (string, error) {
 	re := regexp.MustCompile(`(?s)^.*\(#(?P<prNumber>\d*)?\)\s*$`)
 	messageReader := strings.NewReader(commit.Commit.GetMessage())
 	scanner := bufio.NewScanner(messageReader)
 	scanner.Scan()
 	matches := re.FindStringSubmatch(scanner.Text())
 	if len(matches) != 2 {
-		return fmt.Errorf("failed find PR number in first line of commit message: %s, found %d matched strings", scanner.Text(), len(matches)), ""
+		return "", fmt.Errorf("failed find PR number in first line of commit message: %s, found %d matched strings", scanner.Text(), len(matches))
 	}
-	return nil, matches[1]
+	return matches[1], nil
 }
 
 // verifyPR checks if pull request merge commit match provided commit SHA.
@@ -36,7 +36,7 @@ func verifyPR(pr *github.PullRequest, commitSHA string) error {
 }
 
 // BuildPrTag will extract PR number from commit message, search PR, validate if correct PR was found and print pr tag.
-func BuildPrTag(jobSpec *downwardapi.JobSpec, fromFlags bool, numberOnly bool) (error, string) {
+func BuildPrTag(jobSpec *downwardapi.JobSpec, fromFlags bool, numberOnly bool) (string, error) {
 	var (
 		ctx    = context.Background()
 		commit *github.RepositoryCommit
@@ -48,7 +48,7 @@ func BuildPrTag(jobSpec *downwardapi.JobSpec, fromFlags bool, numberOnly bool) (
 		// get commit for a branch
 		branch, _, err := client.Repositories.GetBranch(ctx, jobSpec.Refs.Org, jobSpec.Refs.Repo, jobSpec.Refs.BaseRef)
 		if err != nil {
-			return fmt.Errorf("failed get branch %s, got error: %w", jobSpec.Refs.BaseRef, err), ""
+			return "", fmt.Errorf("failed get branch %s, got error: %w", jobSpec.Refs.BaseRef, err)
 		}
 		commit = branch.GetCommit()
 		jobSpec.Refs.BaseSHA = *commit.SHA
@@ -57,36 +57,35 @@ func BuildPrTag(jobSpec *downwardapi.JobSpec, fromFlags bool, numberOnly bool) (
 		// get git base reference from postsubmit environment variables
 		jobSpec, err = downwardapi.ResolveSpecFromEnv()
 		if err != nil {
-			return fmt.Errorf("failed to read JOB_SPEC env, got error: %w", err), ""
+			return "", fmt.Errorf("failed to read JOB_SPEC env, got error: %w", err)
 		}
 		// get commit details for base sha
 		commit, _, err = client.Repositories.GetCommit(ctx, jobSpec.Refs.Org, jobSpec.Refs.Repo, jobSpec.Refs.BaseSHA)
 		if err != nil {
-			return fmt.Errorf("failed get commit %s, got error: %w", jobSpec.Refs.BaseSHA, err), ""
+			return "", fmt.Errorf("failed get commit %s, got error: %w", jobSpec.Refs.BaseSHA, err)
 		}
 	}
 	// extract pull request number from commit message
-	err, prNumberAsString := findPRNumber(commit)
+	prNumberAsString, err := findPRNumber(commit)
 	if err != nil {
-		return fmt.Errorf("failed get PR number, got error: %w", err), ""
+		return "", fmt.Errorf("failed get PR number, got error: %w", err)
 	}
 	prNumber, err := strconv.Atoi(prNumberAsString)
 	if err != nil {
-		return fmt.Errorf("failed convert PR number to integer, got error: %w", err), ""
+		return "", fmt.Errorf("failed convert PR number to integer, got error: %w", err)
 	}
 	// get pull request details for extracted pr
 	pr, _, err := client.PullRequests.Get(ctx, jobSpec.Refs.Org, jobSpec.Refs.Repo, prNumber)
 	if err != nil {
-		return fmt.Errorf("failed get Pull Request number %d, got error: %w", prNumber, err), ""
+		return "", fmt.Errorf("failed get Pull Request number %d, got error: %w", prNumber, err)
 	}
 	// check if correct pr was found
 	if err := verifyPR(pr, jobSpec.Refs.BaseSHA); err != nil {
-		return fmt.Errorf("pr verification failed, got error: %w", err), ""
+		return "", fmt.Errorf("pr verification failed, got error: %w", err)
 	}
 	if numberOnly {
-		return nil, fmt.Sprintf("%d", prNumber)
-	} else {
-		// print PR image tag
-		return nil, fmt.Sprintf("PR-%d", prNumber)
+		return fmt.Sprintf("%d", prNumber), nil
 	}
+	// print PR image tag
+	return fmt.Sprintf("PR-%d", prNumber), nil
 }

--- a/development/tools/pkg/prtagbuilder/prtagbuilder.go
+++ b/development/tools/pkg/prtagbuilder/prtagbuilder.go
@@ -17,7 +17,6 @@ var (
 	client *github.Client
 	ctx    = context.Background()
 	commit *github.RepositoryCommit
-	err    error
 )
 
 // findPRNumber match commit message with regex to extract pull request number. By default github add pr number to the commit message.
@@ -56,6 +55,7 @@ func BuildPrTag(jobSpec *downwardapi.JobSpec, fromFlags bool, numberOnly bool) {
 		commit = branch.GetCommit()
 		jobSpec.Refs.BaseSHA = *commit.SHA
 	} else {
+		var err error
 		// get git base reference from postsubmit environment variables
 		jobSpec, err = downwardapi.ResolveSpecFromEnv()
 		if err != nil {


### PR DESCRIPTION
Added support for finding PR number for branch HEAD provided as cli flags.
With flag -O prtagbuilder print pr number only.
