### PR TITLE
Adjust jobs as part of moving compass console to separate repo

### DIFF
--- a/development/tools/go.mod
+++ b/development/tools/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/tidwall/gjson v1.6.0
 	github.com/vrischmann/envconfig v1.2.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
-	golang.org/x/tools v0.0.0-20200930213115-e57f6d466a48 // indirect
+	golang.org/x/tools v0.0.0-20201105001634-bc3cf281b174 // indirect
 	google.golang.org/api v0.22.0
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.17.3

--- a/development/tools/go.mod
+++ b/development/tools/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/tidwall/gjson v1.6.0
 	github.com/vrischmann/envconfig v1.2.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
-	golang.org/x/tools v0.0.0-20201105001634-bc3cf281b174 // indirect
+	golang.org/x/tools v0.0.0-20200930213115-e57f6d466a48 // indirect
 	google.golang.org/api v0.22.0
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.17.3

--- a/development/tools/go.sum
+++ b/development/tools/go.sum
@@ -867,6 +867,8 @@ golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3ob
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -884,6 +886,8 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -930,12 +934,16 @@ golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f h1:gWF768j/LaZugp8dyS4UwsslYCYz9XgFxvlgsn0n9H8=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -998,6 +1006,8 @@ golang.org/x/tools v0.0.0-20200913032122-97363e29fc9b h1:3/5GThpuWHBq2GFcurHBWuW
 golang.org/x/tools v0.0.0-20200913032122-97363e29fc9b/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
 golang.org/x/tools v0.0.0-20200930213115-e57f6d466a48 h1:/N7U6gDrclaaWCzrdxtKeyEcUx2goazt5PelznylQNM=
 golang.org/x/tools v0.0.0-20200930213115-e57f6d466a48/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
+golang.org/x/tools v0.0.0-20201105001634-bc3cf281b174 h1:0rx0F4EjJNbxTuzWe0KjKcIzs+3VEb/Mrs/d1ciNz1c=
+golang.org/x/tools v0.0.0-20201105001634-bc3cf281b174/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/development/tools/go.sum
+++ b/development/tools/go.sum
@@ -867,8 +867,6 @@ golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3ob
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
-golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -886,8 +884,6 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
-golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -934,16 +930,12 @@ golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f h1:gWF768j/LaZugp8dyS4UwsslYCYz9XgFxvlgsn0n9H8=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
-golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
-golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -1006,8 +998,6 @@ golang.org/x/tools v0.0.0-20200913032122-97363e29fc9b h1:3/5GThpuWHBq2GFcurHBWuW
 golang.org/x/tools v0.0.0-20200913032122-97363e29fc9b/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
 golang.org/x/tools v0.0.0-20200930213115-e57f6d466a48 h1:/N7U6gDrclaaWCzrdxtKeyEcUx2goazt5PelznylQNM=
 golang.org/x/tools v0.0.0-20200930213115-e57f6d466a48/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
-golang.org/x/tools v0.0.0-20201105001634-bc3cf281b174 h1:0rx0F4EjJNbxTuzWe0KjKcIzs+3VEb/Mrs/d1ciNz1c=
-golang.org/x/tools v0.0.0-20201105001634-bc3cf281b174/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/development/tools/jobs/control-plane/components_test.go
+++ b/development/tools/jobs/control-plane/components_test.go
@@ -105,5 +105,5 @@ func TestComponentJobs(t *testing.T) {
 			ts.Run(t)
 		})
 	}
-	t.Run("All Files covered by test", jobsuite.CheckFilesAreTested(repos, testedConfigurations, jobBasePath, "components"))
+	t.Run("All Files covered by test", jobsuite.CheckFilesAreTested(repos, testedConfigurations, jobBasePath, []string{"components"}))
 }

--- a/development/tools/jobs/control-plane/tests_test.go
+++ b/development/tools/jobs/control-plane/tests_test.go
@@ -59,5 +59,5 @@ func TestTestJobs(t *testing.T) {
 			ts.Run(t)
 		})
 	}
-	t.Run("All Files covered by test", jobsuite.CheckFilesAreTested(repos, testedConfigurations, jobBasePath, "tests"))
+	t.Run("All Files covered by test", jobsuite.CheckFilesAreTested(repos, testedConfigurations, jobBasePath, []string{"tests"}))
 }

--- a/development/tools/jobs/incubator/compass-console/compass_console_test.go
+++ b/development/tools/jobs/incubator/compass-console/compass_console_test.go
@@ -17,7 +17,7 @@ func TestCompassConsoleJobsPresubmit(t *testing.T) {
 
 	// then
 	require.NoError(t, err)
-	actualPresubmit := tester.FindPresubmitJobByNameAndBranch(jobConfig.AllStaticPresubmits([]string{"kyma-incubator/compass-console"}), "pre-compass-console-compass", "master")
+	actualPresubmit := tester.FindPresubmitJobByNameAndBranch(jobConfig.AllStaticPresubmits([]string{"kyma-incubator/compass-console"}), "pre-compass-console-compass", "main")
 	require.NotNil(t, actualPresubmit)
 
 	assert.Equal(t, 10, actualPresubmit.MaxConcurrency)
@@ -37,7 +37,7 @@ func TestCompassConsoleJobPostsubmit(t *testing.T) {
 	// then
 	require.NoError(t, err)
 
-	actualPostsubmit := tester.FindPostsubmitJobByNameAndBranch(jobConfig.AllStaticPostsubmits([]string{"kyma-incubator/compass-console"}), "post-compass-console-compass", "master")
+	actualPostsubmit := tester.FindPostsubmitJobByNameAndBranch(jobConfig.AllStaticPostsubmits([]string{"kyma-incubator/compass-console"}), "post-compass-console-compass", "main")
 	require.NotNil(t, actualPostsubmit)
 
 	assert.Equal(t, 10, actualPostsubmit.MaxConcurrency)

--- a/development/tools/jobs/incubator/compass-console/compass_console_test.go
+++ b/development/tools/jobs/incubator/compass-console/compass_console_test.go
@@ -1,0 +1,50 @@
+package compassconsole
+
+import (
+	"testing"
+
+	"github.com/kyma-project/test-infra/development/tools/jobs/tester"
+	"github.com/kyma-project/test-infra/development/tools/jobs/tester/preset"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const compassConsoleJobPath = "./../../../../../prow/jobs/incubator/compass-console/compass/compass-ui.yaml"
+
+func TestCompassConsoleJobsPresubmit(t *testing.T) {
+	// when
+	jobConfig, err := tester.ReadJobConfig(compassConsoleJobPath)
+
+	// then
+	require.NoError(t, err)
+	actualPresubmit := tester.FindPresubmitJobByNameAndBranch(jobConfig.AllStaticPresubmits([]string{"kyma-incubator/compass-console"}), "pre-compass-console-compass", "master")
+	require.NotNil(t, actualPresubmit)
+
+	assert.Equal(t, 10, actualPresubmit.MaxConcurrency)
+	assert.False(t, actualPresubmit.SkipReport)
+	assert.True(t, actualPresubmit.Decorate)
+	assert.Equal(t, "github.com/kyma-incubator/compass-console", actualPresubmit.PathAlias)
+	tester.AssertThatHasPresets(t, actualPresubmit.JobBase, preset.DindEnabled, preset.DockerPushRepoIncubator, preset.GcrPush)
+	assert.Equal(t, tester.ImageBootstrap20201009, actualPresubmit.Spec.Containers[0].Image)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-generic.sh"}, actualPresubmit.Spec.Containers[0].Command)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/compass-console/compass"}, actualPresubmit.Spec.Containers[0].Args)
+}
+
+func TestCompassConsoleJobPostsubmit(t *testing.T) {
+	// when
+	jobConfig, err := tester.ReadJobConfig(compassConsoleJobPath)
+
+	// then
+	require.NoError(t, err)
+
+	actualPostsubmit := tester.FindPostsubmitJobByNameAndBranch(jobConfig.AllStaticPostsubmits([]string{"kyma-incubator/compass-console"}), "post-compass-console-compass", "master")
+	require.NotNil(t, actualPostsubmit)
+
+	assert.Equal(t, 10, actualPostsubmit.MaxConcurrency)
+	assert.True(t, actualPostsubmit.Decorate)
+	assert.Equal(t, "github.com/kyma-incubator/compass-console", actualPostsubmit.PathAlias)
+	tester.AssertThatHasPresets(t, actualPostsubmit.JobBase, preset.DindEnabled, preset.DockerPushRepoIncubator, preset.GcrPush)
+	assert.Equal(t, tester.ImageBootstrap20201009, actualPostsubmit.Spec.Containers[0].Image)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-generic.sh"}, actualPostsubmit.Spec.Containers[0].Command)
+	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/compass-console/compass"}, actualPostsubmit.Spec.Containers[0].Args)
+}

--- a/development/tools/jobs/incubator/components_test.go
+++ b/development/tools/jobs/incubator/components_test.go
@@ -149,5 +149,5 @@ func TestComponentJobs(t *testing.T) {
 			ts.Run(t)
 		})
 	}
-	t.Run("All Files covered by test", jobsuite.CheckFilesAreTested(repos, testedConfigurations, jobBasePath, "components", "compass"))
+	t.Run("All Files covered by test", jobsuite.CheckFilesAreTested(repos, testedConfigurations, jobBasePath, []string{"components", "compass"}))
 }

--- a/development/tools/jobs/incubator/components_test.go
+++ b/development/tools/jobs/incubator/components_test.go
@@ -111,15 +111,15 @@ var components = []struct {
 		},
 	},
 	{
-		name:  "compass",
+		name:  "compass-console",
 		image: tester.ImageBootstrapTestInfraLatest,
 		suite: tester.NewGenericComponentSuite,
 		additionalOptions: []jobsuite.Option{
 			func(suite *jobsuite.Config) {
-				suite.Path = "compass/components/console/compass"
+				suite.Path = "compass-console/compass"
 			},
 			jobsuite.JobFileSuffix("ui"),
-			jobsuite.CompassRepo(),
+			jobsuite.CompassConsoleRepo(),
 			jobsuite.Since(releases.Release116),
 		},
 	},
@@ -149,5 +149,5 @@ func TestComponentJobs(t *testing.T) {
 			ts.Run(t)
 		})
 	}
-	t.Run("All Files covered by test", jobsuite.CheckFilesAreTested(repos, testedConfigurations, jobBasePath, "components"))
+	t.Run("All Files covered by test", jobsuite.CheckFilesAreTested(repos, testedConfigurations, jobBasePath, "components", "compass"))
 }

--- a/development/tools/jobs/incubator/tests_test.go
+++ b/development/tools/jobs/incubator/tests_test.go
@@ -69,5 +69,5 @@ func TestTestJobs(t *testing.T) {
 			ts.Run(t)
 		})
 	}
-	t.Run("All Files covered by test", jobsuite.CheckFilesAreTested(repos, testedConfigurations, jobBasePath, "tests"))
+	t.Run("All Files covered by test", jobsuite.CheckFilesAreTested(repos, testedConfigurations, jobBasePath, []string{"tests"}))
 }

--- a/development/tools/jobs/kyma/components_test.go
+++ b/development/tools/jobs/kyma/components_test.go
@@ -197,5 +197,5 @@ func TestComponentJobs(t *testing.T) {
 			ts.Run(t)
 		})
 	}
-	t.Run("All Files covered by test", jobsuite.CheckFilesAreTested(repos, testedConfigurations, jobBasePath, "components"))
+	t.Run("All Files covered by test", jobsuite.CheckFilesAreTested(repos, testedConfigurations, jobBasePath, []string{"components"}))
 }

--- a/development/tools/jobs/kyma/tests_test.go
+++ b/development/tools/jobs/kyma/tests_test.go
@@ -154,5 +154,5 @@ func TestTestJobs(t *testing.T) {
 			ts.Run(t)
 		})
 	}
-	t.Run("All Files covered by test", jobsuite.CheckFilesAreTested(repos, testedConfigurations, jobBasePath, "tests"))
+	t.Run("All Files covered by test", jobsuite.CheckFilesAreTested(repos, testedConfigurations, jobBasePath, []string{"tests"}))
 }

--- a/development/tools/jobs/tester/jobsuite/options.go
+++ b/development/tools/jobs/tester/jobsuite/options.go
@@ -83,6 +83,15 @@ func CompassRepo() Option {
 	}
 }
 
+// CompassConsoleRepo function returns Option type
+func CompassConsoleRepo() Option {
+	return func(suite *Config) {
+		suite.Repository = "github.com/kyma-incubator/compass-console"
+		suite.DockerRepositoryPreset = preset.DockerPushRepoIncubator
+		suite.BuildPresetMaster = preset.BuildMaster
+	}
+}
+
 // ControlPlaneRepo function returns Option type
 func ControlPlaneRepo() Option {
 	return func(suite *Config) {

--- a/development/tools/jobs/tester/jobsuite/suite.go
+++ b/development/tools/jobs/tester/jobsuite/suite.go
@@ -19,33 +19,40 @@ type JobConfigPathProvider interface {
 }
 
 // CheckFilesAreTested function
-func CheckFilesAreTested(repos map[string]struct{}, testedConfigurations map[string]struct{}, jobBasePath, subfolder string) func(t *testing.T) {
+func CheckFilesAreTested(repos map[string]struct{}, testedConfigurations map[string]struct{}, jobBasePath string, subfolders ...string) func(t *testing.T) {
 	return func(t *testing.T) {
 		for repo := range repos {
-			folderToCheck := path.Join(jobBasePath, path.Base(repo), subfolder)
-			err := filepath.Walk(folderToCheck,
-				func(fp string, info os.FileInfo, err error) error {
-					if err != nil {
-						return err
-					}
-					if info.IsDir() {
-						return nil
-					}
-					if path.Ext(fp) != ".yaml" {
-						return nil
-					}
+			var err error
+			found := false
+			for _, subfolder := range subfolders {
+				folderToCheck := path.Join(jobBasePath, path.Base(repo), subfolder)
+				err := filepath.Walk(folderToCheck,
+					func(fp string, info os.FileInfo, err error) error {
+						if err != nil {
+							return err
+						}
+						if info.IsDir() {
+							return nil
+						}
+						if path.Ext(fp) != ".yaml" {
+							return nil
+						}
 
-					if !strings.Contains(path.Base(fp), "generic") {
+						if !strings.Contains(path.Base(fp), "generic") {
+							return nil
+						}
+
+						if _, tested := testedConfigurations[fp]; !tested {
+							t.Errorf("File %v was not covered by test", fp)
+						}
 						return nil
-					}
 
-					if _, tested := testedConfigurations[fp]; !tested {
-						t.Errorf("File %v was not covered by test", fp)
-					}
-					return nil
-
-				})
-			if err != nil {
+					})
+				if err == nil {
+					found = true
+				}
+			}
+			if !found {
 				t.Errorf("%v", err)
 			}
 		}

--- a/development/tools/jobs/tester/jobsuite/suite.go
+++ b/development/tools/jobs/tester/jobsuite/suite.go
@@ -19,7 +19,7 @@ type JobConfigPathProvider interface {
 }
 
 // CheckFilesAreTested function
-func CheckFilesAreTested(repos map[string]struct{}, testedConfigurations map[string]struct{}, jobBasePath string, subfolders ...string) func(t *testing.T) {
+func CheckFilesAreTested(repos map[string]struct{}, testedConfigurations map[string]struct{}, jobBasePath string, subfolders []string) func(t *testing.T) {
 	return func(t *testing.T) {
 		for repo := range repos {
 			var err error

--- a/development/tools/jobs/tester/tester.go
+++ b/development/tools/jobs/tester/tester.go
@@ -49,6 +49,8 @@ const (
 	ImageBootstrap20181204 = "eu.gcr.io/kyma-project/prow/test-infra/bootstrap:v20181204-a6e79be"
 	// ImageBootstrap20190604 represents boostrap image published on 2019.06.04
 	ImageBootstrap20190604 = "eu.gcr.io/kyma-project/test-infra/bootstrap:v20190604-d08e7fe"
+	// ImageBootstrap20201009 represents boostrap image published on 2019.06.04
+	ImageBootstrap20201009 = "eu.gcr.io/kyma-project/test-infra/bootstrap:v20201009-ec3cc352"
 	// ImageBootstrap001 represents version 0.0.1 of bootstrap image
 	ImageBootstrap001 = "eu.gcr.io/kyma-project/prow/bootstrap:0.0.1"
 	// ImageKymaIntegrationK14 represents kyma integration image with kubectl 1.14

--- a/development/tools/jobs/tester/tester.go
+++ b/development/tools/jobs/tester/tester.go
@@ -49,7 +49,7 @@ const (
 	ImageBootstrap20181204 = "eu.gcr.io/kyma-project/prow/test-infra/bootstrap:v20181204-a6e79be"
 	// ImageBootstrap20190604 represents boostrap image published on 2019.06.04
 	ImageBootstrap20190604 = "eu.gcr.io/kyma-project/test-infra/bootstrap:v20190604-d08e7fe"
-	// ImageBootstrap20201009 represents boostrap image published on 2019.06.04
+	// ImageBootstrap20201009 represents boostrap image published on 2020.10.09
 	ImageBootstrap20201009 = "eu.gcr.io/kyma-project/test-infra/bootstrap:v20201009-ec3cc352"
 	// ImageBootstrap001 represents version 0.0.1 of bootstrap image
 	ImageBootstrap001 = "eu.gcr.io/kyma-project/prow/bootstrap:0.0.1"

--- a/prow/jobs/console/add-ons/add-ons.yaml
+++ b/prow/jobs/console/add-ons/add-ons.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-add-ons$
   run_if_changed: "^add-ons/|^components/|^shared/|^package.json"
   spec:

--- a/prow/jobs/console/content/content.yaml
+++ b/prow/jobs/console/content/content.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-content$
   run_if_changed: "^content/|^components/|^package.json"
   spec:

--- a/prow/jobs/console/core-ui/core-ui.yaml
+++ b/prow/jobs/console/core-ui/core-ui.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-core-ui$
   run_if_changed: "^core-ui/|^components/|^shared/|^package.json"
   spec:

--- a/prow/jobs/console/core/core.yaml
+++ b/prow/jobs/console/core/core.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-core$
   run_if_changed: "^core/|^package.json"
   spec:

--- a/prow/jobs/console/logging/console-logging.yaml
+++ b/prow/jobs/console/logging/console-logging.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-logging$
   run_if_changed: "^logging/|^components/|^shared/|^package.json"
   spec:

--- a/prow/jobs/console/service-catalog-ui/service-catalog-ui.yaml
+++ b/prow/jobs/console/service-catalog-ui/service-catalog-ui.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-service-catalog-ui$
   run_if_changed: "^service-catalog-ui/|^components/|^shared/|^package.json"
   spec:

--- a/prow/jobs/console/tests/tests.yaml
+++ b/prow/jobs/console/tests/tests.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-tests$
   run_if_changed: "^tests/|^components/|^shared/|^package.json"
   spec:

--- a/prow/jobs/control-plane/components/kubeconfig-service/kubeconfig-service-generic.yaml
+++ b/prow/jobs/control-plane/components/kubeconfig-service/kubeconfig-service-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-kubeconfig-service$
   run_if_changed: "^components/kubeconfig-service/|^scripts/"
   spec:

--- a/prow/jobs/control-plane/components/kyma-environment-broker/kyma-environment-broker-generic.yaml
+++ b/prow/jobs/control-plane/components/kyma-environment-broker/kyma-environment-broker-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-kyma-environment-broker$
   run_if_changed: "^components/kyma-environment-broker/|^scripts/"
   spec:

--- a/prow/jobs/control-plane/components/metris/metris-generic.yaml
+++ b/prow/jobs/control-plane/components/metris/metris-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-metris$
   run_if_changed: "^components/metris/|^scripts/"
   spec:

--- a/prow/jobs/control-plane/components/provisioner/provisioner-generic.yaml
+++ b/prow/jobs/control-plane/components/provisioner/provisioner-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-provisioner$
   run_if_changed: "^components/provisioner/|^scripts/"
   spec:

--- a/prow/jobs/control-plane/components/schema-migrator/schema-migrator-kcp-generic.yaml
+++ b/prow/jobs/control-plane/components/schema-migrator/schema-migrator-kcp-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-schema-migrator$
   run_if_changed: "^components/schema-migrator/|^scripts/"
   spec:

--- a/prow/jobs/control-plane/components/subscription-cleanup-job/subscription-cleanup-job-generic.yaml
+++ b/prow/jobs/control-plane/components/subscription-cleanup-job/subscription-cleanup-job-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
   run_if_changed: "^components/subscription-cleanup-job/|^scripts/"
   spec:
     containers:

--- a/prow/jobs/control-plane/tests/e2e/provisioning/provisioning-test-generic.yaml
+++ b/prow/jobs/control-plane/tests/e2e/provisioning/provisioning-test-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-provisioning$
   run_if_changed: "^tests/e2e/provisioning/|^scripts/"
   spec:

--- a/prow/jobs/control-plane/tests/provisioner-tests/provisioner-tests-generic.yaml
+++ b/prow/jobs/control-plane/tests/provisioner-tests/provisioner-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-provisioner-tests$
   run_if_changed: "^tests/provisioner-tests/|^scripts/"
   spec:

--- a/prow/jobs/incubator/compass-console/compass/compass-ui.yaml
+++ b/prow/jobs/incubator/compass-console/compass/compass-ui.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16)-compass$
   run_if_changed: "^compass/|^components/|^shared/|^package.json"
   spec:

--- a/prow/jobs/incubator/compass-console/compass/compass-ui.yaml
+++ b/prow/jobs/incubator/compass-console/compass/compass-ui.yaml
@@ -8,7 +8,7 @@ test_infra_ref: &test_infra_ref
 
 job_template: &job_template
   decorate: true
-  path_alias: github.com/kyma-incubator/compass
+  path_alias: github.com/kyma-incubator/compass-console
   max_concurrency: 10
   labels:
     preset-dind-enabled: "true"
@@ -20,7 +20,7 @@ job_template: &job_template
   branches:
     - ^master$
     - ^release-(1\.16)-compass$
-  run_if_changed: "^components/console/compass/|^scripts/"
+  run_if_changed: "^compass/|^components/|^shared/|^package.json"
   spec:
     containers:
       - image: eu.gcr.io/kyma-project/test-infra/bootstrap:v20201009-ec3cc352
@@ -29,22 +29,22 @@ job_template: &job_template
         command:
           - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-generic.sh"
         args:
-          - "/home/prow/go/src/github.com/kyma-incubator/compass/components/console/compass"
+          - "/home/prow/go/src/github.com/kyma-incubator/compass-console/compass"
         resources:
           requests:
             memory: 1.5Gi
             cpu: 0.8
 
 presubmits: # runs on PRs
-  kyma-incubator/compass:
-    - name: pre-compass-components-console-compass
+  kyma-incubator/compass-console:
+    - name: pre-compass-console-compass
       cluster: untrusted-workload
       optional: false
       <<: *job_template
 
 postsubmits:
-  kyma-incubator/compass:
-    - name: post-compass-components-console-compass
+  kyma-incubator/compass-console:
+    - name: post-compass-console-compass
       cluster: trusted-workload
       annotations:
         testgrid-create-test-group: "false"

--- a/prow/jobs/incubator/compass/components/connectivity-adapter/connectivity-adapter-generic.yaml
+++ b/prow/jobs/incubator/compass/components/connectivity-adapter/connectivity-adapter-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-connectivity-adapter$
   run_if_changed: "^components/connectivity-adapter/|^scripts/"
   spec:

--- a/prow/jobs/incubator/compass/components/connector/connector-generic.yaml
+++ b/prow/jobs/incubator/compass/components/connector/connector-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-connector$
   run_if_changed: "^components/connector/|^scripts/"
   spec:

--- a/prow/jobs/incubator/compass/components/director/director-generic.yaml
+++ b/prow/jobs/incubator/compass/components/director/director-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-director$
   run_if_changed: "^components/director/|^scripts/"
   spec:

--- a/prow/jobs/incubator/compass/components/external-services-mock/external-services-mock-generic.yaml
+++ b/prow/jobs/incubator/compass/components/external-services-mock/external-services-mock-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-external-services-mock$
   run_if_changed: "^components/external-services-mock/|^scripts/"
   spec:

--- a/prow/jobs/incubator/compass/components/gateway/gateway-generic.yaml
+++ b/prow/jobs/incubator/compass/components/gateway/gateway-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-gateway$
   run_if_changed: "^components/gateway/|^scripts/"
   spec:

--- a/prow/jobs/incubator/compass/components/healthchecker/healthchecker-generic.yaml
+++ b/prow/jobs/incubator/compass/components/healthchecker/healthchecker-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-healthchecker$
   run_if_changed: "^components/healthchecker/|^scripts/"
   spec:

--- a/prow/jobs/incubator/compass/components/pairing-adapter/pairing-adapter-generic.yaml
+++ b/prow/jobs/incubator/compass/components/pairing-adapter/pairing-adapter-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-pairing-adapter$
   run_if_changed: "^components/pairing-adapter/|^scripts/"
   spec:

--- a/prow/jobs/incubator/compass/components/schema-migrator/schema-migrator-generic.yaml
+++ b/prow/jobs/incubator/compass/components/schema-migrator/schema-migrator-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-schema-migrator$
   run_if_changed: "^components/schema-migrator/|^scripts/"
   spec:

--- a/prow/jobs/incubator/compass/components/system-broker/system-broker-generic.yaml
+++ b/prow/jobs/incubator/compass/components/system-broker/system-broker-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16)-system-broker$
   run_if_changed: "^components/system-broker/"
   spec:

--- a/prow/jobs/incubator/compass/tests/connectivity-adapter/connectivity-adapter-tests-generic.yaml
+++ b/prow/jobs/incubator/compass/tests/connectivity-adapter/connectivity-adapter-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-connectivity-adapter$
   run_if_changed: "^tests/connectivity-adapter/|^scripts/"
   spec:

--- a/prow/jobs/incubator/compass/tests/connector-tests/connector-tests-generic.yaml
+++ b/prow/jobs/incubator/compass/tests/connector-tests/connector-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-connector-tests$
   run_if_changed: "^tests/connector-tests/|^scripts/"
   spec:

--- a/prow/jobs/incubator/compass/tests/director/director-generic-approach.yaml
+++ b/prow/jobs/incubator/compass/tests/director/director-generic-approach.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-director$
   run_if_changed: "^tests/director/|^scripts/"
   spec:

--- a/prow/jobs/kyma/components/apiserver-proxy/apiserver-proxy-generic.yaml
+++ b/prow/jobs/kyma/components/apiserver-proxy/apiserver-proxy-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-apiserver-proxy$
   run_if_changed: "^components/apiserver-proxy/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/application-broker/application-broker-generic.yaml
+++ b/prow/jobs/kyma/components/application-broker/application-broker-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-application-broker$
   run_if_changed: "^components/application-broker/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/application-connectivity-certs-setup-job/application-connectivity-certs-setup-job-generic.yaml
+++ b/prow/jobs/kyma/components/application-connectivity-certs-setup-job/application-connectivity-certs-setup-job-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-application-connectivity-certs-setup-job$
   run_if_changed: "^components/application-connectivity-certs-setup-job/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/application-connectivity-validator/application-connectivity-validator-generic.yaml
+++ b/prow/jobs/kyma/components/application-connectivity-validator/application-connectivity-validator-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-application-connectivity-validator$
   run_if_changed: "^components/application-connectivity-validator/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/application-gateway/application-gateway-generic.yaml
+++ b/prow/jobs/kyma/components/application-gateway/application-gateway-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-application-gateway$
   run_if_changed: "^components/application-gateway/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/application-operator/application-operator-generic.yaml
+++ b/prow/jobs/kyma/components/application-operator/application-operator-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-application-operator$
   run_if_changed: "^components/application-operator/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/application-registry/application-registry-generic.yaml
+++ b/prow/jobs/kyma/components/application-registry/application-registry-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-application-registry$
   run_if_changed: "^components/application-registry/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/compass-runtime-agent/compass-runtime-agent-generic.yaml
+++ b/prow/jobs/kyma/components/compass-runtime-agent/compass-runtime-agent-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-compass-runtime-agent$
   run_if_changed: "^components/compass-runtime-agent/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/connection-token-handler/connection-token-handler-generic.yaml
+++ b/prow/jobs/kyma/components/connection-token-handler/connection-token-handler-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-connection-token-handler$
   run_if_changed: "^components/connection-token-handler/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/connector-service/connector-service-generic.yaml
+++ b/prow/jobs/kyma/components/connector-service/connector-service-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-connector-service$
   run_if_changed: "^components/connector-service/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/console-backend-service/console-backend-service-generic.yaml
+++ b/prow/jobs/kyma/components/console-backend-service/console-backend-service-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-console-backend-service$
   run_if_changed: "^components/console-backend-service/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/dex-static-user-configurer/dex-static-user-configurer-generic.yaml
+++ b/prow/jobs/kyma/components/dex-static-user-configurer/dex-static-user-configurer-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-dex-static-user-configurer$
   run_if_changed: "^components/dex-static-user-configurer/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/event-publisher-proxy/event-publisher-proxy-generic.yaml
+++ b/prow/jobs/kyma/components/event-publisher-proxy/event-publisher-proxy-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
   run_if_changed: "^components/event-publisher-proxy/|^common/makefiles/"
   spec:
     containers:

--- a/prow/jobs/kyma/components/event-service/event-service-generic.yaml
+++ b/prow/jobs/kyma/components/event-service/event-service-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-event-service$
   run_if_changed: "^components/event-service/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/event-sources/event-sources-generic.yaml
+++ b/prow/jobs/kyma/components/event-sources/event-sources-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-event-sources$
   run_if_changed: "^components/event-sources/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/eventing-controller/eventing-controller-generic.yaml
+++ b/prow/jobs/kyma/components/eventing-controller/eventing-controller-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
   run_if_changed: "^components/eventing-controller/|^common/makefiles/"
   spec:
     containers:

--- a/prow/jobs/kyma/components/function-controller/function-controller-generic.yaml
+++ b/prow/jobs/kyma/components/function-controller/function-controller-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-function-controller$
   run_if_changed: "^components/function-controller/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/function-runtimes/function-runtimes-generic.yaml
+++ b/prow/jobs/kyma/components/function-runtimes/function-runtimes-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-function-runtimes$
   run_if_changed: "^components/function-runtimes/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/iam-kubeconfig-service/iam-kubeconfig-service-generic.yaml
+++ b/prow/jobs/kyma/components/iam-kubeconfig-service/iam-kubeconfig-service-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-iam-kubeconfig-service$
   run_if_changed: "^components/iam-kubeconfig-service/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/istio-installer/istio-installer-generic.yaml
+++ b/prow/jobs/kyma/components/istio-installer/istio-installer-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-istio-installer$
   run_if_changed: "^components/istio-installer/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/istio-kyma-patch/istio-kyma-patch-generic.yaml
+++ b/prow/jobs/kyma/components/istio-kyma-patch/istio-kyma-patch-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-istio-kyma-patch$
   run_if_changed: "^components/istio-kyma-patch/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/kyma-operator/kyma-operator-generic.yaml
+++ b/prow/jobs/kyma/components/kyma-operator/kyma-operator-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-kyma-operator$
   run_if_changed: "^components/kyma-operator/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/nats-init/nats-init-generic.yaml
+++ b/prow/jobs/kyma/components/nats-init/nats-init-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-nats-init$
   run_if_changed: "^components/nats-init/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/permission-controller/permission-controller-generic.yaml
+++ b/prow/jobs/kyma/components/permission-controller/permission-controller-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-permission-controller$
   run_if_changed: "^components/permission-controller/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/service-binding-usage-controller/service-binding-usage-controller-generic.yaml
+++ b/prow/jobs/kyma/components/service-binding-usage-controller/service-binding-usage-controller-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-service-binding-usage-controller$
   run_if_changed: "^components/service-binding-usage-controller/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/uaa-activator/uaa-activator-generic.yaml
+++ b/prow/jobs/kyma/components/uaa-activator/uaa-activator-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-uaa-activator$
   run_if_changed: "^components/uaa-activator/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/components/xip-patch/xip-patch-generic.yaml
+++ b/prow/jobs/kyma/components/xip-patch/xip-patch-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-xip-patch$
   run_if_changed: "^components/xip-patch/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tests/application-connector-tests/application-connector-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/application-connector-tests/application-connector-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-application-connector-tests$
   run_if_changed: "^tests/application-connector-tests/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tests/application-gateway-legacy-tests/application-gateway-legacy-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/application-gateway-legacy-tests/application-gateway-legacy-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16)-application-gateway-legacy-tests$
   run_if_changed: "^tests/application-gateway-legacy-tests/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tests/application-gateway-tests/application-gateway-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/application-gateway-tests/application-gateway-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-application-gateway-tests$
   run_if_changed: "^tests/application-gateway-tests/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tests/application-operator-tests/application-operator-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/application-operator-tests/application-operator-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-application-operator-tests$
   run_if_changed: "^tests/application-operator-tests/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tests/application-registry-tests/application-registry-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/application-registry-tests/application-registry-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-application-registry-tests$
   run_if_changed: "^tests/application-registry-tests/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tests/compass-runtime-agent/compass-runtime-agent-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/compass-runtime-agent/compass-runtime-agent-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-compass-runtime-agent$
   run_if_changed: "^tests/compass-runtime-agent/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tests/connection-token-handler-tests/connection-token-handler-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/connection-token-handler-tests/connection-token-handler-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-connection-token-handler-tests$
   run_if_changed: "^tests/connection-token-handler-tests/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tests/connector-service-tests/connector-service-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/connector-service-tests/connector-service-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-connector-service-tests$
   run_if_changed: "^tests/connector-service-tests/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tests/console-backend-service/console-backend-service-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/console-backend-service/console-backend-service-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-console-backend-service$
   run_if_changed: "^tests/console-backend-service/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tests/contract/knative-channel-kafka/knative-channel-kafka-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/contract/knative-channel-kafka/knative-channel-kafka-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-knative-channel-kafka$
   run_if_changed: "^tests/contract/knative-channel-kafka/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tests/end-to-end/external-solution-integration/external-solution-integration-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/end-to-end/external-solution-integration/external-solution-integration-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-external-solution-integration$
   run_if_changed: "^tests/end-to-end/external-solution-integration/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tests/end-to-end/upgrade/upgrade-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/end-to-end/upgrade/upgrade-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-upgrade$
   run_if_changed: "^tests/end-to-end/upgrade/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tests/function-controller/function-controller-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/function-controller/function-controller-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-function-controller$
   run_if_changed: "^tests/function-controller/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tests/integration/api-gateway/api-gateway-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/integration/api-gateway/api-gateway-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-api-gateway$
   run_if_changed: "^tests/integration/api-gateway/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tests/integration/apiserver-proxy/apiserver-proxy-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/integration/apiserver-proxy/apiserver-proxy-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-apiserver-proxy$
   run_if_changed: "^tests/integration/apiserver-proxy/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tests/integration/dex/dex-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/integration/dex/dex-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-dex$
   run_if_changed: "^tests/integration/dex/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tests/integration/event-service/event-service-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/integration/event-service/event-service-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-event-service$
   run_if_changed: "^tests/integration/event-service/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tests/integration/logging/logging-generic.yaml
+++ b/prow/jobs/kyma/tests/integration/logging/logging-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-logging$
   run_if_changed: "^tests/integration/logging/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tests/integration/monitoring/monitoring-generic.yaml
+++ b/prow/jobs/kyma/tests/integration/monitoring/monitoring-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-monitoring$
   run_if_changed: "^tests/integration/monitoring/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tests/rafter/rafter-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/rafter/rafter-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-.*-rafter$
   run_if_changed: "^tests/rafter/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tests/service-catalog/service-catalog-tests-generic.yaml
+++ b/prow/jobs/kyma/tests/service-catalog/service-catalog-tests-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-service-catalog$
   run_if_changed: "^tests/service-catalog/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tools/event-subscriber/event-subscriber-generic.yaml
+++ b/prow/jobs/kyma/tools/event-subscriber/event-subscriber-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15|1\.14)-event-subscriber$
   run_if_changed: "^tools/event-subscriber/|^common/makefiles/"
   spec:

--- a/prow/jobs/kyma/tools/gitserver/gitserver-generic.yaml
+++ b/prow/jobs/kyma/tools/gitserver/gitserver-generic.yaml
@@ -19,6 +19,7 @@ job_template: &job_template
       base_ref: master
   branches:
     - ^master$
+    - ^main$
     - ^release-(1\.16|1\.15)-gitserver$
   run_if_changed: "^tools/gitserver/|^common/makefiles/"
   spec:

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -155,6 +155,16 @@ compass_generic_component: &compass_generic_component
   additionalRunIfChanged:
     - ^scripts/
 
+compass_console_generic_component: &compass_console_generic_component
+  repository: github.com/kyma-incubator/compass-console
+  pushRepository: incubator
+  build: build
+  bootstrapTag: v20201009-ec3cc352
+  additionalRunIfChanged:
+    - ^components/
+    - ^shared/
+    - ^package.json
+
 control_plane_generic_component: &control_plane_generic_component
   repository: github.com/kyma-project/control-plane
   build: build
@@ -372,11 +382,11 @@ templates:
           since: "1.16"
           optional: true
           additionalRunIfChanged: # necessary so that it overrides the additionalRunIfChanged property from compass_generic_component and thus does not include the /scripts folder
-      - to: ../prow/jobs/incubator/compass/components/console/compass/compass-ui.yaml
+      - to: ../prow/jobs/incubator/compass-console/compass/compass-ui.yaml
         values:
           <<: *cluster_default
-          <<: *compass_generic_component
-          path: components/console/compass
+          <<: *compass_console_generic_component
+          path: compass
           since: "1.16"
       - to: ../prow/jobs/incubator/compass/components/external-services-mock/external-services-mock-generic.yaml
         values:

--- a/templates/templates/generic-component.yaml
+++ b/templates/templates/generic-component.yaml
@@ -49,6 +49,7 @@ job_template: &job_template
   branches:
 {{- if $isValidForNextRelease }}
     - ^master$
+    - ^main$
 {{- end }}
 {{- if ne $releaseBranchPattern "" }}
     - {{ $releaseBranchPattern }}


### PR DESCRIPTION
Compass console is moved out of the compass repository to a separate `compass-console` repo. This should be reflected in the prow jobs also.

Since `compass-console` is a new repo there is no `master` branch. Term `main` is used now. This change also add main branch to the generic job template.