### PR TITLE
Introduce k3s pipeline for serverless integration jobs

### DIFF
--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -40,7 +40,7 @@ vm_job_template: &vm_job_template
             memory: 100Mi
             cpu: 50m
 
-vm_job_template_k3s: &vm_job_template_k3s
+vm_job_template_serverless_k3s: &vm_job_template_serverless_k3s
   decorate: true
   path_alias: github.com/kyma-project/kyma
   max_concurrency: 10
@@ -296,7 +296,7 @@ presubmits: # runs on PRs
       cluster: untrusted-workload
       branches:
       - ^master$
-      <<: *vm_job_template_k3s
+      <<: *vm_job_template_serverless_k3s
       # following regexp won't start build if only Markdown files were changed
       run_if_changed: "^((resources/serverless\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -298,7 +298,7 @@ presubmits: # runs on PRs
       - ^master$
       <<: *vm_job_template_k3s
       # following regexp won't start build if only Markdown files were changed
-      run_if_changed: "^((resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
+      run_if_changed: "^((resources/serverless\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         preset-build-pr: "true"
         <<: *vm_job_labels_template

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -40,6 +40,20 @@ vm_job_template: &vm_job_template
             memory: 100Mi
             cpu: 50m
 
+vm_job_template_k3s: &vm_job_template_k3s
+  decorate: true
+  path_alias: github.com/kyma-project/kyma
+  max_concurrency: 10
+  spec:
+    containers:
+    - <<: *base_image_k16
+      command:
+      - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-and-start-serverless-k3s.sh"
+      resources:
+        requests:
+          memory: 100Mi
+          cpu: 50m
+
 vm_job_labels_template: &vm_job_labels_template
   preset-kyma-guard-bot-github-token: "true"
   preset-sa-vm-kyma-integration: "true"
@@ -278,6 +292,19 @@ presubmits: # runs on PRs
       extra_refs:
         - <<: *test_infra_ref
           base_ref: master
+    - name: pre-master-serverless-integration-k3s
+      cluster: untrusted-workload
+      branches:
+      - ^master$
+      <<: *vm_job_template_k3s
+      # following regexp won't start build if only Markdown files were changed
+      run_if_changed: "^((resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
+      labels:
+        preset-build-pr: "true"
+        <<: *vm_job_labels_template
+      extra_refs:
+      - <<: *test_infra_ref
+        base_ref: master
     - name: pre-rel117-kyma-integration
       cluster: untrusted-workload
       branches:

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -88,7 +88,7 @@ docker run -d \
 install::prereq(){
     curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
     apt-get -y install jq
-    wget https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -O /usr/bin/yq &&\
+    wget -q https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -O /usr/bin/yq &&\
     chmod +x /usr/bin/yq
 }
 

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -177,7 +177,7 @@ kubectl logs -l k3s-test=serverless
 echo "#############################################"
 echo "kubectl logs -n kyma-system -l app=serverless"
 kubectl logs -n kyma-system -l app=serverless
-echo "####"
+echo "###############"
 echo ""
 
 echo "Exit code ${job_status}"

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -166,11 +166,11 @@ getjobstatus
 echo "###################"
 echo "kubectl get jobs -A"
 echo "###################"
-kubectl get jobs
+kubectl get jobs -A
 echo "####################"
 echo "kubectl get pods -A"
 echo "###################"
-kubectl get pods 
+kubectl get pods -A
 echo "###################"
 echo "kubectl logs -l k3s-test=serverless"
 kubectl logs -l k3s-test=serverless 

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -135,7 +135,7 @@ echo "##########################################################################
 
 # I know it's bad practice and kinda smelly to do this, but we have two nasty dataraces that might happen, and simple sleep solves them both:
 # webhook might not be ready in time (but somehow it still accepts the function, we have an issue for that)
-# runtime configmaps might now have been copied to that namespace
+# runtime configmaps might now have been copied to that namespace, but it should be handled by https://github.com/kyma-project/kyma/pull/10026
 ########
 sleep 10
 ########

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -196,7 +196,6 @@ spec:
               value: "5m"
             - name: APP_TEST_VERBOSE
               value: "false"
-
 EOF
 
 job_status=""

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -8,7 +8,7 @@ date
 export KANIKO_IMAGE="eu.gcr.io/kyma-project/external/aerfio/kaniko-executor:v1.3.0"
 export DOMAIN=${KYMA_DOMAIN:-local.kyma.dev}
 if [[ -z $REGISTRY_VALUES ]]; then
-  export REGISTRY_VALUES="dockerRegistry.enableInternal=false,dockerRegistry.serverAddress=registry.localhost:5000,dockerRegistry.registryAddress=registry.localhost:5000,docker-registry.destinationRule.enabled=false,containers.manager.envs.functionBuildExecutorImage.value=${KANIKO_IMAGE}"
+  export REGISTRY_VALUES="dockerRegistry.enableInternal=false,dockerRegistry.serverAddress=registry.localhost:5000,dockerRegistry.registryAddress=registry.localhost:5000,docker-registry.destinationRule.enabled=false,containers.manager.envs.functionBuildExecutorImage.value=${KANIKO_IMAGE},images.manager.repository=aerfio/function-controller,images.manager.tag=latest"
 fi
 
 export KYMA_SOURCES_DIR="./kyma"

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -196,6 +196,8 @@ spec:
               value: "5m"
             - name: APP_TEST_VERBOSE
               value: "false"
+            - name: APP_TEST_CLEANUP
+              value: "no"  
 EOF
 
 job_status=""

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -146,7 +146,10 @@ sleep 10
 SERVERLESS_CHART_DIR="${KYMA_SOURCES_DIR}/resources/serverless"
 job_name="k3s-serverless-test"
 
-helm install serverless-test "${SERVERLESS_CHART_DIR}/charts/k3s-tests" -n default -f "${SERVERLESS_CHART_DIR}/values.yaml" --set jobName="${job_name}"
+helm install serverless-test "${SERVERLESS_CHART_DIR}/charts/k3s-tests" -n default -f "${SERVERLESS_CHART_DIR}/values.yaml" --set jobName="${job_name}" --wait
+
+kubectl get jobs
+kubectl get pods 
 
 job_status=""
 

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -171,12 +171,12 @@ echo "####################"
 echo "kubectl get pods -A"
 echo "###################"
 kubectl get pods -A
-echo "###################"
-echo "kubectl logs -l job-name=${job_name} --tail=-1"
-kubectl logs -l job-name=${job_name} --tail=-1
-echo "#############################################"
+echo "########################################################"
 echo "kubectl logs -n kyma-system -l app=serverless --tail=-1"
 kubectl logs -n kyma-system -l app=serverless --tail=-1
+echo "##############################################"
+echo "kubectl logs -l job-name=${job_name} --tail=-1"
+kubectl logs -l job-name=${job_name} --tail=-1
 echo "###############"
 echo ""
 

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -88,8 +88,6 @@ docker run -d \
 install::prereq(){
     curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
     apt-get -y install jq
-    wget -q https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -O /usr/bin/yq &&\
-    chmod +x /usr/bin/yq
 }
 
 install::k3s() {

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -8,7 +8,7 @@ date
 export KANIKO_IMAGE="eu.gcr.io/kyma-project/external/aerfio/kaniko-executor:v1.3.0"
 export DOMAIN=${KYMA_DOMAIN:-local.kyma.dev}
 if [[ -z $REGISTRY_VALUES ]]; then
-  export REGISTRY_VALUES="dockerRegistry.enableInternal=false,dockerRegistry.serverAddress=registry.localhost:5000,dockerRegistry.registryAddress=registry.localhost:5000,containers.manager.envs.functionBuildExecutorImage.value=${KANIKO_IMAGE}"
+  export REGISTRY_VALUES="dockerRegistry.enableInternal=false,dockerRegistry.serverAddress=registry.localhost:5000,dockerRegistry.registryAddress=registry.localhost:5000,docker-registry.destinationRule.enabled=false,containers.manager.envs.functionBuildExecutorImage.value=${KANIKO_IMAGE}"
 fi
 
 export KYMA_SOURCES_DIR="./kyma"

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -9,7 +9,7 @@ date
 export KANIKO_IMAGE="eu.gcr.io/kyma-project/external/aerfio/kaniko-executor:v1.3.0"
 export DOMAIN=${KYMA_DOMAIN:-local.kyma.dev}
 if [[ -z $REGISTRY_VALUES ]]; then
-  export REGISTRY_VALUES="dockerRegistry.enableInternal=false,dockerRegistry.serverAddress=registry.localhost:5000,dockerRegistry.registryAddress=registry.localhost:5000,containers.manager.envs.functionBuildExecutorImage.value=${KANIKO_IMAGE}"
+  export REGISTRY_VALUES="dockerRegistry.enableInternal=false,dockerRegistry.serverAddress=registry.localhost:5000,dockerRegistry.registryAddress=registry.localhost:5000,containers.manager.envs.functionBuildExecutorImage.value=${KANIKO_IMAGE},images.manager.repository=aerfio/function-controller,images.manager.tag=ratelimited"
 fi
 
 export KYMA_SOURCES_DIR="./kyma"

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -173,7 +173,7 @@ echo "###################"
 kubectl get pods -A
 echo "###################"
 echo "kubectl logs -l k3s-test=serverless"
-kubectl logs -l k3s-test=serverless 
+kubectl logs -l job-name=k3s-serverless-test --since=1h
 echo "#############################################"
 echo "kubectl logs -n kyma-system -l app=serverless"
 kubectl logs -n kyma-system -l app=serverless

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -5,9 +5,10 @@ set -o pipefail  # Fail a pipe if any sub-command fails.
 
 date
 
+export KANIKO_IMAGE="eu.gcr.io/kyma-project/external/aerfio/kaniko-executor:v1.3.0"
 export DOMAIN=${KYMA_DOMAIN:-local.kyma.dev}
 if [[ -z $REGISTRY_VALUES ]]; then
-  export REGISTRY_VALUES="dockerRegistry.enableInternal=false,dockerRegistry.serverAddress=registry.localhost:5000,dockerRegistry.registryAddress=registry.localhost:5000,containers.manager.envs.functionBuildExecutorImage.value=aerfio/kaniko:latest"
+  export REGISTRY_VALUES="dockerRegistry.enableInternal=false,dockerRegistry.serverAddress=registry.localhost:5000,dockerRegistry.registryAddress=registry.localhost:5000,containers.manager.envs.functionBuildExecutorImage.value=${KANIKO_IMAGE}"
 fi
 
 export KYMA_SOURCES_DIR="./kyma"

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -150,7 +150,7 @@ kubectl get -f "$KYMA_SOURCES_DIR/components/function-controller/config/samples/
 # TEST_IMG_TAG=$(yq r "${KYMA_SOURCES_DIR}/resources/serverless/values.yaml" "tests.image.tag")
 
 TEST_IMG_REPO="eu.gcr.io/kyma-project/function-controller-test"
-TEST_IMG_TAG="PR-9991"
+TEST_IMG_TAG="PR-10055"
 
 echo "${TEST_IMG_REPO}:${TEST_IMG_TAG}"
 

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -172,11 +172,11 @@ echo "kubectl get pods -A"
 echo "###################"
 kubectl get pods -A
 echo "###################"
-echo "kubectl logs -l k3s-test=serverless"
-kubectl logs -l job-name=k3s-serverless-test --since=1h
+echo "kubectl logs -l job-name=${job_name} --tail=-1"
+kubectl logs -l job-name=${job_name} --tail=-1
 echo "#############################################"
-echo "kubectl logs -n kyma-system -l app=serverless"
-kubectl logs -n kyma-system -l app=serverless
+echo "kubectl logs -n kyma-system -l app=serverless --tail=-1"
+kubectl logs -n kyma-system -l app=serverless --tail=-1
 echo "###############"
 echo ""
 

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -9,7 +9,7 @@ date
 export KANIKO_IMAGE="eu.gcr.io/kyma-project/external/aerfio/kaniko-executor:v1.3.0"
 export DOMAIN=${KYMA_DOMAIN:-local.kyma.dev}
 if [[ -z $REGISTRY_VALUES ]]; then
-  export REGISTRY_VALUES="dockerRegistry.enableInternal=false,dockerRegistry.serverAddress=registry.localhost:5000,dockerRegistry.registryAddress=registry.localhost:5000,containers.manager.envs.functionBuildExecutorImage.value=${KANIKO_IMAGE},images.manager.repository=aerfio/function-controller,images.manager.tag=ratelimited"
+  export REGISTRY_VALUES="dockerRegistry.enableInternal=false,dockerRegistry.serverAddress=registry.localhost:5000,dockerRegistry.registryAddress=registry.localhost:5000,containers.manager.envs.functionBuildExecutorImage.value=${KANIKO_IMAGE}"
 fi
 
 export KYMA_SOURCES_DIR="./kyma"
@@ -139,8 +139,10 @@ kubectl wait --for=condition=Running function/demo --timeout 180s
 echo "success!"
 kubectl get -f "$KYMA_SOURCES_DIR/components/function-controller/config/samples/serverless_v1alpha1_function.yaml" -oyaml
 
-yq r "${KYMA_SOURCES_DIR}/resources/serverless/values.yaml" "tests.image"
+TEST_IMG_REPO=$(yq r "${KYMA_SOURCES_DIR}/resources/serverless/values.yaml" "tests.image.repository")
+TEST_IMG_TAG=$(yq r "${KYMA_SOURCES_DIR}/resources/serverless/values.yaml" "tests.image.tag")
 
+echo "${TEST_IMG_REPO}:${TEST_IMG_TAG}"
 # cat << EOF | kubectl apply -f -
 # apiVersion: batch/v1
 # kind: Job

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -133,6 +133,13 @@ echo "##########################################################################
 echo "# Serverless installed in $(( $SECONDS/60 )) min $(( $SECONDS % 60 )) sec"
 echo "##############################################################################"
 
+# I know it's bad practice and kinda smelly to do this, but we have two nasty dataraces that might happen, and simple sleep solves them both:
+# webhook might not be ready in time (but somehow it still accepts the function, we have an issue for that)
+# runtime configmaps might now have been copied to that namespace
+########
+sleep 10
+########
+
 kubectl apply -f "$KYMA_SOURCES_DIR/components/function-controller/config/samples/serverless_v1alpha1_function.yaml"
 echo "wait 180s for function to be ready"
 kubectl wait --for=condition=Running function/demo --timeout 180s

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -58,9 +58,8 @@ EOL
 }
 
 host::update_etc_hosts(){
-  # needed for 
+  # needed for external docker registry
   echo "${REGISTRY_IP} registry.localhost" >> /etc/hosts
-  cat /etc/hosts
 }
 
 host::create_docker_registry(){
@@ -124,7 +123,7 @@ while [[ $(kubectl get nodes -o 'jsonpath={..status.conditions[?(@.type=="Ready"
 host::patch_coredns
 
 kubectl apply -f "$KYMA_SOURCES_DIR/resources/cluster-essentials/files" -n kyma-system
-helm upgrade --atomic -create-namespace -i serverless "$KYMA_SOURCES_DIR/resources/serverless" -n kyma-system --set "$REGISTRY_VALUES",global.ingress.domainName="$DOMAIN" --wait
+helm upgrade --atomic --create-namespace -i serverless "$KYMA_SOURCES_DIR/resources/serverless" -n kyma-system --set "$REGISTRY_VALUES",global.ingress.domainName="$DOMAIN" --wait
 
 echo "##############################################################################"
 # shellcheck disable=SC2004

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -146,20 +146,12 @@ sleep 10
 SERVERLESS_CHART_DIR="${KYMA_SOURCES_DIR}/resources/serverless"
 job_name="k3s-serverless-test"
 
-helm install serverless-test "${SERVERLESS_CHART_DIR}/charts/k3s-tests" -n default -f "${SERVERLESS_CHART_DIR}/values.yaml" --set jobName="${job_name}" --wait
 
-echo "###################"
-echo "kubectl get jobs -A"
-echo "###################"
-kubectl get jobs
-echo "####################"
-echo "kubectl get pods -A"
-echo "###################"
-kubectl get pods 
-
+helm install serverless-test "${SERVERLESS_CHART_DIR}/charts/k3s-tests" -n default -f "${SERVERLESS_CHART_DIR}/values.yaml" --set jobName="${job_name}"
 
 job_status=""
 
+# helm does not wait for jobs to complete even with --wait
 getjobstatus(){
 while true; do
     echo "Test job not completed yet..."
@@ -170,7 +162,24 @@ done
 }
 
 getjobstatus
-# TODO: add proper logs here
+
+echo "###################"
+echo "kubectl get jobs -A"
+echo "###################"
+kubectl get jobs
+echo "####################"
+echo "kubectl get pods -A"
+echo "###################"
+kubectl get pods 
+echo "###################"
+echo "kubectl logs -l k3s-test=serverless"
+kubectl logs -l k3s-test=serverless 
+echo "#############################################"
+echo "kubectl logs -n kyma-system -l app=serverless"
+kubectl logs -n kyma-system -l app=serverless
+echo "####"
+echo ""
+
 echo "Exit code ${job_status}"
 
 exit $job_status

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -141,14 +141,10 @@ echo "##########################################################################
 echo "# Serverless installed in $(( $SECONDS/60 )) min $(( $SECONDS % 60 )) sec"
 echo "##############################################################################"
 
-sleep 10 # controller sometimes cant get runtime configmap :V
-
 kubectl apply -f "$KYMA_SOURCES_DIR/components/function-controller/config/samples/serverless_v1alpha1_function.yaml"
 echo "wait 180s for function to be ready"
 kubectl wait --for=condition=Running function/demo --timeout 180s
 echo "success!"
 kubectl get -f "$KYMA_SOURCES_DIR/components/function-controller/config/samples/serverless_v1alpha1_function.yaml" -oyaml
-
-date
 
 exit 0

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -140,9 +140,6 @@ echo "##########################################################################
 sleep 10
 ########
 
-# TEST_IMG_REPO=$(yq r "${KYMA_SOURCES_DIR}/resources/serverless/values.yaml" "tests.image.repository")
-# TEST_IMG_TAG=$(yq r "${KYMA_SOURCES_DIR}/resources/serverless/values.yaml" "tests.image.tag")
-
 SERVERLESS_CHART_DIR="${KYMA_SOURCES_DIR}/resources/serverless"
 job_name="k3s-serverless-test"
 
@@ -163,14 +160,14 @@ done
 
 getjobstatus
 
-echo "###################"
-echo "kubectl get jobs -A"
-echo "###################"
-kubectl get jobs -A
 echo "####################"
 echo "kubectl get pods -A"
 echo "###################"
 kubectl get pods -A
+echo "########################"
+echo "kubectl get functions -A"
+echo "########################"
+kubectl get functions -A
 echo "########################################################"
 echo "kubectl logs -n kyma-system -l app=serverless --tail=-1"
 kubectl logs -n kyma-system -l app=serverless --tail=-1

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -148,8 +148,15 @@ job_name="k3s-serverless-test"
 
 helm install serverless-test "${SERVERLESS_CHART_DIR}/charts/k3s-tests" -n default -f "${SERVERLESS_CHART_DIR}/values.yaml" --set jobName="${job_name}" --wait
 
+echo "###################"
+echo "kubectl get jobs -A"
+echo "###################"
 kubectl get jobs
+echo "####################"
+echo "kubectl get pods -A"
+echo "###################"
 kubectl get pods 
+
 
 job_status=""
 

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail  # Fail a pipe if any sub-command fails.
+
+date
+
+export DOMAIN=${KYMA_DOMAIN:-local.kyma.dev}
+if [[ -z $REGISTRY_VALUES ]]; then
+  export REGISTRY_VALUES="dockerRegistry.enableInternal=false,dockerRegistry.serverAddress=registry.localhost:5000,dockerRegistry.registryAddress=registry.localhost:5000,containers.manager.envs.functionBuildExecutorImage.value=aerfio/kaniko:latest"
+fi
+
+export KYMA_SOURCES_DIR="./kyma"
+
+host::create_registries_file(){
+cat > registries.yaml <<EOL
+mirrors:
+  registry.localhost:5000:
+    endpoint:
+    - http://registry.localhost:5000
+  configs: {}
+  auths: {}
+  
+EOL
+}
+
+host::create_coredns_template(){
+cat > coredns-patch.tpl <<EOL
+data:
+  Corefile: |
+    registry.localhost:53 {
+        hosts {
+            REGISTRY_IP registry.localhost
+        }
+    }
+    .:53 {
+        errors
+        health
+        ready
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+          pods insecure
+          upstream
+          fallthrough in-addr.arpa ip6.arpa
+        }
+        hosts /etc/coredns/NodeHosts {
+          reload 1s
+          fallthrough
+        }
+        prometheus :9153
+        forward . /etc/resolv.conf
+        cache 30
+        loop
+        reload
+        loadbalance
+    }
+EOL
+}
+
+host::update_etc_hosts(){
+  # needed for 
+  echo "${REGISTRY_IP} registry.localhost" >> /etc/hosts
+  cat /etc/hosts
+}
+
+host::create_docker_registry(){
+cat > registries.yaml <<EOL
+mirrors:
+  registry.localhost:5000:
+    endpoint:
+    - http://registry.localhost:5000
+  configs: {}
+  auths: {}
+  
+EOL
+
+mkdir -p /etc/rancher/k3s
+cp registries.yaml /etc/rancher/k3s
+
+docker run -d \
+  -p 5000:5000 \
+  --restart=always \
+  --name registry.localhost \
+  -v "$PWD/registry:/var/lib/registry" \
+  registry:2
+}
+
+install::prereq(){
+    curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+    apt-get -y install jq
+}
+
+install::k3s() {
+    echo "--> Installing k3s"
+    curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE=777 INSTALL_K3S_EXEC="server --disable traefik" sh -
+    mkdir -p ~/.kube
+    cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+    chmod 600 ~/.kube/config
+    k3s --version
+    date
+}
+
+function host::patch_coredns() {
+  echo "Patching CoreDns with REGISTRY_IP=$REGISTRY_IP"
+  sed "s/REGISTRY_IP/$REGISTRY_IP/" coredns-patch.tpl >coredns-patch.yaml
+  kubectl -n kube-system patch cm coredns --patch "$(cat coredns-patch.yaml)"
+}
+
+function create_kyma_namespace() {
+cat <<EOF | kubectl apply -f - 
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kyma-system
+EOF
+}
+
+host::create_coredns_template
+host::create_docker_registry
+# shellcheck disable=SC2155
+export REGISTRY_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' /registry.localhost)
+
+host::update_etc_hosts
+
+install::prereq
+
+date
+echo "--> Creating k8s cluster via k3s"
+install::k3s
+
+# shellcheck disable=SC2004
+while [[ $(kubectl get nodes -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do echo "Waiting for cluster nodes to be ready, elapsed time: $(( $SECONDS/60 )) min $(( $SECONDS % 60 )) sec"; sleep 2; done
+host::patch_coredns
+
+create_kyma_namespace
+
+kubectl apply -f "$KYMA_SOURCES_DIR/resources/cluster-essentials/files" -n kyma-system
+helm upgrade --atomic -i serverless "$KYMA_SOURCES_DIR/resources/serverless" -n kyma-system --set "$REGISTRY_VALUES",global.ingress.domainName="$DOMAIN" --wait
+
+echo "##############################################################################"
+# shellcheck disable=SC2004
+echo "# Serverless installed in $(( $SECONDS/60 )) min $(( $SECONDS % 60 )) sec"
+echo "##############################################################################"
+
+sleep 10 # controller sometimes cant get runtime configmap :V
+
+kubectl apply -f "$KYMA_SOURCES_DIR/components/function-controller/config/samples/serverless_v1alpha1_function.yaml"
+echo "wait 180s for function to be ready"
+kubectl wait --for=condition=Running function/demo --timeout 180s
+echo "success!"
+kubectl get -f "$KYMA_SOURCES_DIR/components/function-controller/config/samples/serverless_v1alpha1_function.yaml" -oyaml
+
+date
+
+exit 0

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -5,6 +5,7 @@ set -o pipefail  # Fail a pipe if any sub-command fails.
 
 date
 
+# https://github.com/kyma-project/test-infra/pull/2967 - explanation for that kaniko image
 export KANIKO_IMAGE="eu.gcr.io/kyma-project/external/aerfio/kaniko-executor:v1.3.0"
 export DOMAIN=${KYMA_DOMAIN:-local.kyma.dev}
 if [[ -z $REGISTRY_VALUES ]]; then

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -8,7 +8,7 @@ date
 export KANIKO_IMAGE="eu.gcr.io/kyma-project/external/aerfio/kaniko-executor:v1.3.0"
 export DOMAIN=${KYMA_DOMAIN:-local.kyma.dev}
 if [[ -z $REGISTRY_VALUES ]]; then
-  export REGISTRY_VALUES="dockerRegistry.enableInternal=false,dockerRegistry.serverAddress=registry.localhost:5000,dockerRegistry.registryAddress=registry.localhost:5000,docker-registry.destinationRule.enabled=false,containers.manager.envs.functionBuildExecutorImage.value=${KANIKO_IMAGE},images.manager.repository=aerfio/function-controller,images.manager.tag=latest"
+  export REGISTRY_VALUES="dockerRegistry.enableInternal=false,dockerRegistry.serverAddress=registry.localhost:5000,dockerRegistry.registryAddress=registry.localhost:5000,containers.manager.envs.functionBuildExecutorImage.value=${KANIKO_IMAGE}"
 fi
 
 export KYMA_SOURCES_DIR="./kyma"

--- a/prow/scripts/provision-vm-and-start-serverless-k3s.sh
+++ b/prow/scripts/provision-vm-and-start-serverless-k3s.sh
@@ -15,14 +15,12 @@ source "${SCRIPT_DIR}/library.sh"
 
 if [[ "${BUILD_TYPE}" == "pr" ]]; then
     shout "Execute Job Guard"
-    # TODO uncomment
     "${TEST_INFRA_SOURCES_DIR}/development/jobguard/scripts/run.sh"
 fi
 
 cleanup() {
     ARG=$?
     shout "Removing instance kyma-integration-test-${RANDOM_ID}"
-    # TODO uncomment
     gcloud compute instances delete --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}" || true ### Workaround: not failing the job regardless of the vm deletion result
     date
     exit $ARG

--- a/prow/scripts/provision-vm-and-start-serverless-k3s.sh
+++ b/prow/scripts/provision-vm-and-start-serverless-k3s.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+# This script is designed to provision a new vm and start serverless chart. It takes an optional positional parameter using --image flag
+# Use this flag to specify the custom image for provisining vms. If no flag is provided, the latest custom image is used.
+
+set -o errexit
+
+date
+
+readonly SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+readonly TEST_INFRA_SOURCES_DIR="$(cd "${SCRIPT_DIR}/../../" && pwd)"
+# readonly TMP_DIR=$(mktemp -d)
+# readonly JUNIT_REPORT_PATH="${ARTIFACTS:-${TMP_DIR}}/junit_kyma_octopus-test-suite.xml"
+
+# shellcheck disable=SC1090
+source "${SCRIPT_DIR}/library.sh"
+
+if [[ "${BUILD_TYPE}" == "pr" ]]; then
+    shout "Execute Job Guard"
+    # TODO uncomment me!
+    # "${TEST_INFRA_SOURCES_DIR}/development/jobguard/scripts/run.sh"
+fi
+
+cleanup() {
+    ARG=$?
+    shout "Removing instance kyma-integration-test-${RANDOM_ID}"
+    # gcloud compute instances delete --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}" || true ### Workaround: not failing the job regardless of the vm deletion result
+    date
+    exit $ARG
+}
+
+function testCustomImage() {
+    CUSTOM_IMAGE="$1"
+    IMAGE_EXISTS=$(gcloud compute images list --filter "name:${CUSTOM_IMAGE}" | tail -n +2 | awk '{print $1}')
+    if [[ -z "$IMAGE_EXISTS" ]]; then
+        shout "${CUSTOM_IMAGE} is invalid, it is not available in GCP images list, the script will terminate ..." && exit 1
+    fi
+}
+
+authenticate
+
+RANDOM_ID=$(openssl rand -hex 4)
+
+LABELS=""
+if [[ -z "${PULL_NUMBER}" ]]; then
+    LABELS=(--labels "branch=$PULL_BASE_REF,job-name=kyma-integration")
+else
+    LABELS=(--labels "pull-number=$PULL_NUMBER,job-name=kyma-integration")
+fi
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+
+    key="$1"
+
+    case ${key} in
+        --image)
+            IMAGE="$2"
+            testCustomImage "${IMAGE}"
+            shift
+            shift
+            ;;
+        --*)
+            echo "Unknown flag ${1}"
+            exit 1
+            ;;
+        *)    # unknown option
+            POSITIONAL+=("$1") # save it in an array for later
+            shift # past argument
+            ;;
+    esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
+
+if [[ -z "$IMAGE" ]]; then
+    shout "Provisioning vm using the latest default custom image ..."   
+    
+    IMAGE=$(gcloud compute images list --sort-by "~creationTimestamp" \
+         --filter "family:custom images AND labels.default:yes" --limit=1 | tail -n +2 | awk '{print $1}')
+    
+    if [[ -z "$IMAGE" ]]; then
+       shout "There are no default custom images, the script will exit ..." && exit 1 
+    fi   
+ fi
+
+date
+
+ZONE_LIMIT=${ZONE_LIMIT:-5}
+EU_ZONES=$(gcloud compute zones list --filter="name~europe" --limit="${ZONE_LIMIT}" | tail -n +2 | awk '{print $1}')
+STARTTIME=$(date +%s)
+for ZONE in ${EU_ZONES}; do
+    shout "Attempting to create a new instance named kyma-integration-test-${RANDOM_ID} in zone ${ZONE} using image ${IMAGE}"
+    gcloud compute instances create "kyma-integration-test-${RANDOM_ID}" \
+        --metadata enable-oslogin=TRUE \
+        --image "${IMAGE}" \
+        --machine-type n1-standard-4 \
+        --zone "${ZONE}" \
+        --boot-disk-size 30 "${LABELS[@]}" &&\
+    shout "Created kyma-integration-test-${RANDOM_ID} in zone ${ZONE}" && break
+    shout "Could not create machine in zone ${ZONE}"
+done || exit 1
+ENDTIME=$(date +%s)
+echo "VM creation time: $((ENDTIME - STARTTIME)) seconds."
+
+date
+
+trap cleanup exit INT
+
+shout "Copying Kyma to the instance"
+
+for i in $(seq 1 5); do
+    [[ ${i} -gt 1 ]] && echo 'Retrying in 15 seconds..' && sleep 15;
+    gcloud compute scp --quiet --recurse --zone="${ZONE}" /home/prow/go/src/github.com/kyma-project/kyma "kyma-integration-test-${RANDOM_ID}":~/kyma && break;
+    [[ ${i} -ge 5 ]] && echo "Failed after $i attempts." && exit 1
+done;
+
+date
+
+shout "Triggering the installation"
+gcloud compute ssh --quiet --zone="${ZONE}" --command="sudo bash" --ssh-flag="-o ServerAliveInterval=30" "kyma-integration-test-${RANDOM_ID}" < "${SCRIPT_DIR}/cluster-integration/serverless-integration-k3s.sh"
+
+date
+
+shout "all done"

--- a/prow/scripts/provision-vm-and-start-serverless-k3s.sh
+++ b/prow/scripts/provision-vm-and-start-serverless-k3s.sh
@@ -9,16 +9,13 @@ date
 
 readonly SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 readonly TEST_INFRA_SOURCES_DIR="$(cd "${SCRIPT_DIR}/../../" && pwd)"
-# readonly TMP_DIR=$(mktemp -d)
-# readonly JUNIT_REPORT_PATH="${ARTIFACTS:-${TMP_DIR}}/junit_kyma_octopus-test-suite.xml"
 
 # shellcheck disable=SC1090
 source "${SCRIPT_DIR}/library.sh"
 
 if [[ "${BUILD_TYPE}" == "pr" ]]; then
     shout "Execute Job Guard"
-    # TODO uncomment me!
-    # "${TEST_INFRA_SOURCES_DIR}/development/jobguard/scripts/run.sh"
+    "${TEST_INFRA_SOURCES_DIR}/development/jobguard/scripts/run.sh"
 fi
 
 cleanup() {

--- a/prow/scripts/provision-vm-and-start-serverless-k3s.sh
+++ b/prow/scripts/provision-vm-and-start-serverless-k3s.sh
@@ -15,7 +15,7 @@ source "${SCRIPT_DIR}/library.sh"
 
 if [[ "${BUILD_TYPE}" == "pr" ]]; then
     shout "Execute Job Guard"
-    "${TEST_INFRA_SOURCES_DIR}/development/jobguard/scripts/run.sh"
+    # "${TEST_INFRA_SOURCES_DIR}/development/jobguard/scripts/run.sh"
 fi
 
 cleanup() {

--- a/prow/scripts/provision-vm-and-start-serverless-k3s.sh
+++ b/prow/scripts/provision-vm-and-start-serverless-k3s.sh
@@ -15,12 +15,14 @@ source "${SCRIPT_DIR}/library.sh"
 
 if [[ "${BUILD_TYPE}" == "pr" ]]; then
     shout "Execute Job Guard"
+    # TODO uncomment
     # "${TEST_INFRA_SOURCES_DIR}/development/jobguard/scripts/run.sh"
 fi
 
 cleanup() {
     ARG=$?
     shout "Removing instance kyma-integration-test-${RANDOM_ID}"
+    # TODO uncomment
     # gcloud compute instances delete --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}" || true ### Workaround: not failing the job regardless of the vm deletion result
     date
     exit $ARG

--- a/prow/scripts/provision-vm-and-start-serverless-k3s.sh
+++ b/prow/scripts/provision-vm-and-start-serverless-k3s.sh
@@ -21,7 +21,7 @@ fi
 cleanup() {
     ARG=$?
     shout "Removing instance kyma-integration-test-${RANDOM_ID}"
-    # gcloud compute instances delete --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}" || true ### Workaround: not failing the job regardless of the vm deletion result
+    gcloud compute instances delete --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}" || true ### Workaround: not failing the job regardless of the vm deletion result
     date
     exit $ARG
 }

--- a/prow/scripts/provision-vm-and-start-serverless-k3s.sh
+++ b/prow/scripts/provision-vm-and-start-serverless-k3s.sh
@@ -23,7 +23,7 @@ cleanup() {
     ARG=$?
     shout "Removing instance kyma-integration-test-${RANDOM_ID}"
     # TODO uncomment
-    # gcloud compute instances delete --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}" || true ### Workaround: not failing the job regardless of the vm deletion result
+    gcloud compute instances delete --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}" || true ### Workaround: not failing the job regardless of the vm deletion result
     date
     exit $ARG
 }

--- a/prow/scripts/provision-vm-and-start-serverless-k3s.sh
+++ b/prow/scripts/provision-vm-and-start-serverless-k3s.sh
@@ -23,7 +23,7 @@ cleanup() {
     ARG=$?
     shout "Removing instance kyma-integration-test-${RANDOM_ID}"
     # TODO uncomment
-    gcloud compute instances delete --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}" || true ### Workaround: not failing the job regardless of the vm deletion result
+    # gcloud compute instances delete --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}" || true ### Workaround: not failing the job regardless of the vm deletion result
     date
     exit $ARG
 }

--- a/prow/scripts/provision-vm-and-start-serverless-k3s.sh
+++ b/prow/scripts/provision-vm-and-start-serverless-k3s.sh
@@ -21,7 +21,7 @@ fi
 cleanup() {
     ARG=$?
     shout "Removing instance kyma-integration-test-${RANDOM_ID}"
-    gcloud compute instances delete --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}" || true ### Workaround: not failing the job regardless of the vm deletion result
+    # gcloud compute instances delete --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}" || true ### Workaround: not failing the job regardless of the vm deletion result
     date
     exit $ARG
 }

--- a/prow/scripts/provision-vm-and-start-serverless-k3s.sh
+++ b/prow/scripts/provision-vm-and-start-serverless-k3s.sh
@@ -16,14 +16,14 @@ source "${SCRIPT_DIR}/library.sh"
 if [[ "${BUILD_TYPE}" == "pr" ]]; then
     shout "Execute Job Guard"
     # TODO uncomment
-    # "${TEST_INFRA_SOURCES_DIR}/development/jobguard/scripts/run.sh"
+    "${TEST_INFRA_SOURCES_DIR}/development/jobguard/scripts/run.sh"
 fi
 
 cleanup() {
     ARG=$?
     shout "Removing instance kyma-integration-test-${RANDOM_ID}"
     # TODO uncomment
-    # gcloud compute instances delete --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}" || true ### Workaround: not failing the job regardless of the vm deletion result
+    gcloud compute instances delete --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}" || true ### Workaround: not failing the job regardless of the vm deletion result
     date
     exit $ARG
 }

--- a/templates/templates/kyma-integration.yaml
+++ b/templates/templates/kyma-integration.yaml
@@ -38,6 +38,20 @@ vm_job_template: &vm_job_template
             memory: 100Mi
             cpu: 50m
 
+vm_job_template_k3s: &vm_job_template_k3s
+  decorate: true
+  path_alias: github.com/kyma-project/kyma
+  max_concurrency: 10
+  spec:
+    containers:
+    - <<: *base_image_k16
+      command:
+      - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-and-start-serverless-k3s.sh"
+      resources:
+        requests:
+          memory: 100Mi
+          cpu: 50m
+
 vm_job_labels_template: &vm_job_labels_template
   preset-kyma-guard-bot-github-token: "true"
   preset-sa-vm-kyma-integration: "true"
@@ -276,7 +290,20 @@ presubmits: # runs on PRs
       extra_refs:
         - <<: *test_infra_ref
           base_ref: master
-  
+    - name: pre-master-serverless-integration-k3s
+      cluster: {{if $.Values.cluster.presubmit}}{{ $.Values.cluster.presubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
+      branches:
+      - ^master$
+      <<: *vm_job_template_k3s
+      # following regexp won't start build if only Markdown files were changed
+      run_if_changed: "^((resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
+      labels:
+        preset-build-pr: "true"
+        <<: *vm_job_labels_template
+      extra_refs:
+      - <<: *test_infra_ref
+        base_ref: master
+
   {{- range (matchingReleases .Global.releases "1.11" nil) }}
     - name: pre-rel{{ . | replace "." "" }}-kyma-integration
       cluster: {{if $.Values.cluster.presubmit}}{{ $.Values.cluster.presubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}

--- a/templates/templates/kyma-integration.yaml
+++ b/templates/templates/kyma-integration.yaml
@@ -296,7 +296,7 @@ presubmits: # runs on PRs
       - ^master$
       <<: *vm_job_template_k3s
       # following regexp won't start build if only Markdown files were changed
-      run_if_changed: "^((resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
+      run_if_changed: "^((resources/serverless\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:
         preset-build-pr: "true"
         <<: *vm_job_labels_template

--- a/templates/templates/kyma-integration.yaml
+++ b/templates/templates/kyma-integration.yaml
@@ -38,7 +38,7 @@ vm_job_template: &vm_job_template
             memory: 100Mi
             cpu: 50m
 
-vm_job_template_k3s: &vm_job_template_k3s
+vm_job_template_serverless_k3s: &vm_job_template_serverless_k3s
   decorate: true
   path_alias: github.com/kyma-project/kyma
   max_concurrency: 10
@@ -294,7 +294,7 @@ presubmits: # runs on PRs
       cluster: {{if $.Values.cluster.presubmit}}{{ $.Values.cluster.presubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
       branches:
       - ^master$
-      <<: *vm_job_template_k3s
+      <<: *vm_job_template_serverless_k3s
       # following regexp won't start build if only Markdown files were changed
       run_if_changed: "^((resources/serverless\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
       labels:

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,6 +1,3 @@
 pjNames:
 - pjName: "pre-master-serverless-integration-k3s"
-prConfigs:
-  kyma-project:
-    kyma:
-      prNumber: 9948
+

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,7 +1,0 @@
-pjNames:
-- pjName: "pre-master-serverless-integration-k3s"
-prConfigs:
-  kyma-project:
-    kyma:
-      prNumber: 10059
-        

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,3 +1,6 @@
 pjNames:
 - pjName: "pre-master-serverless-integration-k3s"
-
+prConfigs:
+  kyma-project:
+    kyma:
+      prNumber: 10009

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,6 @@
+pjNames:
+- pjName: "pre-master-serverless-integration-k3s"
+prConfigs:
+  kyma-project:
+    kyma:
+      prNumber: 9948

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -3,4 +3,4 @@ pjNames:
 prConfigs:
   kyma-project:
     kyma:
-      prNumber: 10009
+      prNumber: 10026

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -4,3 +4,4 @@ prConfigs:
   kyma-project:
     kyma:
       prNumber: 10059
+        

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -3,4 +3,4 @@ pjNames:
 prConfigs:
   kyma-project:
     kyma:
-      prNumber: 10026
+      prNumber: 10059


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

There needs to be a bit of explanation as to why I'm using my own kaniko image: due to https://github.com/GoogleContainerTools/kaniko/issues/1287 I needed to resort to apply changes from [this comment](https://github.com/GoogleContainerTools/kaniko/issues/1287#issuecomment-637634928), because it wasn't working with either internal docker registry (run using plain `docker run`) or gcr supplied from Prow's infrastructure.

https://github.com/GoogleContainerTools/kaniko/compare/v1.3.0...aerfio:cred_linux_patch

Changes proposed in this pull request:

- add k3s job that installs serverless chart and runs special version of serverless tests

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/10001