### PR TITLE
Increase the memory limit for prometheus-istio in nightly and weekly cluster

### DIFF
--- a/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
@@ -295,6 +295,7 @@ metadata:
 data:
   global.alertTools.credentials.slack.channel: "${KYMA_ALERTS_CHANNEL}"
   global.alertTools.credentials.slack.apiurl: "${KYMA_ALERTS_SLACK_API_URL}"
+  prometheus-istio.server.resources.limits.memory: "6Gi"
 #---
 #apiVersion: v1
 #kind: ConfigMap

--- a/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
@@ -384,6 +384,14 @@ function test_console_url() {
     exit 1
   fi
 }
+
+function patchlimitrange(){
+  # Patching limitrange on kyma-system namespace to meet prometheus memory requirements.
+	echo "Patching kyma-default LimitRange"
+	kubectl -n kyma-system patch limitrange kyma-default --type merge --patch "$(cat "${TEST_INFRA_SOURCES_DIR}"/prow/scripts/resources/limitrange-patch.yaml)"
+
+}
+
 init
 azureAuthenticating
 
@@ -412,6 +420,11 @@ installKyma
 
 shout "Override kyma-admin-binding ClusterRoleBinding"
 applyDexGithibKymaAdminGroup
+
+# Prometheus-Istio container need minimum 6Gi memory limit.
+shout "Increase cluster max container memory limit"
+date
+patchlimitrange
 
 shout "Install stability-checker"
 date

--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -180,6 +180,7 @@ metadata:
 data:
   global.alertTools.credentials.slack.channel: "${KYMA_ALERTS_CHANNEL}"
   global.alertTools.credentials.slack.apiurl: "${KYMA_ALERTS_SLACK_API_URL}"
+  prometheus-istio.server.resources.limits.memory: "6Gi"
 #---
 #apiVersion: v1
 #kind: ConfigMap


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Increase the memory as due to envoy bug in istio telemetry v2 prometheus-istio server is scraping old metrics from pods. So increase the memory

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
