### PR TITLE
KCP CLI: move out from KEB

### DIFF
--- a/development/tools/jobs/control-plane/cli_test.go
+++ b/development/tools/jobs/control-plane/cli_test.go
@@ -1,0 +1,64 @@
+package controlplane_test
+
+import (
+	"testing"
+
+	"github.com/kyma-project/test-infra/development/tools/jobs/tester"
+	"github.com/kyma-project/test-infra/development/tools/jobs/tester/preset"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKCPPresubmitCLI(t *testing.T) {
+	// WHEN
+	jobConfig, err := tester.ReadJobConfig("./../../../../prow/jobs/control-plane/kcp-cli.yaml")
+	// THEN
+	require.NoError(t, err)
+
+	job := tester.FindPresubmitJobByNameAndBranch(jobConfig.AllStaticPresubmits([]string{"kyma-project/control-plane"}), "pre-master-kcp-cli", "master")
+	require.NotNil(t, job)
+
+	assert.True(t, tester.IfPresubmitShouldRunAgainstChanges(*job, true, "tools/cli/Makefile"))
+	assert.False(t, job.SkipReport)
+	assert.False(t, job.AlwaysRun)
+	assert.False(t, job.Optional)
+	tester.AssertThatHasExtraRefTestInfra(t, job.UtilityConfig, "master")
+	tester.AssertThatHasPresets(t, job.JobBase, "preset-kyma-development-artifacts-bucket", preset.GcrPush)
+	require.Len(t, job.Spec.Containers, 1)
+	cont := job.Spec.Containers[0]
+	assert.Equal(t, tester.ImageGolangToolboxLatest, cont.Image)
+	require.Len(t, cont.Command, 1)
+	assert.Equal(t, "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-kcp-cli.sh", cont.Command[0])
+	require.Len(t, job.Spec.Volumes, 1)
+	assert.Equal(t, "sa-kyma-artifacts", job.Spec.Volumes[0].Name)
+	require.NotNil(t, job.Spec.Volumes[0].Secret)
+	assert.Equal(t, "sa-kyma-artifacts", job.Spec.Volumes[0].Secret.SecretName)
+	require.Len(t, cont.VolumeMounts, 1)
+	assert.Equal(t, "sa-kyma-artifacts", cont.VolumeMounts[0].Name)
+	assert.Equal(t, "/etc/credentials/sa-kyma-artifacts", cont.VolumeMounts[0].MountPath)
+}
+
+func TestKCPPostsubmitCLI(t *testing.T) {
+	// WHEN
+	jobConfig, err := tester.ReadJobConfig("./../../../../prow/jobs/control-plane/kcp-cli.yaml")
+	// THEN
+	require.NoError(t, err)
+
+	job := tester.FindPostsubmitJobByNameAndBranch(jobConfig.AllStaticPostsubmits([]string{"kyma-project/control-plane"}), "post-master-kcp-cli", "master")
+	require.NotNil(t, job)
+	assert.Empty(t, job.RunIfChanged)
+	tester.AssertThatHasExtraRefTestInfra(t, job.UtilityConfig, "master")
+	tester.AssertThatHasPresets(t, job.JobBase, preset.BuildArtifactsMaster, "preset-kyma-development-artifacts-bucket", preset.GcrPush)
+	require.Len(t, job.Spec.Containers, 1)
+	cont := job.Spec.Containers[0]
+	assert.Equal(t, tester.ImageGolangToolboxLatest, cont.Image)
+	require.Len(t, cont.Command, 1)
+	assert.Equal(t, "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-kcp-cli.sh", cont.Command[0])
+	require.Len(t, job.Spec.Volumes, 1)
+	assert.Equal(t, "sa-kyma-artifacts", job.Spec.Volumes[0].Name)
+	require.NotNil(t, job.Spec.Volumes[0].Secret)
+	assert.Equal(t, "sa-kyma-artifacts", job.Spec.Volumes[0].Secret.SecretName)
+	require.Len(t, cont.VolumeMounts, 1)
+	assert.Equal(t, "sa-kyma-artifacts", cont.VolumeMounts[0].Name)
+	assert.Equal(t, "/etc/credentials/sa-kyma-artifacts", cont.VolumeMounts[0].MountPath)
+}

--- a/prow/jobs/control-plane/kcp-cli.yaml
+++ b/prow/jobs/control-plane/kcp-cli.yaml
@@ -4,10 +4,6 @@ test_infra_ref: &test_infra_ref
   path_alias: github.com/kyma-project/test-infra
 
 job_template: &job_template
-  optional: true
-  reporter_config: # TODO: Remove after testing
-        slack:
-          channel: 'kyma-prow-dev-null'
   decorate: true
   path_alias: github.com/kyma-project/control-plane
   max_concurrency: 10
@@ -17,7 +13,7 @@ job_template: &job_template
       securityContext:
         privileged: true
       command:
-      - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-kcp-development-artifacts.sh"
+      - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-kcp-cli.sh"
       resources:
         requests:
           memory: 1Gi
@@ -32,16 +28,14 @@ job_template: &job_template
           secretName: sa-kyma-artifacts
 
 job_labels_template: &job_labels_template
-  preset-dind-enabled: "true"
-  preset-docker-push-repository-kyma: "true"
   preset-kyma-development-artifacts-bucket: "true"
   preset-sa-gcr-push: "true"
 
 presubmits: # runs on PRs
   kyma-project/control-plane:
-  - name: pre-master-kcp-development-artifacts
+  - name: pre-master-kcp-cli
     cluster: untrusted-workload
-    run_if_changed: "^installation|^resources|^tools/kcp-installer"
+    run_if_changed: "^tools/cli"
     branches:
     - ^master$
     <<: *job_template
@@ -53,7 +47,7 @@ presubmits: # runs on PRs
 
 postsubmits:
   kyma-project/control-plane:
-  - name: post-master-kcp-development-artifacts
+  - name: post-master-kcp-cli
     cluster: trusted-workload
     annotations:
       testgrid-create-test-group: "false"

--- a/prow/jobs/control-plane/kcp-development-artifacts.yaml
+++ b/prow/jobs/control-plane/kcp-development-artifacts.yaml
@@ -41,7 +41,7 @@ presubmits: # runs on PRs
   kyma-project/control-plane:
   - name: pre-master-kcp-development-artifacts
     cluster: untrusted-workload
-    run_if_changed: "^installation|^resources|^tools/kcp-installer|^components/kyma-environment-broker/cmd/cli"
+    run_if_changed: "^installation|^resources|^tools/kcp-installer|^components/cli"
     branches:
     - ^master$
     <<: *job_template

--- a/prow/scripts/build-kcp-cli.sh
+++ b/prow/scripts/build-kcp-cli.sh
@@ -6,12 +6,15 @@ set -e
 
 discoverUnsetVar=false
 
-for var in KYMA_DEVELOPMENT_ARTIFACTS_BUCKET; do
+function check_missing_var() {
+    local var=$1
     if [ -z "${!var}" ] ; then
         echo "ERROR: $var is not set"
         discoverUnsetVar=true
     fi
-done
+}
+
+check_missing_var KYMA_DEVELOPMENT_ARTIFACTS_BUCKET
 if [ "${discoverUnsetVar}" = true ] ; then
     exit 1
 fi

--- a/prow/scripts/build-kcp-cli.sh
+++ b/prow/scripts/build-kcp-cli.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# This script builds and publishes KCP CLI development artifacts
+
+set -e
+
+discoverUnsetVar=false
+
+for var in KYMA_DEVELOPMENT_ARTIFACTS_BUCKET; do
+    if [ -z "${!var}" ] ; then
+        echo "ERROR: $var is not set"
+        discoverUnsetVar=true
+    fi
+done
+if [ "${discoverUnsetVar}" = true ] ; then
+    exit 1
+fi
+
+readonly KCP_DEVELOPMENT_ARTIFACTS_BUCKET="${KYMA_DEVELOPMENT_ARTIFACTS_BUCKET}/kcp"
+readonly CURRENT_TIMESTAMP=$(date +%s)
+
+readonly SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck disable=SC1090
+source "${SCRIPT_DIR}/library.sh"
+
+function export_variables() {
+    COMMIT_ID=$(echo "${PULL_BASE_SHA}" | cut -c1-8)
+   if [[ -n "${PULL_NUMBER}" ]]; then
+        BUCKET_DIR="PR-${PULL_NUMBER}"
+        CLI_VERSION="PR-${PULL_NUMBER}-${COMMIT_ID}"
+    else
+        BUCKET_DIR="master-${COMMIT_ID}"
+        CLI_VERSION="master-${COMMIT_ID}"
+    fi
+
+   readonly BUCKET_DIR
+   readonly CLI_VERSION
+
+   export BUCKET_DIR
+   export CLI_VERSION
+}
+
+init
+export_variables
+
+export KCP_PATH="/home/prow/go/src/github.com/kyma-project/control-plane"
+buildTarget="release"
+
+shout "Build KCP CLI with target ${buildTarget}"
+make -C "${KCP_PATH}/tools/cli" ${buildTarget}
+
+shout "Switch to a different service account to push to GCS bucket"
+export GOOGLE_APPLICATION_CREDENTIALS=/etc/credentials/sa-kyma-artifacts/service-account.json
+authenticate
+
+shout "Content of the local artifacts directory"
+ls -la "${ARTIFACTS}"
+
+shout "Copy artifacts to ${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}"
+
+gsutil cp "${ARTIFACTS}/kcp.exe" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/kcp.exe"
+gsutil cp "${ARTIFACTS}/kcp-linux" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/kcp-linux"
+gsutil cp "${ARTIFACTS}/kcp-darwin" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/kcp-darwin"
+
+if [[ "${BUILD_TYPE}" == "master" ]]; then
+  shout "Copy artifacts to ${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master"
+
+  gsutil cp "${ARTIFACTS}/kcp.exe" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/kcp.exe"
+  gsutil cp "${ARTIFACTS}/kcp-linux" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/kcp-linux"
+  gsutil cp "${ARTIFACTS}/kcp-darwin" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/kcp-darwin"
+fi

--- a/prow/scripts/build-kcp-development-artifacts.sh
+++ b/prow/scripts/build-kcp-development-artifacts.sh
@@ -67,7 +67,7 @@ shout "Build kcp-installer with target ${buildTarget}"
 make -C "${KCP_PATH}/tools/kcp-installer" ${buildTarget}
 
 shout "Build KCP CLI with target ${buildTarget}"
-make -C "${KCP_PATH}/components/kyma-environment-broker" -f Makefile.cli ${buildTarget}
+make -C "${KCP_PATH}/components/cli" ${buildTarget}
 
 shout "Switch to a different service account to push to GCS bucket"
 export GOOGLE_APPLICATION_CREDENTIALS=/etc/credentials/sa-kyma-artifacts/service-account.json

--- a/prow/scripts/build-kcp-development-artifacts.sh
+++ b/prow/scripts/build-kcp-development-artifacts.sh
@@ -34,23 +34,19 @@ function export_variables() {
    if [[ -n "${PULL_NUMBER}" ]]; then
         DOCKER_TAG="PR-${PULL_NUMBER}-${COMMIT_ID}"
         BUCKET_DIR="PR-${PULL_NUMBER}"
-        CLI_VERSION="PR-${PULL_NUMBER}-${COMMIT_ID}"
     else
         DOCKER_TAG="master-${COMMIT_ID}-${CURRENT_TIMESTAMP}"
         BUCKET_DIR="master-${COMMIT_ID}"
-        CLI_VERSION="master-${COMMIT_ID}"
     fi
 
    readonly DOCKER_TAG
    readonly KCP_INSTALLER_PUSH_DIR
    readonly BUCKET_DIR
    readonly KCP_INSTALLER_VERSION
-   readonly CLI_VERSION
 
    export DOCKER_TAG
    export KCP_INSTALLER_PUSH_DIR
    export BUCKET_DIR
-   export CLI_VERSION
 }
 
 init
@@ -65,9 +61,6 @@ buildTarget="release"
 
 shout "Build kcp-installer with target ${buildTarget}"
 make -C "${KCP_PATH}/tools/kcp-installer" ${buildTarget}
-
-shout "Build KCP CLI with target ${buildTarget}"
-make -C "${KCP_PATH}/components/cli" ${buildTarget}
 
 shout "Switch to a different service account to push to GCS bucket"
 export GOOGLE_APPLICATION_CREDENTIALS=/etc/credentials/sa-kyma-artifacts/service-account.json
@@ -94,10 +87,6 @@ gsutil cp  "${ARTIFACTS}/is-kyma-installed.sh" "${KCP_DEVELOPMENT_ARTIFACTS_BUCK
 gsutil cp  "${ARTIFACTS}/compass-installer.yaml" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/compass-installer.yaml"
 gsutil cp  "${ARTIFACTS}/is-compass-installed.sh" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/is-compass-installed.sh"
 
-gsutil cp "${ARTIFACTS}/kcp.exe" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/kcp.exe"
-gsutil cp "${ARTIFACTS}/kcp-linux" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/kcp-linux"
-gsutil cp "${ARTIFACTS}/kcp-darwin" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/kcp-darwin"
-
 if [[ "${BUILD_TYPE}" == "master" ]]; then
   shout "Copy artifacts to ${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master"
   gsutil cp "${ARTIFACTS}/kcp-installer.yaml" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/kcp-installer.yaml"
@@ -108,8 +97,4 @@ if [[ "${BUILD_TYPE}" == "master" ]]; then
 
   gsutil cp "${ARTIFACTS}/compass-installer.yaml" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/compass-installer.yaml"
   gsutil cp  "${ARTIFACTS}/is-compass-installed.sh" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/is-compass-installed.sh"
-
-  gsutil cp "${ARTIFACTS}/kcp.exe" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/kcp.exe"
-  gsutil cp "${ARTIFACTS}/kcp-linux" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/kcp-linux"
-  gsutil cp "${ARTIFACTS}/kcp-darwin" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/kcp-darwin"
 fi


### PR DESCRIPTION
**Description**

KCP CLI is moved out from KEB codebase to `tools/cli`
