### PR TITLE
Uncomment and bump version of postgresql in image-syncer

### DIFF
--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -24,7 +24,7 @@ images:
 - source: "oryd/hydra:v1.4.6"
 - source: "oryd/oathkeeper-maester:v0.1.0"
 - source: "oryd/oathkeeper:v0.38.2-beta.1-alpine"
-# - source: "postgres:11.9-alpine"
+- source: "postgres:11.10-alpine"
 - source: "prom/pushgateway:v1.3.0"
 - source: "quay.io/coreos/configmap-reload:v0.0.1"
 - source: "quay.io/coreos/etcd:v3.3.25"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The bump is necessary because the currently used version (11.9) contains vulnerabilities that are fixed in 11.10.

Changes proposed in this pull request:

- Uncomment and bump version of postgresql in image-syncer

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
