### PR TITLE
Make pre-rel kyma-gke-compass-integration optional

### DIFF
--- a/development/tools/jobs/kyma/kyma_gke_compass_integration_test.go
+++ b/development/tools/jobs/kyma/kyma_gke_compass_integration_test.go
@@ -57,7 +57,7 @@ func TestKymaGKECompassIntegrationJobsReleases(t *testing.T) {
 			require.NoError(t, err)
 			actualPresubmit := tester.FindPresubmitJobByNameAndBranch(jobConfig.AllStaticPresubmits([]string{"kyma-project/kyma"}), tester.GetReleaseJobName("kyma-gke-compass-integration", currentRelease), currentRelease.Branch())
 			require.NotNil(t, actualPresubmit)
-			assert.False(t, actualPresubmit.Optional)
+			assert.True(t, actualPresubmit.Optional)
 			assert.False(t, actualPresubmit.SkipReport)
 			assert.True(t, actualPresubmit.Decorate)
 			assert.Equal(t, "github.com/kyma-project/kyma", actualPresubmit.PathAlias)

--- a/prow/jobs/kyma/kyma-gke-compass-integration.yaml
+++ b/prow/jobs/kyma/kyma-gke-compass-integration.yaml
@@ -82,6 +82,7 @@ presubmits: # runs on PRs
       branches:
         - release-1.18
       always_run: false
+      optional: true
       <<: *gke_integration_job_template_k16
       labels:
         preset-build-release: "true"
@@ -94,6 +95,7 @@ presubmits: # runs on PRs
       branches:
         - release-1.17
       always_run: false
+      optional: true
       <<: *gke_integration_job_template_k16
       labels:
         preset-build-release: "true"
@@ -106,6 +108,7 @@ presubmits: # runs on PRs
       branches:
         - release-1.16
       always_run: false
+      optional: true
       <<: *gke_integration_job_template_k16
       labels:
         preset-build-release: "true"

--- a/templates/templates/kyma-gke-compass-integration.yaml
+++ b/templates/templates/kyma-gke-compass-integration.yaml
@@ -82,6 +82,7 @@ presubmits: # runs on PRs
       branches:
         - release-{{ . }}
       always_run: false
+      optional: true
       <<: *gke_integration_job_template_k16
       labels:
         preset-build-release: "true"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

This job is broken, on pre-masters its already optional. It was failing during previous release as well

Changes proposed in this pull request:

- pre-relXX-kyma-gke-compass-integration is now optional
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
