### PR TITLE
Add hibernation job

### DIFF
--- a/prow/jobs/kyma/kyma-integration-gardener.yaml
+++ b/prow/jobs/kyma/kyma-integration-gardener.yaml
@@ -185,6 +185,40 @@ gardener_azure_evaluation_job_template: &gardener_azure_evaluation_job_template
           memory: 1Gi
           cpu: 400m
 
+gardener_azure_hibernation_job_template: &gardener_azure_hibernation_job_template
+  decorate: true
+  path_alias: github.com/kyma-project/kyma
+  max_concurrency: 10
+  spec:
+    containers:
+    - <<: *base_image_k16
+      securityContext:
+        privileged: true
+      command:
+      - "bash"
+      args:
+      - "-c"
+      - "${KYMA_PROJECT_DIR}/test-infra/prow/scripts/cluster-integration/kyma-integration-gardener-azure.sh"
+      env:
+      - name: RS_GROUP
+        value: "kyma-gardener-azure"
+      - name: REGION
+        value: "northeurope"
+      - name: KYMA_PROJECT_DIR
+        value: "/home/prow/go/src/github.com/kyma-project"
+      - name: GARDENER_REGION
+        value: "westeurope"
+      - name: GARDENER_ZONES
+        value: "1"
+      - name: EXECUTION_PROFILE
+        value: "evaluation"
+      - name: HIBERNATION_ENABLED
+        value: "true"
+      resources:
+        requests:
+          memory: 1Gi
+          cpu: 400m
+
 presubmits:
   kyma-project/kyma:
     - name: pre-master-kyma-gardener-azure-integration
@@ -339,6 +373,27 @@ periodics:
       testgrid-create-test-group: "false"
     decoration_config:
       timeout: 3600000000000 # 45min
+      grace_period: 600000000000 # 10min
+    cron: "0 5,8,11,14 * * *"
+    extra_refs:
+    - <<: *test_infra_ref
+      base_ref: master
+    - <<: *kyma_ref
+      base_ref: master
+    - <<: *kyma_local_ref
+      base_ref: main
+    labels:
+      preset-log-collector-slack-token: "true"
+      <<: *gardener_azure_job_labels_template
+
+  - name: kyma-integration-hibernation-gardener-azure
+    cluster: untrusted-workload
+    <<: *gardener_azure_hibernation_job_template
+    decorate: true
+    annotations:
+      testgrid-create-test-group: "false"
+    decoration_config:
+      timeout: 5400000000000  # 90min
       grace_period: 600000000000 # 10min
     cron: "0 5,8,11,14 * * *"
     extra_refs:

--- a/prow/scripts/cluster-integration/kyma-integration-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-integration-gardener-azure.sh
@@ -324,6 +324,17 @@ test_kyma(){
 
 
 hibernate_kyma(){
+    shout "Checking if cluster can be hibernated"
+    HIBERNATION_POSSIBLE=$(kubectl get shoots "${CLUSTER_NAME}" -o jsonpath='{.status.constraints[?(@.type=="HibernationPossible")].status}')
+
+    if [[ "$HIBERNATION_POSSIBLE" != "True" ]]; then
+      echo "Hibenration for this cluster is not possible! Please take a look at the constraints :"
+      kubectl get shoots "${CLUSTER_NAME}}" -o jsonpath='{.status.constraints}'
+      exit 1
+    fi
+
+    echo "Cluster can be hibernated"
+
     local SAVED_KUBECONFIG=$KUBECONFIG
     export KUBECONFIG=$GARDENER_KYMA_PROW_KUBECONFIG
 

--- a/prow/scripts/cluster-integration/kyma-integration-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-integration-gardener-azure.sh
@@ -375,7 +375,7 @@ wake_up_kyma(){
 
     local STATUS
     SECONDS=0
-    local END_TIME=$((SECONDS+1000))
+    local END_TIME=$((SECONDS+1200))
     while [ ${SECONDS} -lt ${END_TIME} ];do
         STATUS=$(kubectl get shoot "${CLUSTER_NAME}" -o jsonpath='{.status.hibernated}')
         if [ "$STATUS" == "false" ]; then

--- a/prow/scripts/cluster-integration/kyma-integration-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-integration-gardener-azure.sh
@@ -324,6 +324,9 @@ test_kyma(){
 
 
 hibernate_kyma(){
+    local SAVED_KUBECONFIG=$KUBECONFIG
+    export KUBECONFIG=$GARDENER_KYMA_PROW_KUBECONFIG
+
     shout "Checking if cluster can be hibernated"
     HIBERNATION_POSSIBLE=$(kubectl get shoots "${CLUSTER_NAME}" -o jsonpath='{.status.constraints[?(@.type=="HibernationPossible")].status}')
 
@@ -334,9 +337,6 @@ hibernate_kyma(){
     fi
 
     echo "Cluster can be hibernated"
-
-    local SAVED_KUBECONFIG=$KUBECONFIG
-    export KUBECONFIG=$GARDENER_KYMA_PROW_KUBECONFIG
 
     shout "Hibernating kyma cluster"
     date

--- a/templates/templates/kyma-integration-gardener.yaml
+++ b/templates/templates/kyma-integration-gardener.yaml
@@ -183,6 +183,40 @@ gardener_azure_evaluation_job_template: &gardener_azure_evaluation_job_template
           memory: 1Gi
           cpu: 400m
 
+gardener_azure_hibernation_job_template: &gardener_azure_hibernation_job_template
+  decorate: true
+  path_alias: github.com/kyma-project/kyma
+  max_concurrency: 10
+  spec:
+    containers:
+    - <<: *base_image_k16
+      securityContext:
+        privileged: true
+      command:
+      - "bash"
+      args:
+      - "-c"
+      - "${KYMA_PROJECT_DIR}/test-infra/prow/scripts/cluster-integration/kyma-integration-gardener-azure.sh"
+      env:
+      - name: RS_GROUP
+        value: "kyma-gardener-azure"
+      - name: REGION
+        value: "northeurope"
+      - name: KYMA_PROJECT_DIR
+        value: "/home/prow/go/src/github.com/kyma-project"
+      - name: GARDENER_REGION
+        value: "westeurope"
+      - name: GARDENER_ZONES
+        value: "1"
+      - name: EXECUTION_PROFILE
+        value: "evaluation"
+      - name: HIBERNATION_ENABLED
+        value: "true"
+      resources:
+        requests:
+          memory: 1Gi
+          cpu: 400m
+
 presubmits:
   kyma-project/kyma:
     - name: pre-master-kyma-gardener-azure-integration
@@ -337,6 +371,27 @@ periodics:
       testgrid-create-test-group: "false"
     decoration_config:
       timeout: 3600000000000 # 45min
+      grace_period: 600000000000 # 10min
+    cron: "0 5,8,11,14 * * *"
+    extra_refs:
+    - <<: *test_infra_ref
+      base_ref: master
+    - <<: *kyma_ref
+      base_ref: master
+    - <<: *kyma_local_ref
+      base_ref: main
+    labels:
+      preset-log-collector-slack-token: "true"
+      <<: *gardener_azure_job_labels_template
+
+  - name: kyma-integration-hibernation-gardener-azure
+    cluster: {{if $.Values.cluster.periodic}}{{ $.Values.cluster.periodic }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
+    <<: *gardener_azure_hibernation_job_template
+    decorate: true
+    annotations:
+      testgrid-create-test-group: "false"
+    decoration_config:
+      timeout: 5400000000000  # 90min
       grace_period: 600000000000 # 10min
     cron: "0 5,8,11,14 * * *"
     extra_refs:

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,6 +1,0 @@
-pjNames:
-- pjName: "kyma-integration-hibernation-gardener-azure"
-prConfigs:
-  kyma-project:
-    kyma:
-      prNumber: 10115

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,6 @@
+pjNames:
+- pjName: "kyma-integration-hibernation-gardener-azure"
+prConfigs:
+  kyma-project:
+    kyma:
+      prNumber: 10115


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
This PR adds prow jobs testing kyma hibernation scenario on Gardener based clusters.
Job is periodic, runs 4x per day, uses the same machine type as job for evaluation profile (single node, Standard_D4_v3).
Job in an overview performs following actions : 

1. Provision Kyma cluster
2. Hibernate cluster checking first if it's possible
3. Wake up cluster
4. Run tests from evaluation profile scenario

Note :  hibernation for now is enabled only with evaluation profile.


Changes proposed in this pull request:

- Added periodic job testing kyma hibernation scenario on Gradener (Azure)


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
