### PR TITLE
Remove cluster-users test definition 

### DIFF
--- a/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
@@ -375,12 +375,11 @@ function testKyma() {
   test_args+=("2h")
 
   log::banner "Test Kyma " "${test_args[@]}"
-  "${TEST_INFRA_SOURCES_DIR}"/prow/scripts/kyma-testing.sh "${test_args[@]}"
-
-  testing::remove_addons_if_necessary
-  
+  "${TEST_INFRA_SOURCES_DIR}"/prow/scripts/kyma-testing.sh "${test_args[@]}" &
   # remove cluster-users test as it takes more than 1h to run
   kubectl delete -n kyma-system testdefinition/cluster-users --ignore-not-found
+
+  testing::remove_addons_if_necessary
 }
 
 trap cleanup EXIT INT

--- a/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
@@ -377,10 +377,10 @@ function testKyma() {
   log::banner "Test Kyma " "${test_args[@]}"
   "${TEST_INFRA_SOURCES_DIR}"/prow/scripts/kyma-testing.sh "${test_args[@]}"
 
+  testing::remove_addons_if_necessary
+  
   # remove cluster-users test as it takes more than 1h to run
   kubectl delete -n kyma-system testdefinition/cluster-users --ignore-not-found
-
-  testing::remove_addons_if_necessary
 }
 
 trap cleanup EXIT INT

--- a/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
@@ -378,9 +378,7 @@ function testKyma() {
   "${TEST_INFRA_SOURCES_DIR}"/prow/scripts/kyma-testing.sh "${test_args[@]}"
 
   # remove cluster-users test as it takes more than 1h to run
-  if [[ "${labelquery}" == "${POST_UPGRADE_LABEL_QUERY}" ]]; then
-    kubectl delete -n kyma-system testdefinition/cluster-users --ignore-not-found
-  fi
+  kubectl delete -n kyma-system testdefinition/cluster-users --ignore-not-found
 
   testing::remove_addons_if_necessary
 }

--- a/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
@@ -378,7 +378,7 @@ function testKyma() {
   "${TEST_INFRA_SOURCES_DIR}"/prow/scripts/kyma-testing.sh "${test_args[@]}"
 
   # remove cluster-users test as it takes more than 1h to run
-  if [[ "${labelquery}" == "${POST_UPGRADE_LABEL_QUERY}"]]; then
+  if [[ "${labelquery}" == "${POST_UPGRADE_LABEL_QUERY}" ]]; then
     kubectl delete -n kyma-system testdefinition/cluster-users --ignore-not-found
   fi
 

--- a/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
@@ -378,6 +378,7 @@ function testKyma() {
   "${TEST_INFRA_SOURCES_DIR}"/prow/scripts/kyma-testing.sh "${test_args[@]}" &
   # remove cluster-users test as it takes more than 1h to run
   kubectl delete -n kyma-system testdefinition/cluster-users --ignore-not-found
+  wait
 
   testing::remove_addons_if_necessary
 }

--- a/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
@@ -377,6 +377,11 @@ function testKyma() {
   log::banner "Test Kyma " "${test_args[@]}"
   "${TEST_INFRA_SOURCES_DIR}"/prow/scripts/kyma-testing.sh "${test_args[@]}"
 
+  # remove cluster-users test as it takes more than 1h to run
+  if [[ "${labelquery}" == "${POST_UPGRADE_LABEL_QUERY}"]]; then
+    kubectl delete -n kyma-system testdefinition/cluster-users --ignore-not-found
+  fi
+
   testing::remove_addons_if_necessary
 }
 

--- a/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-gardener-azure.sh
@@ -374,11 +374,11 @@ function testKyma() {
   test_args+=("-t")
   test_args+=("2h")
 
-  log::banner "Test Kyma " "${test_args[@]}"
-  "${TEST_INFRA_SOURCES_DIR}"/prow/scripts/kyma-testing.sh "${test_args[@]}" &
-  # remove cluster-users test as it takes more than 1h to run
+  # remove cluster-users test as it takes more than 1h to run and is not an essential test
   kubectl delete -n kyma-system testdefinition/cluster-users --ignore-not-found
-  wait
+
+  log::banner "Test Kyma " "${test_args[@]}"
+  "${TEST_INFRA_SOURCES_DIR}"/prow/scripts/kyma-testing.sh "${test_args[@]}"
 
   testing::remove_addons_if_necessary
 }

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,2 +1,0 @@
-pjNames:
-    - pjName: "kyma-upgrade-gardener-azure"

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,2 @@
+pjNames:
+    - pjName: "kyma-upgrade-gardener-azure"

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,2 +1,0 @@
-pjNames:
-   - pjName: "kyma-upgrade-gardener-azure"

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,2 @@
+pjNames:
+   - pjName: "kyma-upgrade-gardener-azure"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Test installs the latest Kyma release and executes before-upgrade tests. Then Kyma is upgraded to the latest commit on master and after-upgrade tests are run. Post-upgrade tests take longer than 2h to finish, with the cluster-users test alone taking over 1h to finish. 

Changes proposed in this pull request:

- Delete cluster-users test definition

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#3037 