### PR TITLE
Fix bug in installing helm binary in install-deps-debian.sh

### DIFF
--- a/development/custom-image/install-deps-debian.sh
+++ b/development/custom-image/install-deps-debian.sh
@@ -46,8 +46,9 @@ curl -Lo /tmp/kubectl https://storage.googleapis.com/kubernetes-release/release/
  sudo mv /tmp/kubectl /usr/local/bin/kubectl
 
 # install helm
-wget https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm &&\
-	chmod +x /usr/local/bin/helm &&\
+wget https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /tmp/helm && \
+	chmod +x /tmp/helm && \
+	sudo mv /tmp/helm /usr/local/bin/helm && \
    rm -rf helm-${HELM_VERSION}-linux-amd64.tar.gz linux-amd64
 
 # install minikube


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The path `/usr/local/bin` needs privileged permissions to write files there. Helm installation was failing because the script didn't have proper permissions to it.
Changes proposed in this pull request:

- download helm to temporary repository then copy it with privileged permissions.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
