### PR TITLE
Bump ServiceCatalog image for image syncer

### DIFF
--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -33,7 +33,7 @@ images:
 - source: "quay.io/coreos/kube-state-metrics:v1.9.7"
 - source: "quay.io/prometheus-operator/prometheus-config-reloader:v0.43.2"
 - source: "quay.io/prometheus-operator/prometheus-operator:v0.43.2"
-- source: "quay.io/kubernetes-service-catalog/service-catalog:v0.3.0-6-g8e85904-dirty"
+- source: "quay.io/kubernetes-service-catalog/service-catalog:v0.3.1-3-g87e8bc4-dirty"
 - source: "quay.io/prometheus/alertmanager:v0.21.0"
 - source: "quay.io/prometheus/prometheus:v2.22.1"
 - source: "quay.io/service-manager/sb-proxy-k8s:v0.8.10"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Bump ServiceCatalog image for image syncer to latest master `v0.3.1-3-g87e8bc4-dirty`