### PR TITLE
Add Maven to Java Buildpack

### DIFF
--- a/prow/images/buildpack-java/Dockerfile
+++ b/prow/images/buildpack-java/Dockerfile
@@ -9,7 +9,7 @@ ENV IMAGE_COMMIT=$commit
 LABEL io.kyma-project.test-infra.commit=$commit
 
 ENV JAVA_VERSION 8u212-b04
-ENV JAVA_BASE_URL https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u212-b04/OpenJDK8U-jre_
+ENV JAVA_BASE_URL https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b04/OpenJDK8U-jdk_
 ENV JAVA_URL_VERSION 8u212b04
 
 ENV JAVA_HOME /usr/local/openjdk-8
@@ -19,11 +19,11 @@ ENV PATH $JAVA_HOME/bin:$PATH
 ENV LANG C.UTF-8
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates p11-kit \
+    ca-certificates p11-kit maven \
     && apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget -O openjdk.tgz "${JAVA_BASE_URL}x64_linux_${JAVA_URL_VERSION}.tar.gz"
+RUN wget -O openjdk.tgz "${JAVA_BASE_URL}x64_linux_hotspot_${JAVA_URL_VERSION}.tar.gz"
 
 RUN mkdir -p "$JAVA_HOME"; \
 	tar --extract \

--- a/prow/images/buildpack-java/README.md
+++ b/prow/images/buildpack-java/README.md
@@ -4,7 +4,7 @@
 
 This folder contains the Buildpack Java image that is based on the Bootstrap image. Use it to run Java components.
 
-The Buildpack Java Docker Image contains `java openjdk jre8 8u212-b04`.
+The Buildpack Java Docker Image contains `java openjdk jre8 8u212-b04` and also Maven.
 
 ## Installation
 

--- a/prow/images/buildpack-java/README.md
+++ b/prow/images/buildpack-java/README.md
@@ -4,7 +4,7 @@
 
 This folder contains the Buildpack Java image that is based on the Bootstrap image. Use it to run Java components.
 
-The Buildpack Java Docker Image contains `java openjdk jre8 8u212-b04` and also Maven.
+The Buildpack Java Docker Image contains `java openjdk jdk8 8u212-b04` and also Maven.
 
 ## Installation
 

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,7 @@
+pjNames:
+  - pjName: "pre-test-infra-buildpack-java"
+    pjPath: "test-infra/prow/jobs/test-infra/"
+prConfigs:
+  kyma-incubator:
+    compass:
+      prNumber: 3076

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,7 +1,0 @@
-pjNames:
-  - pjName: "pre-test-infra-buildpack-java"
-    pjPath: "test-infra/prow/jobs/test-infra/"
-prConfigs:
-  kyma-incubator:
-    compass:
-      prNumber: 3076


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add Maven to Java Buildpack
- Download whole Java JDK (as opposed to just JRE as it was before)