### PR TITLE
Build Compass Installer images on tag creation

### DIFF
--- a/prow/jobs/incubator/compass/compass-development-artifacts.yaml
+++ b/prow/jobs/incubator/compass/compass-development-artifacts.yaml
@@ -59,6 +59,7 @@ postsubmits:
       testgrid-create-test-group: "false"
     branches:
       - ^master$
+      - "^v\\d+\\.\\d+\\.\\d+$" # release tags
     <<: *job_template
     extra_refs:
       - <<: *test_infra_ref

--- a/prow/scripts/build-compass-development-artifacts.sh
+++ b/prow/scripts/build-compass-development-artifacts.sh
@@ -36,7 +36,7 @@ function export_variables() {
         BUCKET_DIR="PR-${PULL_NUMBER}"
    elif [[ "${PULL_BASE_REF}" != "master" ]]; then
         DOCKER_TAG="${PULL_BASE_REF}"
-        SKIP_ARTIFACT_UPLOAD = true
+        SKIP_ARTIFACT_UPLOAD=true
    else
         DOCKER_TAG="master-${COMMIT_ID}-${CURRENT_TIMESTAMP}"
         BUCKET_DIR="master-${COMMIT_ID}"

--- a/prow/scripts/build-compass-development-artifacts.sh
+++ b/prow/scripts/build-compass-development-artifacts.sh
@@ -34,10 +34,13 @@ function export_variables() {
    if [[ -n "${PULL_NUMBER}" ]]; then
         DOCKER_TAG="PR-${PULL_NUMBER}-${COMMIT_ID}"
         BUCKET_DIR="PR-${PULL_NUMBER}"
-    else
+   elif [[ "${PULL_BASE_REF}" != "master" ]]; then
+        DOCKER_TAG="${PULL_BASE_REF}"
+        SKIP_ARTIFACT_UPLOAD = true
+   else
         DOCKER_TAG="master-${COMMIT_ID}-${CURRENT_TIMESTAMP}"
         BUCKET_DIR="master-${COMMIT_ID}"
-    fi
+   fi
 
    readonly DOCKER_TAG
    readonly COMPASS_INSTALLER_PUSH_DIR
@@ -62,6 +65,11 @@ buildTarget="release"
 
 shout "Build compass-installer with target ${buildTarget}"
 make -C "${COMPASS_PATH}/tools/compass-installer" ${buildTarget}
+
+if [[ -n "${SKIP_ARTIFACT_UPLOAD}" ]]; then
+    shout "Skipping development artifacts upload"
+    exit
+fi
 
 shout "Create development artifacts"
 # INPUTS:


### PR DESCRIPTION
# Build Compass Installer images on tag creation

**Description**

Changes proposed in this pull request:

- Modify `compass-development-artifacts` job to run when new tags are created
