### PR TITLE
fix bucket path for postsubmit artifacts

### DIFF
--- a/prow/scripts/build-kyma-artifacts.sh
+++ b/prow/scripts/build-kyma-artifacts.sh
@@ -72,6 +72,6 @@ elif [[ "$PULL_BASE_REF" =~ ^release-.* ]]; then
   # TODO this script needs to be revisited for future improvements...
   "${SCRIPT_DIR}"changelog-generator.sh
 else
-  copy_artifacts "${KYMA_DEVELOPMENT_ARTIFACTS_BUCKET}/${DOCKER_TAG}"
+  copy_artifacts "${KYMA_DEVELOPMENT_ARTIFACTS_BUCKET}/master-${DOCKER_TAG}"
   copy_artifacts "${KYMA_DEVELOPMENT_ARTIFACTS_BUCKET}/master"
 fi


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The reworked build-kyma-artifacts.sh script was pushing post submit artifacts to wrong path which Kyma-cli couldn't find. We need to push script to paths `master-{COMMIT_SHA}` instead of `{COMMIT_SHA}`
Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
