### PR TITLE
Scripts: deprecate some helpers

### DIFF
--- a/prow/scripts/cluster-integration/compass-gke-integration.sh
+++ b/prow/scripts/cluster-integration/compass-gke-integration.sh
@@ -132,7 +132,7 @@ function createCluster() {
 
   log::info "Reserve IP Address for Ingressgateway"
   GATEWAY_IP_ADDRESS_NAME="${COMMON_NAME}"
-  GATEWAY_IP_ADDRESS=$(IP_ADDRESS_NAME=${GATEWAY_IP_ADDRESS_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/reserve-ip-address.sh)
+  GATEWAY_IP_ADDRESS=$(gcloud::reserve_ip_address "${GATEWAY_IP_ADDRESS_NAME}")
   CLEANUP_GATEWAY_IP_ADDRESS="true"
   echo "Created IP Address for Ingressgateway: ${GATEWAY_IP_ADDRESS}"
 

--- a/prow/scripts/cluster-integration/compass-gke-integration.sh
+++ b/prow/scripts/cluster-integration/compass-gke-integration.sh
@@ -139,7 +139,7 @@ function createCluster() {
   log::info "Create DNS Record for Ingressgateway IP"
   GATEWAY_DNS_FULL_NAME="*.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
   CLEANUP_GATEWAY_DNS_RECORD="true"
-  IP_ADDRESS=${GATEWAY_IP_ADDRESS} DNS_FULL_NAME=${GATEWAY_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/create-dns-record.sh
+  gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 
   NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
   if [ "$NETWORK_EXISTS" -gt 0 ]; then
@@ -326,7 +326,7 @@ function installCompass() {
     APISERVER_IP_ADDRESS=$(kubectl get service -n kyma-system apiserver-proxy-ssl -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     APISERVER_DNS_FULL_NAME="apiserver.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
     CLEANUP_APISERVER_DNS_RECORD="true"
-    IP_ADDRESS=${APISERVER_IP_ADDRESS} DNS_FULL_NAME=${APISERVER_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
+    gcloud::create_dns_record "${APISERVER_IP_ADDRESS}" "${APISERVER_DNS_FULL_NAME}"
   fi
 }
 

--- a/prow/scripts/cluster-integration/compass-gke-integration.sh
+++ b/prow/scripts/cluster-integration/compass-gke-integration.sh
@@ -141,13 +141,8 @@ function createCluster() {
   CLEANUP_GATEWAY_DNS_RECORD="true"
   gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 
-  NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
-  if [ "$NETWORK_EXISTS" -gt 0 ]; then
-    log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
-    "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-network-with-subnet.sh"
-  else
-    log::info "Network ${GCLOUD_NETWORK_NAME} exists"
-  fi
+  log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
+  gcloud::create_network "${GCLOUD_NETWORK_NAME}" "${GCLOUD_SUBNET_NAME}"
 
   log::info "Provision cluster: \"${CLUSTER_NAME}\""
   export GCLOUD_SERVICE_KEY_PATH="${GOOGLE_APPLICATION_CREDENTIALS}"

--- a/prow/scripts/cluster-integration/control-plane-gke-integration.sh
+++ b/prow/scripts/cluster-integration/control-plane-gke-integration.sh
@@ -145,7 +145,7 @@ function createCluster() {
 
   log::info "Reserve IP Address for Ingressgateway"
   GATEWAY_IP_ADDRESS_NAME="${COMMON_NAME}"
-  GATEWAY_IP_ADDRESS=$(IP_ADDRESS_NAME=${GATEWAY_IP_ADDRESS_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/reserve-ip-address.sh)
+  GATEWAY_IP_ADDRESS=$(gcloud::reserve_ip_address "${GATEWAY_IP_ADDRESS_NAME}")
   CLEANUP_GATEWAY_IP_ADDRESS="true"
   echo "Created IP Address for Ingressgateway: ${GATEWAY_IP_ADDRESS}"
 

--- a/prow/scripts/cluster-integration/control-plane-gke-integration.sh
+++ b/prow/scripts/cluster-integration/control-plane-gke-integration.sh
@@ -152,7 +152,7 @@ function createCluster() {
   log::info "Create DNS Record for Ingressgateway IP"
   GATEWAY_DNS_FULL_NAME="*.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
   CLEANUP_GATEWAY_DNS_RECORD="true"
-  IP_ADDRESS=${GATEWAY_IP_ADDRESS} DNS_FULL_NAME=${GATEWAY_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/create-dns-record.sh
+  gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 
   NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
   if [ "$NETWORK_EXISTS" -gt 0 ]; then
@@ -394,7 +394,7 @@ function installControlPlane() {
     APISERVER_IP_ADDRESS=$(kubectl get service -n kyma-system apiserver-proxy-ssl -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     APISERVER_DNS_FULL_NAME="apiserver.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
     CLEANUP_APISERVER_DNS_RECORD="true"
-    IP_ADDRESS=${APISERVER_IP_ADDRESS} DNS_FULL_NAME=${APISERVER_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
+    gcloud::create_dns_record "${APISERVER_IP_ADDRESS}" "${APISERVER_DNS_FULL_NAME}"
   fi
 }
 

--- a/prow/scripts/cluster-integration/control-plane-gke-integration.sh
+++ b/prow/scripts/cluster-integration/control-plane-gke-integration.sh
@@ -154,13 +154,8 @@ function createCluster() {
   CLEANUP_GATEWAY_DNS_RECORD="true"
   gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 
-  NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
-  if [ "$NETWORK_EXISTS" -gt 0 ]; then
-    log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
-    "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-network-with-subnet.sh"
-  else
-    log::info "Network ${GCLOUD_NETWORK_NAME} exists"
-  fi
+  log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
+  gcloud::create_network "${GCLOUD_NETWORK_NAME}" "${GCLOUD_SUBNET_NAME}"
 
   log::info "Provision cluster: \"${CLUSTER_NAME}\""
   export GCLOUD_SERVICE_KEY_PATH="${GOOGLE_APPLICATION_CREDENTIALS}"

--- a/prow/scripts/cluster-integration/helpers/create-cluster.sh
+++ b/prow/scripts/cluster-integration/helpers/create-cluster.sh
@@ -39,7 +39,7 @@ function createCluster() {
 
 		log::info "Reserve IP Address for Ingressgateway"
 		GATEWAY_IP_ADDRESS_NAME="${STANDARIZED_NAME}"
-		GATEWAY_IP_ADDRESS=$(IP_ADDRESS_NAME=${GATEWAY_IP_ADDRESS_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/reserve-ip-address.sh)
+		GATEWAY_IP_ADDRESS=$(gcloud::reserve_ip_address "${GATEWAY_IP_ADDRESS_NAME}")
 		echo "Created IP Address for Ingressgateway: ${GATEWAY_IP_ADDRESS}"
 
 		log::info "Create DNS Record for Ingressgateway IP"

--- a/prow/scripts/cluster-integration/helpers/create-cluster.sh
+++ b/prow/scripts/cluster-integration/helpers/create-cluster.sh
@@ -12,6 +12,9 @@
 source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/log.sh"
 # shellcheck source=prow/scripts/lib/utils.sh
 source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/utils.sh"
+# shellcheck source=prow/scripts/lib/gcloud.sh
+source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/gcloud.sh"
+
 
 function createCluster() {
 	requiredVars=(
@@ -41,7 +44,7 @@ function createCluster() {
 
 		log::info "Create DNS Record for Ingressgateway IP"
 		GATEWAY_DNS_FULL_NAME="*.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
-		IP_ADDRESS=${GATEWAY_IP_ADDRESS} DNS_FULL_NAME=${GATEWAY_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/create-dns-record.sh
+		gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 
 		NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
 		if [ "$NETWORK_EXISTS" -gt 0 ]; then

--- a/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-aks-long-lasting.sh
@@ -209,7 +209,7 @@ function createPublicIPandDNS() {
 	log::info "Create DNS Record for Ingressgateway IP"
 
 	GATEWAY_DNS_FULL_NAME="*.${DOMAIN}."
-	IP_ADDRESS=${GATEWAY_IP_ADDRESS} DNS_FULL_NAME=${GATEWAY_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/create-dns-record.sh
+	gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 }
 
 function setupKubeconfig() {
@@ -365,7 +365,7 @@ EOF
 		log::info "Create DNS Record for Apiserver proxy IP"
 		APISERVER_IP_ADDRESS=$(kubectl get service -n kyma-system apiserver-proxy-ssl -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 		APISERVER_DNS_FULL_NAME="apiserver.${DOMAIN}."
-		IP_ADDRESS=${APISERVER_IP_ADDRESS} DNS_FULL_NAME=${APISERVER_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
+		gcloud::create_dns_record "${APISERVER_IP_ADDRESS}" "${APISERVER_DNS_FULL_NAME}"
 	fi
 }
 

--- a/prow/scripts/cluster-integration/kyma-gke-central.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-central.sh
@@ -148,7 +148,7 @@ DNS_DOMAIN="$(gcloud dns managed-zones describe "${CLOUDSDK_DNS_ZONE_NAME}" --fo
 
 log::info "Reserve IP Address for Ingressgateway"
 GATEWAY_IP_ADDRESS_NAME="${COMMON_NAME}"
-GATEWAY_IP_ADDRESS=$(IP_ADDRESS_NAME=${GATEWAY_IP_ADDRESS_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/reserve-ip-address.sh")
+GATEWAY_IP_ADDRESS=$(gcloud::reserve_ip_address "${GATEWAY_IP_ADDRESS_NAME}")
 CLEANUP_GATEWAY_IP_ADDRESS="true"
 log::info "Created IP Address for Ingressgateway: ${GATEWAY_IP_ADDRESS}"
 

--- a/prow/scripts/cluster-integration/kyma-gke-central.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-central.sh
@@ -156,7 +156,7 @@ log::info "Created IP Address for Ingressgateway: ${GATEWAY_IP_ADDRESS}"
 log::info "Create DNS Record for Ingressgateway IP"
 GATEWAY_DNS_FULL_NAME="*.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
 CLEANUP_GATEWAY_DNS_RECORD="true"
-IP_ADDRESS=${GATEWAY_IP_ADDRESS} DNS_FULL_NAME=${GATEWAY_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
+gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 
 
 NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
@@ -270,7 +270,7 @@ if [ -n "$(kubectl get  service -n kyma-system apiserver-proxy-ssl --ignore-not-
     APISERVER_IP_ADDRESS=$(kubectl get  service -n kyma-system apiserver-proxy-ssl -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     APISERVER_DNS_FULL_NAME="apiserver.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
     CLEANUP_APISERVER_DNS_RECORD="true"
-    IP_ADDRESS=${APISERVER_IP_ADDRESS} DNS_FULL_NAME=${APISERVER_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
+    gcloud::create_dns_record "${APISERVER_IP_ADDRESS}" "${APISERVER_DNS_FULL_NAME}"
 fi
 
 # enable test-log-collector before tests; if prowjob fails before test phase we do not have any reason to enable it earlier

--- a/prow/scripts/cluster-integration/kyma-gke-central.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-central.sh
@@ -159,13 +159,8 @@ CLEANUP_GATEWAY_DNS_RECORD="true"
 gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 
 
-NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
-if [ "$NETWORK_EXISTS" -gt 0 ]; then
-    log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
-    "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-network-with-subnet.sh"
-else
-    log::warn "Network ${GCLOUD_NETWORK_NAME} exists"
-fi
+log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
+gcloud::create_network "${GCLOUD_NETWORK_NAME}" "${GCLOUD_SUBNET_NAME}"
 
 
 log::info "Provision cluster: \"${CLUSTER_NAME}\""

--- a/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
@@ -159,7 +159,7 @@ function createCluster() {
   log::info "Create DNS Record for Ingressgateway IP"
   GATEWAY_DNS_FULL_NAME="*.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
   CLEANUP_GATEWAY_DNS_RECORD="true"
-  IP_ADDRESS=${GATEWAY_IP_ADDRESS} DNS_FULL_NAME=${GATEWAY_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/create-dns-record.sh
+  gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 
   NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
   if [ "$NETWORK_EXISTS" -gt 0 ]; then
@@ -339,7 +339,7 @@ function installKyma() {
     APISERVER_IP_ADDRESS=$(kubectl get service -n kyma-system apiserver-proxy-ssl -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     APISERVER_DNS_FULL_NAME="apiserver.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
     CLEANUP_APISERVER_DNS_RECORD="true"
-    IP_ADDRESS=${APISERVER_IP_ADDRESS} DNS_FULL_NAME=${APISERVER_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
+    gcloud::create_dns_record "${APISERVER_IP_ADDRESS}" "${APISERVER_DNS_FULL_NAME}"
   fi
 }
 

--- a/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
@@ -152,7 +152,7 @@ function createCluster() {
 
   log::info "Reserve IP Address for Ingressgateway"
   GATEWAY_IP_ADDRESS_NAME="${COMMON_NAME}"
-  GATEWAY_IP_ADDRESS=$(IP_ADDRESS_NAME=${GATEWAY_IP_ADDRESS_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/reserve-ip-address.sh)
+  GATEWAY_IP_ADDRESS=$(gcloud::reserve_ip_address "${GATEWAY_IP_ADDRESS_NAME}")
   CLEANUP_GATEWAY_IP_ADDRESS="true"
   echo "Created IP Address for Ingressgateway: ${GATEWAY_IP_ADDRESS}"
 

--- a/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
@@ -161,13 +161,8 @@ function createCluster() {
   CLEANUP_GATEWAY_DNS_RECORD="true"
   gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 
-  NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
-  if [ "$NETWORK_EXISTS" -gt 0 ]; then
-    log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
-    "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-network-with-subnet.sh"
-  else
-    log::info "Network ${GCLOUD_NETWORK_NAME} exists"
-  fi
+  log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
+  gcloud::create_network "${GCLOUD_NETWORK_NAME}" "${GCLOUD_SUBNET_NAME}"
 
   log::info "Provision cluster: \"${CLUSTER_NAME}\""
   export GCLOUD_SERVICE_KEY_PATH="${GOOGLE_APPLICATION_CREDENTIALS}"

--- a/prow/scripts/cluster-integration/kyma-gke-external-registry.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-external-registry.sh
@@ -177,7 +177,7 @@ fi
 
 log::info "Reserve IP Address for Ingressgateway"
 GATEWAY_IP_ADDRESS_NAME="${COMMON_NAME}"
-GATEWAY_IP_ADDRESS=$(IP_ADDRESS_NAME=${GATEWAY_IP_ADDRESS_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/reserve-ip-address.sh")
+GATEWAY_IP_ADDRESS=$(gcloud::reserve_ip_address "${GATEWAY_IP_ADDRESS_NAME}")
 CLEANUP_GATEWAY_IP_ADDRESS="true"
 echo "Created IP Address for Ingressgateway: ${GATEWAY_IP_ADDRESS}"
 

--- a/prow/scripts/cluster-integration/kyma-gke-external-registry.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-external-registry.sh
@@ -188,13 +188,8 @@ CLEANUP_GATEWAY_DNS_RECORD="true"
 gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 
 
-NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
-if [ "$NETWORK_EXISTS" -gt 0 ]; then
-    log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
-    "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-network-with-subnet.sh"
-else
-    log::info "Network ${GCLOUD_NETWORK_NAME} exists"
-fi
+log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
+gcloud::create_network "${GCLOUD_NETWORK_NAME}" "${GCLOUD_SUBNET_NAME}"
 
 
 log::info "Provision cluster: \"${CLUSTER_NAME}\""

--- a/prow/scripts/cluster-integration/kyma-gke-external-registry.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-external-registry.sh
@@ -185,7 +185,7 @@ echo "Created IP Address for Ingressgateway: ${GATEWAY_IP_ADDRESS}"
 log::info "Create DNS Record for Ingressgateway IP"
 GATEWAY_DNS_FULL_NAME="*.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
 CLEANUP_GATEWAY_DNS_RECORD="true"
-IP_ADDRESS=${GATEWAY_IP_ADDRESS} DNS_FULL_NAME=${GATEWAY_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
+gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 
 
 NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
@@ -286,7 +286,7 @@ if [ -n "$(kubectl get  service -n kyma-system apiserver-proxy-ssl --ignore-not-
     APISERVER_IP_ADDRESS=$(kubectl get  service -n kyma-system apiserver-proxy-ssl -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     APISERVER_DNS_FULL_NAME="apiserver.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
     CLEANUP_APISERVER_DNS_RECORD="true"
-    IP_ADDRESS=${APISERVER_IP_ADDRESS} DNS_FULL_NAME=${APISERVER_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
+    gcloud::create_dns_record "${APISERVER_IP_ADDRESS}" "${APISERVER_DNS_FULL_NAME}"
 fi
 
 

--- a/prow/scripts/cluster-integration/kyma-gke-integration-cli.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-integration-cli.sh
@@ -101,7 +101,7 @@ DNS_DOMAIN="$(gcloud dns managed-zones describe "${CLOUDSDK_DNS_ZONE_NAME}" --fo
 
 log::info "Reserve IP Address for Ingressgateway"
 GATEWAY_IP_ADDRESS_NAME="${COMMON_NAME}"
-GATEWAY_IP_ADDRESS=$(IP_ADDRESS_NAME=${GATEWAY_IP_ADDRESS_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/reserve-ip-address.sh")
+GATEWAY_IP_ADDRESS=$(gcloud::reserve_ip_address "${GATEWAY_IP_ADDRESS_NAME}")
 CLEANUP_GATEWAY_IP_ADDRESS="true"
 echo "Created IP Address for Ingressgateway: ${GATEWAY_IP_ADDRESS}"
 

--- a/prow/scripts/cluster-integration/kyma-gke-integration-cli.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-integration-cli.sh
@@ -112,13 +112,8 @@ CLEANUP_GATEWAY_DNS_RECORD="true"
 gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 
 
-NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
-if [ "$NETWORK_EXISTS" -gt 0 ]; then
-    log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
-    "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-network-with-subnet.sh"
-else
-    log::info "Network ${GCLOUD_NETWORK_NAME} exists"
-fi
+log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
+gcloud::create_network "${GCLOUD_NETWORK_NAME}" "${GCLOUD_SUBNET_NAME}"
 
 
 log::info "Provision cluster: \"${CLUSTER_NAME}\""

--- a/prow/scripts/cluster-integration/kyma-gke-integration-cli.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-integration-cli.sh
@@ -109,7 +109,7 @@ echo "Created IP Address for Ingressgateway: ${GATEWAY_IP_ADDRESS}"
 log::info "Create DNS Record for Ingressgateway IP"
 GATEWAY_DNS_FULL_NAME="*.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
 CLEANUP_GATEWAY_DNS_RECORD="true"
-IP_ADDRESS=${GATEWAY_IP_ADDRESS} DNS_FULL_NAME=${GATEWAY_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
+gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 
 
 NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
@@ -208,7 +208,7 @@ if [ -n "$(kubectl get  service -n kyma-system apiserver-proxy-ssl --ignore-not-
     APISERVER_IP_ADDRESS=$(kubectl get  service -n kyma-system apiserver-proxy-ssl -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     APISERVER_DNS_FULL_NAME="apiserver.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
     CLEANUP_APISERVER_DNS_RECORD="true"
-    IP_ADDRESS=${APISERVER_IP_ADDRESS} DNS_FULL_NAME=${APISERVER_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
+    gcloud::create_dns_record "${APISERVER_IP_ADDRESS}" "${APISERVER_DNS_FULL_NAME}"
 fi
 
 log::info "Create local resources for a sample Function"

--- a/prow/scripts/cluster-integration/kyma-gke-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-integration.sh
@@ -164,7 +164,7 @@ log::info "Created IP Address for Ingressgateway: ${GATEWAY_IP_ADDRESS}"
 log::info "Create DNS Record for Ingressgateway IP"
 GATEWAY_DNS_FULL_NAME="*.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
 CLEANUP_GATEWAY_DNS_RECORD="true"
-IP_ADDRESS=${GATEWAY_IP_ADDRESS} DNS_FULL_NAME=${GATEWAY_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
+gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 
 
 NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
@@ -275,7 +275,7 @@ if [ -n "$(kubectl get  service -n kyma-system apiserver-proxy-ssl --ignore-not-
     APISERVER_IP_ADDRESS=$(kubectl get service -n kyma-system apiserver-proxy-ssl -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     APISERVER_DNS_FULL_NAME="apiserver.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
     CLEANUP_APISERVER_DNS_RECORD="true"
-    IP_ADDRESS=${APISERVER_IP_ADDRESS} DNS_FULL_NAME=${APISERVER_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
+    gcloud::create_dns_record "${APISERVER_IP_ADDRESS}" "${APISERVER_DNS_FULL_NAME}"
 fi
 
 # enable test-log-collector before tests; if prowjob fails before test phase we do not have any reason to enable it earlier

--- a/prow/scripts/cluster-integration/kyma-gke-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-integration.sh
@@ -167,13 +167,8 @@ CLEANUP_GATEWAY_DNS_RECORD="true"
 gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 
 
-NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
-if [ "$NETWORK_EXISTS" -gt 0 ]; then
-    log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
-    "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-network-with-subnet.sh"
-else
-    log::warn "Network ${GCLOUD_NETWORK_NAME} exists"
-fi
+log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
+gcloud::create_network "${GCLOUD_NETWORK_NAME}" "${GCLOUD_SUBNET_NAME}"
 
 
 log::info "Provision cluster: \"${CLUSTER_NAME}\""

--- a/prow/scripts/cluster-integration/kyma-gke-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-integration.sh
@@ -156,7 +156,7 @@ DNS_DOMAIN="$(gcloud dns managed-zones describe "${CLOUDSDK_DNS_ZONE_NAME}" --fo
 
 log::info "Reserve IP Address for Ingressgateway"
 GATEWAY_IP_ADDRESS_NAME="${COMMON_NAME}"
-GATEWAY_IP_ADDRESS=$(IP_ADDRESS_NAME=${GATEWAY_IP_ADDRESS_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/reserve-ip-address.sh")
+GATEWAY_IP_ADDRESS=$(gcloud::reserve_ip_address "${GATEWAY_IP_ADDRESS_NAME}")
 CLEANUP_GATEWAY_IP_ADDRESS="true"
 log::info "Created IP Address for Ingressgateway: ${GATEWAY_IP_ADDRESS}"
 

--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -95,7 +95,7 @@ function createCluster() {
 
 	log::info "Create DNS Record for Ingressgateway IP"
 	GATEWAY_DNS_FULL_NAME="*.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
-	IP_ADDRESS=${GATEWAY_IP_ADDRESS} DNS_FULL_NAME=${GATEWAY_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/create-dns-record.sh
+	gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 
 	NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
 	if [ "$NETWORK_EXISTS" -gt 0 ]; then
@@ -275,7 +275,7 @@ EOF
 		log::info "Create DNS Record for Apiserver proxy IP"
 		APISERVER_IP_ADDRESS=$(kubectl get service -n kyma-system apiserver-proxy-ssl -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 		APISERVER_DNS_FULL_NAME="apiserver.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
-		IP_ADDRESS=${APISERVER_IP_ADDRESS} DNS_FULL_NAME=${APISERVER_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
+		gcloud::create_dns_record "${APISERVER_IP_ADDRESS}" "${APISERVER_DNS_FULL_NAME}"
 	fi
 }
 

--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -90,7 +90,7 @@ source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/docker.sh"
 function createCluster() {
 	log::info "Reserve IP Address for Ingressgateway"
 	GATEWAY_IP_ADDRESS_NAME="${STANDARIZED_NAME}"
-	GATEWAY_IP_ADDRESS=$(IP_ADDRESS_NAME=${GATEWAY_IP_ADDRESS_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}"/reserve-ip-address.sh)
+	GATEWAY_IP_ADDRESS=$(gcloud::reserve_ip_address "${GATEWAY_IP_ADDRESS_NAME}")
 	echo "Created IP Address for Ingressgateway: ${GATEWAY_IP_ADDRESS}"
 
 	log::info "Create DNS Record for Ingressgateway IP"

--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -97,13 +97,8 @@ function createCluster() {
 	GATEWAY_DNS_FULL_NAME="*.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
 	gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 
-	NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
-	if [ "$NETWORK_EXISTS" -gt 0 ]; then
-		log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
-		"${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-network-with-subnet.sh"
-	else
-		log::info "Network ${GCLOUD_NETWORK_NAME} exists"
-	fi
+	log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
+	gcloud::create_network "${GCLOUD_NETWORK_NAME}" "${GCLOUD_SUBNET_NAME}"
 
 	log::info "Provision cluster: \"${CLUSTER_NAME}\""
 	date

--- a/prow/scripts/cluster-integration/kyma-gke-rel2rel-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-rel2rel-upgrade.sh
@@ -188,7 +188,7 @@ reserveIPsAndCreateDNSRecords() {
 
     log::info "Reserve IP Address for Ingressgateway"
     GATEWAY_IP_ADDRESS_NAME="${COMMON_NAME}"
-    GATEWAY_IP_ADDRESS=$(IP_ADDRESS_NAME=${GATEWAY_IP_ADDRESS_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/reserve-ip-address.sh")
+    GATEWAY_IP_ADDRESS=$(gcloud::reserve_ip_address "${GATEWAY_IP_ADDRESS_NAME}")
     CLEANUP_GATEWAY_IP_ADDRESS="true"
     echo "Created IP Address for Ingressgateway: ${GATEWAY_IP_ADDRESS}"
 

--- a/prow/scripts/cluster-integration/kyma-gke-rel2rel-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-rel2rel-upgrade.sh
@@ -195,7 +195,7 @@ reserveIPsAndCreateDNSRecords() {
     log::info "Create DNS Record for Ingressgateway IP"
     GATEWAY_DNS_FULL_NAME="*.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
     CLEANUP_GATEWAY_DNS_RECORD="true"
-    IP_ADDRESS=${GATEWAY_IP_ADDRESS} DNS_FULL_NAME=${GATEWAY_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
+    gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 
     DOMAIN="${DNS_SUBDOMAIN}.${DNS_DOMAIN%?}"
     export DOMAIN
@@ -398,7 +398,7 @@ upgradeKyma() {
     #     APISERVER_IP_ADDRESS=$(kubectl get  service -n kyma-system apiserver-proxy-ssl -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     #     APISERVER_DNS_FULL_NAME="apiserver.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
     #     CLEANUP_APISERVER_DNS_RECORD="true"
-    #     IP_ADDRESS=${APISERVER_IP_ADDRESS} DNS_FULL_NAME=${APISERVER_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
+    #     gcloud::create_dns_record "${APISERVER_IP_ADDRESS}" "${APISERVER_DNS_FULL_NAME}"
     # fi
 }
 
@@ -468,7 +468,7 @@ function createDNSRecord() {
     APISERVER_IP_ADDRESS=$(kubectl get service -n kyma-system apiserver-proxy-ssl -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     APISERVER_DNS_FULL_NAME="apiserver.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
     CLEANUP_APISERVER_DNS_RECORD="true"
-    IP_ADDRESS=${APISERVER_IP_ADDRESS} DNS_FULL_NAME=${APISERVER_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
+    gcloud::create_dns_record "${APISERVER_IP_ADDRESS}" "${APISERVER_DNS_FULL_NAME}"
   fi
 }
 

--- a/prow/scripts/cluster-integration/kyma-gke-rel2rel-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-rel2rel-upgrade.sh
@@ -213,13 +213,8 @@ generateAndExportCerts() {
 
 createNetwork() {
     export GCLOUD_PROJECT_NAME="${CLOUDSDK_CORE_PROJECT}"
-    NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
-    if [ "$NETWORK_EXISTS" -gt 0 ]; then
-        log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
-        "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-network-with-subnet.sh"
-    else
-        log::info "Network ${GCLOUD_NETWORK_NAME} exists"
-    fi
+    log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
+    gcloud::create_network "${GCLOUD_NETWORK_NAME}" "${GCLOUD_SUBNET_NAME}"
 }
 
 createCluster() {

--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -166,15 +166,8 @@ CLEANUP_GATEWAY_DNS_RECORD="true"
 gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 
 
-NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
-if [ "$NETWORK_EXISTS" -gt 0 ]; then
-    log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
-    date
-    "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-network-with-subnet.sh"
-else
-    log::info "Network ${GCLOUD_NETWORK_NAME} exists"
-fi
-
+log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
+gcloud::create_network "${GCLOUD_NETWORK_NAME}" "${GCLOUD_SUBNET_NAME}"
 
 log::info "Provision cluster: \"${CLUSTER_NAME}\""
 export GCLOUD_SERVICE_KEY_PATH="${GOOGLE_APPLICATION_CREDENTIALS}"

--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -155,7 +155,7 @@ DNS_DOMAIN="$(gcloud dns managed-zones describe "${CLOUDSDK_DNS_ZONE_NAME}" --fo
 
 log::info "Reserve IP Address for Ingressgateway"
 GATEWAY_IP_ADDRESS_NAME="${COMMON_NAME}"
-GATEWAY_IP_ADDRESS=$(IP_ADDRESS_NAME=${GATEWAY_IP_ADDRESS_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/reserve-ip-address.sh")
+GATEWAY_IP_ADDRESS=$(gcloud::reserve_ip_address "${GATEWAY_IP_ADDRESS_NAME}")
 CLEANUP_GATEWAY_IP_ADDRESS="true"
 echo "Created IP Address for Ingressgateway: ${GATEWAY_IP_ADDRESS}"
 

--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -163,7 +163,7 @@ echo "Created IP Address for Ingressgateway: ${GATEWAY_IP_ADDRESS}"
 log::info "Create DNS Record for Ingressgateway IP"
 GATEWAY_DNS_FULL_NAME="*.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
 CLEANUP_GATEWAY_DNS_RECORD="true"
-IP_ADDRESS=${GATEWAY_IP_ADDRESS} DNS_FULL_NAME=${GATEWAY_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
+gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 
 
 NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
@@ -277,7 +277,7 @@ if [ -n "$(kubectl get  service -n kyma-system apiserver-proxy-ssl --ignore-not-
     APISERVER_IP_ADDRESS=$(kubectl get  service -n kyma-system apiserver-proxy-ssl -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     APISERVER_DNS_FULL_NAME="apiserver.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
     CLEANUP_APISERVER_DNS_RECORD="true"
-    IP_ADDRESS=${APISERVER_IP_ADDRESS} DNS_FULL_NAME=${APISERVER_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
+    gcloud::create_dns_record "${APISERVER_IP_ADDRESS}" "${APISERVER_DNS_FULL_NAME}"
 fi
 
 log::info "Collect list of images"

--- a/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
@@ -200,13 +200,8 @@ function generateAndExportCerts() {
 
 function createNetwork() {
   export GCLOUD_PROJECT_NAME="${CLOUDSDK_CORE_PROJECT}"
-  NETWORK_EXISTS=$("${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/network-exists.sh")
-  if [ "$NETWORK_EXISTS" -gt 0 ]; then
-    log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
-    "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-network-with-subnet.sh"
-  else
-    log::info "Network ${GCLOUD_NETWORK_NAME} exists"
-  fi
+  log::info "Create ${GCLOUD_NETWORK_NAME} network with ${GCLOUD_SUBNET_NAME} subnet"
+  gcloud::create_network "${GCLOUD_NETWORK_NAME}" "${GCLOUD_SUBNET_NAME}"
 }
 
 function createCluster() {

--- a/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
@@ -175,7 +175,7 @@ function reserveIPsAndCreateDNSRecords() {
 
   log::info "Reserve IP Address for Ingressgateway"
   GATEWAY_IP_ADDRESS_NAME="${COMMON_NAME}"
-  GATEWAY_IP_ADDRESS=$(IP_ADDRESS_NAME=${GATEWAY_IP_ADDRESS_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/reserve-ip-address.sh")
+  GATEWAY_IP_ADDRESS=$(gcloud::reserve_ip_address "${GATEWAY_IP_ADDRESS_NAME}")
   CLEANUP_GATEWAY_IP_ADDRESS="true"
   log::info "Created IP Address for Ingressgateway: ${GATEWAY_IP_ADDRESS}"
 

--- a/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
@@ -182,7 +182,7 @@ function reserveIPsAndCreateDNSRecords() {
   log::info "Create DNS Record for Ingressgateway IP"
   GATEWAY_DNS_FULL_NAME="*.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
   CLEANUP_GATEWAY_DNS_RECORD="true"
-  IP_ADDRESS=${GATEWAY_IP_ADDRESS} DNS_FULL_NAME=${GATEWAY_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
+  gcloud::create_dns_record "${GATEWAY_IP_ADDRESS}" "${GATEWAY_DNS_FULL_NAME}"
 
   DOMAIN="${DNS_SUBDOMAIN}.${DNS_DOMAIN%?}"
   export DOMAIN
@@ -412,7 +412,7 @@ function createDNSRecord() {
     APISERVER_IP_ADDRESS=$(kubectl get service -n kyma-system apiserver-proxy-ssl -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     APISERVER_DNS_FULL_NAME="apiserver.${DNS_SUBDOMAIN}.${DNS_DOMAIN}"
     CLEANUP_APISERVER_DNS_RECORD="true"
-    IP_ADDRESS=${APISERVER_IP_ADDRESS} DNS_FULL_NAME=${APISERVER_DNS_FULL_NAME} "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-dns-record.sh"
+    gcloud::create_dns_record "${APISERVER_IP_ADDRESS}" "${APISERVER_DNS_FULL_NAME}"
   fi
 }
 

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,2 +1,3 @@
 pjNames:
   - pjName: pre-master-kyma-gke-compass-integration
+  - pjName: pre-master-compass-gke-integration

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,2 @@
+pjNames:
+  - pjName: pre-master-kyma-gke-compass-integration


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- deprecate some of `prow/scripts/cluster-integration/helpers` in favour of `gcloud::` altervatives:
    - `encrypt`/`decrypt`
    - `create-dns-record`
    - `reserve-ip-address`
    - `create-network-with-subnet` and `network-exists`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#2974