### PR TITLE
Rename readonly parameters to local in gcloud.sh encrypt/decrypt functions

### DIFF
--- a/prow/scripts/lib/gcloud.sh
+++ b/prow/scripts/lib/gcloud.sh
@@ -206,12 +206,12 @@ function gcloud::delete_dns_record {
 # $1 - plain text to encrypt
 # $2 - cipher
 function gcloud::encrypt {
-  readonly PLAIN_TEXT="$1"
+  local PLAIN_TEXT="$1"
   if [ -p "$PLAIN_TEXT" ]; then
       log::error "Plaintext variable is missing! Exiting..."
       exit 1
   fi
-  readonly CIPHER_TEXT="$2"
+  local CIPHER_TEXT="$2"
   if [ -c "$CIPHER_TEXT" ]; then
       log::error "Ciphertext variable is missing! Exiting..."
       exit 1
@@ -236,17 +236,18 @@ function gcloud::encrypt {
 # $1 - plain text to encrypt
 # $2 - cipher
 function gcloud::decrypt {
-  readonly PLAIN_TEXT="$1"
+  local PLAIN_TEXT="$1"
   if [ -p "$PLAIN_TEXT" ]; then
       echo "PLAIN_TEXT variable is missing!"
       exit 1
   fi
-  readonly CIPHER_TEXT="$2"
+  local CIPHER_TEXT="$2"
   if [ -c "$CIPHER_TEXT" ]; then
       echo "CIPHER_TEXT variable is missing. Exiting..."
       exit 1
   fi
 
+  log::info "Decrypting ${CIPHER_TEXT} to ${PLAIN_TEXT}"
   log::info "Decrypting ${CIPHER_TEXT} to ${PLAIN_TEXT}"
 
   gcloud kms decrypt --location global \


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
`gcloud::encrypt` and `gcloud::decrypt` were failing due to setting readonly variable for arguments. 

Changes proposed in this pull request:

- Rename readonly parameters to local in gcloud.sh encrypt/decrypt functions
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
