### PR TITLE
scripts: additional labels as optional argument for gcloud::provide_gke_cluster

### DIFF
--- a/prow/scripts/cluster-integration/compass-gke-integration.sh
+++ b/prow/scripts/cluster-integration/compass-gke-integration.sh
@@ -47,7 +47,6 @@ export REPO_OWNER
 readonly REPO_NAME=$(echo "${REPO_NAME}" | tr '[:upper:]' '[:lower:]')
 export REPO_NAME
 
-readonly CURRENT_TIMESTAMP=$(date +%Y%m%d)
 readonly RANDOM_NAME_SUFFIX=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c10)
 
 if [[ "$BUILD_TYPE" == "pr" ]]; then
@@ -153,7 +152,6 @@ function createCluster() {
     export CLUSTER_VERSION="${DEFAULT_CLUSTER_VERSION}"
   fi
   CLEANUP_CLUSTER="true"
-  export ADDITIONAL_LABELS="created-at=${CURRENT_TIMESTAMP}"
   gcloud::provision_gke_cluster "$CLUSTER_NAME"
 }
 

--- a/prow/scripts/cluster-integration/control-plane-gke-integration.sh
+++ b/prow/scripts/cluster-integration/control-plane-gke-integration.sh
@@ -49,7 +49,6 @@ export REPO_OWNER
 readonly REPO_NAME=$(echo "${REPO_NAME}" | tr '[:upper:]' '[:lower:]')
 export REPO_NAME
 
-readonly CURRENT_TIMESTAMP=$(date +%Y%m%d)
 readonly RANDOM_NAME_SUFFIX=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c10)
 
 if [[ "$BUILD_TYPE" == "pr" ]]; then
@@ -166,7 +165,6 @@ function createCluster() {
     export CLUSTER_VERSION="${DEFAULT_CLUSTER_VERSION}"
   fi
   CLEANUP_CLUSTER="true"
-  export ADDITIONAL_LABELS="created-at=${CURRENT_TIMESTAMP}"
   gcloud::provision_gke_cluster "$CLUSTER_NAME"
 }
 

--- a/prow/scripts/cluster-integration/helpers/create-cluster.sh
+++ b/prow/scripts/cluster-integration/helpers/create-cluster.sh
@@ -65,7 +65,6 @@ function createCluster() {
 	if [ -z "${CLUSTER_VERSION}" ]; then
 		export CLUSTER_VERSION="${DEFAULT_CLUSTER_VERSION}"
 	fi
-	export ADDITIONAL_LABELS="created-at=${CURRENT_TIMESTAMP}"
 	gcloud::provision_gke_cluster "$CLUSTER_NAME"
 
 }

--- a/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
@@ -58,7 +58,6 @@ export REPO_OWNER
 readonly REPO_NAME=$(echo "${REPO_NAME}" | tr '[:upper:]' '[:lower:]')
 export REPO_NAME
 
-readonly CURRENT_TIMESTAMP=$(date +%Y%m%d)
 readonly RANDOM_NAME_SUFFIX=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c10)
 
 if [[ "$BUILD_TYPE" == "pr" ]]; then
@@ -173,7 +172,6 @@ function createCluster() {
     export CLUSTER_VERSION="${DEFAULT_CLUSTER_VERSION}"
   fi
   CLEANUP_CLUSTER="true"
-  export ADDITIONAL_LABELS="created-at=${CURRENT_TIMESTAMP}"
   gcloud::provision_gke_cluster "$CLUSTER_NAME"
 }
 

--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -106,7 +106,6 @@ function createCluster() {
 	if [ -z "${CLUSTER_VERSION}" ]; then
 		export CLUSTER_VERSION="${DEFAULT_CLUSTER_VERSION}"
 	fi
-	export ADDITIONAL_LABELS="created-at=${CURRENT_TIMESTAMP}"
 	gcloud::provision_gke_cluster "$CLUSTER_NAME"
 }
 

--- a/prow/scripts/lib/gcloud.sh
+++ b/prow/scripts/lib/gcloud.sh
@@ -317,12 +317,18 @@ function gcloud::delete_network {
 #
 # Arguments:
 # $1 - cluster name
+# $2 - optional additional labels for the cluster
 function gcloud::provision_gke_cluster {
   if [ -z "$1" ]; then
     log::error "Cluster name not provided. Provide proper cluster name."
     exit 1
   fi
   CLUSTER_NAME=$1
+
+  if [ -z "$2" ]; then
+    log::info "No additional labels provided"
+  fi
+  ADDITIONAL_LABELS=$2
 
   readonly CURRENT_TIMESTAMP_READABLE_PARAM=$(date +%Y%m%d)
   readonly CURRENT_TIMESTAMP_PARAM=$(date +%s)
@@ -355,7 +361,7 @@ function gcloud::provision_gke_cluster {
   fi
   if [ "${GCLOUD_SECURITY_GROUP_DOMAIN}" ]; then params+=("--security-group=gke-security-groups@${GCLOUD_SECURITY_GROUP_DOMAIN}"); fi
 
-  APPENDED_LABELS=""
+  APPENDED_LABELS=()
   if [ "${ADDITIONAL_LABELS}" ]; then APPENDED_LABELS=(",${ADDITIONAL_LABELS}") ; fi
   params+=("--labels=job=${JOB_NAME},job-id=${PROW_JOB_ID},cluster=${CLUSTER_NAME},volatile=true${APPENDED_LABELS[@]},${CLEANER_LABELS_PARAM}")
 

--- a/prow/scripts/lib/gcloud.sh
+++ b/prow/scripts/lib/gcloud.sh
@@ -324,10 +324,6 @@ function gcloud::provision_gke_cluster {
     exit 1
   fi
   CLUSTER_NAME=$1
-
-  if [ -z "$2" ]; then
-    log::info "No additional labels provided"
-  fi
   ADDITIONAL_LABELS=$2
 
   readonly CURRENT_TIMESTAMP_READABLE_PARAM=$(date +%Y%m%d)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Improve `gcloud::provision_gke_cluster` as discussed here: https://github.com/kyma-project/test-infra/pull/3056#discussion_r556864989
- remove `ADDITIONAL_LABELS` sa they were just setting `created-at` label that gets overwritten with UNIX time anyway

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#3056, #2974