### PR TITLE
Adjust GKE integration job to install KCP with Kyma 1.16

### DIFF
--- a/prow/scripts/cluster-integration/control-plane-gke-integration.sh
+++ b/prow/scripts/cluster-integration/control-plane-gke-integration.sh
@@ -211,6 +211,10 @@ function applyKymaOverrides() {
     --data "global.istio.gateway.name=compass-istio-gateway" \
     --data "global.istio.gateway.namespace=compass-system" \
     --label "component=ory"
+
+  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "tracing-overrides" \
+      --data "global.tracing.enabled=true" \
+      --label "component=tracing"
 }
 
 function applyCompassOverrides() {


### PR DESCRIPTION
Changes proposed in this pull request:

- Add `tracing-overrides` to `control-plane-gke-integration` (install Kyma section) job. Override is necessary to install Kyma 1.16 for KCP.