### PR TITLE
Fix alpha CLI calls

### DIFF
--- a/prow/scripts/cluster-integration/kyma-cli-alpha-uninstall.sh
+++ b/prow/scripts/cluster-integration/kyma-cli-alpha-uninstall.sh
@@ -81,69 +81,9 @@ gardener::provision_cluster
 
 log::info "Installing Kyma"
 
-# Parallel-install library installs cluster-essentials, istio, and xip-patch before kyma installation. That's why they should not exist on the InstallationCR.
-# Once we figure out a way to fix this, this custom CR can be deleted from this script.
-cat << EOF > "/tmp/kyma-parallel-install-installationCR.yaml"
-apiVersion: "installer.kyma-project.io/v1alpha1"
-kind: Installation
-metadata:
-  name: kyma-installation
-  namespace: default
-spec:
-  components:
-    - name: "testing"
-      namespace: "kyma-system"
-    - name: "knative-eventing"
-      namespace: "knative-eventing"
-    - name: "dex"
-      namespace: "kyma-system"
-    - name: "ory"
-      namespace: "kyma-system"
-    - name: "api-gateway"
-      namespace: "kyma-system"
-    - name: "rafter"
-      namespace: "kyma-system"
-    - name: "service-catalog"
-      namespace: "kyma-system"
-    - name: "service-catalog-addons"
-      namespace: "kyma-system"
-    - name: "helm-broker"
-      namespace: "kyma-system"
-    - name: "nats-streaming"
-      namespace: "natss"
-    - name: "core"
-      namespace: "kyma-system"
-    - name: "cluster-users"
-      namespace: "kyma-system"
-    - name: "logging"
-      namespace: "kyma-system"
-    - name: "permission-controller"
-      namespace: "kyma-system"
-    - name: "apiserver-proxy"
-      namespace: "kyma-system"
-    - name: "iam-kubeconfig-service"
-      namespace: "kyma-system"
-    - name: "serverless"
-      namespace: "kyma-system"
-    - name: "knative-provisioner-natss"
-      namespace: "knative-eventing"
-    - name: "event-sources"
-      namespace: "kyma-system"
-    - name: "application-connector"
-      namespace: "kyma-integration"
-    - name: "tracing"
-      namespace: "kyma-system"
-    - name: "monitoring"
-      namespace: "kyma-system"
-    - name: "kiali"
-      namespace: "kyma-system"
-    - name: "console"
-      namespace: "kyma-system"
-EOF
-
 (
 cd "${KYMA_PROJECT_DIR}/kyma"
-cli-alpha::deploy "${KYMA_PROJECT_DIR}/kyma/resources" "/tmp/kyma-parallel-install-installationCR.yaml"
+cli-alpha::deploy
 )
 
 sleep 1m
@@ -151,9 +91,7 @@ sleep 1m
 log::info "Uninstall Kyma"
 (
 cd "${KYMA_PROJECT_DIR}/kyma"
-kyma alpha uninstall \
-    --ci \
-    --components "/tmp/kyma-parallel-install-installationCR.yaml"
+kyma alpha uninstall -v
 )
 
 sleep 1m
@@ -161,7 +99,7 @@ sleep 1m
 log::info "Install Kyma again"
 (
 cd "${KYMA_PROJECT_DIR}/kyma"
-cli-alpha::deploy "${KYMA_PROJECT_DIR}/kyma/resources" "/tmp/kyma-parallel-install-installationCR.yaml"
+cli-alpha::deploy
 )
 
 log::info "Run Kyma tests"

--- a/prow/scripts/cluster-integration/kyma-cli-alpha-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-cli-alpha-upgrade.sh
@@ -79,66 +79,6 @@ gardener::provision_cluster
 
 log::info "Installing Kyma"
 
-# Parallel-install library installs cluster-essentials, istio, and xip-patch before kyma installation. That's why they should not exist on the InstallationCR.
-# Once we figure out a way to fix this, this custom CR can be deleted from this script.
-cat << EOF > "/tmp/kyma-parallel-install-installationCR.yaml"
-apiVersion: "installer.kyma-project.io/v1alpha1"
-kind: Installation
-metadata:
-  name: kyma-installation
-  namespace: default
-spec:
-  components:
-    - name: "testing"
-      namespace: "kyma-system"
-    - name: "knative-eventing"
-      namespace: "knative-eventing"
-    - name: "dex"
-      namespace: "kyma-system"
-    - name: "ory"
-      namespace: "kyma-system"
-    - name: "api-gateway"
-      namespace: "kyma-system"
-    - name: "rafter"
-      namespace: "kyma-system"
-    - name: "service-catalog"
-      namespace: "kyma-system"
-    - name: "service-catalog-addons"
-      namespace: "kyma-system"
-    - name: "helm-broker"
-      namespace: "kyma-system"
-    - name: "nats-streaming"
-      namespace: "natss"
-    - name: "core"
-      namespace: "kyma-system"
-    - name: "cluster-users"
-      namespace: "kyma-system"
-    - name: "logging"
-      namespace: "kyma-system"
-    - name: "permission-controller"
-      namespace: "kyma-system"
-    - name: "apiserver-proxy"
-      namespace: "kyma-system"
-    - name: "iam-kubeconfig-service"
-      namespace: "kyma-system"
-    - name: "serverless"
-      namespace: "kyma-system"
-    - name: "knative-provisioner-natss"
-      namespace: "knative-eventing"
-    - name: "event-sources"
-      namespace: "kyma-system"
-    - name: "application-connector"
-      namespace: "kyma-integration"
-    - name: "tracing"
-      namespace: "kyma-system"
-    - name: "monitoring"
-      namespace: "kyma-system"
-    - name: "kiali"
-      namespace: "kyma-system"
-    - name: "console"
-      namespace: "kyma-system"
-EOF
-
 log::info "Get kyma 1.18.0 & run tests"
 
 (
@@ -148,7 +88,7 @@ git fetch --tags
 # shout "Installing Kyma in version: $latestTag"
 # git checkout "$latestTag"
 git checkout 1.18.0
-cli-alpha::deploy "${KYMA_PROJECT_DIR}/kyma/resources" "/tmp/kyma-parallel-install-installationCR.yaml"
+cli-alpha::deploy
 
 kyma test run \
     --name "testsuite-alpha-$(date '+%Y-%m-%d-%H-%M')" \
@@ -169,7 +109,7 @@ set +e
 (
 cd "${KYMA_PROJECT_DIR}/kyma"
 git checkout master
-cli-alpha::deploy "${KYMA_PROJECT_DIR}/kyma/resources" "/tmp/kyma-parallel-install-installationCR.yaml"
+cli-alpha::deploy
 
 kyma test run \
     --name "testsuite-alpha-$(date '+%Y-%m-%d-%H-%M')" \

--- a/prow/scripts/lib/cli-alpha.sh
+++ b/prow/scripts/lib/cli-alpha.sh
@@ -6,8 +6,10 @@
 #	$1 - Path to local resource directory
 #	$2 - Path to local components.yaml file
 function cli-alpha::deploy {
+	local overrides=$1
+
 	kyma alpha deploy \
-    	--ci \
-    	--resources "${1}" \
-    	--components "${2}"
+		-v \
+		"$( if [ -n "$overrides" ]; then echo "-f $overrides"; fi )"
+
 }

--- a/prow/scripts/lib/cli-alpha.sh
+++ b/prow/scripts/lib/cli-alpha.sh
@@ -2,14 +2,6 @@
 
 # cli-alpha::deploy starts Kyma installation using the alpha deploy command
 #
-# Arguments:
-#	$1 - OPtional path to an overrides file
 function cli-alpha::deploy {
-	# shellcheck disable=SC2119
-	local overrides=$1
-
-	kyma alpha deploy \
-		-v \
-		"$( if [ -n "$overrides" ]; then echo "-f $overrides"; fi )"
-
+	kyma alpha deploy -v
 }

--- a/prow/scripts/lib/cli-alpha.sh
+++ b/prow/scripts/lib/cli-alpha.sh
@@ -3,9 +3,9 @@
 # cli-alpha::deploy starts Kyma installation using the alpha deploy command
 #
 # Arguments:
-#	$1 - Path to local resource directory
-#	$2 - Path to local components.yaml file
+#	$1 - OPtional path to an overrides file
 function cli-alpha::deploy {
+	# shellcheck disable=SC2119
 	local overrides=$1
 
 	kyma alpha deploy \


### PR DESCRIPTION

**Description**

Caused by changes made to the alpha-cli deploy command the existing alpha-cli test jobs were failing. This is fixing these issues.

**Related issue(s)**

