### PR TITLE
Adjust kyma overrides in GKE integration job to install KCP with Kyma…

### DIFF
--- a/prow/scripts/cluster-integration/control-plane-gke-integration.sh
+++ b/prow/scripts/cluster-integration/control-plane-gke-integration.sh
@@ -193,23 +193,33 @@ function applyKymaOverrides() {
     --data "pushgateway.enabled=true" \
     --label "component=monitoring"
 
-  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "istio-overrides" \
-    --data "gateways.istio-ingressgateway.loadBalancerIP=${GATEWAY_IP_ADDRESS}" \
-    --label "component=istio"
+  cat << EOF > "$PWD/kyma_istio_operator"
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: istio-system
+spec:
+  components:
+    ingressGateways:
+      - name: istio-ingressgateway
+        k8s:
+          service:
+            loadBalancerIP: ${GATEWAY_IP_ADDRESS}
+            type: LoadBalancer
+EOF
 
-  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "api-gateway-overrides" \
-    --data "tests.env.gatewayName=compass-istio-gateway" \
-    --data "tests.env.gatewayNamespace=compass-system" \
-    --label "component=api-gateway"
+  "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map-file.sh" --name "istio-overrides" \
+    --label "component=istio" \
+    --file "$PWD/kyma_istio_operator"
 
   "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "dex-overrides" \
-    --data "global.istio.gateway.name=compass-istio-gateway" \
-    --data "global.istio.gateway.namespace=compass-system" \
+    --data "global.istio.gateway.name=kyma-gateway" \
+    --data "global.istio.gateway.namespace=kyma-system" \
     --label "component=dex"
 
   "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "ory-overrides" \
-    --data "global.istio.gateway.name=compass-istio-gateway" \
-    --data "global.istio.gateway.namespace=compass-system" \
+    --data "global.istio.gateway.name=kyma-gateway" \
+    --data "global.istio.gateway.namespace=kyma-system" \
     --label "component=ory"
 
   "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "tracing-overrides" \


### PR DESCRIPTION
**Description**
Adjust GKE integration job to install KCP with Kyma 1.16. Modify Kyma overrides.

Changes proposed in this pull request:

- change overrides for components ory and dex to use `kyma-gateway`
- remove api-gateway overrides
- modify istio overrides to work with IstioOperator