### PR TITLE
Change VM type to N2 in k3s jobs

### DIFF
--- a/prow/scripts/provision-vm-and-start-kyma-k3s.sh
+++ b/prow/scripts/provision-vm-and-start-kyma-k3s.sh
@@ -24,6 +24,7 @@ cleanup() {
   # TODO - collect junit results
   log::info "Removing instance kyma-integration-test-${RANDOM_ID}"
   gcloud compute instances delete --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}" || true ### Workaround: not failing the job regardless of the vm deletion result
+  log::info "Instance removed"
 }
 
 function testCustomImage() {

--- a/prow/scripts/provision-vm-and-start-kyma-k3s.sh
+++ b/prow/scripts/provision-vm-and-start-kyma-k3s.sh
@@ -88,7 +88,7 @@ for ZONE in ${EU_ZONES}; do
   gcloud compute instances create "kyma-integration-test-${RANDOM_ID}" \
       --metadata enable-oslogin=TRUE \
       --image "${IMAGE}" \
-      --machine-type n1-standard-4 \
+      --machine-type n2-standard-4 \
       --zone "${ZONE}" \
       --boot-disk-size 30 "${LABELS[@]}" && \
   log::info "Created kyma-integration-test-${RANDOM_ID} in zone ${ZONE}" && break

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,2 @@
+pjNames:
+- pjName: "kyma-integration-k3s"

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,2 +1,0 @@
-pjNames:
-- pjName: "kyma-integration-k3s"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->


**Description**

Price comparison (europe-west1):
- n1-standard-4	4	15GB	$0.2092
- n2-standard-4	4	16GB	$0.213668

Performance:
- N1 - https://cloud.google.com/compute/docs/benchmarks-linux#n1_standard_machine_types
   n1-standard-4 | Skylake | 4 | 54,678

- N2 https://cloud.google.com/compute/docs/benchmarks-linux#n2_standard_machine_types
   n2-standard-4 | Cascade Lake | 4 | 69,020

Performance in prowjob:
Test job: https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/logs/adamwalach_test_of_prowjob_kyma-integration-k3s/1352364217889460224
Before introducing changes: https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/logs/kyma-integration-k3s/1352361700979904512
Looks like we get >30s, that's worth the 1cent of price difference.

Changes proposed in this pull request:

- VM type in k3s job changed to n2-standard-4
- ...
- ...

**Related issue(s)**
