### PR TITLE
Increase failed gardener clusters deletion period

### DIFF
--- a/prow/scripts/cluster-integration/helpers/cleanup-gardener.sh
+++ b/prow/scripts/cluster-integration/helpers/cleanup-gardener.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #Description: Gardener cleanup job. Deletes all orphaned clusters allocated by integration jobs that coud not be successfully deleted.
-# Deletes all clusters that are more than 4 hours old.
+# Deletes all clusters that are more than 24 hours old.
 #
 #
 #Expected vars:
@@ -55,8 +55,8 @@ do
     NOW_TS="$(date +%s)"
     HOURS_OLD=$(( (NOW_TS - CREATION_TS) / SECONDS_PER_HOUR ))
     
-    # clusters older than 4h get deleted
-    if [[ ${HOURS_OLD} -ge 4 ]]; then
+    # clusters older than 24h get deleted
+    if [[ ${HOURS_OLD} -ge 24 ]]; then
         log::info "Deprovision cluster: \"${CLUSTER}\" (${HOURS_OLD}h old)"
         # Export envvars for the script
         export GARDENER_CLUSTER_NAME=${CLUSTER}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Increase failed gardener clusters deletion period to 24h. Right now it is only 4 hours, it is not enough for use to debug failed clusters, especially those provisioned during the night.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
