### PR TITLE
Make VM cleanup async in k3s jobs

### DIFF
--- a/development/tools/pkg/vmscollector/collector.go
+++ b/development/tools/pkg/vmscollector/collector.go
@@ -126,6 +126,14 @@ func DefaultInstanceRemovalPredicate(instanceNameRegexp *regexp.Regexp, jobLabel
 		instanceAgeThreshold := time.Since(instanceCreationTime).Hours() - float64(ageInHours)
 		ageMatches = instanceAgeThreshold > 0
 
+		if nameMatches && jobLabelMatches {
+			// If instance is stopped we do not need to check its age
+			if instance.Status == "TERMINATED" {
+				log.Infof("VM Instance is stopped, removing. Name: \"%s\", zone: \"%s\", creationTimestamp: \"%s\"", instance.Name, formatZone(instance.Zone), instance.CreationTimestamp)
+				return true, nil
+			}
+		}
+
 		if nameMatches && jobLabelMatches && ageMatches {
 			//Filter out instances that are not RUNNING at this moment
 			if instance.Status != "RUNNING" {

--- a/prow/scripts/provision-vm-and-start-kyma-k3s.sh
+++ b/prow/scripts/provision-vm-and-start-kyma-k3s.sh
@@ -22,9 +22,14 @@ fi
 
 cleanup() {
   # TODO - collect junit results
-  log::info "Removing instance kyma-integration-test-${RANDOM_ID}"
-  gcloud compute instances delete --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}" || true ### Workaround: not failing the job regardless of the vm deletion result
-  log::info "Instance removed"
+  log::info "Stopping instance kyma-integration-test-${RANDOM_ID}"
+  log::info "It will be removed automatically by cleaner job"
+
+  # do not fail the job regardless of the vm deletion result
+  set +e
+  gcloud compute instances stop --async --zone="${ZONE}" "kyma-integration-test-${RANDOM_ID}"
+
+  log::info "End of cleanup"
 }
 
 function testCustomImage() {

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,2 @@
+pjNames:
+- pjName: "kyma-integration-k3s"

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,2 +1,0 @@
-pjNames:
-- pjName: "kyma-integration-k3s"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

VM is not deleted now, only stopped:
```
2021/01/22 10:39:22 UTC [INFO] Stopping instance kyma-integration-test-f3add759
2021/01/22 10:39:22 UTC [INFO] It will be removed automatically by cleaner job
Stop instance in progress for [https://www.googleapis.com/compute/v1/projects/sap-kyma-prow-workloads/zones/europe-west4-a/operations/operation-xxxxxxxx].
Use [gcloud compute operations describe URI] command to check the status of the operation(s).
2021/01/22 10:39:23 UTC [INFO] End of cleanup
```

Cleaner logs:
https://storage.googleapis.com/kyma-prow-logs/logs/adamwalach_test_of_prowjob_orphaned-vms-cleaner/1352585805377310720/build-log.txt

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
