### PR TITLE
Bump base image version of buildpack-golang-toolbox

### DIFF
--- a/prow/images/buildpack-golang-toolbox/Dockerfile
+++ b/prow/images/buildpack-golang-toolbox/Dockerfile
@@ -1,6 +1,6 @@
 # Basic golang buildpack
 
-FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.15.5
+FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.15.7
 
 # Commit details
 


### PR DESCRIPTION
- Bump version of buildpack-golang used in buildpack-golang-toolbox to 1.15.7
