### PR TITLE
Make pre-master-control-plane-gke-integration job as optional

### DIFF
--- a/development/tools/jobs/control-plane/control_plane_gke_integration_test.go
+++ b/development/tools/jobs/control-plane/control_plane_gke_integration_test.go
@@ -18,7 +18,7 @@ func TestKCPGKEIntegrationPresubmit(t *testing.T) {
 	require.NotNil(t, actualJob)
 
 	// then
-	assert.False(t, actualJob.Optional)
+	assert.True(t, actualJob.Optional)
 	assert.True(t, actualJob.Decorate)
 	assert.Equal(t, "^((resources\\S+|installation\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))", actualJob.RunIfChanged)
 	assert.Equal(t, "github.com/kyma-project/control-plane", actualJob.PathAlias)

--- a/prow/jobs/control-plane/control-plane-gke-integration.yaml
+++ b/prow/jobs/control-plane/control-plane-gke-integration.yaml
@@ -57,6 +57,7 @@ presubmits: # runs on PRs
   kyma-project/control-plane:
     - name: pre-master-control-plane-gke-integration
       cluster: untrusted-workload
+      optional: true
       branches:
         - ^master$
       <<: *gke_integration_job_template_k16


### PR DESCRIPTION
**Description**

Make `pre-master-control-plane-gke-integration` job as optional till https://github.com/kyma-project/control-plane/pull/401 will be merged.