### PR TITLE
Add override for KEB in control-plane-gke-integration

### DIFF
--- a/prow/scripts/cluster-integration/control-plane-gke-integration.sh
+++ b/prow/scripts/cluster-integration/control-plane-gke-integration.sh
@@ -287,13 +287,14 @@ function applyControlPlaneOverrides() {
     --data "provisioner.gardener.project=$GARDENER_PROJECT_NAME" \
     --label "component=kcp"
 
-   #Create Provisioning overrides
+   #Create Provisioning/KEB overrides
   "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --namespace "${NAMESPACE}" --name "provisioning-enable-overrides" \
     --data "global.provisioning.enabled=true" \
     --data "global.metris.enabled=true" \
     --data "global.database.embedded.enabled=true" \
     --data "global.kyma_environment_broker.enabled=true" \
     --data "kyma-environment-broker.e2e.enabled=false" \
+    --data "kyma-environment-broker.disableProcessOperationsInProgress=true" \
     --label "component=kcp"
 
   if [ "${RUN_PROVISIONER_TESTS}" == "true" ]; then


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

Add override for KEB in `control-plane-gke-integration` : parameter `disableProcessOperationsInProgress` is set to true