### PR TITLE
Fix compass-gke-integration

### DIFF
--- a/prow/scripts/cluster-integration/compass-gke-integration.sh
+++ b/prow/scripts/cluster-integration/compass-gke-integration.sh
@@ -347,7 +347,7 @@ log::info "Install Compass"
 installCompass
 
 log::info "Test Kyma with Compass"
-"${TEST_INFRA_SOURCES_DIR}"/prow/scripts/kyma-testing.sh
+CONCURRENCY=1 "${TEST_INFRA_SOURCES_DIR}"/prow/scripts/kyma-testing.sh
 
 log::success "Success"
 

--- a/prow/scripts/kyma-testing.sh
+++ b/prow/scripts/kyma-testing.sh
@@ -5,7 +5,9 @@ KYMA_TEST_TIMEOUT=${KYMA_TEST_TIMEOUT:=1h}
 
 readonly TMP_DIR=$(mktemp -d)
 readonly JUNIT_REPORT_PATH="${ARTIFACTS:-${TMP_DIR}}/junit_Kyma_octopus-test-suite-$(date +%s).xml"
-readonly CONCURRENCY=5
+if [ -z "$CONCURRENCY" ]; then
+  CONCURRENCY=5
+fi
 # Should be fixed name, it is displayed in TestGrid
 SUITE_NAME="testsuite-all"
 


### PR DESCRIPTION
Currently, compass e2e tests are not concurrency safe.