### PR TITLE
Add kyma-kcp-installer to build-kcp-development-artifacts

### DIFF
--- a/prow/scripts/build-kcp-development-artifacts.sh
+++ b/prow/scripts/build-kcp-development-artifacts.sh
@@ -85,6 +85,7 @@ gsutil cp  "${ARTIFACTS}/kcp-installer.yaml" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET
 gsutil cp  "${KCP_PATH}/installation/scripts/is-installed.sh" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/is-installed.sh"
 
 gsutil cp  "${ARTIFACTS}/kyma-installer.yaml" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/kyma-installer.yaml"
+gsutil cp  "${ARTIFACTS}/kyma-kcp-installer.yaml" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/kyma-kcp-installer.yaml"
 gsutil cp  "${ARTIFACTS}/is-kyma-installed.sh" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/is-kyma-installed.sh"
 
 gsutil cp  "${ARTIFACTS}/compass-installer.yaml" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/${BUCKET_DIR}/compass-installer.yaml"
@@ -96,6 +97,7 @@ if [[ "${BUILD_TYPE}" == "master" ]]; then
   gsutil cp  "${KCP_PATH}/installation/scripts/is-installed.sh" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/is-installed.sh"
 
   gsutil cp  "${ARTIFACTS}/kyma-installer.yaml" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/kyma-installer.yaml"
+  gsutil cp  "${ARTIFACTS}/kyma-kcp-installer.yaml" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/kyma-kcp-installer.yaml"
   gsutil cp  "${ARTIFACTS}/is-kyma-installed.sh" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/is-kyma-installed.sh"
 
   gsutil cp "${ARTIFACTS}/compass-installer.yaml" "${KCP_DEVELOPMENT_ARTIFACTS_BUCKET}/master/compass-installer.yaml"


### PR DESCRIPTION
Changes proposed in this pull request:

- Add `kyma-kcp-installer.yaml` to `build-kcp-development-artifacts.sh`. Now local/prow installation kcp is difference than mps installation so diffrent cr-installer is needed. New `kyma-kcp-installer.yaml` file is generated by script in KCP (check related PR section)

**Related PR(s)**
https://github.com/kyma-project/control-plane/pull/482
