### PR TITLE
Enable holdApplicationUntilProxyStarts on compass-gke-integration

### DIFF
--- a/prow/scripts/cluster-integration/compass-gke-integration.sh
+++ b/prow/scripts/cluster-integration/compass-gke-integration.sh
@@ -187,6 +187,10 @@ kind: IstioOperator
 metadata:
   namespace: istio-system
 spec:
+  values:
+    global:
+      proxy:
+        holdApplicationUntilProxyStarts: true
   components:
     ingressGateways:
       - name: istio-ingressgateway

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,8 @@
+pjNames:
+  - pjName: "pre-master-compass-gke-integration"
+    pjPath: "test-infra/prow/jobs/incubator/compass/"
+    report: true
+prConfigs:
+  kyma-incubator:
+    compass:
+      prNumber: 1715

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,8 +1,0 @@
-pjNames:
-  - pjName: "pre-master-compass-gke-integration"
-    pjPath: "test-infra/prow/jobs/incubator/compass/"
-    report: true
-prConfigs:
-  kyma-incubator:
-    compass:
-      prNumber: 1715


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Enable holdApplicationUntilProxyStarts Istio flag (compass-gke-integration)