### PR TITLE
 Use exit instead of return outside of fcts

### DIFF
--- a/prow/scripts/cluster-integration/kyma-cli-alpha-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-cli-alpha-upgrade.sh
@@ -130,7 +130,7 @@ kyma::run_test_log_collector "kyma-cli-alpha-upgrade-gke"
 if ! kyma::test_summary; then
     log::error "Tests have failed"
     set -e
-    return 1
+    exit 1
 fi
 set -e
 


### PR DESCRIPTION

**Description**

Fix syntax issue in alpha-cli upgrade job.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
