### PR TITLE
Add override to jobs using self-signed certificate

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-central.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-central.sh
@@ -191,6 +191,7 @@ metadata:
 data:
   global.domainName: "${DOMAIN}"
   global.loadBalancerIP: "${GATEWAY_IP_ADDRESS}"
+  global.certificates.selfSigned: "true"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-compass-integration.sh
@@ -260,7 +260,8 @@ function applyCommonOverrides() {
 
   "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --namespace "${NAMESPACE}" --name "installation-config-overrides" \
     --data "global.domainName=${DOMAIN}" \
-    --data "global.loadBalancerIP=${GATEWAY_IP_ADDRESS}"
+    --data "global.loadBalancerIP=${GATEWAY_IP_ADDRESS}" \
+    --data "global.certificates.selfSigned=true"
 
   "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --namespace "${NAMESPACE}" --name "feature-flags-overrides" \
     --data "global.enableAPIPackages=true" \

--- a/prow/scripts/cluster-integration/kyma-gke-external-registry.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-external-registry.sh
@@ -212,7 +212,8 @@ kubectl create namespace "kyma-installer"
 
 "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "installation-config-overrides" \
     --data "global.domainName=${DOMAIN}" \
-    --data "global.loadBalancerIP=${GATEWAY_IP_ADDRESS}"
+    --data "global.loadBalancerIP=${GATEWAY_IP_ADDRESS}" \
+    --data "global.certificates.selfSigned=true"
 
 "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "core-test-ui-acceptance-overrides" \
     --data "test.acceptance.ui.logging.enabled=true" \

--- a/prow/scripts/cluster-integration/kyma-gke-integration-cli.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-integration-cli.sh
@@ -152,6 +152,8 @@ metadata:
     kyma-project.io/installation: ""
 data:
   global.loadBalancerIP: "${GATEWAY_IP_ADDRESS}"
+  global.certificates.selfSigned: "true"
+
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/prow/scripts/cluster-integration/kyma-gke-integration.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-integration.sh
@@ -201,6 +201,7 @@ metadata:
 data:
   global.domainName: "${DOMAIN}"
   global.loadBalancerIP: "${GATEWAY_IP_ADDRESS}"
+  global.certificates.selfSigned: "true"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/prow/scripts/cluster-integration/kyma-gke-rel2rel-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-rel2rel-upgrade.sh
@@ -240,7 +240,8 @@ installKyma() {
 
     "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "installation-config-overrides" \
         --data "global.domainName=${DOMAIN}" \
-        --data "global.loadBalancerIP=${GATEWAY_IP_ADDRESS}"
+        --data "global.loadBalancerIP=${GATEWAY_IP_ADDRESS}" \
+        --data "global.certificates.selfSigned=true"
 
     "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "core-test-ui-acceptance-overrides" \
         --data "test.acceptance.ui.logging.enabled=true" \

--- a/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
@@ -240,7 +240,8 @@ function installKyma() {
 
   "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "installation-config-overrides" \
     --data "global.domainName=${DOMAIN}" \
-    --data "global.loadBalancerIP=${GATEWAY_IP_ADDRESS}"
+    --data "global.loadBalancerIP=${GATEWAY_IP_ADDRESS}" \
+    --data "global.certificates.selfSigned=true"
 
   "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --name "core-test-ui-acceptance-overrides" \
     --data "test.acceptance.ui.logging.enabled=true" \


### PR DESCRIPTION
**Description**
With the new way of certificate management, it's necessary to pass an override `global.certificates.selfSigned=true` if Kyma is using a self-signed certificate. This change is not affecting the current state of certificate management.

Changes proposed in this pull request:

- Add override `global.certificates.selfSigned=true` to pipelines that use self-signed certificate

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/10336
https://github.com/kyma-project/kyma/pull/10423/