### PR TITLE
Add missing presets to image-syncer-data.yaml

### DIFF
--- a/prow/jobs/test-infra/image-syncer.yaml
+++ b/prow/jobs/test-infra/image-syncer.yaml
@@ -4,9 +4,6 @@
 presubmits: # runs on PRs
   kyma-project/test-infra:
     - name: pre-master-test-infra-image-syncer-validate
-      labels:
-        preset-build-pr: "true"
-        preset-dind-enabled: "true"
       run_if_changed: '^(development/image-syncer)'
       skip_report: false
       decorate: true
@@ -31,8 +28,9 @@ presubmits: # runs on PRs
                 cpu: 0.8
     - name: pre-master-test-infra-image-syncer-dry-run
       labels:
-        preset-build-pr: "true"
         preset-dind-enabled: "true"
+        preset-docker-push-repository: "true"
+        preset-sa-gcr-push: "true"
       run_if_changed: '^(development/image-syncer/external-images.yaml)'
       skip_report: false
       decorate: true
@@ -61,8 +59,8 @@ postsubmits: # runs on master
       annotations:
         testgrid-create-test-group: "false"
       labels:
-        preset-build-release: "true"
         preset-dind-enabled: "true"
+        preset-docker-push-repository: "true"
         preset-sa-gcr-push: "true"
       run_if_changed: '^(development/image-syncer/external-images.yaml)'
       skip_report: false

--- a/templates/data/image-syncer-data.yaml
+++ b/templates/data/image-syncer-data.yaml
@@ -7,9 +7,6 @@ templates:
             jobs:
               - jobConfig:
                   name: "pre-master-test-infra-image-syncer-validate"
-                  labels:
-                    preset-build-pr: "true"
-                    preset-dind-enabled: "true"
                   privileged: "false"
                   run_if_changed: "^(development/image-syncer)"
                   command: "make"
@@ -25,7 +22,8 @@ templates:
               - jobConfig:
                   name: "pre-master-test-infra-image-syncer-dry-run"
                   labels:
-                    preset-build-pr: "true"
+                    preset-docker-push-repository: "true"
+                    preset-sa-gcr-push: "true"
                     preset-dind-enabled: "true"
                   run_if_changed: "^(development/image-syncer/external-images.yaml)"
                   command: "bash"
@@ -40,7 +38,7 @@ templates:
               - jobConfig:
                   name: "post-master-test-infra-image-syncer-run"
                   labels:
-                    preset-build-release: "true"
+                    preset-docker-push-repository: "true"
                     preset-dind-enabled: "true"
                     preset-sa-gcr-push: "true"
                   run_if_changed: "^(development/image-syncer/external-images.yaml)"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
After switching to the templates for image-syncer prowjobs the job is broken. The `GOOGLE_APPLICATION_CREDENTIALS` variable is missing.

https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/pr-logs/pull/kyma-project_test-infra/3278/pre-master-test-infra-image-syncer-dry-run/1359497777565929472

Changes proposed in this pull request:

- add/remove missing or not needed presets for image-syncer prowjobs.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
