### PR TITLE
Sort releases in compatibility job

### DIFF
--- a/prow/scripts/compatibility-cli.sh
+++ b/prow/scripts/compatibility-cli.sh
@@ -43,6 +43,9 @@ RELEASES=${RELEASES//\-rc[0-9]}
 # Split into array
 RELEASES=(${RELEASES})
 
+# sort the releases in case there was a patch release after another higher minor release (e.g. chronologically: 1.0.1, 1.1.0, 1.0.0)
+RELEASES=($(printf "%s\n" "${RELEASES[@]}" | sort -r))
+
 # Remove duplicates
 RELEASES=($(printf "%s\n" "${RELEASES[@]}" | uniq))
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- It is possible to have a patch release after a higher major or minor release (e.g. chronologically: 1.0.1, 1.1.0, 1.0.0).
  Sorting the releases fixes this issue when backtracking for compatibility.

**Related issue(s)**
https://github.com/kyma-project/test-infra/issues/3229
