### PR TITLE
Separate testgrid annotations from jobConfig_default

### DIFF
--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -37,11 +37,12 @@ globalSets:
   jobConfig_postsubmit:
     type_postsubmit: "true"
     cluster: "trusted-workload"
-    annotations:
-      testgrid-create-test-group: "false"
   jobConfig_periodic:
     type_periodic: "true"
     cluster: "untrusted-workload"
+  disable_testgrid:
+    annotations:
+      testgrid-create-test-group: "false"
   # extra_refs sets
   extra_refs_test-infra:
     extra_refs:

--- a/templates/data/examples-data.yaml
+++ b/templates/data/examples-data.yaml
@@ -36,6 +36,7 @@ templates:
                     - "jobConfig_postsubmit"
                     - "extra_refs_test-infra"
                     - "build_labels"
+                    - "disable_testgrid"
                   local:
                     - "default"
 
@@ -67,6 +68,7 @@ templates:
                     - "jobConfig_postsubmit"
                     - "extra_refs_test-infra"
                     - "build_labels"
+                    - "disable_testgrid"
                   local:
                     - "default"
 
@@ -98,6 +100,7 @@ templates:
                     - "jobConfig_postsubmit"
                     - "extra_refs_test-infra"
                     - "build_labels"
+                    - "disable_testgrid"
                   local:
                     - "default"
 
@@ -129,6 +132,7 @@ templates:
                     - "jobConfig_postsubmit"
                     - "extra_refs_test-infra"
                     - "build_labels"
+                    - "disable_testgrid"
                   local:
                     - "default"
 
@@ -160,6 +164,7 @@ templates:
                     - "jobConfig_postsubmit"
                     - "extra_refs_test-infra"
                     - "build_labels"
+                    - "disable_testgrid"
                   local:
                     - "default"
 
@@ -191,5 +196,6 @@ templates:
                     - "jobConfig_postsubmit"
                     - "extra_refs_test-infra"
                     - "build_labels"
+                    - "disable_testgrid"
                   local:
                     - "default"

--- a/templates/data/image-syncer-data.yaml
+++ b/templates/data/image-syncer-data.yaml
@@ -51,3 +51,4 @@ templates:
                     - "jobConfig_default"
                     - "image_buildpack-golang"
                     - "jobConfig_postsubmit"
+                    - "disable_testgrid"

--- a/templates/data/incubator-third-party-images-data.yaml
+++ b/templates/data/incubator-third-party-images-data.yaml
@@ -38,6 +38,7 @@ templates:
                     - "jobConfig_default"
                     - "jobConfig_postsubmit"
                     - "extra_refs_test-infra"
+                    - "disable_testgrid"
                   local:
                     - "default"
 
@@ -67,6 +68,7 @@ templates:
                     - "jobConfig_default"
                     - "jobConfig_postsubmit"
                     - "extra_refs_test-infra"
+                    - "disable_testgrid"
                   local:
                     - "default"
 
@@ -96,6 +98,7 @@ templates:
                     - "jobConfig_default"
                     - "jobConfig_postsubmit"
                     - "extra_refs_test-infra"
+                    - "disable_testgrid"
                   local:
                     - "default"
 
@@ -125,6 +128,7 @@ templates:
                     - "jobConfig_default"
                     - "jobConfig_postsubmit"
                     - "extra_refs_test-infra"
+                    - "disable_testgrid"
                   local:
                     - "default"
 
@@ -154,6 +158,7 @@ templates:
                     - "jobConfig_default"
                     - "jobConfig_postsubmit"
                     - "extra_refs_test-infra"
+                    - "disable_testgrid"
                   local:
                     - "default"
 
@@ -183,6 +188,7 @@ templates:
                     - "jobConfig_default"
                     - "jobConfig_postsubmit"
                     - "extra_refs_test-infra"
+                    - "disable_testgrid"
                   local:
                     - "default"
 
@@ -212,6 +218,7 @@ templates:
                     - "jobConfig_default"
                     - "jobConfig_postsubmit"
                     - "extra_refs_test-infra"
+                    - "disable_testgrid"
                   local:
                     - "default"
 
@@ -241,6 +248,7 @@ templates:
                     - "jobConfig_default"
                     - "jobConfig_postsubmit"
                     - "extra_refs_test-infra"
+                    - "disable_testgrid"
                   local:
                     - "default"
 
@@ -270,6 +278,7 @@ templates:
                     - "jobConfig_default"
                     - "jobConfig_postsubmit"
                     - "extra_refs_test-infra"
+                    - "disable_testgrid"
                   local:
                     - "default"
 
@@ -299,6 +308,7 @@ templates:
                     - "jobConfig_default"
                     - "jobConfig_postsubmit"
                     - "extra_refs_test-infra"
+                    - "disable_testgrid"
                   local:
                     - "default"
 
@@ -328,6 +338,7 @@ templates:
                     - "jobConfig_default"
                     - "jobConfig_postsubmit"
                     - "extra_refs_test-infra"
+                    - "disable_testgrid"
                   local:
                     - "default"
 
@@ -357,5 +368,6 @@ templates:
                     - "jobConfig_default"
                     - "jobConfig_postsubmit"
                     - "extra_refs_test-infra"
+                    - "disable_testgrid"
                   local:
                     - "default"

--- a/templates/data/react-components-data.yaml
+++ b/templates/data/react-components-data.yaml
@@ -33,5 +33,6 @@ templates:
                     - "image_buildpack-node"
                     - "jobConfig_postsubmit"
                     - "extra_refs_test-infra"
+                    - "disable_testgrid"
                   local:
                     - "jobConfig_default"

--- a/templates/data/stability-checker-data.yaml
+++ b/templates/data/stability-checker-data.yaml
@@ -30,5 +30,6 @@ templates:
                     - "image_buildpack-golang"
                     - "build_labels"
                     - "jobConfig_postsubmit"
+                    - "disable_testgrid"
                   local:
                     - "jobConfig_default"

--- a/templates/data/test-log-collector-data.yaml
+++ b/templates/data/test-log-collector-data.yaml
@@ -29,6 +29,7 @@ templates:
                   global:
                     - "jobConfig_default"
                     - "jobConfig_postsubmit"
+                    - "disable_testgrid"
                     - "image_buildpack-golang"
                     - "build_labels"
                   local:

--- a/templates/data/testgrid-automation-data.yaml
+++ b/templates/data/testgrid-automation-data.yaml
@@ -48,5 +48,6 @@ templates:
                   global:
                     - "jobConfig_default"
                     - "jobConfig_postsubmit"
+                    - "disable_testgrid"
                   local:
                     - "jobConfig_default"

--- a/templates/data/watch-pods-data.yaml
+++ b/templates/data/watch-pods-data.yaml
@@ -32,6 +32,7 @@ templates:
                     - "default"
                   global:
                     - "image_buildpack-golang"
+                    - "disable_testgrid"
                     - "jobConfig_postsubmit"
                     - "jobConfig_default"
                     - "build_labels"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Separate TestGrid configuration from default post submit config. It seems the annotations for the testgrid are merged and that not wanted behaviour.

Changes proposed in this pull request:

- Separate testgrid annotations from jobConfig_default
- 
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
