### PR TITLE
Enable podinfo reporter

### DIFF
--- a/prow/cluster/components/11-plank_deployment.yaml
+++ b/prow/cluster/components/11-plank_deployment.yaml
@@ -30,6 +30,7 @@ spec:
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
             - --github-token-path=/etc/github/oauth
+            - --skip-report=true
           volumeMounts:
             - name: kubeconfig
               mountPath: /etc/workload-clusters

--- a/prow/cluster/components/30-crier_deployment.yaml
+++ b/prow/cluster/components/30-crier_deployment.yaml
@@ -23,10 +23,15 @@ spec:
           args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config
+            - --github-workers=5
+            - --github-endpoint=http://ghproxy
+            - --github-endpoint=https://api.github.com
+            - --github-token-path=/etc/github/oauth
             - --slack-workers=1
             - --slack-token-file=/etc/slack/token
             - --gcs-workers=1
             - --gcs-credentials-file=/etc/credentials/service-account.json
+            - --kubernetes-gcs-workers=1
             - --kubeconfig=/etc/workload-clusters/config
           volumeMounts:
             - name: kubeconfig
@@ -44,6 +49,9 @@ spec:
             - name: gcs-service-account
               mountPath: /etc/credentials
               readOnly: true
+            - name: oauth
+              mountPath: /etc/github
+              readOnly: true
       volumes:
         - name: kubeconfig
           secret:
@@ -60,3 +68,6 @@ spec:
         - name: gcs-service-account
           secret:
             secretName: sa-crier
+        - name: oauth
+          secret:
+            secretName: oauth-token

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -653,6 +653,10 @@ deck:
           name: junit
         required_files:
           - artifacts/junit.*\.xml
+      - lens:
+          name: podinfo
+        required_files:
+          - podinfo.json
   branding:
     header_color: "#0b74de" # Kyma color
     logo: "/static/extensions/logo.svg"

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -651,6 +651,10 @@ deck:
           name: junit
         required_files:
           - artifacts/junit.*\.xml
+      - lens:
+          name: podinfo
+        required_files:
+          - podinfo.json
   branding:
     header_color: "#0b74de" # Kyma color
     logo: "/static/extensions/logo.svg"


### PR DESCRIPTION
k8s testgrid instance require podinfo.json file to render test results. This file is provided by crier gcs kubernetes reporter.