### PR TITLE
Fix oom debug

### DIFF
--- a/prow/scripts/resources/debug-container.yaml
+++ b/prow/scripts/resources/debug-container.yaml
@@ -53,7 +53,7 @@ data:
           echo "[$docker_pid] Container memory.max_usage_percentage: $max_mem_usage_percent"
           echo "[$docker_pid] cgroup processes: $(cat $host_cgroup_base$docker_cgroup/cgroup.procs)"
         done
-      done } > /var/oom_debug
+      done } 2>&1 | tee /var/oom_debug
 ---
 apiVersion: v1
 kind: Pod

--- a/prow/scripts/resources/debug-container.yaml
+++ b/prow/scripts/resources/debug-container.yaml
@@ -7,6 +7,7 @@ data:
   entrypoint.sh: |-
     #!/bin/bash
     set +e
+    set -x
     host_cgroup_base="/host-sys/fs/cgroup/memory"
     { while true
       do

--- a/prow/scripts/resources/debug-container.yaml
+++ b/prow/scripts/resources/debug-container.yaml
@@ -7,7 +7,6 @@ data:
   entrypoint.sh: |-
     #!/bin/bash
     set +e
-    set -x
     host_cgroup_base="/host-sys/fs/cgroup/memory"
     { while true
       do
@@ -39,7 +38,7 @@ data:
         for docker_id in $docker_ids
         do
           docker_pid=$(docker inspect --format '{{ .State.Pid }}' "$docker_id")
-          docker_cgroup=$(cat /host-proc/$docker_pid/cgroup | awk -F":memory:" '{print $2}' | awk '{$1=$1;print}')
+          docker_cgroup=$(cat /host-proc/$docker_pid/cgroup | grep ":memory:" | awk -F":memory:" '{print $2}')
           mem_usage=$(cat $host_cgroup_base$docker_cgroup/memory.usage_in_bytes)
           mem_limit=$(cat $host_cgroup_base$docker_cgroup/memory.limit_in_bytes)
           max_mem_usage=$(cat $host_cgroup_base$docker_cgroup/memory.max_usage_in_bytes)
@@ -53,7 +52,7 @@ data:
           echo "[$docker_pid] Container memory.max_usage_percentage: $max_mem_usage_percent"
           echo "[$docker_pid] cgroup processes: $(cat $host_cgroup_base$docker_cgroup/cgroup.procs)"
         done
-      done } 2>&1 | tee /var/oom_debug
+      done } > /var/oom_debug
 ---
 apiVersion: v1
 kind: Pod

--- a/prow/scripts/resources/debug-container.yaml
+++ b/prow/scripts/resources/debug-container.yaml
@@ -38,17 +38,18 @@ data:
         for docker_id in $docker_ids
         do
           docker_pid=$(docker inspect --format '{{ .State.Pid }}' "$docker_id")
-          docker_cgroup=$(cat /host-proc/$docker_pid/cgroup | awk -F":memory:" '{print $2}')
+          docker_cgroup=$(cat /host-proc/$docker_pid/cgroup | awk -F":memory:" '{print $2}' | awk '{$1=$1;print}')
           mem_usage=$(cat $host_cgroup_base$docker_cgroup/memory.usage_in_bytes)
           mem_limit=$(cat $host_cgroup_base$docker_cgroup/memory.limit_in_bytes)
           max_mem_usage=$(cat $host_cgroup_base$docker_cgroup/memory.max_usage_in_bytes)
           mem_usage_percent=$(( $mem_usage * 100 / $mem_limit))
+          max_mem_usage_percent=$(( $max_mem_usage * 100 / $mem_limit))
           echo "[$docker_pid] Container PID and name: $(docker inspect --format '{{ .State.Pid }}:{{ .Name }}' "$docker_id")"
           echo "[$docker_pid] Container memory.usage_in_bytes: $mem_usage"
           echo "[$docker_pid] Container memory.max_usage_in_bytes: $max_mem_usage"
           echo "[$docker_pid] Container memory.limit_in_bytes: $mem_limit"
           echo "[$docker_pid] Container memory.usage_percentage: $mem_usage_percent"
-          echo "[$docker_pid] Container memory.max_usage_percentage: $(( $max_mem_usage * 100 / $mem_limit))"
+          echo "[$docker_pid] Container memory.max_usage_percentage: $max_mem_usage_percent"
           echo "[$docker_pid] cgroup processes: $(cat $host_cgroup_base$docker_cgroup/cgroup.procs)"
         done
       done } > /var/oom_debug

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,2 +1,0 @@
-pjNames:
-  - pjName: "kyma-integration-evaluation-gardener-azure"

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,2 @@
+pjNames:
+  - pjName: "kyma-integration-evaluation-gardener-azure"


### PR DESCRIPTION
For some containers, cgroup path container leading space. This breaks path to the cgroup in a container.
