### PR TITLE
enable pubsub reporter

### DIFF
--- a/prow/cluster/components/30-crier_deployment.yaml
+++ b/prow/cluster/components/30-crier_deployment.yaml
@@ -20,6 +20,9 @@ spec:
       containers:
         - name: crier
           image: gcr.io/k8s-prow/crier:v20200319-1aea24112
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/etc/credentials/service-account.json"
           args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/prow/cluster/components/30-crier_deployment.yaml
+++ b/prow/cluster/components/30-crier_deployment.yaml
@@ -32,6 +32,7 @@ spec:
             - --gcs-workers=1
             - --gcs-credentials-file=/etc/credentials/service-account.json
             - --kubernetes-gcs-workers=1
+            - --pubsub-workers=5
             - --kubeconfig=/etc/workload-clusters/config
           volumeMounts:
             - name: kubeconfig

--- a/prow/jobs/kyma/kyma-integration-gardener.yaml
+++ b/prow/jobs/kyma/kyma-integration-gardener.yaml
@@ -388,6 +388,9 @@ periodics:
     - <<: *kyma_local_ref
       base_ref: main
     labels:
+      prow.k8s.io/pubsub.project: sap-kyma-prow
+      prow.k8s.io/pubsub.runID: test-run
+      prow.k8s.io/pubsub.topic: test-infra-periodics
       preset-log-collector-slack-token: "true"
       <<: *gardener_azure_job_labels_template
 

--- a/templates/templates/kyma-integration-gardener.yaml
+++ b/templates/templates/kyma-integration-gardener.yaml
@@ -386,6 +386,9 @@ periodics:
     - <<: *kyma_local_ref
       base_ref: main
     labels:
+      prow.k8s.io/pubsub.project: sap-kyma-prow
+      prow.k8s.io/pubsub.runID: test-run
+      prow.k8s.io/pubsub.topic: test-infra-periodics
       preset-log-collector-slack-token: "true"
       <<: *gardener_azure_job_labels_template
 

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,3 @@
+pjNames:
+  - pjName: "kyma-integration-production-gardener-azure"
+    report: true

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,3 +1,0 @@
-pjNames:
-  - pjName: "kyma-integration-production-gardener-azure"
-    report: true


### PR DESCRIPTION
Enabling pubsub reporter in crier to offload prowjob postprocessing outside prowjob context.
