### PR TITLE
Add golangci-lint to golang-toolbox image

### DIFF
--- a/prow/images/buildpack-golang-toolbox/Dockerfile
+++ b/prow/images/buildpack-golang-toolbox/Dockerfile
@@ -8,6 +8,9 @@ ARG commit
 ENV IMAGE_COMMIT=$commit
 LABEL io.kyma-project.test-infra.commit=$commit
 
+ARG linterVersion
+ENV LINTER_VERSION=$linterVersion
+
 # Install additional tools
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -25,6 +28,10 @@ RUN go get golang.org/x/tools/cmd/goimports \
 
 COPY ./license-puller.sh /license-puller.sh
 ENV LICENSE_PULLER_PATH=/license-puller.sh
+
+# Install linter
+
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b ${GOPATH}/bin ${LINTER_VERSION}
 
 # Prow Tools
 

--- a/prow/images/buildpack-golang-toolbox/Makefile
+++ b/prow/images/buildpack-golang-toolbox/Makefile
@@ -5,6 +5,7 @@
 
 IMG_NAME = buildpack-golang-toolbox
 IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(IMG_NAME)
+LINTER_VERSION = v1.38.0
 
 
 # build and push on PR, tag with PR number
@@ -33,7 +34,7 @@ endif
 # build image and tag it with commit ID or PR number
 .PHONY: build-image
 build-image:
-	docker build -t $(IMG):$(DOCKER_TAG) --build-arg commit=$(DOCKER_TAG) .
+	docker build -t $(IMG):$(DOCKER_TAG) --build-arg commit=$(DOCKER_TAG) --build-arg linterVersion=$(LINTER_VERSION) .
 
 
 # push image with all tags

--- a/prow/images/buildpack-golang-toolbox/README.md
+++ b/prow/images/buildpack-golang-toolbox/README.md
@@ -8,6 +8,7 @@ In addition to the version introduced in Buildpack Golang, this image adds these
 - goimports
 - errcheck
 - golint
+- glangci-lint
 - mockery
 - failery
 - kind (v0.5.1)

--- a/prow/images/buildpack-golang-toolbox/README.md
+++ b/prow/images/buildpack-golang-toolbox/README.md
@@ -8,7 +8,7 @@ In addition to the version introduced in Buildpack Golang, this image adds these
 - goimports
 - errcheck
 - golint
-- glangci-lint
+- golangci-lint
 - mockery
 - failery
 - kind (v0.5.1)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add golangci-lint to golang-toolbox image


**Related issue(s)**
https://github.com/kyma-incubator/hydroform/issues/221