### PR TITLE
slack reporting to dev null

### DIFF
--- a/development/tools/pkg/pjtester/pjtester.go
+++ b/development/tools/pkg/pjtester/pjtester.go
@@ -465,7 +465,7 @@ func newTestPJ(pjCfg pjCfg, opt options) prowapi.ProwJob {
 	if pjCfg.Report {
 		pj.Spec.Report = true
 	} else {
-		pj.Spec.Report = false
+		pj.Spec.ReporterConfig = &prowapi.ReporterConfig{Slack: &prowapi.SlackReporterConfig{Channel: "kyma-prow-dev-null"}}
 	}
 	return pj
 }


### PR DESCRIPTION
Podinfo lens provide usefull data for troubleshooting and testing of prowjob. This data should be provided for jobs tested by pjtester.
Podinfo data is provided by crier reporter, when all reporting is disabled podinfo was not generated. We can enable all reporting and redirect slack notifications to kyma-prow-dev-null channel to avoid false positive and garbage on ci-force channel.