### PR TITLE
Fix Prow monitoring links

### DIFF
--- a/docs/prow/prow-monitoring.md
+++ b/docs/prow/prow-monitoring.md
@@ -1,6 +1,6 @@
 # Prow Cluster Monitoring Setup
 
-This document describes how to install and manage Prow cluster monitoring that is available at `https://monitoring.build.kyma-project.io`. 
+This document describes how to install and manage Prow cluster monitoring that is available at the URL `monitoring.build.kyma-project.io`.
 This document also describes how to create and manage Grafana dashboards.
 
 ## Prerequisites
@@ -43,8 +43,8 @@ Follow these steps:
    ```
 
 5. Open the Grafana dashboard.
-   
-   Grafana dashboard is available at `https://monitoring.build.kyma-project.io`. It can take some time till the dashboard is accessible.
+
+   Grafana dashboard is available at the URL `monitoring.build.kyma-project.io`. It can take some time till the dashboard is accessible.
 
 ## Authenticate to Grafana
 
@@ -56,7 +56,7 @@ By default, Grafana dashboards are visible for anonymous users with the read-onl
    kubectl -n {namespaceName} get secret {releaseName}-grafana -o jsonpath="{.data.admin-password}" | base64 -D
    ```
 
-2. Go to `https://monitoring.build.kyma-project.io/login`.
+2. Go to the URL `monitoring.build.kyma-project.io/login`.
 
 3. Provide credentials:
 

--- a/docs/prow/prow-monitoring.md
+++ b/docs/prow/prow-monitoring.md
@@ -1,6 +1,6 @@
 # Prow Cluster Monitoring Setup
 
-This document describes how to install and manage Prow cluster monitoring that is available at the URL `monitoring.build.kyma-project.io`.
+This document describes how to install and manage Prow cluster monitoring that is available at `https://monitoring.build.kyma-project.io`. 
 This document also describes how to create and manage Grafana dashboards.
 
 ## Prerequisites
@@ -43,8 +43,8 @@ Follow these steps:
    ```
 
 5. Open the Grafana dashboard.
-
-   Grafana dashboard is available at the URL `monitoring.build.kyma-project.io`. It can take some time till the dashboard is accessible.
+   
+   Grafana dashboard is available at `https://monitoring.build.kyma-project.io`. It can take some time till the dashboard is accessible.
 
 ## Authenticate to Grafana
 
@@ -56,7 +56,7 @@ By default, Grafana dashboards are visible for anonymous users with the read-onl
    kubectl -n {namespaceName} get secret {releaseName}-grafana -o jsonpath="{.data.admin-password}" | base64 -D
    ```
 
-2. Go to the URL `monitoring.build.kyma-project.io/login`.
+2. Go to `https://monitoring.build.kyma-project.io/login`.
 
 3. Provide credentials:
 

--- a/milv.config.yaml
+++ b/milv.config.yaml
@@ -15,3 +15,6 @@ files:
   - path: "./test-infra/docs/prow/prow-architecture.md"
     config:
       external-links-to-ignore: ["https://status.build.kyma-project.io/hook"]
+  - path: "./test-infra/docs/prow/prow-monitoring.md"
+    config:
+      external-links-to-ignore: ["https://monitoring.build.kyma-project.io/login", "https://monitoring.build.kyma-project.io"]


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

- A [Prow job error](https://storage.googleapis.com/kyma-prow-logs/logs/test-infra-governance-nightly/1376398803283742721/build-log.txt) found links with the error `"https://monitoring.build.kyma-project.io":  x509: certificate has expired or is not yet valid` 
- The reason is that these are not "real" links but something the user should run locally after setting up [monitoring](https://github.com/kyma-project/test-infra/blob/main/docs/prow/prow-monitoring.md#prow-cluster-monitoring-setup). This is indicated by the links being written in `code font`. However, Prow job checks them anyway because they start with `https://` 

Changes proposed in this pull request:

- This PR adds the links to the MILV list so they will be ignored

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
