### PR TITLE
search for oom events by default

### DIFF
--- a/prow/scripts/lib/utils.sh
+++ b/prow/scripts/lib/utils.sh
@@ -285,6 +285,7 @@ function utils::describe_nodes() {
       kubectl top nodes
       kubectl top pods --all-namespaces
     } > "${ARTIFACTS}/describe_nodes.txt"
+    grep -i "System OOM encountered" "${ARTIFACTS}/describe_nodes.txt"
 }
 
 


### PR DESCRIPTION
Cleanup function should search for oom events always when describe nodes is called. Adding grep which was removed by mistake.