### PR TITLE
Adjust kyma-incubator/compass branch protection rules

### DIFF
--- a/prow/branchprotector-config.yaml
+++ b/prow/branchprotector-config.yaml
@@ -59,8 +59,17 @@ branch-protection:
               required_status_checks:
                 strict: true
         compass-console:
+          protect: false
           branches:
             main:
+              protect: true
+              required_status_checks:
+                strict: true
+        ord-service:
+          protect: false
+          branches:
+            main:
+              protect: true
               required_status_checks:
                 strict: true
 plank:

--- a/prow/branchprotector-config.yaml
+++ b/prow/branchprotector-config.yaml
@@ -52,8 +52,10 @@ branch-protection:
       protect: true # protect all repos & branches in kyma-incubator org
       repos:
         compass:
+          protect: false
           branches:
             master:
+              protect: true
               required_status_checks:
                 strict: true
         compass-console:

--- a/templates/templates/branchprotector-config.yaml
+++ b/templates/templates/branchprotector-config.yaml
@@ -39,13 +39,24 @@ branch-protection:
       protect: true # protect all repos & branches in kyma-incubator org
       repos:
         compass:
+          protect: false
           branches:
             master:
+              protect: true
               required_status_checks:
                 strict: true
         compass-console:
+          protect: false
           branches:
             main:
+              protect: true
+              required_status_checks:
+                strict: true
+        ord-service:
+          protect: false
+          branches:
+            main:
+              protect: true
               required_status_checks:
                 strict: true
 plank:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Protect only the `main` branches in `compass`, `compass-console`, and `ord-service` - the team often works in pairs and in topic branches, which is more complicated with forks
