### PR TITLE
suppress k3s integration with compass

### DIFF
--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -211,7 +211,7 @@ presubmits: # runs on PRs
         base_ref: main
       
     - name: pre-master-kyma-integration-k3s-compass-dev
-      optional: false
+      optional: true
       cluster: untrusted-workload
       branches:
       - ^master$
@@ -317,6 +317,7 @@ postsubmits:
 
     - name: post-master-kyma-integration-k3s-compass-dev
       cluster: trusted-workload
+      optional: true
       annotations:
         testgrid-dashboards: kyma_integration
         description: Kyma integration job on k3s with compass dev.
@@ -877,7 +878,7 @@ periodics:
       preset-kyma-integration-compass-enabled: "true"
       <<: *vm_job_labels_template
     decorate: true
-    cron: "5 * * * *"
+    cron: "5 1 * * *"
     branches:
     - ^master$
     - ^main$

--- a/templates/templates/kyma-integration.yaml
+++ b/templates/templates/kyma-integration.yaml
@@ -215,7 +215,7 @@ presubmits: # runs on PRs
         base_ref: main
       
     - name: pre-master-kyma-integration-k3s-compass-dev
-      optional: false
+      optional: true
       cluster: {{if $.Values.cluster.presubmit}}{{ $.Values.cluster.presubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
       branches:
       - ^master$
@@ -341,6 +341,7 @@ postsubmits:
 
     - name: post-master-kyma-integration-k3s-compass-dev
       cluster: {{if $.Values.cluster.postsubmit}}{{ $.Values.cluster.postsubmit }}{{else}}{{fail "Value for cluster not provided"}}{{end}}
+      optional: true
       annotations:
         testgrid-dashboards: kyma_integration
         description: Kyma integration job on k3s with compass dev.
@@ -907,7 +908,7 @@ periodics:
       preset-kyma-integration-compass-enabled: "true"
       <<: *vm_job_labels_template
     decorate: true
-    cron: "5 * * * *"
+    cron: "5 1 * * *"
     branches:
     - ^master$
     - ^main$


### PR DESCRIPTION
Due to issues on compass dev instance our compass-dev related pipelines are failing. To release development making presubmit and posubmit as optional, decreasing periodic to one run per day.