### PR TITLE
Revert "Adjust kyma-incubator/compass branch protection rules"

### DIFF
--- a/prow/branchprotector-config.yaml
+++ b/prow/branchprotector-config.yaml
@@ -58,24 +58,13 @@ branch-protection:
       protect: true # protect all repos & branches in kyma-incubator org
       repos:
         compass:
-          protect: false
           branches:
             master:
-              protect: true
               required_status_checks:
                 strict: true
         compass-console:
-          protect: false
           branches:
             main:
-              protect: true
-              required_status_checks:
-                strict: true
-        ord-service:
-          protect: false
-          branches:
-            main:
-              protect: true
               required_status_checks:
                 strict: true
 plank:

--- a/templates/templates/branchprotector-config.yaml
+++ b/templates/templates/branchprotector-config.yaml
@@ -45,24 +45,13 @@ branch-protection:
       protect: true # protect all repos & branches in kyma-incubator org
       repos:
         compass:
-          protect: false
           branches:
             master:
-              protect: true
               required_status_checks:
                 strict: true
         compass-console:
-          protect: false
           branches:
             main:
-              protect: true
-              required_status_checks:
-                strict: true
-        ord-service:
-          protect: false
-          branches:
-            main:
-              protect: true
               required_status_checks:
                 strict: true
 plank:


### PR DESCRIPTION
Reverts kyma-project/test-infra#3484
With current used branchprotector version we can't have requried jobs defined by prow on repositories/branches which are not protected.
Newer version of branchprotector allow for such configuration when allow_disabled_job_policies flag is set.