### PR TITLE
Remove remove release branch protection config from kyma

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -106,27 +106,6 @@ branch-protection:
       repos:
         kyma:
           branches:
-            release-1.22:
-              required_status_checks:
-                contexts:
-                    - pre-rel122-kyma-integration
-                    - pre-rel122-kyma-gke-integration
-                    - pre-rel122-kyma-gke-upgrade
-                    - pre-rel122-kyma-artifacts
-            release-1.21:
-              required_status_checks:
-                contexts:
-                    - pre-rel121-kyma-integration
-                    - pre-rel121-kyma-gke-integration
-                    - pre-rel121-kyma-gke-upgrade
-                    - pre-rel121-kyma-artifacts
-            release-1.20:
-              required_status_checks:
-                contexts:
-                    - pre-rel120-kyma-integration
-                    - pre-rel120-kyma-gke-integration
-                    - pre-rel120-kyma-gke-upgrade
-                    - pre-rel120-kyma-artifacts
             kyma-2.0-docu:
               required_pull_request_reviews:
                 require_code_owner_reviews: false

--- a/prow/jobs/test-infra/branchprotector.yaml
+++ b/prow/jobs/test-infra/branchprotector.yaml
@@ -1,6 +1,6 @@
 periodics:
   - name: ci-prow-branchprotector
-    cron: "54 */3 * * *" # at 54th minute every 3rd hour
+    cron: "54 * * * *" # at 54th minute every hour
     decorate: true
     decoration_config:
       timeout: 5h

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -104,16 +104,6 @@ branch-protection:
       repos:
         kyma:
           branches:
-            {{- range $rel := .Global.releases }}
-            release-{{ $rel }}:
-              required_status_checks:
-                contexts:
-                  {{- range $.Values.contexts }}
-                    {{- if releaseMatches $rel .since .until }}
-                    - pre-rel{{ $rel | replace "." "" }}-{{ .name }}
-                    {{- end }}
-                    {{- end }}
-            {{- end }}
             kyma-2.0-docu:
               required_pull_request_reviews:
                 require_code_owner_reviews: false


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Tide is spitting errors for the release branch PR:
```
{"component":"tide","controller":"sync","duration":"1.194371396s","file":"prow/tide/tide.go:362","func":"k8s.io/test-infra/prow/tide.(*Controller).Sync.func1","level":"info","msg":"Synced","severity":"info","time":"2021-04-28T11:19:27Z"}
{"branch":"release-1.22","component":"tide","controller":"status-update","error":"failed to set up context register: contexts pre-rel122-kyma-gke-integration, pre-rel122-kyma-gke-upgrade, pre-rel122-kyma-integration are defined as required and required if present","file":"prow/tide/status.go:371","func":"k8s.io/test-infra/prow/tide.(*statusController).setStatuses.func1","level":"error","msg":"getting expected status","org":"kyma-project","pr":11194,"repo":"kyma","severity":"error","sha":"23be088c5f08a3f7f1763e4027e595952a557741","time":"2021-04-28T11:19:28Z"}
```
I believe it's because in the config.yaml there are defined branch protection rules for jobs with `run_if_changed` directive. 
This PR removes the release statuses, as Tide should take care of this.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
