### PR TITLE
Missing service account and rbac for pjtester on new prow

### DIFF
--- a/prow/cluster/components/pjtester_prowjob-scheduler_rbac.yaml
+++ b/prow/cluster/components/pjtester_prowjob-scheduler_rbac.yaml
@@ -1,0 +1,38 @@
+# prowjob-scheduler is used by pjtester to create prowjob custom resource on prow cluster.
+# This allow pjtester to schedule prowjob on prow outside prow regular scheduling logic.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prowjob-scheduler
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prowjob-scheduler
+  namespace: default
+rules:
+  - apiGroups:
+      - prow.k8s.io
+    resources:
+      - prowjobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prowjob-scheduler
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prowjob-scheduler
+subjects:
+  - kind: ServiceAccount
+    name: prowjob-scheduler
+    namespace: default


### PR DESCRIPTION
Adding missing service account and rbac for pjtester to start test prowjobs.
We lost this during prow upgrade.