### PR TITLE
Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,7 +26,7 @@
 /development/tools/jobs/testinfra/ @kyma-project/prow
 
 # Stability checker
-/stability-checker/ @PK85 @piotrmiskiewicz @polskikiel @jasiu001 @adamwalach
+/stability-checker/ @PK85 @piotrmiskiewicz @jasiu001 @adamwalach
 
 # The watch-pods directory
 /watch-pods/ @suleymanakbas91 @clebs @a-thaler @lilitgh
@@ -39,4 +39,4 @@
 /templates/templates @kyma-project/prow @sjanota
 
 # All .md files
-*.md @kazydek @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @superojla
+*.md @kazydek @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @NHingerl


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

Recently, Michał Kempski and Justyna Sztyper left the company. According to the [offboarding guidelines](https://kyma-project.io/community/governance#kyma-working-model-kyma-working-model-when-does-a-maintainer-lose-the-maintainer-status), a person should be removed from codeowners in case they are no longer interested in contributing or haven't contributed to the project for more than 3 months. Also, Nina Hingerl went through the probationary period and thus should be added to codeowners.

Changes proposed in this pull request:
- Remove `polskikiel` from codeowners
- Remove `superojla` from codeowners
- Add `NHingerl` to codeowners

**Related issue(s)**
https://github.tools.sap/kyma/community/issues/88