### PR TITLE
update pubsub-connector and github-connector paths

### DIFF
--- a/prow/jobs/test-infra/buildpack.yaml
+++ b/prow/jobs/test-infra/buildpack.yaml
@@ -492,7 +492,7 @@ presubmits: # runs on PRs
         preset-dind-enabled: "true"
         preset-docker-push-repository-test-infra: "true"
         preset-sa-gcr-push: "true"
-      run_if_changed: '^development/github-slack-connector/githubWebhookGateway/(.*\.go|go\.mod|go\.sum|Dockerfile|Makefile)$'
+      run_if_changed: '^development/kyma-github-connector/githubWebhookGateway/(.*\.go|go\.mod|go\.sum|Dockerfile|Makefile)$'
       skip_report: false
       decorate: true
       cluster: untrusted-workload
@@ -508,7 +508,7 @@ presubmits: # runs on PRs
             command:
               - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/publish-buildpack.sh"
             args:
-              - "/home/prow/go/src/github.com/kyma-project/test-infra/development/github-slack-connector/githubWebhookGateway"
+              - "/home/prow/go/src/github.com/kyma-project/test-infra/development/kyma-github-connector/githubWebhookGateway"
             resources:
               requests:
                 memory: 1.5Gi
@@ -522,7 +522,7 @@ presubmits: # runs on PRs
         preset-dind-enabled: "true"
         preset-docker-push-repository-test-infra: "true"
         preset-sa-gcr-push: "true"
-      run_if_changed: '^development/pubsub-connector/pubSubGateway/(.*\.go|go\.mod|go\.sum|Dockerfile|Makefile)$'
+      run_if_changed: '^development/kyma-pubsub-connector/pubSubGateway/(.*\.go|go\.mod|go\.sum|Dockerfile|Makefile)$'
       skip_report: false
       decorate: true
       cluster: untrusted-workload
@@ -538,7 +538,7 @@ presubmits: # runs on PRs
             command:
               - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/publish-buildpack.sh"
             args:
-              - "/home/prow/go/src/github.com/kyma-project/test-infra/development/pubsub-connector/pubSubGateway"
+              - "/home/prow/go/src/github.com/kyma-project/test-infra/development/kyma-pubsub-connector/pubSubGateway"
             resources:
               requests:
                 memory: 1.5Gi
@@ -1069,7 +1069,7 @@ postsubmits: # runs on main
         preset-dind-enabled: "true"
         preset-docker-push-repository-test-infra: "true"
         preset-sa-gcr-push: "true"
-      run_if_changed: '^development/github-slack-connector/githubWebhookGateway/(.*\.go|go\.mod|go\.sum|Dockerfile|Makefile)$'
+      run_if_changed: '^development/kyma-github-connector/githubWebhookGateway/(.*\.go|go\.mod|go\.sum|Dockerfile|Makefile)$'
       skip_report: false
       decorate: true
       cluster: trusted-workload
@@ -1085,7 +1085,7 @@ postsubmits: # runs on main
             command:
               - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/publish-buildpack.sh"
             args:
-              - "/home/prow/go/src/github.com/kyma-project/test-infra/development/github-slack-connector/githubWebhookGateway"
+              - "/home/prow/go/src/github.com/kyma-project/test-infra/development/kyma-github-connector/githubWebhookGateway"
             resources:
               requests:
                 memory: 1.5Gi
@@ -1101,7 +1101,7 @@ postsubmits: # runs on main
         preset-dind-enabled: "true"
         preset-docker-push-repository-test-infra: "true"
         preset-sa-gcr-push: "true"
-      run_if_changed: '^development/pubsub-connector/pubSubGateway/(.*\.go|go\.mod|go\.sum|Dockerfile|Makefile)$'
+      run_if_changed: '^development/kyma-pubsub-connector/pubSubGateway/(.*\.go|go\.mod|go\.sum|Dockerfile|Makefile)$'
       skip_report: false
       decorate: true
       cluster: trusted-workload
@@ -1117,7 +1117,7 @@ postsubmits: # runs on main
             command:
               - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/publish-buildpack.sh"
             args:
-              - "/home/prow/go/src/github.com/kyma-project/test-infra/development/pubsub-connector/pubSubGateway"
+              - "/home/prow/go/src/github.com/kyma-project/test-infra/development/kyma-pubsub-connector/pubSubGateway"
             resources:
               requests:
                 memory: 1.5Gi

--- a/templates/data/buildpack-data.yaml
+++ b/templates/data/buildpack-data.yaml
@@ -410,9 +410,9 @@ templates:
                         - "postsubmit"
                   - jobConfig:
                      name: "pre-test-infra-github-connector-webhook-gateway"
-                     run_if_changed: '^development/github-slack-connector/githubWebhookGateway/(.*\.go|go\.mod|go\.sum|Dockerfile|Makefile)$'
+                     run_if_changed: '^development/kyma-github-connector/githubWebhookGateway/(.*\.go|go\.mod|go\.sum|Dockerfile|Makefile)$'
                      args:
-                       - "/home/prow/go/src/github.com/kyma-project/test-infra/development/github-slack-connector/githubWebhookGateway"
+                       - "/home/prow/go/src/github.com/kyma-project/test-infra/development/kyma-github-connector/githubWebhookGateway"
                     inheritedConfigs:
                       global:
                         - "image_buildpack-golang"
@@ -422,9 +422,9 @@ templates:
                         - "presubmit"
                   - jobConfig:
                       name: "post-test-infra-github-connector-webhook-gateway"
-                      run_if_changed: '^development/github-slack-connector/githubWebhookGateway/(.*\.go|go\.mod|go\.sum|Dockerfile|Makefile)$'
+                      run_if_changed: '^development/kyma-github-connector/githubWebhookGateway/(.*\.go|go\.mod|go\.sum|Dockerfile|Makefile)$'
                       args:
-                        - "/home/prow/go/src/github.com/kyma-project/test-infra/development/github-slack-connector/githubWebhookGateway"
+                        - "/home/prow/go/src/github.com/kyma-project/test-infra/development/kyma-github-connector/githubWebhookGateway"
                     inheritedConfigs:
                       global:
                         - "image_buildpack-golang"
@@ -434,9 +434,9 @@ templates:
                         - "postsubmit"
                   - jobConfig:
                       name: "pre-test-infra-pubsub-connector-gateway"
-                      run_if_changed: '^development/pubsub-connector/pubSubGateway/(.*\.go|go\.mod|go\.sum|Dockerfile|Makefile)$'
+                      run_if_changed: '^development/kyma-pubsub-connector/pubSubGateway/(.*\.go|go\.mod|go\.sum|Dockerfile|Makefile)$'
                       args:
-                        - "/home/prow/go/src/github.com/kyma-project/test-infra/development/pubsub-connector/pubSubGateway"
+                        - "/home/prow/go/src/github.com/kyma-project/test-infra/development/kyma-pubsub-connector/pubSubGateway"
                     inheritedConfigs:
                       global:
                         - "image_buildpack-golang"
@@ -446,9 +446,9 @@ templates:
                         - "presubmit"
                   - jobConfig:
                       name: "post-test-infra-pubsub-connector-gateway"
-                      run_if_changed: '^development/pubsub-connector/pubSubGateway/(.*\.go|go\.mod|go\.sum|Dockerfile|Makefile)$'
+                      run_if_changed: '^development/kyma-pubsub-connector/pubSubGateway/(.*\.go|go\.mod|go\.sum|Dockerfile|Makefile)$'
                       args:
-                        - "/home/prow/go/src/github.com/kyma-project/test-infra/development/pubsub-connector/pubSubGateway"
+                        - "/home/prow/go/src/github.com/kyma-project/test-infra/development/kyma-pubsub-connector/pubSubGateway"
                     inheritedConfigs:
                       global:
                         - "image_buildpack-golang"


### PR DESCRIPTION
**Description**

pubsub-connector and github-connector are now separated from slack-connector. Moved to new directories.
Updating paths in prowjobs definitions.

**Related issue(s)**
See #3701 
