### PR TITLE
Omit benchmarks on integration tests

### DIFF
--- a/prow/scripts/cluster-integration/compass-gke-integration.sh
+++ b/prow/scripts/cluster-integration/compass-gke-integration.sh
@@ -350,7 +350,7 @@ log::info "Install Compass"
 installCompass
 
 log::info "Test Kyma with Compass"
-CONCURRENCY=1 "${TEST_INFRA_SOURCES_DIR}"/prow/scripts/kyma-testing.sh
+CONCURRENCY=1 "${TEST_INFRA_SOURCES_DIR}"/prow/scripts/kyma-testing.sh "!benchmark"
 
 log::success "Success"
 

--- a/prow/scripts/cluster-integration/compass-gke-integration.sh
+++ b/prow/scripts/cluster-integration/compass-gke-integration.sh
@@ -350,7 +350,7 @@ log::info "Install Compass"
 installCompass
 
 log::info "Test Kyma with Compass"
-CONCURRENCY=1 "${TEST_INFRA_SOURCES_DIR}"/prow/scripts/kyma-testing.sh "benchmark notin (true)"
+CONCURRENCY=1 "${TEST_INFRA_SOURCES_DIR}"/prow/scripts/kyma-testing.sh -l "!benchmark"
 
 log::success "Success"
 

--- a/prow/scripts/cluster-integration/compass-gke-integration.sh
+++ b/prow/scripts/cluster-integration/compass-gke-integration.sh
@@ -350,7 +350,7 @@ log::info "Install Compass"
 installCompass
 
 log::info "Test Kyma with Compass"
-CONCURRENCY=1 "${TEST_INFRA_SOURCES_DIR}"/prow/scripts/kyma-testing.sh "!benchmark"
+CONCURRENCY=1 "${TEST_INFRA_SOURCES_DIR}"/prow/scripts/kyma-testing.sh "benchmark notin (true)"
 
 log::success "Success"
 

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,5 +1,5 @@
 pjNames:
-  - pjName: "pre-main-compass-gke-benchmark"
+  - pjName: "pre-main-compass-gke-integration"
     pjPath: "test-infra/prow/jobs/incubator/compass/"
     report: true
   prConfigs:

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,8 @@
+pjNames:
+  - pjName: "pre-main-compass-gke-benchmark"
+    pjPath: "test-infra/prow/jobs/incubator/compass/"
+    report: true
+  prConfigs:
+    kyma-incubator:
+      compass:
+        prNumber: 1877

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,8 +1,0 @@
-pjNames:
-  - pjName: "pre-main-compass-gke-integration"
-    pjPath: "test-infra/prow/jobs/incubator/compass/"
-    report: true
-prConfigs:
-  kyma-incubator:
-    compass:
-      prNumber: 1877

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -2,7 +2,7 @@ pjNames:
   - pjName: "pre-main-compass-gke-integration"
     pjPath: "test-infra/prow/jobs/incubator/compass/"
     report: true
-  prConfigs:
-    kyma-incubator:
-      compass:
-        prNumber: 1877
+prConfigs:
+  kyma-incubator:
+    compass:
+      prNumber: 1877


### PR DESCRIPTION
**Description**

Benchmark tests should not be executed on gke-integration job.