### PR TITLE
Execute benchmark tests on a dedicated node

### DIFF
--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,8 @@
+pjNames:
+  - pjName: "pre-main-compass-gke-benchmark"
+    pjPath: "test-infra/prow/jobs/incubator/compass/"
+    report: true
+prConfigs:
+  kyma-incubator:
+    compass:
+      prNumber: 1869

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,8 +1,0 @@
-pjNames:
-  - pjName: "pre-main-compass-gke-benchmark"
-    pjPath: "test-infra/prow/jobs/incubator/compass/"
-    report: true
-prConfigs:
-  kyma-incubator:
-    compass:
-      prNumber: 1869


### PR DESCRIPTION
As there is variable load on each node and this makes benchmark tests flapping we need to dedicate a whole clean node for them.