### PR TITLE
Bump Go version to latest 1.16.4

### DIFF
--- a/prow/images/buildpack-golang/Makefile
+++ b/prow/images/buildpack-golang/Makefile
@@ -21,8 +21,8 @@ tag-image: build-image
 # tag image with current tag
 .PHONY: tag-image
 tag-image:
-	@echo "___ Tagging as go1.15.7 ___"
-	docker tag $(IMG):$(DOCKER_TAG) $(IMG):go1.15.7
+	@echo "___ Tagging as go1.16.4 ___"
+	docker tag $(IMG):$(DOCKER_TAG) $(IMG):go1.16.4
 	@echo "___ Tagging as current ___"
 	docker tag $(IMG):$(DOCKER_TAG) $(IMG):current
 ifdef DOCKER_POST_PR_TAG
@@ -34,7 +34,7 @@ endif
 # build image and tag it with commit ID or PR number
 .PHONY: build-image
 build-image:
-	docker build -t $(IMG):$(DOCKER_TAG) --build-arg goVersion=1.15.7 --build-arg depReleaseTag=v0.5.4 --build-arg commit=$(DOCKER_TAG) .
+	docker build -t $(IMG):$(DOCKER_TAG) --build-arg goVersion=1.16.4 --build-arg depReleaseTag=v0.5.4 --build-arg commit=$(DOCKER_TAG) .
 
 
 # push image with all tags


### PR DESCRIPTION
**Description**

Bump Go version to the latest 1.16.4 for buildpack image
