### PR TITLE
Bump Go version to latest 1.16.4

### DIFF
--- a/development/tools/jobs/incubator/milv/milv_test.go
+++ b/development/tools/jobs/incubator/milv/milv_test.go
@@ -30,7 +30,7 @@ func TestMilvJobsPresubmit(t *testing.T) {
 	assert.Empty(t, actualPresubmit.RunIfChanged)
 	tester.AssertThatHasExtraRefTestInfra(t, actualPresubmit.JobBase.UtilityConfig, "main")
 	tester.AssertThatHasPresets(t, actualPresubmit.JobBase, preset.DindEnabled, preset.DockerPushRepoIncubator, preset.GcrPush)
-	assert.Equal(t, "eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.15.7", actualPresubmit.Spec.Containers[0].Image)
+	assert.Equal(t, "eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.16.4", actualPresubmit.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-generic.sh"}, actualPresubmit.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/milv"}, actualPresubmit.Spec.Containers[0].Args)
 }
@@ -54,7 +54,7 @@ func TestMilvJobPostsubmit(t *testing.T) {
 
 	tester.AssertThatHasExtraRefTestInfra(t, actualPost.JobBase.UtilityConfig, "main")
 	tester.AssertThatHasPresets(t, actualPost.JobBase, preset.DindEnabled, preset.DockerPushRepoIncubator, preset.GcrPush)
-	assert.Equal(t, "eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.15.7", actualPost.Spec.Containers[0].Image)
+	assert.Equal(t, "eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.16.4", actualPost.Spec.Containers[0].Image)
 	assert.Empty(t, actualPost.RunIfChanged)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-generic.sh"}, actualPost.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/milv"}, actualPost.Spec.Containers[0].Args)

--- a/prow/images/buildpack-golang-toolbox/Dockerfile
+++ b/prow/images/buildpack-golang-toolbox/Dockerfile
@@ -1,6 +1,6 @@
 # Basic golang buildpack
 
-FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.15.7
+FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.16.4
 
 # Commit details
 

--- a/prow/images/buildpack-golang/README.md
+++ b/prow/images/buildpack-golang/README.md
@@ -6,7 +6,7 @@ This folder contains the Buildpack Golang image that is based on the Bootstrap i
 
 The image consists of:
 
-- golang 1.15.7
+- golang 1.16.4
 - dep 0.5.4
 
 ## Installation

--- a/prow/images/debug-commando/Dockerfile
+++ b/prow/images/debug-commando/Dockerfile
@@ -1,6 +1,6 @@
 # Image with tools for troubleshooting and debugging.
 
-FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.15.7
+FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.16.4
 
 # Commit details
 

--- a/prow/jobs/incubator/milv/milv.yaml
+++ b/prow/jobs/incubator/milv/milv.yaml
@@ -25,7 +25,7 @@ presubmits: # runs on PRs
           base_ref: main
       spec:
         containers:
-          - image: "eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.15.7"
+          - image: "eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.16.4"
             securityContext:
               privileged: true
             command:
@@ -65,7 +65,7 @@ postsubmits: # runs on main
           base_ref: main
       spec:
         containers:
-          - image: "eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.15.7"
+          - image: "eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.16.4"
             securityContext:
               privileged: true
             command:

--- a/templates/data/incubator-buildpack-data.yaml
+++ b/templates/data/incubator-buildpack-data.yaml
@@ -163,7 +163,7 @@ templates:
       - to: ../prow/jobs/incubator/milv/milv.yaml
         localSets:
           milv_jobConfig:
-            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.15.7
+            image: eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.16.4
             args:
               - "/home/prow/go/src/github.com/kyma-incubator/milv"
             env:


### PR DESCRIPTION
**Description**

Bump Go version to latest 1.16.4 for all images other than buildpack-golang