### PR TITLE
Bump buildpack kubebuillder2 image

### DIFF
--- a/prow/images/buildpack-golang-kubebuilder2/Dockerfile
+++ b/prow/images/buildpack-golang-kubebuilder2/Dockerfile
@@ -1,6 +1,6 @@
 # Golang buildpack with kubebuilder
 
-FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20210402-70b4b74f
+FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20210601-19326f24
 
 # Commit details
 


### PR DESCRIPTION
**Description**

Bump buildpack kubebuillder2 image (`prow/images/buildpack-golang-kubebuilder2/Dockerfile` file) to the latest `v20210601-19326f24` version