### PR TITLE
Enable ext svc mock auditlog for tests

### DIFF
--- a/prow/scripts/cluster-integration/compass-gke-integration.sh
+++ b/prow/scripts/cluster-integration/compass-gke-integration.sh
@@ -234,6 +234,7 @@ function applyCompassOverrides() {
 
   "${TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS}/create-config-map.sh" --namespace "${NAMESPACE}" --name "compass-auditlog-mock-tests" \
     --data "global.externalServicesMock.enabled=true" \
+    --data "global.externalServicesMock.auditlog=true" \
     --data "gateway.gateway.auditlog.enabled=true" \
     --data "gateway.gateway.auditlog.authMode=oauth" \
     --label "component=compass"


### PR DESCRIPTION
**Enable ext svc mock auditlog for tests**

Changes proposed in this pull request:

- Enabled external services mock's auditlog tests for compass by settings an override