### PR TITLE
Adding Cosign to the bootstrap image

### DIFF
--- a/prow/images/bootstrap/Dockerfile
+++ b/prow/images/bootstrap/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     software-properties-common \
     lsb-release \
     gettext \
+    libpcsclite1 \
     && apt-get clean
 
 # Install gcloud
@@ -77,3 +78,7 @@ RUN mkdir /docker-graph
 COPY --from=eu.gcr.io/kyma-project/test-infra/prow-tools:v20210401-294e46e5 /prow-tools /prow-tools
 # for better access to prow-tools
 ENV PATH=$PATH:/prow-tools
+
+# Adding Cosign
+RUN wget https://github.com/sigstore/cosign/releases/download/v0.4.0/cosign-linux-amd64 -O /usr/local/bin/cosign &&\
+    chmod +x /usr/local/bin/cosign


### PR DESCRIPTION
As part of securing the images, we are adding cosign to the bootstrap
image. This will allow the signing of the images.

The version is hard-coded to prevent any future new breaking updates.

Signed-off-by: Youssef Azrak <yazrak.tech@gmail.com>
