### PR TITLE
Remove readiness probe disablement from stability-checker helm chart

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -136,7 +136,7 @@ function installKyma() {
 
 	kyma install \
 			--ci \
-			--source main \
+			--source PR-11432 \
 			-o "$PWD/kyma-installer-overrides.yaml" \
 			-o "$PWD/overrides-dex-and-monitoring.yaml" \
 			-o "${TEST_INFRA_SOURCES_DIR}/prow/scripts/resources/prometheus-cluster-essentials-overrides.tpl.yaml" \

--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -136,7 +136,7 @@ function installKyma() {
 
 	kyma install \
 			--ci \
-			--source PR-11432 \
+			--source main \
 			-o "$PWD/kyma-installer-overrides.yaml" \
 			-o "$PWD/overrides-dex-and-monitoring.yaml" \
 			-o "${TEST_INFRA_SOURCES_DIR}/prow/scripts/resources/prometheus-cluster-essentials-overrides.tpl.yaml" \

--- a/stability-checker/deploy/chart/stability-checker/templates/deploy.yaml
+++ b/stability-checker/deploy/chart/stability-checker/templates/deploy.yaml
@@ -20,9 +20,6 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "true"
-        #For pods running sidecars w/o service there's a problem with envoy readiness probe.
-        #Details https://github.com/istio/istio/issues/9504#issuecomment-439432130
-        status.sidecar.istio.io/port: "0"
       labels:
         app: {{ template "stability-checker.fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
When `holdApplicationUntilProxyStarts: true` is set in in istio configuration installation of stability-checker broke. It was caused by disabled Envoy readiness probe annotation `status.sidecar.istio.io/port: "0"` set in a chart. Because of that kubelet was returning errors:
```
  Warning  FailedPostStartHook  7m6s (x66 over 6h50m)  kubelet  (combined from similar events): Exec lifecycle hook ([pilot-agent wait]) for Container "istio-proxy" in Pod "stability-checker-59b8dd9f44-2jnrg_kyma-system(4cef429c-cb71-4fca-b843-b7a5649ca8b6)" failed - error: command 'pilot-agent wait' exited with 255: Error: timeout waiting for Envoy proxy to become ready. Last error: HTTP status code 503
, message: "2021-06-08T11:35:26.086996Z\tinfo\tWaiting for Envoy proxy to be ready (timeout: 60 seconds)...\n2021-06-08T11:36:26.204096Z\terror\ttimeout waiting for Envoy proxy to become ready. Last error: HTTP status code 503\nError: timeout waiting for Envoy proxy to become ready. Last error: HTTP status code 503\n"
```

After removing the annotation the cluster got provisioned successfully: https://status.build.kyma-project.io/view/gs/kyma-prow-logs/logs/kyma-gke-nightly/1402563703508832256

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Closes #3744