### PR TITLE
fix cleanup second failed cluster.

### DIFF
--- a/prow/scripts/cluster-integration/kyma-integration-gardener.sh
+++ b/prow/scripts/cluster-integration/kyma-integration-gardener.sh
@@ -68,8 +68,7 @@ else
 fi
 
 # nice cleanup on exit, be it succesful or on fail
-trap gardener::cleanup EXIT INT
-trap 'echo "CLUSTER_NAME variable used with value $CLUSTER_NAME"' DEBUG
+trap 'gardener::cleanup' EXIT INT
 set -x
 
 #Used to detect errors for logging purposes
@@ -81,8 +80,7 @@ utils::generate_commonName "${COMMON_NAME_PREFIX}"
 
 ### Cluster name must be less than 10 characters!
 
-declare -t CLUSTER_NAME="${COMMON_NAME}"
-export CLUSTER_NAME
+export CLUSTER_NAME="${COMMON_NAME}"
 
 # set KYMA_SOURCE used by gardener::install_kyma
 # at the time of writing this comment, kyma-integration-gardener never sets BUILD_TYPE to "release"

--- a/prow/scripts/cluster-integration/kyma-integration-gardener.sh
+++ b/prow/scripts/cluster-integration/kyma-integration-gardener.sh
@@ -70,6 +70,7 @@ fi
 # nice cleanup on exit, be it succesful or on fail
 trap gardener::cleanup EXIT INT
 trap 'echo "CLUSTER_NAME variable used with value $CLUSTER_NAME"' DEBUG
+set -x
 
 #Used to detect errors for logging purposes
 ERROR_LOGGING_GUARD="true"
@@ -80,7 +81,7 @@ utils::generate_commonName "${COMMON_NAME_PREFIX}"
 
 ### Cluster name must be less than 10 characters!
 
-decalre -t CLUSTER_NAME="${COMMON_NAME}"
+declare -t CLUSTER_NAME="${COMMON_NAME}"
 export CLUSTER_NAME
 
 # set KYMA_SOURCE used by gardener::install_kyma

--- a/prow/scripts/cluster-integration/kyma-integration-gardener.sh
+++ b/prow/scripts/cluster-integration/kyma-integration-gardener.sh
@@ -68,8 +68,7 @@ else
 fi
 
 # nice cleanup on exit, be it succesful or on fail
-trap 'gardener::cleanup $CLUSTER_NAME' EXIT INT
-set -x
+trap gardener::cleanup EXIT INT
 
 #Used to detect errors for logging purposes
 ERROR_LOGGING_GUARD="true"

--- a/prow/scripts/cluster-integration/kyma-integration-gardener.sh
+++ b/prow/scripts/cluster-integration/kyma-integration-gardener.sh
@@ -69,6 +69,7 @@ fi
 
 # nice cleanup on exit, be it succesful or on fail
 trap gardener::cleanup EXIT INT
+trap 'echo "CLUSTER_NAME variable used with value $CLUSTER_NAME"' DEBUG
 
 #Used to detect errors for logging purposes
 ERROR_LOGGING_GUARD="true"
@@ -78,7 +79,9 @@ readonly COMMON_NAME_PREFIX="grd"
 utils::generate_commonName "${COMMON_NAME_PREFIX}"
 
 ### Cluster name must be less than 10 characters!
-export CLUSTER_NAME="${COMMON_NAME}"
+
+decalre -t CLUSTER_NAME="${COMMON_NAME}"
+export CLUSTER_NAME
 
 # set KYMA_SOURCE used by gardener::install_kyma
 # at the time of writing this comment, kyma-integration-gardener never sets BUILD_TYPE to "release"

--- a/prow/scripts/cluster-integration/kyma-integration-gardener.sh
+++ b/prow/scripts/cluster-integration/kyma-integration-gardener.sh
@@ -68,7 +68,7 @@ else
 fi
 
 # nice cleanup on exit, be it succesful or on fail
-trap 'gardener::cleanup' EXIT INT
+trap 'gardener::cleanup $CLUSTER_NAME' EXIT INT
 set -x
 
 #Used to detect errors for logging purposes

--- a/prow/scripts/lib/gardener/aws.sh
+++ b/prow/scripts/lib/gardener/aws.sh
@@ -78,7 +78,6 @@ gardener::provision_cluster() {
     log::info "Provision cluster: \"${CLUSTER_NAME}\""
 
     CLEANUP_CLUSTER="true"
-    (
       # enable trap to catch kyma provision failures
       trap gardener::reprovision_cluster ERR
       # decreasing attempts to 2 because we will try to create new cluster from scratch on exit code other than 0
@@ -94,7 +93,6 @@ gardener::provision_cluster() {
         --scaler-min 2 \
         --kube-version="${GARDENER_CLUSTER_VERSION}" \
         --attempts 2
-    )
     # trap cleanup we want other errors fail pipeline immediately
     trap - ERR
     if [ "$DEBUG_COMMANDO_OOM" = "true" ]; then

--- a/prow/scripts/lib/gardener/azure.sh
+++ b/prow/scripts/lib/gardener/azure.sh
@@ -29,6 +29,8 @@ source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/gardener/gardener.sh"
 gardener::cleanup() {
     #!!! Must be at the beginning of this function !!!
     EXIT_STATUS=$?
+    local clusterNameArg="$1"
+    CLUSTER_NAME="${clusterNameArg:-$CLUSTER_NAME}"
     if [ "${ERROR_LOGGING_GUARD}" = "true" ]; then
         log::error "AN ERROR OCCURED! Take a look at preceding log entries."
     fi

--- a/prow/scripts/lib/gardener/azure.sh
+++ b/prow/scripts/lib/gardener/azure.sh
@@ -104,7 +104,6 @@ gardener::provision_cluster() {
 
     CLEANUP_CLUSTER="true"
     if [[ "$EXECUTION_PROFILE" == "evaluation" ]]; then
-        (
             # enable trap to catch kyma provision failures
             trap gardener::reprovision_cluster ERR
             # decreasing attempts to 2 because we will try to create new cluster from scratch on exit code other than 0
@@ -121,9 +120,7 @@ gardener::provision_cluster() {
                 --kube-version="${GARDENER_CLUSTER_VERSION}" \
                 --attempts 2
             false
-        )
     else
-        (
             # enable trap to catch kyma provision failures
             trap gardener::reprovision_cluster ERR
             # decreasing attempts to 2 because we will try to create new cluster from scratch on exit code other than 0
@@ -139,7 +136,6 @@ gardener::provision_cluster() {
                 --kube-version="${GARDENER_CLUSTER_VERSION}" \
                 --attempts 2
             false
-        )
     fi
     # trap cleanup we want other errors fail pipeline immediately
     trap - ERR

--- a/prow/scripts/lib/gardener/azure.sh
+++ b/prow/scripts/lib/gardener/azure.sh
@@ -97,7 +97,6 @@ gardener::generate_overrides() {
 }
 
 gardener::provision_cluster() {
-    set -x
     log::info "Provision cluster: \"${CLUSTER_NAME}\""
 
     CLEANUP_CLUSTER="true"

--- a/prow/scripts/lib/gardener/azure.sh
+++ b/prow/scripts/lib/gardener/azure.sh
@@ -97,6 +97,7 @@ gardener::generate_overrides() {
 }
 
 gardener::provision_cluster() {
+    set -x
     log::info "Provision cluster: \"${CLUSTER_NAME}\""
 
     CLEANUP_CLUSTER="true"
@@ -116,8 +117,8 @@ gardener::provision_cluster() {
                 --scaler-max 1 --scaler-min 1 \
                 --disk-type StandardSSD_LRS \
                 --kube-version="${GARDENER_CLUSTER_VERSION}" \
-                --verbose \
                 --attempts 2
+            false
         )
     else
         (
@@ -134,8 +135,8 @@ gardener::provision_cluster() {
                 -t "${MACHINE_TYPE}" \
                 --disk-type StandardSSD_LRS \
                 --kube-version="${GARDENER_CLUSTER_VERSION}" \
-                --verbose \
                 --attempts 2
+            false
         )
     fi
     # trap cleanup we want other errors fail pipeline immediately

--- a/prow/scripts/lib/gardener/azure.sh
+++ b/prow/scripts/lib/gardener/azure.sh
@@ -29,8 +29,6 @@ source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/gardener/gardener.sh"
 gardener::cleanup() {
     #!!! Must be at the beginning of this function !!!
     EXIT_STATUS=$?
-    local clusterNameArg="$1"
-    CLUSTER_NAME="${clusterNameArg:-$CLUSTER_NAME}"
     if [ "${ERROR_LOGGING_GUARD}" = "true" ]; then
         log::error "AN ERROR OCCURED! Take a look at preceding log entries."
     fi

--- a/prow/scripts/lib/gardener/azure.sh
+++ b/prow/scripts/lib/gardener/azure.sh
@@ -116,7 +116,6 @@ gardener::provision_cluster() {
                 --disk-type StandardSSD_LRS \
                 --kube-version="${GARDENER_CLUSTER_VERSION}" \
                 --attempts 2
-            false
     else
             # enable trap to catch kyma provision failures
             trap gardener::reprovision_cluster ERR
@@ -132,7 +131,6 @@ gardener::provision_cluster() {
                 --disk-type StandardSSD_LRS \
                 --kube-version="${GARDENER_CLUSTER_VERSION}" \
                 --attempts 2
-            false
     fi
     # trap cleanup we want other errors fail pipeline immediately
     trap - ERR

--- a/prow/scripts/lib/gardener/gcp.sh
+++ b/prow/scripts/lib/gardener/gcp.sh
@@ -80,7 +80,6 @@ gardener::provision_cluster() {
     log::info "Provision cluster: \"${CLUSTER_NAME}\""
 
     CLEANUP_CLUSTER="true"
-    (
       # enable trap to catch kyma provision failures
       trap gardener::reprovision_cluster ERR
       # decreasing attempts to 2 because we will try to create new cluster from scratch on exit code other than 0
@@ -96,7 +95,6 @@ gardener::provision_cluster() {
         --scaler-min 2 \
         --kube-version="${GARDENER_CLUSTER_VERSION}" \
         --attempts 2
-    )
     # trap cleanup we want other errors fail pipeline immediately
     trap - ERR
     if [ "$DEBUG_COMMANDO_OOM" = "true" ]; then

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,2 +1,0 @@
-pjNames:
-  - pjName: pre-main-kyma-gardener-azure-alpha-prod

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,2 @@
+pjNames:
+  - pjName: pre-main-kyma-gardener-azure-alpha-prod


### PR DESCRIPTION
If gardener provision cluster failed and script tries provision second fresh cluster, cleanup function called by trap on INT and EXIT was trying to clean first cluster again. This cluster didn't exist already and second cluster was not cleaned.