### PR TITLE
Initial Prow autobump configuration

### DIFF
--- a/prow/autobump-config/prow-cluster-autobump-config.yaml
+++ b/prow/autobump-config/prow-cluster-autobump-config.yaml
@@ -1,0 +1,22 @@
+gitHubLogin: "kyma-bot"
+gitHubToken: "/etc/github/oauth"
+gitName: "Kyma Bot"
+gitEmail: "kyma.bot@sap.com"
+skipPullRequest: false
+gitHubOrg: "kyma-project"
+gitHubRepo: "test-infra"
+remoteName: "test-infra-1"
+upstreamURLBase: "https://raw.githubusercontent.com/kyma-project/test-infra/main"
+includedConfigPaths:
+  - "."
+excludedConfigPaths:
+  - "prow/staging"
+targetVersion: "latest"
+prefixes:
+  - name: "Prow"
+    prefix: "gcr.io/k8s-prow/"
+    refConfigFile: "prow/cluster/components/deck_deployment.yaml"
+    stagingRefConfigFile: "prow/staging/cluster/deck_deployment.yaml"
+    repo: "https://github.com/kyma-project/test-infra"
+    summarise: true
+    consistentImages: true

--- a/prow/jobs/test-infra/prow-periodics.yaml
+++ b/prow/jobs/test-infra/prow-periodics.yaml
@@ -40,4 +40,38 @@ periodics: # runs on schedule
           - name: config
             configMap:
               name: label-config
+    - name: ci-prow-autobump
+      annotations:
+        testgrid-create-test-group: "false"
+      labels:
+        prow.k8s.io/pubsub.project: "sap-kyma-prow"
+        prow.k8s.io/pubsub.runID: "ci-prow-autobump"
+        prow.k8s.io/pubsub.topic: "prowjobs"
+      cron: "30 * * * 1-5"
+      skip_report: false
+      decorate: true
+      cluster: trusted-workload
+      extra_refs:
+        - org: kyma-project
+          repo: test-infra
+          path_alias: github.com/kyma-project/test-infra
+          base_ref: main
+      reporter_config:
+        slack:
+          channel: kyma-prow-alerts
+      spec:
+        containers:
+          - image: "gcr.io/k8s-prow/generic-autobumper:v20210614-aafe2da0f3"
+            command:
+              - "/app/prow/cmd/generic-autobumper/app.binary"
+            args:
+              - "--config=prow/autobump-config/prow-cluster-autobump-config.yaml"
+            volumeMounts:
+              - name: kyma-bot-github-token
+                mountPath: /etc/github
+                readOnly: true
+        volumes:
+          - name: kyma-bot-github-token
+            secret:
+              secretName: kyma-bot-github-token
   

--- a/templates/data/prow-periodics-data.yaml
+++ b/templates/data/prow-periodics-data.yaml
@@ -7,12 +7,17 @@ templates:
             skip_report: "false"
             max_concurrency: "10"
             decorate: "true"
-            branches:
-              - "^master$"
-              - "^main$"
             type_periodic: "true"
             cluster: "trusted-workload"
           github_token_mounts:
+            volumes:
+              - name: kyma-bot-github-token
+                secretName: kyma-bot-github-token
+            volumeMounts:
+              - name: kyma-bot-github-token
+                mountPath: /etc/github
+                readOnly: true
+          label_sync_mounts:
             volumes:
               - name: kyma-bot-github-token
                 secretName: kyma-bot-github-token
@@ -44,7 +49,23 @@ templates:
                 inheritedConfigs:
                   local:
                     - periodic_config
+                    - label_sync_mounts
+                  global:
+                    - "pubsub_labels"
+                    - "disable_testgrid"
+              - jobConfig:
+                  name: ci-prow-autobump
+                  cron: "30 * * * 1-5"
+                  slack_channel: kyma-prow-alerts
+                  image: gcr.io/k8s-prow/generic-autobumper:v20210614-aafe2da0f3
+                  command: /app/prow/cmd/generic-autobumper/app.binary
+                  args:
+                    - --config=prow/autobump-config/prow-cluster-autobump-config.yaml
+                inheritedConfigs:
+                  local:
+                    - periodic_config
                     - github_token_mounts
                   global:
                     - "pubsub_labels"
                     - "disable_testgrid"
+                    - extra_refs_test-infra


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Initial prow autobump configuration based on the https://github.com/kubernetes/test-infra/tree/master/prow/cmd/generic-autobumper. For now without auto bump postsubmit - it should only open PR with bumps automatically.

The binary should iterate over the entire test-infra repository and look for images with given prefix ("gcr.io/k8s-prow/" in this case) and bump all the images to the latest tag available on the registry. Additionally it can exclude some directories from bumping, see the config.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#3498

/hold