### PR TITLE
Change deck service type from not working ClusterIP to NodePort

### DIFF
--- a/prow/cluster/components/deck_service.yaml
+++ b/prow/cluster/components/deck_service.yaml
@@ -28,4 +28,4 @@ spec:
     targetPort: 8080
   - name: metrics
     port: 9090
-  type: ClusterIP
+  type: NodePort


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Ingress is complaining:
```
Translation failed: invalid ingress spec: service "default/deck" is type "ClusterIP", expected "NodePort" or "LoadBalancer"
```
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
