### PR TITLE
GZIP job-config

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -37,6 +37,7 @@ config_updater:
   maps:
     prow/jobs/**/*.yaml:
       name: job-config
+      gzip: true
     prow/config.yaml:
       name: config
     prow/branchprotector-config.yaml:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
After merging #3733 job-config couldn't be updated due to the following error:
```
{"component":"unset","configmap":{"cluster":"default","name":"job-config","namespace":"default"},"error":"update config map err: ConfigMap \"job-config\" is invalid: []: Too long: must have at most 1048576 bytes","file":"/Users/i531931/go/src/k8s.io/test-infra/prow/cmd/config-bootstrapper/main.go:155","func":"main.run","level":"error","msg":"failed to update config on cluster","severity":"error","time":"2021-06-18T11:15:40+02:00"}
```

Possible solution:
https://github.com/kubernetes/test-infra/blob/master/prow/plugins/config.go#L452
