### PR TITLE
CLI compatibility script: check 2 latest kyma versions and set node runtime

### DIFF
--- a/prow/scripts/cli-tests/test-function.sh
+++ b/prow/scripts/cli-tests/test-function.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 log::info "Create local resources for a sample Function"
-clitests::assertRemoteCommand "sudo kyma init function --name first-function"
+clitests::assertRemoteCommand "sudo kyma init function --name first-function --runtime nodejs12"
 
 log::info "Apply local resources for the Function to the Kyma cluster"
 clitests::assertRemoteCommand "sudo kyma apply function"

--- a/prow/scripts/compatibility-cli.sh
+++ b/prow/scripts/compatibility-cli.sh
@@ -49,27 +49,31 @@ RELEASES=($(printf "%s\n" "${RELEASES[@]}" | sort -r))
 # Remove duplicates
 RELEASES=($(printf "%s\n" "${RELEASES[@]}" | uniq))
 
-# Go through releases ignoring patch versions in descending order until we skip the desired number of minor releases
-
-# remove patch
-CURRENT=$(echo "${RELEASES[1]}" | awk -F'.' '{print $1"."$2}')
-for r in "${RELEASES[@]}"; do
-    # remove patch from candidate
-    WANT=$(echo "${r}" | awk -F'.' '{print $1"."$2}')
-
-    if [[ "$WANT" != "$CURRENT" ]]; then
-        # check if we need to backtrack more
-        if [[ $COMPAT_BACKTRACK == 1 ]]; then
-            # Found the target release
-            TARGET=$r
-            break
-        else
-            # Still need to backtrack further
-            COMPAT_BACKTRACK=$((COMPAT_BACKTRACK - 1))
-            CURRENT=$(echo "${r}" | awk -F'.' '{print $1"."$2}')
+if [[ $COMPAT_BACKTRACK == 1 ]]; then
+    # Found the target release
+    TARGET="${RELEASES[1]}"
+else
+    COMPAT_BACKTRACK=$((COMPAT_BACKTRACK - 1))
+    # Go through releases ignoring patch versions in descending order until we skip the desired number of minor releases
+    # remove patch
+    CURRENT=$(echo "${RELEASES[1]}" | awk -F'.' '{print $1"."$2}')
+    for r in "${RELEASES[@]}"; do
+        # remove patch from candidate
+        WANT=$(echo "${r}" | awk -F'.' '{print $1"."$2}')
+        if [[ "$WANT" != "$CURRENT" ]]; then
+            # check if we need to backtrack more
+            if [[ $COMPAT_BACKTRACK == 1 ]]; then
+                # Found the target release
+                TARGET=$r
+                break
+            else
+                # Still need to backtrack further
+                COMPAT_BACKTRACK=$((COMPAT_BACKTRACK - 1))
+                CURRENT=$(echo "${r}" | awk -F'.' '{print $1"."$2}')
+            fi
         fi
-    fi
-done
+    done
+fi
 
 # Exceptional release replacements. Add a replacement pair here as follows: "release::replacement"
 # This is required when we have special releases that do not follow the regular pattern.


### PR DESCRIPTION
Description
This fixes the pipeline failure.
 
Greetings from Icke :)

Changes proposed in this pull request:

- 1 in COMPAT_BACKTRACK refers to current release. 2 refers two previous release. In the old version, the value 1 was not fetching the current release version, but backtracking one major version
- Change node runtime to v12 when creating kyma functions in the tests
...
Related issue(s)

kyma-project/cli#921