### PR TITLE
Add `show-output-dir` flag to rendertemplates

### DIFF
--- a/development/tools/cmd/rendertemplates/main.go
+++ b/development/tools/cmd/rendertemplates/main.go
@@ -24,7 +24,9 @@ const (
 )
 
 var (
-	configFilePath  = flag.String("config", "", "Path of the config file")
+	configFilePath = flag.String("config", "", "Path of the config file")
+	showOutputDir  = flag.Bool("show-output-dir", false, "Print generated output file paths to stdout")
+
 	additionalFuncs = map[string]interface{}{
 		"matchingReleases": rt.MatchingReleases,
 		"releaseMatches":   rt.ReleaseMatches,
@@ -141,6 +143,9 @@ func renderFileFromTemplate(basePath string, templateInstance *template.Template
 
 	values := map[string]interface{}{"Values": renderConfig.Values, "Global": config.Global}
 
+	if *showOutputDir {
+		fmt.Println(destFile.Name())
+	}
 	return templateInstance.Execute(destFile, values)
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Add `show-output-dir` flag to allow printing generated files to the stdout during template generation. It's useful to know the output directories that were added in specific workloads. 
