### PR TITLE
Bump service manager proxy external image

### DIFF
--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -32,7 +32,7 @@ images:
 - source: "quay.io/kubernetes-service-catalog/service-catalog:v0.3.1-12-g880e400-dirty"
 - source: "quay.io/prometheus/alertmanager:v0.21.0"
 - source: "quay.io/prometheus/prometheus:v2.22.1"
-- source: "quay.io/service-manager/sb-proxy-k8s:v0.8.18"
+- source: "quay.io/service-manager/sb-proxy-k8s:v0.9.0"
 - source: "jmedrek/application-gateway-alpine:1.14"
 - source: "jmedrek/application-gateway-alpine:1.15"
 - source: "jmedrek/connectivity-validator-alpine:1.14"


### PR DESCRIPTION
**Description**
Bump `service-manager-proxy` external image from `v0.8.18` to `v0.9.0`