### PR TITLE
Image syncer: allow for SHA digests

### DIFF
--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -1,6 +1,7 @@
 targetRepoPrefix:  "eu.gcr.io/kyma-project/external/"
 images:
-- source: "alpine:3.13.5"
+- source: "alpine@sha256:1775bebec23e1f3ce486989bfc9ff3c4e951690df84aa9f926497d82f2ffca9d"
+  tag: "3.14.0"
 #- source: "bitnami/keycloak-gatekeeper:10.0.0"
 - source: "bitnami/postgres-exporter:0.8.0-debian-10-r28"
 #- source: "busybox:1.32.0"

--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -1,7 +1,6 @@
 targetRepoPrefix:  "eu.gcr.io/kyma-project/external/"
 images:
-- source: "alpine@sha256:1775bebec23e1f3ce486989bfc9ff3c4e951690df84aa9f926497d82f2ffca9d"
-  tag: "3.14.0"
+- source: "alpine:3.13.5"
 #- source: "bitnami/keycloak-gatekeeper:10.0.0"
 - source: "bitnami/postgres-exporter:0.8.0-debian-10-r28"
 #- source: "busybox:1.32.0"

--- a/development/image-syncer/main.go
+++ b/development/image-syncer/main.go
@@ -121,7 +121,7 @@ func safeCopyImage(ctx context.Context, cli *client.Client, authString, sourceIm
 		}
 
 		if strings.Contains(sourceImage, "@sha256:") {
-			// TODO for new images check if the tag is consistent with the digest
+			// check if the tag is consistent with the digest
 			imageName := strings.Split(sourceImage, "@sha256:")[0]
 			sourceWithTag := imageName + ":" + targetTag
 			sourceWithTagID, sourceWithTagDigest, err := getImageIDAndRepoDigest(ctx, cli, sourceWithTag)

--- a/development/image-syncer/main.go
+++ b/development/image-syncer/main.go
@@ -124,6 +124,15 @@ func safeCopyImage(ctx context.Context, cli *client.Client, authString, sourceIm
 		// When tag value is set then image source contains digest instead of tag
 		if sourceTag != "" {
 			// TODO for new images check if the tag is consistent with the digest
+			imageName := strings.Split(sourceImage, "@sha256:")[0]
+			sourceWithTag := imageName + ":" + sourceTag
+			sourceWithTagID, sourceWithTagDigest, err := getImageIDAndRepoDigest(ctx, cli, sourceWithTag)
+			if err != nil {
+				return err
+			}
+			if sourceID != sourceWithTagID {
+				return fmt.Errorf("source IDs are different - digest and tag mismatch in config file: tag: %s, expected digest:%s, got %s", sourceTag, sourceWithTagDigest, sourceDigest)
+			}
 		}
 
 		log.Info("Image re-tagged")

--- a/development/image-syncer/main.go
+++ b/development/image-syncer/main.go
@@ -122,7 +122,7 @@ func safeCopyImage(ctx context.Context, cli *client.Client, authString, sourceIm
 				return err
 			}
 			if sourceID != sourceWithTagID {
-				return fmt.Errorf("source IDs are different - digest and tag mismatch in config file")
+				log.Info("source IDs are different - digest and tag mismatch in config file")
 			}
 		}
 

--- a/development/image-syncer/main.go
+++ b/development/image-syncer/main.go
@@ -87,7 +87,7 @@ func getImageIDAndRepoDigest(ctx context.Context, cli *client.Client, image stri
 	return "", "", fmt.Errorf("unable to find digest for '%s'", image)
 }
 
-func safeCopyImage(ctx context.Context, cli *client.Client, authString, sourceImage, sourceTag, targetRepo string, dryRun bool) error {
+func safeCopyImage(ctx context.Context, cli *client.Client, authString, sourceImage, targetTag, targetRepo string, dryRun bool) error {
 	if sourceImage == "" {
 		return fmt.Errorf("source image can not be empty")
 	}
@@ -101,11 +101,11 @@ func safeCopyImage(ctx context.Context, cli *client.Client, authString, sourceIm
 
 	target := targetRepo + sourceImage
 	if strings.Contains(sourceImage, "@sha256:") {
-		if sourceTag != "" {
+		if targetTag != "" {
 			return errors.New("sha256 digest detected, but the \"tag\" was not specified")
 		}
 		imageName := strings.Split(sourceImage, "@sha256:")[0]
-		target = targetRepo + imageName + ":" + sourceTag
+		target = targetRepo + imageName + ":" + targetTag
 	}
 
 	log.Infof("Target image: %s", target)
@@ -123,13 +123,13 @@ func safeCopyImage(ctx context.Context, cli *client.Client, authString, sourceIm
 		if strings.Contains(sourceImage, "@sha256:") {
 			// TODO for new images check if the tag is consistent with the digest
 			imageName := strings.Split(sourceImage, "@sha256:")[0]
-			sourceWithTag := imageName + ":" + sourceTag
+			sourceWithTag := imageName + ":" + targetTag
 			sourceWithTagID, sourceWithTagDigest, err := getImageIDAndRepoDigest(ctx, cli, sourceWithTag)
 			if err != nil {
 				return err
 			}
 			if sourceID != sourceWithTagID {
-				return fmt.Errorf("source IDs are different - digest and tag mismatch in config file: tag: %s, expected digest:%s, got %s", sourceTag, sourceWithTagDigest, sourceDigest)
+				return fmt.Errorf("source IDs are different - digest and tag mismatch in config file: tag: %s, expected digest:%s, got %s", targetTag, sourceWithTagDigest, sourceDigest)
 			}
 		}
 

--- a/development/image-syncer/main.go
+++ b/development/image-syncer/main.go
@@ -119,7 +119,7 @@ func safeCopyImage(ctx context.Context, cli *client.Client, authString, sourceIm
 			sourceWithTag := imageName + ":" + targetTag
 			sourceWithTagID, _, err := getImageIDAndRepoDigest(ctx, cli, sourceWithTag)
 			if err != nil {
-				return err
+				log.Info("couldn't get info about the tagged image")
 			}
 			if sourceID != sourceWithTagID {
 				log.Info("source IDs are different - digest and tag mismatch in config file")

--- a/development/image-syncer/main.go
+++ b/development/image-syncer/main.go
@@ -34,6 +34,7 @@ type SyncDef struct {
 // Image stores image location
 type Image struct {
 	Source string
+	Tag    string `yaml:"tag,omitempty"`
 }
 
 // Config stores command line arguments

--- a/development/image-syncer/main.go
+++ b/development/image-syncer/main.go
@@ -100,10 +100,9 @@ func safeCopyImage(ctx context.Context, cli *client.Client, authString, sourceIm
 	log.Infof("Source repo digest: %s", sourceDigest)
 
 	target := targetRepo + sourceImage
-	// When tag value is set assume image source contains digest instead of tag
-	if sourceTag != "" {
-		if !strings.Contains(sourceImage, "@sha256:") {
-			return errors.New("invalid source syntax, could not find sha256 digest")
+	if strings.Contains(sourceImage, "@sha256:") {
+		if sourceTag != "" {
+			return errors.New("sha256 digest detected, but the \"tag\" was not specified")
 		}
 		imageName := strings.Split(sourceImage, "@sha256:")[0]
 		target = targetRepo + imageName + ":" + sourceTag
@@ -121,8 +120,7 @@ func safeCopyImage(ctx context.Context, cli *client.Client, authString, sourceIm
 			return err
 		}
 
-		// When tag value is set then image source contains digest instead of tag
-		if sourceTag != "" {
+		if strings.Contains(sourceImage, "@sha256:") {
 			// TODO for new images check if the tag is consistent with the digest
 			imageName := strings.Split(sourceImage, "@sha256:")[0]
 			sourceWithTag := imageName + ":" + sourceTag

--- a/development/image-syncer/main.go
+++ b/development/image-syncer/main.go
@@ -120,8 +120,7 @@ func safeCopyImage(ctx context.Context, cli *client.Client, authString, sourceIm
 			sourceWithTagID, _, err := getImageIDAndRepoDigest(ctx, cli, sourceWithTag)
 			if err != nil {
 				log.Info("couldn't get info about the tagged image")
-			}
-			if sourceID != sourceWithTagID {
+			} else if sourceID != sourceWithTagID {
 				log.Info("source IDs are different - digest and tag mismatch in config file")
 			}
 		}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- add support for SHA digests
    - if the `source` field contains SHA256 checksum, then `tag` field is required, as the target will get tagged with tag instead of the digest
- check if tag and digest matches for new images, but don't exit the program if they don't

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#3861