### PR TITLE
Compass down migrations

### DIFF
--- a/prow/scripts/cluster-integration/compass-gke-integration.sh
+++ b/prow/scripts/cluster-integration/compass-gke-integration.sh
@@ -323,7 +323,7 @@ function installCompass() {
   NODE=$(kubectl get nodes | tail -n 1 | cut -d ' ' -f 1)
 
   log::info "DB migration up and down jobs will be executed on node: $NODE"
-  kubectl label node "$NODE" migrationJobs: true
+  kubectl label node "$NODE" migrationJobs=true
 
   echo "Manual concatenating yamls"
   "${COMPASS_SCRIPTS_DIR}"/concat-yamls.sh "${INSTALLER_YAML}" "${INSTALLER_CR}" \

--- a/prow/scripts/cluster-integration/compass-gke-integration.sh
+++ b/prow/scripts/cluster-integration/compass-gke-integration.sh
@@ -246,6 +246,7 @@ function applyCompassOverrides() {
     --data "global.systemFetcher.oauth.tokenURLPattern=http://compass-external-services-mock:8080/systemfetcher/oauth/token" \
     --data "global.systemFetcher.oauth.scopesClaim=scopes" \
     --data "global.systemFetcher.oauth.tenantHeaderName=x-zid" \
+    --data "global.migratorJob.nodeSelectorEnabled=true" \
     --label "component=compass"
 }
 
@@ -317,6 +318,12 @@ function installCompass() {
   kubectl create namespace "compass-installer"
   applyCommonOverrides "compass-installer"
   applyCompassOverrides
+
+  log::info "Choose node for migration jobs execution"
+  NODE=$(kubectl get nodes | tail -n 1 | cut -d ' ' -f 1)
+
+  log::info "DB migration up and down jobs will be executed on node: $NODE"
+  kubectl label node "$NODE" migrationJobs: true
 
   echo "Manual concatenating yamls"
   "${COMPASS_SCRIPTS_DIR}"/concat-yamls.sh "${INSTALLER_YAML}" "${INSTALLER_CR}" \

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,7 +1,0 @@
-pjNames:
-  - pjName: "pre-main-compass-gke-integration"
-    pjPath: "test-infra/prow/jobs/incubator/compass/"
-prConfigs:
-  kyma-incubator:
-    compass:
-      prNumber: 1948

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,6 +1,6 @@
 pjNames:
   - pjName: "pre-main-compass-gke-integration"
-    pjPath: "test-infra/prow/jobs/compass/"
+    pjPath: "test-infra/prow/jobs/incubator/compass/"
 prConfigs:
   kyma-incubator:
     compass:

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,7 @@
+pjNames:
+  - pjName: "pre-main-compass-gke-integration"
+    pjPath: "test-infra/prow/jobs/compass/"
+prConfigs:
+  kyma-incubator:
+    compass:
+      prNumber: 1948


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The new approach for running "down" migrations in Compass requires a Persistent Volume, which is bound to two jobs - the one that will execute the "up" migrations, and the one that will execute the "down" migration before the helm roll-back.
The pods of those jobs can be scheduled on different nodes, and GKE does not support ReadWriteMany access type for storages, hence, we need to make sure that the pods of those jobs will run on the same node.

Changes proposed in this pull request:
- Label GKE node for Compass integration tests

**Related PR(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-incubator/compass/pull/1948