### PR TITLE
Fix  `kyma-cli-compatibility-2` job for Kyma 2.0.0

### DIFF
--- a/prow/scripts/compatibility-cli.sh
+++ b/prow/scripts/compatibility-cli.sh
@@ -77,7 +77,7 @@ fi
 
 # Exceptional release replacements. Add a replacement pair here as follows: "release::replacement"
 # This is required when we have special releases that do not follow the regular pattern.
-EXCEPTIONS=('1.16.0::1.16.0-rc3')
+EXCEPTIONS=('1.16.0::1.16.0-rc3', '2.0.0::2.0.0-rc1')
 
 for index in "${EXCEPTIONS[@]}" ; do
     KEY="${index%%::*}"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
This PR fixes a failing pipeline for Kyma 2. In the pipeline the version Kyma 2.0.0 is fetched and tried to being deployed, but since we only have artifacts for Kyma 2.0.0-rc1, we need to add this as a special target.

Changes proposed in this pull request:

- Add `rc1` to Kyma version 
- Fixes [this job](https://status.build.kyma-project.io/view/gs/kyma-prow-logs/logs/kyma-cli-compatibility-2/1419492787203608576)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
