### PR TITLE
rm installCompass from pre-main-control-plane-gke-integration testing case

### DIFF
--- a/prow/scripts/cluster-integration/control-plane-gke-integration.sh
+++ b/prow/scripts/cluster-integration/control-plane-gke-integration.sh
@@ -430,8 +430,8 @@ export TLS_KEY="${utils_generate_self_signed_cert_return_tls_key:?}"
 log::info "Install Kyma"
 installKyma
 
-log::info "Install Compass"
-installCompass
+#log::info "Install Compass"
+#installCompass
 
 log::info "Install Control Plane"
 installControlPlane

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,9 @@
+pjNames:
+  - pjName: "pre-main-control-plane-gke-integration"
+    pjPath: "test-infra/prow/jobs/control-plane/"
+  - pjName: "pre-main-control-plane-integration"
+    pjPath: "test-infra/prow/jobs/control-plane/"
+prConfigs:
+  kyma-project:
+    control-plane:
+      prNumber: 861

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,9 +1,0 @@
-pjNames:
-  - pjName: "pre-main-control-plane-gke-integration"
-    pjPath: "test-infra/prow/jobs/control-plane/"
-  - pjName: "pre-main-control-plane-integration"
-    pjPath: "test-infra/prow/jobs/control-plane/"
-prConfigs:
-  kyma-project:
-    control-plane:
-      prNumber: 861


### PR DESCRIPTION
**Description**
rm the step of `installCompass` in the `control-plane-gke-integration.sh`

**Related issue(s)**
[PR861](https://github.com/kyma-project/control-plane/pull/861) failed at the compass install phase in the https://storage.googleapis.com/kyma-prow-logs/pr-logs/pull/kyma-project_control-plane/861/pre-main-control-plane-gke-integration/1418488550575312896/build-log.txt