### PR TITLE
Add dependency k3d for fast-integration tests to VM image

### DIFF
--- a/development/custom-image/install-deps-debian.sh
+++ b/development/custom-image/install-deps-debian.sh
@@ -19,6 +19,7 @@ CRICTL_VERSION=v1.12.0
 HELM_VERSION="v3.4.2"
 DOCKER_VERSION=5:20.10.5~3-0~debian-buster
 NODEJS_VERSION="14.x"
+K3D_VERSION="4.4.7"
 
 # install docker
 sudo apt-get update
@@ -71,6 +72,9 @@ curl -sL https://deb.nodesource.com/setup_${NODEJS_VERSION} | sudo bash -
 sudo apt-get -y install \
      jq \
      nodejs
+
+# install k3d
+wget -q -O - https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v${K3D_VERSION} bash
 
 # install monitoring agent
 # https://cloud.google.com/monitoring/agent/installation


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Changes pending in https://github.com/kyma-project/test-infra/pull/4023 require that k3d is present on the VM image for Kyma to be able to provision a k3d cluster

**Related issue(s)**
* #4023
* https://github.com/kyma-project/kyma/issues/11668
