### PR TITLE
Replace occurences of ci-no-install make target with ci

### DIFF
--- a/prow/scripts/cluster-integration/fast-integration-test.sh
+++ b/prow/scripts/cluster-integration/fast-integration-test.sh
@@ -74,7 +74,7 @@ function test_fast_integration_kyma() {
     log::info "Running Kyma Fast Integration tests"
 
     pushd /home/prow/go/src/github.com/kyma-project/kyma/tests/fast-integration
-    make ci-no-install
+    make ci
     popd
 }
 

--- a/prow/scripts/lib/gardener/azure.sh
+++ b/prow/scripts/lib/gardener/azure.sh
@@ -309,7 +309,7 @@ gardener::test_fast_integration_kyma() {
     log::info "Running Kyma Fast Integration tests"
 
     pushd /home/prow/go/src/github.com/kyma-project/kyma/tests/fast-integration
-    make ci-no-install
+    make ci
     popd
 
     log::success "Tests completed"

--- a/prow/scripts/lib/gardener/gcp.sh
+++ b/prow/scripts/lib/gardener/gcp.sh
@@ -134,7 +134,7 @@ gardener::test_fast_integration_kyma() {
     log::info "Running Kyma Fast Integration tests"
 
     pushd /home/prow/go/src/github.com/kyma-project/kyma/tests/fast-integration
-    make ci-no-install
+    make ci
     popd
 
     log::success "Tests completed"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Since Kyma is installed on the pipeline for fast-integration tests all make targets are running tests without installation from test code. To remove target `ci-no-install` it is replaced here with `ci` since both are currently doing the same and `ci-no-install` should be deleted from tests/fast-integration in kyma repository.

Changes proposed in this pull request:

- Replace all occurences of `make ci-no-install` with `make ci`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
* https://github.com/kyma-project/kyma/issues/11668