### PR TITLE
Introduce compass integration without db-dump

### DIFF
--- a/prow/jobs/incubator/compass/compass-integration-no-dump.yaml
+++ b/prow/jobs/incubator/compass/compass-integration-no-dump.yaml
@@ -50,7 +50,7 @@ presubmits: # runs on PRs
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
-
+  
 postsubmits: # runs on main
   kyma-incubator/compass:
     - name: post-main-compass-integration-no-dump
@@ -101,3 +101,4 @@ postsubmits: # runs on main
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
+  

--- a/prow/jobs/incubator/compass/compass-integration-no-dump.yaml
+++ b/prow/jobs/incubator/compass/compass-integration-no-dump.yaml
@@ -3,12 +3,12 @@
 
 presubmits: # runs on PRs
   kyma-incubator/compass:
-    - name: pre-main-compass-integration
+    - name: pre-main-compass-integration-no-dump
       annotations:
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pre-main-compass-integration"
+        prow.k8s.io/pubsub.runID: "pre-main-compass-integration-no-dump"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-pr: "true"
         preset-gc-project-env: "true"
@@ -35,7 +35,7 @@ presubmits: # runs on PRs
             securityContext:
               privileged: true
             command:
-              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-compass.sh --dump-db"
+              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-compass.sh"
             env:
               - name: GO111MODULE
                 value: "on"
@@ -50,18 +50,18 @@ presubmits: # runs on PRs
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
-  
+
 postsubmits: # runs on main
   kyma-incubator/compass:
-    - name: post-main-compass-integration
+    - name: post-main-compass-integration-no-dump
       annotations:
-        description: "Compass integration job."
+        description: "Compass integration job without db dump."
         pipeline.trigger: "pr-merge"
         testgrid-dashboards: "kyma-incubator_compass"
         testgrid-days-of-results: "60"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "post-main-compass-integration"
+        prow.k8s.io/pubsub.runID: "post-main-compass-integration-no-dump"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-main: "true"
         preset-gc-project-env: "true"
@@ -86,7 +86,7 @@ postsubmits: # runs on main
             securityContext:
               privileged: true
             command:
-              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-compass.sh --dump-db"
+              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-compass.sh"
             env:
               - name: GO111MODULE
                 value: "on"
@@ -101,4 +101,3 @@ postsubmits: # runs on main
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
-  

--- a/prow/jobs/incubator/compass/compass-integration.yaml
+++ b/prow/jobs/incubator/compass/compass-integration.yaml
@@ -35,7 +35,9 @@ presubmits: # runs on PRs
             securityContext:
               privileged: true
             command:
-              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-compass.sh --dump-db"
+              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-compass.sh"
+            args:
+              - "--dump-db"
             env:
               - name: GO111MODULE
                 value: "on"
@@ -86,7 +88,9 @@ postsubmits: # runs on main
             securityContext:
               privileged: true
             command:
-              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-compass.sh --dump-db"
+              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-compass.sh"
+            args:
+              - "--dump-db"
             env:
               - name: GO111MODULE
                 value: "on"

--- a/prow/scripts/provision-vm-compass.sh
+++ b/prow/scripts/provision-vm-compass.sh
@@ -62,6 +62,10 @@ do
             shift
             shift
             ;;
+        --dump-db)
+            DUMP_DB="--dump-db"
+            shift
+            ;;
         --*)
             echo "Unknown flag ${1}"
             exit 1
@@ -123,7 +127,7 @@ gcloud compute ssh --quiet --zone="${ZONE}" "compass-integration-test-${RANDOM_I
 
 log::info "Triggering the installation"
 
-gcloud compute ssh --quiet --zone="${ZONE}" "compass-integration-test-${RANDOM_ID}" -- "yes | ./compass/installation/scripts/prow/deploy-and-test.sh --dump-db"
+gcloud compute ssh --quiet --zone="${ZONE}" "compass-integration-test-${RANDOM_ID}" -- "yes | ./compass/installation/scripts/prow/deploy-and-test.sh ${DUMP_DB}"
 
 log::info "Copying test artifacts from VM"
 utils::receive_from_vm "${ZONE}" "compass-integration-test-${RANDOM_ID}" "/var/log/prow_artifacts" "${ARTIFACTS}"

--- a/templates/data/compass-integration-data.yaml
+++ b/templates/data/compass-integration-data.yaml
@@ -6,8 +6,8 @@ templates:
           jobConfig_default:
             path_alias: github.com/kyma-incubator/compass
             command: "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-compass.sh"
-          args:
-            - "--dump-db"
+            args:
+              - "--dump-db"
             request_memory: 100Mi
             request_mcpu: 50m
             env:

--- a/templates/data/compass-integration-data.yaml
+++ b/templates/data/compass-integration-data.yaml
@@ -5,7 +5,9 @@ templates:
         localSets:
           jobConfig_default:
             path_alias: github.com/kyma-incubator/compass
-            command: "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-compass.sh --dump-db"
+            command: "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-compass.sh"
+          args:
+            - "--dump-db"
             request_memory: 100Mi
             request_mcpu: 50m
             env:

--- a/templates/data/compass-integration-no-dump.yaml
+++ b/templates/data/compass-integration-no-dump.yaml
@@ -40,7 +40,7 @@ templates:
                     preset-build-main: "true"
                   annotations:
                     testgrid-dashboards: kyma-incubator_compass
-                    description: Compass integration job.
+                    description: Compass integration job without db dump.
                     testgrid-days-of-results: "60"
                 inheritedConfigs:
                   global:

--- a/templates/data/compass-integration-no-dump.yaml
+++ b/templates/data/compass-integration-no-dump.yaml
@@ -1,11 +1,11 @@
 templates:
   - from: templates/generic.tmpl
     render:
-      - to: ../prow/jobs/incubator/compass/compass-integration.yaml
+      - to: ../prow/jobs/incubator/compass/compass-integration-no-dump.yaml
         localSets:
           jobConfig_default:
             path_alias: github.com/kyma-incubator/compass
-            command: "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-compass.sh --dump-db"
+            command: "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-compass.sh"
             request_memory: 100Mi
             request_mcpu: 50m
             env:
@@ -18,7 +18,7 @@ templates:
           - repoName: "kyma-incubator/compass"
             jobs:
               - jobConfig:
-                  name: "pre-main-compass-integration"
+                  name: "pre-main-compass-integration-no-dump"
                   run_if_changed: "^(chart|installation)/"
                   labels:
                     preset-build-pr: "true"
@@ -35,7 +35,7 @@ templates:
                   local:
                     - "jobConfig_default"
               - jobConfig:
-                  name: "post-main-compass-integration"
+                  name: "post-main-compass-integration-no-dump"
                   labels:
                     preset-build-main: "true"
                   annotations:


### PR DESCRIPTION
**Description**

Some tests need to be executed on clusters that are not previously populated with dump. This PR introduces a second compass-integration job which will execute such tests in a cluster which is not populated by db-dump. 