### PR TITLE
Provide components for compass tests via file

### DIFF
--- a/prow/scripts/cluster-integration/kyma-integration-k3d-compass-components.yaml
+++ b/prow/scripts/cluster-integration/kyma-integration-k3d-compass-components.yaml
@@ -1,0 +1,22 @@
+---
+defaultNamespace: kyma-system
+prerequisites:
+  - name: "cluster-essentials"
+  - name: "istio"
+    namespace: "istio-system"
+  - name: "certificates"
+    namespace: "istio-system"
+components:
+  - name: "eventing"
+  - name: "ory"
+  - name: "api-gateway"
+  - name: "service-catalog"
+  - name: "service-catalog-addons"
+  - name: "rafter"
+  - name: "helm-broker"
+  - name: "cluster-users"
+  - name: "serverless"
+  - name: "application-connector"
+    namespace: "kyma-integration"
+  - name: "compass-runtime-agent"
+    namespace: "compass-system"

--- a/prow/scripts/cluster-integration/kyma-integration-k3d.sh
+++ b/prow/scripts/cluster-integration/kyma-integration-k3d.sh
@@ -56,20 +56,7 @@ function deploy_kyma() {
 
   if [[ -v COMPASS_INTEGRATION_ENABLED ]]; then
     kyma_deploy_cmd+=" --value global.disableLegacyConnectivity=true"
-    kyma_deploy_cmd+=" --component cluster-essentials@kyma-system"
-    kyma_deploy_cmd+=" --component istio@istio-system"
-    kyma_deploy_cmd+=" --component certificates@istio-system"
-    kyma_deploy_cmd+=" --component eventing@kyma-system"
-    kyma_deploy_cmd+=" --component ory@kyma-system"
-    kyma_deploy_cmd+=" --component api-gateway@kyma-system"
-    kyma_deploy_cmd+=" --component service-catalog@kyma-system"
-    kyma_deploy_cmd+=" --component service-catalog-addons@kyma-system"
-    kyma_deploy_cmd+=" --component rafter@kyma-system"
-    kyma_deploy_cmd+=" --component helm-broker@kyma-system"
-    kyma_deploy_cmd+=" --component cluster-users@kyma-system"
-    kyma_deploy_cmd+=" --component serverless@kyma-system"
-    kyma_deploy_cmd+=" --component application-connector@kyma-integration"
-    kyma_deploy_cmd+=" --component compass-runtime-agent@compass-system"
+    kyma_deploy_cmd+=" --components-file kyma-integration-k3d-compass-components.yaml"
   fi
 
   $kyma_deploy_cmd

--- a/prow/scripts/provision-vm-and-start-kyma-k3d.sh
+++ b/prow/scripts/provision-vm-and-start-kyma-k3d.sh
@@ -129,6 +129,7 @@ utils::compress_send_to_vm "${ZONE}" "kyma-integration-test-${RANDOM_ID}" "/home
 
 if [[ -v COMPASS_INTEGRATION_ENABLED ]]; then
   log::info "Copying components file for compass tests"
+  #shellcheck disable=SC2088
   utils::send_to_vm "${ZONE}" "kyma-integration-test-${RANDOM_ID}" "${SCRIPT_DIR}/cluster-integration/kyma-integration-k3d-compass-components.yaml" "~/kyma-integration-k3d-compass-components.yaml"
 fi
 

--- a/prow/scripts/provision-vm-and-start-kyma-k3d.sh
+++ b/prow/scripts/provision-vm-and-start-kyma-k3d.sh
@@ -127,6 +127,11 @@ log::info "Copying Kyma to the instance"
 #shellcheck disable=SC2088
 utils::compress_send_to_vm "${ZONE}" "kyma-integration-test-${RANDOM_ID}" "/home/prow/go/src/github.com/kyma-project/kyma" "~/kyma"
 
+if [[ -v COMPASS_INTEGRATION_ENABLED ]]; then
+  log::info "Copying components file for compass tests"
+  utils::send_to_vm "${ZONE}" "kyma-integration-test-${RANDOM_ID}" "${SCRIPT_DIR}/cluster-integration/kyma-integration-k3d-compass-components.yaml" "~/kyma-integration-k3d-compass-components.yaml"
+fi
+
 log::info "Triggering the installation"
 gcloud compute ssh --quiet --zone="${ZONE}" --command="sudo bash" --ssh-flag="-o ServerAliveInterval=30" "kyma-integration-test-${RANDOM_ID}" < "${SCRIPT_DIR}/cluster-integration/kyma-integration-k3d.sh"
 

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,8 +1,0 @@
-pjNames:
-  - pjName: "pre-main-kyma-integration-k3d-central-app-connectivity-compass"
-  - pjName: "pre-main-kyma-integration-k3d-compass-dev"
-  - pjName: "kyma-integration-k3d"
-prConfigs:
-  kyma-project:
-    kyma:
-      prNumber: 11879

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,4 +1,8 @@
 pjNames:
-  - pjName: "post-main-kyma-integration-k3d-central-app-connectivity-compass"
+  - pjName: "pre-main-kyma-integration-k3d-central-app-connectivity-compass"
   - pjName: "pre-main-kyma-integration-k3d-compass-dev"
   - pjName: "kyma-integration-k3d"
+prConfigs:
+  kyma-project:
+    kyma:
+      prNumber: 11879

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,4 @@
+pjNames:
+  - pjName: "post-main-kyma-integration-k3d-central-app-connectivity-compass"
+  - pjName: "pre-main-kyma-integration-k3d-compass-dev"
+  - pjName: "kyma-integration-k3d"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
It seems that the `--component` flag of `kyma deploy` can only be used to patch existing Kyma installations.
Listing components via this flag made tests flaky because istio is a prereq and the order of installed components matters.
To fix this for the compass test scenario where some components are skipped and compass-runtime-agent needs to be added it is more reasonable to use a components file.

Changes proposed in this pull request:
- Replace specification of components for compass scenario by `--components-file`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
* https://github.com/kyma-project/kyma/pull/11879
* https://github.com/kyma-project/kyma/issues/11668
