### PR TITLE
Fix sequential compass installations in benchmark tests

### DIFF
--- a/prow/scripts/cluster-integration/compass-gke-benchmark.sh
+++ b/prow/scripts/cluster-integration/compass-gke-benchmark.sh
@@ -400,6 +400,10 @@ done
 
 kubectl delete cts $SUITE_NAME
 
+# Because of sequential compass installation, the second one fails due to compass-migration job patching failure. K8s job's fields are immutable.
+log::info "Deleting the old compass-migration job"
+kubectl delete jobs -n compass-system compass-migration
+
 log::info "Install New Compass version"
 installCompassNew
 


### PR DESCRIPTION
**Description**
Due to recently changed compass-migration job in the compass repository, the deletion of this job is no longer managed by Helm and in the benchmark test, the second compass installation fails due to K8s job patching failure. To solve this problem we manually delete the compass-migration job before the second installation.

Changes proposed in this pull request:
- Delete compass-migration job before the second compass installation 

