### PR TITLE
Replace dot to dash provision-vm-cli.sh labels

### DIFF
--- a/prow/scripts/provision-vm-cli.sh
+++ b/prow/scripts/provision-vm-cli.sh
@@ -39,7 +39,7 @@ RANDOM_ID=$(openssl rand -hex 4)
 
 LABELS=""
 if [[ -z "${PULL_NUMBER}" ]]; then
-    LABELS=(--labels "branch=$PULL_BASE_REF,job-name=cli-integration")
+    LABELS=(--labels "branch=${PULL_BASE_REF/./-},job-name=cli-integration")
 else
     LABELS=(--labels "pull-number=$PULL_NUMBER,job-name=cli-integration")
 fi


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
gcloud labels do not support dots as characters. Env `PULL_BASE_REF` will contain dots if the job is run against `release-x.xx` branch. The dot character has to be replaced with either dash or underscore.
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
