### PR TITLE
fixing typo in yaml anotation

### DIFF
--- a/development/gcp/cloud-functions/getslackuserforgithubuser/main.go
+++ b/development/gcp/cloud-functions/getslackuserforgithubuser/main.go
@@ -148,7 +148,8 @@ func GetSlackUserForGithubUser(ctx context.Context, m pubsub.MessagePayload) {
 		go func(wg *sync.WaitGroup, message *pubsub.FailingTestMessage, logger *cloudfunctions.LogEntry, out <-chan string, done <-chan int) {
 			for {
 				select {
-				case slackUser := <-out:
+				case slackUser := <- out:
+					logger.LogInfo(fmt.Sprintf("adding slack user %s to CommitersSlacklogins", slackUser))
 					// Save slack username in FailingTestMessage.CommiterSlackLogins
 					message.CommitersSlackLogins = append(message.CommitersSlackLogins, slackUser)
 				case <-done:

--- a/development/types/types.go
+++ b/development/types/types.go
@@ -5,7 +5,7 @@ package types
 type User struct {
 	ComGithubUsername          string `yaml:"com.github.username,omitempty"`
 	SapToolsGithubUsername     string `yaml:"sap.tools.github.username,omitempty"`
-	ComEnterpriseSlackUsername string `yaml:"com.enterprise.slack.username,omitempty"`
+	ComEnterpriseSlackUsername string `yaml:"com.slack.enterprise.username,omitempty"`
 }
 
 type Logger interface {


### PR DESCRIPTION
Yaml anotation has wrong order in name field.
