### PR TITLE
Bump kubectl to v1.18 and helm to v3.6.2 in kyma-integration

### DIFF
--- a/prow/images/kyma-integration/Dockerfile
+++ b/prow/images/kyma-integration/Dockerfile
@@ -11,7 +11,7 @@ LABEL io.kyma-project.test-infra.commit=$commit
 #################################################################
 ###################### Basic Bootstrap ##########################
 #################################################################
-ARG K8S_VERSION=1.16
+ARG K8S_VERSION=1.20
 ARG commit
 ENV IMAGE_COMMIT=$commit
 LABEL IMAGE_COMMIT=$commit

--- a/prow/images/kyma-integration/Dockerfile
+++ b/prow/images/kyma-integration/Dockerfile
@@ -11,7 +11,7 @@ LABEL io.kyma-project.test-infra.commit=$commit
 #################################################################
 ###################### Basic Bootstrap ##########################
 #################################################################
-ARG K8S_VERSION=1.20
+ARG K8S_VERSION=1.18
 ARG commit
 ENV IMAGE_COMMIT=$commit
 LABEL IMAGE_COMMIT=$commit

--- a/prow/images/kyma-integration/Dockerfile
+++ b/prow/images/kyma-integration/Dockerfile
@@ -101,7 +101,7 @@ RUN apt -y install nodejs
 
 #Install helm
 
-ENV HELM_VERSION="v3.2.1"
+ENV HELM_VERSION="v3.6.2"
 
 RUN wget https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm &&\
 	  chmod +x /usr/local/bin/helm &&\

--- a/prow/images/kyma-integration/Makefile
+++ b/prow/images/kyma-integration/Makefile
@@ -20,18 +20,18 @@ ci-release: build-image tag-image push-image
 .PHONY: tag-image
 tag-image:
 	@echo "___ Tagging as current ___"
-	docker tag $(IMG):$(DOCKER_TAG)-k8s1.20 $(IMG):current
-	docker tag $(IMG):$(DOCKER_TAG)-k8s1.20 $(IMG):k8s1.20-current
+	docker tag $(IMG):$(DOCKER_TAG)-k8s1.18 $(IMG):current
+	docker tag $(IMG):$(DOCKER_TAG)-k8s1.18 $(IMG):k8s1.18-current
 ifdef DOCKER_POST_PR_TAG
 	@echo "___ Tagging with pr number ___"
-	docker tag $(IMG):$(DOCKER_TAG)-k8s1.20 $(IMG):k8s1.20-$(DOCKER_POST_PR_TAG)
+	docker tag $(IMG):$(DOCKER_TAG)-k8s1.18 $(IMG):k8s1.18-$(DOCKER_POST_PR_TAG)
 endif
 
 
 # build image and tag it with commit ID or PR number
 .PHONY: build-image
 build-image:
-	docker build -t $(IMG):$(DOCKER_TAG)-k8s1.20 --build-arg K8S_VERSION=1.20 --build-arg commit=$(DOCKER_TAG) .
+	docker build -t $(IMG):$(DOCKER_TAG)-k8s1.18 --build-arg K8S_VERSION=1.18 --build-arg commit=$(DOCKER_TAG) .
 
 
 # push image with all tags

--- a/prow/images/kyma-integration/Makefile
+++ b/prow/images/kyma-integration/Makefile
@@ -20,18 +20,18 @@ ci-release: build-image tag-image push-image
 .PHONY: tag-image
 tag-image:
 	@echo "___ Tagging as current ___"
-	docker tag $(IMG):$(DOCKER_TAG)-k8s1.16 $(IMG):current
-	docker tag $(IMG):$(DOCKER_TAG)-k8s1.16 $(IMG):k8s1.16-current
+	docker tag $(IMG):$(DOCKER_TAG)-k8s1.20 $(IMG):current
+	docker tag $(IMG):$(DOCKER_TAG)-k8s1.20 $(IMG):k8s1.20-current
 ifdef DOCKER_POST_PR_TAG
 	@echo "___ Tagging with pr number ___"
-	docker tag $(IMG):$(DOCKER_TAG)-k8s1.16 $(IMG):k8s1.16-$(DOCKER_POST_PR_TAG)
+	docker tag $(IMG):$(DOCKER_TAG)-k8s1.20 $(IMG):k8s1.20-$(DOCKER_POST_PR_TAG)
 endif
 
 
 # build image and tag it with commit ID or PR number
 .PHONY: build-image
 build-image:
-	docker build -t $(IMG):$(DOCKER_TAG)-k8s1.16 --build-arg K8S_VERSION=1.16 --build-arg commit=$(DOCKER_TAG) .
+	docker build -t $(IMG):$(DOCKER_TAG)-k8s1.20 --build-arg K8S_VERSION=1.20 --build-arg commit=$(DOCKER_TAG) .
 
 
 # push image with all tags


### PR DESCRIPTION
**Description**
 
Changes proposed in this pull request:
- Updates kubectl version to 1.18 in kyma-integration
- Updates Helm version to 3.6.2 in kyma-integration


**Related issue(s)**
- kubectl v1.18 is needed for [reconciler e2e testing](https://github.com/kyma-project/test-infra/pull/4071)