### PR TITLE
Update Prometheus Alertmanager to Version 0.23.0

### DIFF
--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -33,7 +33,7 @@ images:
 - source: "quay.io/prometheus-operator/prometheus-config-reloader:v0.43.2"
 - source: "quay.io/prometheus-operator/prometheus-operator:v0.43.2"
 - source: "quay.io/kubernetes-service-catalog/service-catalog:v0.3.1-12-g880e400-dirty"
-- source: "quay.io/prometheus/alertmanager:v0.21.0"
+- source: "quay.io/prometheus/alertmanager:v0.23.0"
 - source: "quay.io/prometheus/prometheus:v2.22.1"
 - source: "quay.io/service-manager/sb-proxy-k8s:v0.9.0"
 - source: "nats:2.1.8"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Regarding this [Protecode issue](https://github.tools.sap/kyma/security-scans/issues/8486) we need to update the alertmanager image.

Changes proposed in this pull request:

- Changed alertmanager image for imagesyncer to `v0.23.0`, which is the newest stable release

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
