### PR TITLE
Fix whitesource scan for podpreset project

### DIFF
--- a/prow/jobs/scans/whitesource-periodics.yaml
+++ b/prow/jobs/scans/whitesource-periodics.yaml
@@ -765,7 +765,7 @@ periodics: # runs on schedule
               - name: CUSTOM_PROJECTNAME
                 value: podpreset
               - name: SCAN_LANGUAGE
-                value: golang
+                value: golang-mod
             resources:
               requests:
                 memory: 1Gi

--- a/templates/data/whitesource-periodics-data.yaml
+++ b/templates/data/whitesource-periodics-data.yaml
@@ -221,7 +221,7 @@ templates:
                     - "jobConfig_default"
               - jobConfig:
                   name: "podpreset-crd"
-                  language: "golang"
+                  language: "golang-mod"
                   project: "kyma-incubator"
                   custom_projectname: "podpreset"
                 inheritedConfigs:


### PR DESCRIPTION
After https://github.com/kyma-incubator/podpreset-crd was migrated to Go Mod, the whitesource scanner failed to provide the proper scan for dependencies using Go Mod package manager.