### PR TITLE
Disable kyma-whitesource-scan

### DIFF
--- a/prow/jobs/scans/whitesource-periodics.yaml
+++ b/prow/jobs/scans/whitesource-periodics.yaml
@@ -98,54 +98,6 @@ periodics: # runs on schedule
               requests:
                 memory: 1Gi
                 cpu: 400m
-    - name: kyma-whitesource-scan
-      annotations:
-        pipeline.trigger: "periodic"
-        testgrid-create-test-group: "false"
-      labels:
-        preset-gc-project-env: "true"
-        preset-kms-gc-project-env: "true"
-        preset-kyma-encryption-key: "true"
-        preset-kyma-keyring: "true"
-        preset-kyma-wssagent-config: "true"
-        preset-wssagent-keys: "true"
-        preset-sa-gke-kyma-integration-kyma-project-whitesource: "true"
-      cron: "0 4 * * *"
-      skip_report: false
-      decorate: true
-      cluster: trusted-workload
-      extra_refs:
-        - org: kyma-project
-          repo: test-infra
-          path_alias: github.com/kyma-project/test-infra
-          base_ref: main
-        - org: kyma-project
-          repo: kyma
-          path_alias: github.com/kyma-project/kyma
-          base_ref: main
-      spec:
-        containers:
-          - image: "eu.gcr.io/kyma-project/test-infra/wssagent:v20210713-bdbc20c8"
-            securityContext:
-              privileged: false
-            command:
-              - "bash"
-            args:
-              - "-c"
-              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/helpers/start-wssagent.sh"
-            env:
-              - name: DRYRUN
-                value: "false"
-              - name : PROJECTNAME
-                value: kyma
-              - name: CUSTOM_PROJECTNAME
-                value: 
-              - name: SCAN_LANGUAGE
-                value: golang
-            resources:
-              requests:
-                memory: 1Gi
-                cpu: 400m
     - name: kyma-mod-whitesource-scan
       annotations:
         pipeline.trigger: "periodic"

--- a/templates/data/whitesource-periodics-data.yaml
+++ b/templates/data/whitesource-periodics-data.yaml
@@ -54,19 +54,21 @@ templates:
                     - "jobConfig_periodic"
                   local:
                     - "jobConfig_default"
-              - jobConfig:
-                  name: "kyma"
-                  language: "golang"
-                  project: "kyma-project"
-                  base_ref: "main"
-                inheritedConfigs:
-                  global:
-                    - "jobConfig_default"
-                    - "image_wssagent"
-                    - "extra_refs_test-infra"
-                    - "jobConfig_periodic"
-                  local:
-                    - "jobConfig_default"
+#              Disabled - it only runs tests over tools/failery, which will eventually be removed
+#              once console-backend-service is deleted.
+#              - jobConfig:
+#                  name: "kyma"
+#                  language: "golang"
+#                  project: "kyma-project"
+#                  base_ref: "main"
+#                inheritedConfigs:
+#                  global:
+#                    - "jobConfig_default"
+#                    - "image_wssagent"
+#                    - "extra_refs_test-infra"
+#                    - "jobConfig_periodic"
+#                  local:
+#                    - "jobConfig_default"
               - jobConfig:
                   name: "kyma"
                   language: "golang-mod"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The `kyma-whitesource-scan` runs only against `kyma/tools/failery` which still operates on go-dep, where the rest of Kyma is already on go mod. This tool is not updated for 14 months and the result scan report is broken. This PR disables the job.

https://status.build.kyma-project.io/view/gs/kyma-prow-logs/logs/kyma-whitesource-scan/1440163893530857472
```
[WARN] [2021-09-21 04:00:58,204 +0000] - CommandLineProcess - executeProcessCommand - error in execute command 'go build', Exit Status 1
```