### PR TITLE
Rename cli integration pipelines

### DIFF
--- a/development/tools/jobs/cli/cli_integration_test.go
+++ b/development/tools/jobs/cli/cli_integration_test.go
@@ -17,7 +17,7 @@ func TestKymaCliIntegrationPresubmit(t *testing.T) {
 	// THEN
 	require.NoError(t, err)
 
-	expName := "pre-kyma-cli-integration"
+	expName := "pre-cli-integration-kyma-1"
 	actualPresubmit := tester.FindPresubmitJobByNameAndBranch(jobConfig.AllStaticPresubmits([]string{"kyma-project/cli"}), expName, "main")
 	require.NotNil(t, actualPresubmit)
 	assert.Equal(t, expName, actualPresubmit.Name)
@@ -39,7 +39,7 @@ func TestKymaCliIntegrationJobPostsubmit(t *testing.T) {
 	// THEN
 	require.NoError(t, err)
 
-	expName := "post-kyma-cli-integration"
+	expName := "post-cli-integration-kyma-2"
 	actualPost := tester.FindPostsubmitJobByNameAndBranch(jobConfig.AllStaticPostsubmits([]string{"kyma-project/cli"}), expName, "main")
 	require.NotNil(t, actualPost)
 

--- a/prow/jobs/cli/cli-integration.yaml
+++ b/prow/jobs/cli/cli-integration.yaml
@@ -3,12 +3,12 @@
 
 presubmits: # runs on PRs
   kyma-project/cli:
-    - name: pre-kyma-cli-integration
+    - name: pre-cli-integration-kyma-1
       annotations:
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pre-kyma-cli-integration"
+        prow.k8s.io/pubsub.runID: "pre-cli-integration-kyma-1"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-pr: "true"
         preset-gc-project-env: "true"
@@ -48,12 +48,12 @@ presubmits: # runs on PRs
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
-    - name: pre-cli-integration-k3s
+    - name: pre-cli-integration-kyma-2
       annotations:
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pre-cli-integration-k3s"
+        prow.k8s.io/pubsub.runID: "pre-cli-integration-kyma-2"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-pr: "true"
         preset-gc-project-env: "true"
@@ -82,8 +82,6 @@ presubmits: # runs on PRs
             env:
               - name: GO111MODULE
                 value: "on"
-              - name: INSTALLATION
-                value: "alpha"
               - name: KUBERNETES_RUNTIME
                 value: "k3d"
             resources:
@@ -97,12 +95,12 @@ presubmits: # runs on PRs
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
-    - name: pre-rel124-cli-integration-k3s
+    - name: pre-rel124-cli-integration-kyma-2
       annotations:
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pre-rel124-cli-integration-k3s"
+        prow.k8s.io/pubsub.runID: "pre-rel124-cli-integration-kyma-2"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-pr: "true"
         preset-gc-project-env: "true"
@@ -130,8 +128,6 @@ presubmits: # runs on PRs
             env:
               - name: GO111MODULE
                 value: "on"
-              - name: INSTALLATION
-                value: "alpha"
               - name: KUBERNETES_RUNTIME
                 value: "k3d"
             resources:
@@ -145,12 +141,12 @@ presubmits: # runs on PRs
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
-    - name: pre-rel123-cli-integration-k3s
+    - name: pre-rel123-cli-integration-kyma-2
       annotations:
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pre-rel123-cli-integration-k3s"
+        prow.k8s.io/pubsub.runID: "pre-rel123-cli-integration-kyma-2"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-pr: "true"
         preset-gc-project-env: "true"
@@ -178,8 +174,6 @@ presubmits: # runs on PRs
             env:
               - name: GO111MODULE
                 value: "on"
-              - name: INSTALLATION
-                value: "alpha"
               - name: KUBERNETES_RUNTIME
                 value: "k3d"
             resources:
@@ -193,12 +187,12 @@ presubmits: # runs on PRs
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
-    - name: pre-rel122-cli-integration-k3s
+    - name: pre-rel122-cli-integration-kyma-2
       annotations:
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pre-rel122-cli-integration-k3s"
+        prow.k8s.io/pubsub.runID: "pre-rel122-cli-integration-kyma-2"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-pr: "true"
         preset-gc-project-env: "true"
@@ -226,8 +220,6 @@ presubmits: # runs on PRs
             env:
               - name: GO111MODULE
                 value: "on"
-              - name: INSTALLATION
-                value: "alpha"
               - name: KUBERNETES_RUNTIME
                 value: "k3d"
             resources:
@@ -244,13 +236,13 @@ presubmits: # runs on PRs
   
 postsubmits: # runs on main
   kyma-project/cli:
-    - name: post-cli-integration-k3s
+    - name: post-cli-integration-kyma-2
       annotations:
         pipeline.trigger: "pr-merge"
         testgrid-create-test-group: "false"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "post-cli-integration-k3s"
+        prow.k8s.io/pubsub.runID: "post-cli-integration-kyma-2"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-main: "true"
         preset-gc-project-env: "true"
@@ -279,8 +271,6 @@ postsubmits: # runs on main
             env:
               - name: GO111MODULE
                 value: "on"
-              - name: INSTALLATION
-                value: "alpha"
               - name: KUBERNETES_RUNTIME
                 value: "k3d"
             resources:
@@ -294,13 +284,13 @@ postsubmits: # runs on main
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
-    - name: post-rel124-cli-integration-k3s
+    - name: post-rel124-cli-integration-kyma-2
       annotations:
         pipeline.trigger: "pr-merge"
         testgrid-create-test-group: "false"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "post-rel124-cli-integration-k3s"
+        prow.k8s.io/pubsub.runID: "post-rel124-cli-integration-kyma-2"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-main: "true"
         preset-gc-project-env: "true"
@@ -328,8 +318,6 @@ postsubmits: # runs on main
             env:
               - name: GO111MODULE
                 value: "on"
-              - name: INSTALLATION
-                value: "alpha"
               - name: KUBERNETES_RUNTIME
                 value: "k3d"
             resources:
@@ -343,13 +331,13 @@ postsubmits: # runs on main
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
-    - name: post-rel123-cli-integration-k3s
+    - name: post-rel123-cli-integration-kyma-2
       annotations:
         pipeline.trigger: "pr-merge"
         testgrid-create-test-group: "false"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "post-rel123-cli-integration-k3s"
+        prow.k8s.io/pubsub.runID: "post-rel123-cli-integration-kyma-2"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-main: "true"
         preset-gc-project-env: "true"
@@ -377,8 +365,6 @@ postsubmits: # runs on main
             env:
               - name: GO111MODULE
                 value: "on"
-              - name: INSTALLATION
-                value: "alpha"
               - name: KUBERNETES_RUNTIME
                 value: "k3d"
             resources:
@@ -392,13 +378,13 @@ postsubmits: # runs on main
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
-    - name: post-rel122-cli-integration-k3s
+    - name: post-rel122-cli-integration-kyma-2
       annotations:
         pipeline.trigger: "pr-merge"
         testgrid-create-test-group: "false"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "post-rel122-cli-integration-k3s"
+        prow.k8s.io/pubsub.runID: "post-rel122-cli-integration-kyma-2"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-main: "true"
         preset-gc-project-env: "true"
@@ -426,8 +412,6 @@ postsubmits: # runs on main
             env:
               - name: GO111MODULE
                 value: "on"
-              - name: INSTALLATION
-                value: "alpha"
               - name: KUBERNETES_RUNTIME
                 value: "k3d"
             resources:
@@ -441,13 +425,13 @@ postsubmits: # runs on main
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
-    - name: post-kyma-cli-integration
+    - name: post-cli-integration-kyma-1
       annotations:
         pipeline.trigger: "pr-merge"
         testgrid-create-test-group: "false"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "post-kyma-cli-integration"
+        prow.k8s.io/pubsub.runID: "post-cli-integration-kyma-1"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-main: "true"
         preset-gc-project-env: "true"

--- a/prow/scripts/provision-vm-cli.sh
+++ b/prow/scripts/provision-vm-cli.sh
@@ -46,8 +46,6 @@ fi
 
 # Support configuration via ENV vars (can be be overwritten by CLI args)
 KUBERNETES_RUNTIME="${KUBERNETES_RUNTIME:=minikube}"
-# Either use the default Kyma install command or kyma deploy.
-INSTALLATION="${INSTALLATION:=default}"
 
 POSITIONAL=()
 while [[ $# -gt 0 ]]
@@ -67,10 +65,6 @@ do
             ;;
         --kubernetes-runtime|-kr)
             KUBERNETES_RUNTIME="$2"
-            shift 2
-            ;;
-        --installation)
-            INSTALLATION="$2"
             shift 2
             ;;
         --*)

--- a/templates/data/cli-data.yaml
+++ b/templates/data/cli-data.yaml
@@ -99,9 +99,8 @@ templates:
           jobConfig_postsubmit:
             labels:
               preset-build-main: "true"
-          k3s_template:
+          kyma_2_template:
             env:
-              INSTALLATION: "alpha"
               KUBERNETES_RUNTIME: "k3d"
           smaller_cluster:
             request_memory: 1Gi
@@ -110,7 +109,7 @@ templates:
           - repoName: "github.com/kyma-project/cli"
             jobs:
               - jobConfig:
-                  name: pre-kyma-cli-integration
+                  name: pre-cli-integration-kyma-1
                   branches:
                     - ^main$
                     - ^release-.*$
@@ -125,7 +124,7 @@ templates:
                     - "jobConfig_submit"
                     - "jobConfig_presubmit"
               - jobConfig:
-                  path: integration-k3s
+                  path: integration-kyma-2
                   release_since: "1.7"
                 inheritedConfigs:
                   global:
@@ -134,7 +133,7 @@ templates:
                     - "extra_refs_test-infra"
                   local:
                     - "jobConfig_default"
-                    - "k3s_template"
+                    - "kyma_2_template"
                     - "jobConfig_submit"
                   preConfigs:
                     global:
@@ -148,7 +147,7 @@ templates:
                     local:
                       - "jobConfig_postsubmit"
               - jobConfig:
-                  name: post-kyma-cli-integration
+                  name: post-cli-integration-kyma-1
                 inheritedConfigs:
                   global:
                     - "jobConfig_default"

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,3 @@
+pjNames:
+  - pjName: "pre-cli-integration-kyma-1"
+  - pjName: "pre-cli-integration-kyma-2"

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,3 +1,0 @@
-pjNames:
-  - pjName: "pre-cli-integration-kyma-1"
-  - pjName: "pre-cli-integration-kyma-2"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Rename cli integration jobs in `cli-integration-kyma-1` (which uses `kyma install` on minikube) and `cli-integration-kyma-2` (which uses `kyma deploy` on k3d)
- No pipelines added, just renamed

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
