### PR TITLE
Adapt kyma delete to undeploy

### DIFF
--- a/prow/scripts/cluster-integration/kyma-busola-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-busola-long-lasting.sh
@@ -128,7 +128,7 @@ function provisionKyma2(){
     set +x
 }
 
-function deleteKyma(){
+function undeployKyma(){
     export DOMAIN_NAME=$1
 
     log::info "Uninstalling Kyma on the cluster : ${DOMAIN_NAME} using ${CPU_COUNT} cpus"
@@ -140,7 +140,7 @@ function deleteKyma(){
     kyma::install_cli
 
     set -x
-    TERM=dumb kyma delete \
+    TERM=dumb kyma undeploy \
     --kubeconfig="${RESOURCES_PATH}/kubeconfig--kyma--${DOMAIN_NAME}.yaml" \
     --concurrency="${CPU_COUNT}" \
     --non-interactive \
@@ -217,7 +217,7 @@ if [[ $BUSOLA_PROVISION_TYPE == "KYMA" ]]; then
     log::info "Kyma cluster name: ${KYMA_COMMON_NAME}"
     if [[ $RECREATE_CLUSTER == "true" ]]; then
         set +e
-        deleteKyma "${KYMA_COMMON_NAME}"
+        undeployKyma "${KYMA_COMMON_NAME}"
         set -e
 
         export KUBECONFIG="${GARDENER_KYMA_PROW_KUBECONFIG}"
@@ -228,7 +228,7 @@ if [[ $BUSOLA_PROVISION_TYPE == "KYMA" ]]; then
         provisionCluster "${KYMA_COMMON_NAME}" "${RESOURCES_PATH}/cluster-kyma.yaml"
     else
         echo "Delete kyma"
-        deleteKyma "${KYMA_COMMON_NAME}"
+        undeployKyma "${KYMA_COMMON_NAME}"
         log::info "We wait 60s for Kyma cluster to settle"
         sleep 60
     fi

--- a/prow/scripts/cluster-integration/kyma-integration-gardener.sh
+++ b/prow/scripts/cluster-integration/kyma-integration-gardener.sh
@@ -126,7 +126,7 @@ if [[ "${KYMA_MAJOR_VERSION}" == "2" ]]; then
     -s "$KYMA_SOURCES_DIR"
   if [[ "${KYMA_DELETE}" == "true" ]]; then
     sleep 30
-    kyma::delete_kyma
+    kyma::undeploy_kyma
     sleep 30
     kyma::deploy_kyma \
        -p "$EXECUTION_PROFILE" \

--- a/prow/scripts/lib/kyma.sh
+++ b/prow/scripts/lib/kyma.sh
@@ -52,11 +52,11 @@ function kyma::deploy_kyma() {
     fi
 }
 
-# kyma::delete_kyma uninstalls Kyma using new deletion method
-function kyma::delete_kyma() {
+# kyma::undeploy_kyma uninstalls Kyma using new deletion method
+function kyma::undeploy_kyma() {
   log::info "Uninstalling Kyma"
 
-  kyma delete --ci --verbose
+  kyma undeploy --ci --verbose
 }
 
 # kyma::get_last_release_version returns latest Kyma release version


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Regarding [this change](https://github.com/kyma-project/cli/pull/1000) `kyma delete` is not available anymore.
Kyma gets now installed with `kyma deploy` (based on reconciler) and uses `kyma undeploy` to remove kyma from a running K8s cluster.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
