### PR TITLE
use variable for firestore collection name

### DIFF
--- a/development/kyma-ci-force-bot/ciforcebot/cmd/main.go
+++ b/development/kyma-ci-force-bot/ciforcebot/cmd/main.go
@@ -135,7 +135,7 @@ func receive(event cloudevents.Event) {
 		},
 	})
 
-	iter := firestoreClient.Collection("testFailures").Where("open", "==", true).Where("githubIssueNumber", "==", issueEvent.Issue.GetNumber()).Documents(ctx)
+	iter := firestoreClient.Collection(conf.FirestoreCollection).Where("open", "==", true).Where("githubIssueNumber", "==", issueEvent.Issue.GetNumber()).Documents(ctx)
 	failureInstances, err := iter.GetAll()
 
 	if err != nil {


### PR DESCRIPTION
ci-force-bot running on tooling kyma use env variable to setup firestore collection name
