### PR TITLE
Use non-regional clusters for Compass GKE integration tests

### DIFF
--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,7 +1,0 @@
-pjNames:
-  - pjName: "pre-main-compass-gke-integration"
-    pjPath: "test-infra/prow/jobs/incubator/compass/"
-prConfigs:
-  kyma-incubator:
-    compass:
-      prNumber: 2044


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Our GKE installation in Prow is now suited for regional clusters and the installation fails.

Changes proposed in this pull request:

- Keep using zonal clusters for Compass

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
