### PR TITLE
Re-enable reconciler nightly and make e2e job non-optional

### DIFF
--- a/development/tools/jobs/incubator/reconciler/reconciler_test.go
+++ b/development/tools/jobs/incubator/reconciler/reconciler_test.go
@@ -131,7 +131,7 @@ func TestReconcilerJobsNightlyMain(t *testing.T) {
 	expName := "nightly-main-reconciler"
 	actualPeriodic := tester.FindPeriodicJobByName(reconcilerPeriodics, expName)
 	assert.Equal(t, expName, actualPeriodic.Name)
-	assert.Equal(t, "0 0 * * *", actualPeriodic.Cron)
+	assert.Equal(t, "0 0 * * 1-5", actualPeriodic.Cron)
 	assert.Equal(t, 0, actualPeriodic.JobBase.MaxConcurrency)
 	tester.AssertThatHasExtraRefTestInfra(t, actualPeriodic.JobBase.UtilityConfig, "main")
 	tester.AssertThatHasExtraRef(t, actualPeriodic.JobBase.UtilityConfig, []prowapi.Refs{

--- a/development/tools/jobs/incubator/reconciler/reconciler_test.go
+++ b/development/tools/jobs/incubator/reconciler/reconciler_test.go
@@ -179,7 +179,7 @@ func TestReconcilerJobNightlyE2E(t *testing.T) {
 	expName := "nightly-main-reconciler-e2e"
 	actualNightlyJob := tester.FindPeriodicJobByName(allPeriodics, expName)
 	assert.Equal(t, expName, actualNightlyJob.Name)
-	assert.Equal(t, "0 1-22/2 * * *", actualNightlyJob.Cron)
+	assert.Equal(t, "0 1-22/2 * * 1-5", actualNightlyJob.Cron)
 	tester.AssertThatHasExtraRef(t, actualNightlyJob.JobBase.UtilityConfig, []prowapi.Refs{
 		{
 			Org:       "kyma-incubator",

--- a/development/tools/jobs/incubator/reconciler/reconciler_test.go
+++ b/development/tools/jobs/incubator/reconciler/reconciler_test.go
@@ -17,17 +17,13 @@ func TestReconcilerJobsPresubmit(t *testing.T) {
 	// THEN
 	require.NoError(t, err)
 
-	assert.Len(t, jobConfig.PresubmitsStatic, 1)
 	kymaPresubmits := jobConfig.AllStaticPresubmits([]string{"kyma-incubator/reconciler"})
-	assert.Len(t, kymaPresubmits, 3)
-
 	expName := "pre-main-kyma-incubator-reconciler"
 	actualPresubmit := tester.FindPresubmitJobByName(kymaPresubmits, expName)
 	assert.Equal(t, expName, actualPresubmit.Name)
 	assert.Equal(t, []string{"^main$"}, actualPresubmit.Branches)
 	assert.Equal(t, 10, actualPresubmit.MaxConcurrency)
 	assert.False(t, actualPresubmit.SkipReport)
-
 	assert.True(t, actualPresubmit.AlwaysRun)
 	assert.Empty(t, actualPresubmit.RunIfChanged)
 	tester.AssertThatHasExtraRefTestInfra(t, actualPresubmit.JobBase.UtilityConfig, "main")
@@ -43,10 +39,7 @@ func TestReconcilerIntegrationJobsPresubmit(t *testing.T) {
 	// THEN
 	require.NoError(t, err)
 
-	assert.Len(t, jobConfig.PresubmitsStatic, 1)
 	kymaPresubmits := jobConfig.AllStaticPresubmits([]string{"kyma-incubator/reconciler"})
-	assert.Len(t, kymaPresubmits, 3)
-
 	expName := "pre-main-reconciler-integration-k3d"
 	actualPresubmit := tester.FindPresubmitJobByName(kymaPresubmits, expName)
 	assert.Equal(t, expName, actualPresubmit.Name)
@@ -67,10 +60,7 @@ func TestReconcilerJobsPresubmitE2E(t *testing.T) {
 	// THEN
 	require.NoError(t, err)
 
-	assert.Len(t, jobConfig.PresubmitsStatic, 1)
 	kymaPresubmits := jobConfig.AllStaticPresubmits([]string{"kyma-incubator/reconciler"})
-	assert.Len(t, kymaPresubmits, 3)
-
 	expName := "pre-main-kyma-incubator-reconciler-e2e"
 	actualPresubmit := tester.FindPresubmitJobByName(kymaPresubmits, expName)
 	assert.Equal(t, expName, actualPresubmit.Name)
@@ -95,16 +85,12 @@ func TestReconcilerJobsPeriodicE2EUpgrade(t *testing.T) {
 	// THEN
 	require.NoError(t, err)
 
-	assert.Len(t, jobConfig.Periodics, 3)
 	kymaPeriodics := jobConfig.AllPeriodics()
-	assert.Len(t, kymaPeriodics, 3)
-
 	expName := "periodic-main-kyma-incubator-reconciler-kyma1-kyma2-upgrade"
 	actualPeriodic := tester.FindPeriodicJobByName(kymaPeriodics, expName)
 	assert.Equal(t, expName, actualPeriodic.Name)
 	assert.Equal(t, "30 * * * *", actualPeriodic.Cron)
 	assert.Equal(t, 0, actualPeriodic.JobBase.MaxConcurrency)
-
 	tester.AssertThatHasExtraRefTestInfra(t, actualPeriodic.JobBase.UtilityConfig, "main")
 	tester.AssertThatHasExtraRef(t, actualPeriodic.JobBase.UtilityConfig, []prowapi.Refs{
 		{
@@ -130,7 +116,6 @@ func TestReconcilerJobsPeriodicE2EUpgrade(t *testing.T) {
 			PathAlias: "github.com/kyma-incubator/reconciler",
 		},
 	})
-
 	assert.Equal(t, "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20210902-035ae0cc-k8s1.18", actualPeriodic.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/reconciler-e2e-upgrade-gardener.sh"}, actualPeriodic.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/reconciler"}, actualPeriodic.Spec.Containers[0].Args)
@@ -142,16 +127,12 @@ func TestReconcilerJobsNightlyMain(t *testing.T) {
 	// THEN
 	require.NoError(t, err)
 
-	assert.Len(t, jobConfig.Periodics, 3)
 	reconcilerPeriodics := jobConfig.AllPeriodics()
-	assert.Len(t, reconcilerPeriodics, 3)
-
 	expName := "nightly-main-reconciler"
 	actualPeriodic := tester.FindPeriodicJobByName(reconcilerPeriodics, expName)
 	assert.Equal(t, expName, actualPeriodic.Name)
 	assert.Equal(t, "0 0 * * *", actualPeriodic.Cron)
 	assert.Equal(t, 0, actualPeriodic.JobBase.MaxConcurrency)
-
 	tester.AssertThatHasExtraRefTestInfra(t, actualPeriodic.JobBase.UtilityConfig, "main")
 	tester.AssertThatHasExtraRef(t, actualPeriodic.JobBase.UtilityConfig, []prowapi.Refs{
 		{
@@ -174,17 +155,12 @@ func TestReconcilerJobPostsubmit(t *testing.T) {
 	// THEN
 	require.NoError(t, err)
 
-	assert.Len(t, jobConfig.PostsubmitsStatic, 1)
 	kymaPost := jobConfig.AllStaticPostsubmits([]string{"kyma-incubator/reconciler"})
-	assert.Len(t, kymaPost, 1)
-
-	actualPost := kymaPost[0]
 	expName := "post-main-kyma-incubator-reconciler"
+	actualPost := tester.FindPostsubmitJobByName(kymaPost, expName)
 	assert.Equal(t, expName, actualPost.Name)
 	assert.Equal(t, []string{"^main$"}, actualPost.Branches)
-
 	assert.Equal(t, 10, actualPost.MaxConcurrency)
-
 	tester.AssertThatHasExtraRefTestInfra(t, actualPost.JobBase.UtilityConfig, "main")
 	tester.AssertThatHasPresets(t, actualPost.JobBase, preset.DindEnabled, preset.DockerPushRepoIncubator, preset.GcrPush)
 	assert.Equal(t, tester.ImageGolangBuildpack1_16, actualPost.Spec.Containers[0].Image)
@@ -198,9 +174,8 @@ func TestReconcilerJobNightlyE2E(t *testing.T) {
 	jobConfig, err := tester.ReadJobConfig("./../../../../../prow/jobs/incubator/reconciler/reconciler.yaml")
 	// THEN
 	require.NoError(t, err)
-	allPeriodics := jobConfig.AllPeriodics()
-	assert.Len(t, allPeriodics, 3)
 
+	allPeriodics := jobConfig.AllPeriodics()
 	expName := "nightly-main-reconciler-e2e"
 	actualNightlyJob := tester.FindPeriodicJobByName(allPeriodics, expName)
 	assert.Equal(t, expName, actualNightlyJob.Name)

--- a/development/tools/jobs/incubator/reconciler/reconciler_test.go
+++ b/development/tools/jobs/incubator/reconciler/reconciler_test.go
@@ -146,7 +146,7 @@ func TestReconcilerJobsNightlyMain(t *testing.T) {
 	assert.Equal(t, "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20210902-035ae0cc-k8s1.18", actualPeriodic.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/reconciler-gardener-long-lasting.sh"}, actualPeriodic.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/reconciler"}, actualPeriodic.Spec.Containers[0].Args)
-	tester.AssertThatContainerHasEnv(t, actualPeriodic.Spec.Containers[0], "INPUT_CLUSTER_NAME", "rec-nightly")
+	tester.AssertThatContainerHasEnv(t, actualPeriodic.Spec.Containers[0], "INPUT_CLUSTER_NAME", "rec-night")
 }
 
 func TestReconcilerJobPostsubmit(t *testing.T) {
@@ -208,5 +208,5 @@ func TestReconcilerJobNightlyE2E(t *testing.T) {
 	assert.Equal(t, "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20210902-035ae0cc-k8s1.18", actualNightlyJob.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/reconciler-e2e-nightly-gardener.sh"}, actualNightlyJob.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-incubator/reconciler"}, actualNightlyJob.Spec.Containers[0].Args)
-	tester.AssertThatContainerHasEnv(t, actualNightlyJob.Spec.Containers[0], "INPUT_CLUSTER_NAME", "rec-nightly")
+	tester.AssertThatContainerHasEnv(t, actualNightlyJob.Spec.Containers[0], "INPUT_CLUSTER_NAME", "rec-night")
 }

--- a/development/tools/jobs/incubator/reconciler/reconciler_test.go
+++ b/development/tools/jobs/incubator/reconciler/reconciler_test.go
@@ -77,7 +77,7 @@ func TestReconcilerJobsPresubmitE2E(t *testing.T) {
 	assert.Equal(t, []string{"^master$", "^main$"}, actualPresubmit.Branches)
 	assert.Equal(t, 10, actualPresubmit.MaxConcurrency)
 	assert.False(t, actualPresubmit.SkipReport)
-	assert.True(t, actualPresubmit.Optional)
+	assert.False(t, actualPresubmit.Optional)
 	assert.False(t, actualPresubmit.AlwaysRun)
 	assert.Equal(t, actualPresubmit.RunIfChanged, "^resources")
 	tester.AssertThatHasExtraRefTestInfra(t, actualPresubmit.JobBase.UtilityConfig, "main")

--- a/development/tools/jobs/incubator/reconciler/reconciler_test.go
+++ b/development/tools/jobs/incubator/reconciler/reconciler_test.go
@@ -95,7 +95,9 @@ func TestReconcilerJobsPeriodicE2EUpgrade(t *testing.T) {
 	// THEN
 	require.NoError(t, err)
 
+	assert.Len(t, jobConfig.Periodics, 3)
 	kymaPeriodics := jobConfig.AllPeriodics()
+	assert.Len(t, kymaPeriodics, 3)
 
 	expName := "periodic-main-kyma-incubator-reconciler-kyma1-kyma2-upgrade"
 	actualPeriodic := tester.FindPeriodicJobByName(kymaPeriodics, expName)
@@ -140,7 +142,9 @@ func TestReconcilerJobsNightlyMain(t *testing.T) {
 	// THEN
 	require.NoError(t, err)
 
+	assert.Len(t, jobConfig.Periodics, 3)
 	reconcilerPeriodics := jobConfig.AllPeriodics()
+	assert.Len(t, reconcilerPeriodics, 3)
 
 	expName := "nightly-main-reconciler"
 	actualPeriodic := tester.FindPeriodicJobByName(reconcilerPeriodics, expName)
@@ -190,12 +194,12 @@ func TestReconcilerJobPostsubmit(t *testing.T) {
 }
 
 func TestReconcilerJobNightlyE2E(t *testing.T) {
-	t.Skip("Test is failing, see: https://github.com/kyma-project/test-infra/issues/4240")
 	// WHEN
 	jobConfig, err := tester.ReadJobConfig("./../../../../../prow/jobs/incubator/reconciler/reconciler.yaml")
 	// THEN
 	require.NoError(t, err)
 	allPeriodics := jobConfig.AllPeriodics()
+	assert.Len(t, allPeriodics, 3)
 
 	expName := "nightly-main-reconciler-e2e"
 	actualNightlyJob := tester.FindPeriodicJobByName(allPeriodics, expName)

--- a/development/tools/jobs/kyma/kyma_gardener_cleanup_test.go
+++ b/development/tools/jobs/kyma/kyma_gardener_cleanup_test.go
@@ -28,7 +28,7 @@ func TestKymaGardenerCleanupJobPeriodics(t *testing.T) {
 	tester.AssertThatHasExtraRepoRefCustom(t, job.JobBase.UtilityConfig, []string{"test-infra"}, []string{"main"})
 	assert.Equal(t, tester.ImageKymaIntegrationLatest, job.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/helpers/cleanup-gardener.sh"}, job.Spec.Containers[0].Command)
-	assert.Equal(t, []string{"--excluded-clusters", "(nbusola|nkyma|rec-nightly)"}, job.Spec.Containers[0].Args)
+	assert.Equal(t, []string{"--excluded-clusters", "(nbusola|nkyma|rec-night)"}, job.Spec.Containers[0].Args)
 	tester.AssertThatContainerHasEnv(t, job.Spec.Containers[0], "KYMA_PROJECT_DIR", "/home/prow/go/src/github.com/kyma-project")
 	tester.AssertThatSpecifiesResourceRequests(t, job.JobBase)
 }

--- a/prow/jobs/incubator/reconciler/reconciler.yaml
+++ b/prow/jobs/incubator/reconciler/reconciler.yaml
@@ -58,7 +58,6 @@ presubmits: # runs on PRs
         preset-gardener-gcp-kyma-integration: "true"
         preset-kyma-cli-stable: "true"
       run_if_changed: '^resources'
-      optional: true
       skip_report: false
       decorate: true
       cluster: untrusted-workload

--- a/prow/jobs/incubator/reconciler/reconciler.yaml
+++ b/prow/jobs/incubator/reconciler/reconciler.yaml
@@ -337,4 +337,70 @@ periodics: # runs on schedule
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
+    - name: nightly-main-reconciler-e2e
+      annotations:
+        description: "Executes e2e test periodically on nightly cluster for reconciler."
+        pipeline.installer: "reconciler"
+        pipeline.platform: "gcp"
+        pipeline.test: "fast-integration"
+        pipeline.trigger: "nightly"
+        testgrid-create-test-group: "false"
+      labels:
+        prow.k8s.io/pubsub.project: "sap-kyma-prow"
+        prow.k8s.io/pubsub.runID: "nightly-main-reconciler-e2e"
+        prow.k8s.io/pubsub.topic: "prowjobs"
+        preset-bot-github-token: "true"
+        preset-cluster-version: "true"
+        preset-gardener-gcp-kyma-integration: "true"
+        preset-kyma-cli-stable: "true"
+        preset-log-collector-slack-token: "true"
+      cron: "0 1-22/2 * * *"
+      skip_report: false
+      decorate: true
+      decoration_config:
+        grace_period: 600000000000
+        timeout: 14400000000000
+      cluster: untrusted-workload
+      extra_refs:
+        - org: kyma-project
+          repo: kyma
+          path_alias: github.com/kyma-project/kyma
+          base_ref: main
+        - org: kyma-incubator
+          repo: reconciler
+          path_alias: github.com/kyma-incubator/reconciler
+          base_ref: main
+        - org: kyma-project
+          repo: test-infra
+          path_alias: github.com/kyma-project/test-infra
+          base_ref: main
+      spec:
+        containers:
+          - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20210902-035ae0cc-k8s1.18"
+            command:
+              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/reconciler-e2e-nightly-gardener.sh"
+            args:
+              - "/home/prow/go/src/github.com/kyma-incubator/reconciler"
+            env:
+              - name: GARDENER_REGION
+                value: "europe-west4"
+              - name: GARDENER_ZONES
+                value: "europe-west4-b"
+              - name: INPUT_CLUSTER_NAME
+                value: "rec-nightly"
+              - name: KYMA_MAJOR_VERSION
+                value: "1"
+              - name: KYMA_PROJECT_DIR
+                value: "/home/prow/go/src/github.com/kyma-project"
+            resources:
+              requests:
+                memory: 3Gi
+                cpu: 2
+        tolerations:
+          - key: dedicated
+            operator: Equal
+            value: high-cpu
+            effect: NoSchedule
+        nodeSelector:
+            dedicated: "high-cpu"
   

--- a/prow/jobs/incubator/reconciler/reconciler.yaml
+++ b/prow/jobs/incubator/reconciler/reconciler.yaml
@@ -388,7 +388,7 @@ periodics: # runs on schedule
               - name: INPUT_CLUSTER_NAME
                 value: "rec-nightly"
               - name: KYMA_MAJOR_VERSION
-                value: "1"
+                value: "2"
               - name: KYMA_PROJECT_DIR
                 value: "/home/prow/go/src/github.com/kyma-project"
             resources:

--- a/prow/jobs/incubator/reconciler/reconciler.yaml
+++ b/prow/jobs/incubator/reconciler/reconciler.yaml
@@ -387,8 +387,6 @@ periodics: # runs on schedule
                 value: "europe-west4-b"
               - name: INPUT_CLUSTER_NAME
                 value: "rec-nightly"
-              - name: KYMA_MAJOR_VERSION
-                value: "2"
               - name: KYMA_PROJECT_DIR
                 value: "/home/prow/go/src/github.com/kyma-project"
             resources:

--- a/prow/jobs/incubator/reconciler/reconciler.yaml
+++ b/prow/jobs/incubator/reconciler/reconciler.yaml
@@ -353,7 +353,7 @@ periodics: # runs on schedule
         preset-gardener-gcp-kyma-integration: "true"
         preset-kyma-cli-stable: "true"
         preset-log-collector-slack-token: "true"
-      cron: "0 1-22/2 * * *"
+      cron: "0 1-22/2 * * 1-5"
       skip_report: false
       decorate: true
       decoration_config:

--- a/prow/jobs/incubator/reconciler/reconciler.yaml
+++ b/prow/jobs/incubator/reconciler/reconciler.yaml
@@ -290,7 +290,7 @@ periodics: # runs on schedule
         preset-gardener-gcp-kyma-integration: "true"
         preset-kyma-cli-stable: "true"
         preset-log-collector-slack-token: "true"
-      cron: "0 0 * * *"
+      cron: "0 0 * * 1-5"
       skip_report: false
       decorate: true
       decoration_config:
@@ -322,7 +322,7 @@ periodics: # runs on schedule
               - name: GARDENER_ZONES
                 value: "europe-west4-b"
               - name: INPUT_CLUSTER_NAME
-                value: "rec-nightly"
+                value: "rec-night"
               - name: KYMA_PROJECT_DIR
                 value: "/home/prow/go/src/github.com/kyma-project"
             resources:
@@ -386,7 +386,9 @@ periodics: # runs on schedule
               - name: GARDENER_ZONES
                 value: "europe-west4-b"
               - name: INPUT_CLUSTER_NAME
-                value: "rec-nightly"
+                value: "rec-night"
+              - name: KYMA_MAJOR_VERSION
+                value: "2"
               - name: KYMA_PROJECT_DIR
                 value: "/home/prow/go/src/github.com/kyma-project"
             resources:

--- a/prow/jobs/kyma/kyma-gardener-cleanup.yaml
+++ b/prow/jobs/kyma/kyma-gardener-cleanup.yaml
@@ -32,7 +32,7 @@ periodics: # runs on schedule
               - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/helpers/cleanup-gardener.sh"
             args:
               - "--excluded-clusters"
-              - "(nbusola|nkyma|rec-nightly)"
+              - "(nbusola|nkyma|rec-night)"
             env:
               - name: KYMA_PROJECT_DIR
                 value: "/home/prow/go/src/github.com/kyma-project"

--- a/prow/scripts/cluster-integration/helpers/reconciler.sh
+++ b/prow/scripts/cluster-integration/helpers/reconciler.sh
@@ -3,7 +3,7 @@
 readonly RECONCILER_SUFFIX="-reconciler"
 readonly RECONCILER_NAMESPACE=reconciler
 readonly RECONCILER_TIMEOUT=1200 # in secs
-readonly RECONCILER_DELAY=10 # in secs
+readonly RECONCILER_DELAY=15 # in secs
 readonly LOCAL_KUBECONFIG="$HOME/.kube/config"
 
 

--- a/prow/scripts/resources/reconciler/shoot-template.yaml
+++ b/prow/scripts/resources/reconciler/shoot-template.yaml
@@ -26,7 +26,7 @@ spec:
         image:
           name: gardenlinux
           version: 184.0.0
-        type: n1-standard-2
+        type: n1-standard-4
       maxSurge: 1
       maxUnavailable: 0
       maximum: 4

--- a/templates/data/incubator-buildpack-data.yaml
+++ b/templates/data/incubator-buildpack-data.yaml
@@ -391,7 +391,6 @@ templates:
                     - extra_refs_test-infra
                     - extra_refs_kyma
                     - extra_refs_reconciler
-                    - kyma_major_version_2
                     - disable_testgrid
                   local:
                     - reconciler_nightly_e2e_jobConfig

--- a/templates/data/incubator-buildpack-data.yaml
+++ b/templates/data/incubator-buildpack-data.yaml
@@ -391,7 +391,7 @@ templates:
                     - extra_refs_test-infra
                     - extra_refs_kyma
                     - extra_refs_reconciler
-                    - kyma_major_version_1
+                    - kyma_major_version_2
                     - disable_testgrid
                   local:
                     - reconciler_nightly_e2e_jobConfig

--- a/templates/data/incubator-buildpack-data.yaml
+++ b/templates/data/incubator-buildpack-data.yaml
@@ -276,7 +276,6 @@ templates:
                   name: pre-main-kyma-incubator-reconciler-e2e
                   run_if_changed: "^resources"
                   image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20210902-035ae0cc-k8s1.18"
-                  optional: true
                 inheritedConfigs:
                   global:
                     - jobConfig_default

--- a/templates/data/incubator-buildpack-data.yaml
+++ b/templates/data/incubator-buildpack-data.yaml
@@ -366,37 +366,37 @@ templates:
                   local:
                     - reconciler_nightly_cluster_jobConfig
                     - reconciler_jobConfig_args
-              # - jobConfig:
-              #     name: nightly-main-reconciler-e2e
-              #     image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20210902-035ae0cc-k8s1.18"
-              #     annotations:
-              #       description: Executes e2e test periodically on nightly cluster for reconciler.
-              #       pipeline.installer: "reconciler"
-              #       pipeline.platform: "gcp"
-              #       pipeline.test: "fast-integration"
-              #       pipeline.trigger: "nightly"
-              #     decoration_config:
-              #       timeout: 14400000000000 # 4h
-              #       grace_period: 600000000000 # 10min
-              #     cron: "0 1-22/2 * * *" # "At minute 0 past every 2nd hour from 1 through 22."
-              #     labels:
-              #       preset-log-collector-slack-token: "true"
-              #       preset-bot-github-token: "true"
-              #       preset-gardener-gcp-kyma-integration: "true"
-              #       preset-cluster-version: "true"
-              #   inheritedConfigs:
-              #     global:
-              #       - jobConfig_default
-              #       - jobConfig_periodic
-              #       - gardener_gcp_job
-              #       - extra_refs_test-infra
-              #       - extra_refs_kyma
-              #       - extra_refs_reconciler
-              #       - kyma_major_version_1
-              #       - disable_testgrid
-              #     local:
-              #       - reconciler_nightly_e2e_jobConfig
-              #       - reconciler_jobConfig_args
+              - jobConfig:
+                  name: nightly-main-reconciler-e2e
+                  image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20210902-035ae0cc-k8s1.18"
+                  annotations:
+                    description: Executes e2e test periodically on nightly cluster for reconciler.
+                    pipeline.installer: "reconciler"
+                    pipeline.platform: "gcp"
+                    pipeline.test: "fast-integration"
+                    pipeline.trigger: "nightly"
+                  decoration_config:
+                    timeout: 14400000000000 # 4h
+                    grace_period: 600000000000 # 10min
+                  cron: "0 1-22/2 * * *" # "At minute 0 past every 2nd hour from 1 through 22."
+                  labels:
+                    preset-log-collector-slack-token: "true"
+                    preset-bot-github-token: "true"
+                    preset-gardener-gcp-kyma-integration: "true"
+                    preset-cluster-version: "true"
+                inheritedConfigs:
+                  global:
+                    - jobConfig_default
+                    - jobConfig_periodic
+                    - gardener_gcp_job
+                    - extra_refs_test-infra
+                    - extra_refs_kyma
+                    - extra_refs_reconciler
+                    - kyma_major_version_1
+                    - disable_testgrid
+                  local:
+                    - reconciler_nightly_e2e_jobConfig
+                    - reconciler_jobConfig_args
       - to: ../prow/jobs/incubator/octopus/octopus.yaml
         jobConfigs:
           - repoName: kyma-incubator/octopus

--- a/templates/data/incubator-buildpack-data.yaml
+++ b/templates/data/incubator-buildpack-data.yaml
@@ -377,7 +377,7 @@ templates:
                   decoration_config:
                     timeout: 14400000000000 # 4h
                     grace_period: 600000000000 # 10min
-                  cron: "0 1-22/2 * * *" # "At minute 0 past every 2nd hour from 1 through 22."
+                  cron: "0 1-22/2 * * 1-5" # "At minute 0 past every 2nd hour from 1 through 22 on every day-of-week from Monday through Friday."
                   labels:
                     preset-log-collector-slack-token: "true"
                     preset-bot-github-token: "true"

--- a/templates/data/incubator-buildpack-data.yaml
+++ b/templates/data/incubator-buildpack-data.yaml
@@ -230,7 +230,7 @@ templates:
             command: "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/reconciler-e2e-nightly-gardener.sh"
             privileged: false
             env:
-              INPUT_CLUSTER_NAME: "rec-nightly"
+              INPUT_CLUSTER_NAME: "rec-night"
           reconciler_jobConfig_args:
             args:
               - "/home/prow/go/src/github.com/kyma-incubator/reconciler"
@@ -243,7 +243,7 @@ templates:
           reconciler_nightly_cluster_jobConfig:
             privileged: false
             env:
-              INPUT_CLUSTER_NAME: "rec-nightly"
+              INPUT_CLUSTER_NAME: "rec-night"
             command: "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/reconciler-gardener-long-lasting.sh"
             annotations:
               pipeline.platform: "gardener_gcp"
@@ -349,7 +349,7 @@ templates:
                   decoration_config:
                     timeout: 14400000000000 # 4h
                     grace_period: 600000000000 # 10min
-                  cron: "0 0 * * *" # "At 30 minutes past every hour"
+                  cron: "0 0 * * 1-5" # "At 00:00 on every day-of-week from Monday through Friday"
                   labels:
                     preset-log-collector-slack-token: "true"
                     preset-bot-github-token: "true"
@@ -391,6 +391,7 @@ templates:
                     - extra_refs_test-infra
                     - extra_refs_kyma
                     - extra_refs_reconciler
+                    - kyma_major_version_2
                     - disable_testgrid
                   local:
                     - reconciler_nightly_e2e_jobConfig

--- a/templates/data/kyma-gardener-cleanup-data.yaml
+++ b/templates/data/kyma-gardener-cleanup-data.yaml
@@ -7,7 +7,7 @@ templates:
             command: "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/helpers/cleanup-gardener.sh"
             args:
               - "--excluded-clusters"
-              - '(nbusola|nkyma|rec-nightly)'
+              - '(nbusola|nkyma|rec-night)'
             labels:
               preset-gardener-gcp-kyma-integration: "true"
             env:

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,3 +1,3 @@
 pjNames:
-  - pjName: "nightly-main-reconciler"
+  - pjName: "nightly-main-reconciler-e2e"
     report: false

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,3 +1,0 @@
-pjNames:
-  - pjName: "nightly-main-reconciler-e2e"
-    report: false

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,3 @@
+pjNames:
+  - pjName: "nightly-main-reconciler"
+    report: false

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,3 +1,0 @@
-pjNames:
-  - pjName: "nightly-main-reconciler"
-    report: false

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,3 +1,3 @@
 pjNames:
-  - pjName: "nightly-main-reconciler-e2e"
+  - pjName: "nightly-main-reconciler"
     report: false

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,3 @@
+pjNames:
+  - pjName: "nightly-main-reconciler-e2e"
+    report: false


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Re-enable nightly-main-reconciler-e2e
- Make pre-main-reconciler-integration-k3d job non-optional

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See https://github.com/kyma-project/test-infra/issues/4240