### PR TITLE
Install hadolint for bootstrap image

### DIFF
--- a/prow/images/bootstrap/Dockerfile
+++ b/prow/images/bootstrap/Dockerfile
@@ -101,3 +101,6 @@ RUN curl -fLSs -o shellcheck.tar.xz https://github.com/koalaman/shellcheck/relea
     && tar xvf shellcheck.tar.xz \
     && mv shellcheck-v0.5.0/shellcheck /usr/bin/ \
     && rm -rf shellcheck-v0.5.0 shellcheck.tar.xz
+
+RUN curl -fLSs -o /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.7.0/hadolint-Linux-x86_64 && \
+    chmod +x /usr/local/bin/hadolint


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Install hadolint for docker linting in bootstrap image

**Related issue(s)**
- Related to #4316