### PR TITLE
Revert kyma-integration image changes for legacy 1.24 prow jobs. 

### DIFF
--- a/prow/autobump-config/test-infra-autobump-config.yaml
+++ b/prow/autobump-config/test-infra-autobump-config.yaml
@@ -12,6 +12,7 @@ includedConfigPaths:
   - "."
 excludedConfigPaths:
   - "prow/staging"
+  - "prow/jobs/kyma/releases"
 extraFiles:
   - "development/tools/jobs/tester/tester.go"
 targetVersion: "latest"

--- a/prow/jobs/kyma/releases/kyma-release-124.yaml
+++ b/prow/jobs/kyma/releases/kyma-release-124.yaml
@@ -141,7 +141,7 @@ presubmits: # runs on PRs
           base_ref: release-1.24
       spec:
         containers:
-          - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20211020-638b6f95"
+          - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20210927-76bcfd5e"
             securityContext:
               privileged: true
             command:
@@ -201,7 +201,7 @@ presubmits: # runs on PRs
           base_ref: release-1.24
       spec:
         containers:
-          - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20211020-638b6f95"
+          - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20210927-76bcfd5e"
             securityContext:
               privileged: true
             command:
@@ -263,7 +263,7 @@ presubmits: # runs on PRs
           base_ref: release-1.24
       spec:
         containers:
-          - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20211020-638b6f95"
+          - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20210927-76bcfd5e"
             securityContext:
               privileged: true
             command:
@@ -325,7 +325,7 @@ presubmits: # runs on PRs
           base_ref: release-1.24
       spec:
         containers:
-          - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20211020-638b6f95"
+          - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20210927-76bcfd5e"
             securityContext:
               privileged: true
             command:
@@ -387,7 +387,7 @@ presubmits: # runs on PRs
           base_ref: release-1.24
       spec:
         containers:
-          - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20211020-638b6f95"
+          - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20210927-76bcfd5e"
             securityContext:
               privileged: true
             command:
@@ -578,7 +578,7 @@ postsubmits: # runs on release 1.24
           base_ref: release-1.24
       spec:
         containers:
-          - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20211020-638b6f95"
+          - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20210927-76bcfd5e"
             securityContext:
               privileged: true
             command:
@@ -757,7 +757,7 @@ postsubmits: # runs on release 1.24
           base_ref: release-1.24
       spec:
         containers:
-          - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20211020-638b6f95"
+          - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20210927-76bcfd5e"
             securityContext:
               privileged: true
             command:
@@ -833,7 +833,7 @@ periodics:
         base_ref: release-1.24
     spec:
       containers:
-        - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20211020-638b6f95"
+        - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20210927-76bcfd5e"
           securityContext:
             privileged: true
           command:
@@ -924,7 +924,7 @@ periodics:
         base_ref: release-1.24
     spec:
       containers:
-        - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20211020-638b6f95"
+        - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20210927-76bcfd5e"
           securityContext:
             privileged: true
           command:
@@ -1015,7 +1015,7 @@ periodics:
         base_ref: release-1.24
     spec:
       containers:
-        - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20211020-638b6f95"
+        - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20210927-76bcfd5e"
           securityContext:
             privileged: true
           command:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The jobs that reside in `prow/jobs/kyma/releases` should not be autobumped. This PR addresses the problem where auto-bump tool updates the frozen jobs. Also revert changes in the integration image to the one before bump.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
