### PR TITLE
revert back to k3d v4, remove alpha provision k3d

### DIFF
--- a/development/custom-image/install-deps-debian.sh
+++ b/development/custom-image/install-deps-debian.sh
@@ -19,7 +19,7 @@ CRICTL_VERSION=v1.12.0
 HELM_VERSION="v3.7.1"
 DOCKER_VERSION=5:20.10.5~3-0~debian-buster
 NODEJS_VERSION="14.x"
-K3D_VERSION="5.0.0"
+K3D_VERSION="4.4.7"
 
 # install docker
 sudo apt-get update

--- a/prow/scripts/cluster-integration/kyma-integration-k3d.sh
+++ b/prow/scripts/cluster-integration/kyma-integration-k3d.sh
@@ -45,7 +45,7 @@ function install_cli() {
 }
 
 function deploy_kyma() {
-  kyma alpha provision k3d -p 80:80@loadbalancer -p 443:443@loadbalancer
+  kyma provision k3d -p 80:80@loadbalancer -p 443:443@loadbalancer
 
   local kyma_deploy_cmd
   kyma_deploy_cmd="kyma deploy -p evaluation --ci --verbose --source=local --workspace ${KYMA_SOURCES_DIR}"

--- a/prow/scripts/cluster-integration/reconciler-integration-k3d.sh
+++ b/prow/scripts/cluster-integration/reconciler-integration-k3d.sh
@@ -38,7 +38,7 @@ function install_cli() {
 }
 
 function provision_k3d() {
-  kyma alpha provision k3d -p 80:80@loadbalancer -p 443:443@loadbalancer
+  kyma provision k3d -p 80:80@loadbalancer -p 443:443@loadbalancer
 }
 
 function run_tests() {

--- a/prow/scripts/cluster-integration/serverless-integration-k3s.sh
+++ b/prow/scripts/cluster-integration/serverless-integration-k3s.sh
@@ -145,7 +145,7 @@ echo "--> Installing kyma-cli"
 install::kyma_cli
 
 echo "--> Provisioning k3d cluster for Kyma"
-kyma alpha provision k3d --ci
+kyma provision k3d --ci
 
 echo "--> Deploying Serverless"
 # The python38 function requires 40M+ of memory to work. Mostly used by kubeless. I need to overrride the defaultPreset to M to avoid OOMkill.

--- a/prow/scripts/provision-vm-cli.sh
+++ b/prow/scripts/provision-vm-cli.sh
@@ -127,7 +127,7 @@ date
 if [ "$KUBERNETES_RUNTIME" = 'minikube' ]; then
     gcloud compute ssh --ssh-key-file="${SSH_KEY_FILE_PATH:-/root/.ssh/user/google_compute_engine}" --verbosity="${GCLOUD_SSH_LOG_LEVEL:-error}" --quiet --zone="${ZONE}" "cli-integration-test-${RANDOM_ID}" --command="yes | sudo kyma provision minikube --non-interactive"
 else
-    gcloud compute ssh --ssh-key-file="${SSH_KEY_FILE_PATH:-/root/.ssh/user/google_compute_engine}" --verbosity="${GCLOUD_SSH_LOG_LEVEL:-error}" --quiet --zone="${ZONE}" "cli-integration-test-${RANDOM_ID}" --command="yes | sudo kyma alpha provision k3d --ci"
+    gcloud compute ssh --ssh-key-file="${SSH_KEY_FILE_PATH:-/root/.ssh/user/google_compute_engine}" --verbosity="${GCLOUD_SSH_LOG_LEVEL:-error}" --quiet --zone="${ZONE}" "cli-integration-test-${RANDOM_ID}" --command="yes | sudo kyma provision k3d --ci"
 fi
 
 # Install kyma


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- remove the usage of the alpha provision k3d command and use the normal provision k3d command
- use k3d v4 instead of k3d v5

**Related issue(s)**
https://github.com/kyma-project/cli/issues/1052