### PR TITLE
Remove deprecated files required by github-release

### DIFF
--- a/development/tools/cmd/githubrelease/main.go
+++ b/development/tools/cmd/githubrelease/main.go
@@ -17,10 +17,7 @@ import (
 var (
 	targetCommit           = flag.String("targetCommit", "", "Target commitish [Required]")
 	bucketName             = flag.String("bucketName", "kyma-prow-artifacts", "Google bucket name where artifacts are stored [Optional]")
-	kymaInstaller          = flag.String("kymaInstaller", "kyma-installer.yaml", "Filename for list of CRDs and deployment artifact [Optional]")
-	kymaConfigLocal        = flag.String("kymaConfigLocal", "kyma-config-local.yaml", "Filename for local config artifact [Optional]")
-	kymaInstallerCRLocal   = flag.String("kymaInstallerCRLocal", "kyma-installer-cr-local.yaml", "Filename for list of componets kyma installer would install for local [Optional]")
-	kymaInstallerCRCluster = flag.String("kymaInstallerCRCluster", "kyma-installer-cr-cluster.yaml", "Filename for list of componets kyma installer would install for cluster [Optional]")
+	kymaComponents         = flag.String("kymaComponents", "kyma-components.yaml", "Filename for kyma-components.yaml file. [Optional]")
 	kymaChangelog          = flag.String("kymaChangelog", "release-changelog.md", "Filename for release changelog [Optional]")
 	githubRepoOwner        = flag.String("githubRepoOwner", "", "Github repository owner [Required]")
 	githubRepoName         = flag.String("githubRepoName", "", "Github repository name [Required]")
@@ -78,7 +75,7 @@ func main() {
 	}
 
 	// Github release
-	err = c.CreateNewRelease(ctx, relOpts, *kymaConfigLocal, *kymaInstallerCRLocal, *kymaInstallerCRCluster, *kymaInstaller)
+	err = c.CreateNewRelease(ctx, relOpts, *kymaComponents)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This is a temporary solution for not-working Kyma Release action job. The files were removed from the artifacts upload job are not accesible anymore. Simply replacing the used flags should be sufficient to restore functionality of github-release binary.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#4313 