### PR TITLE
Fix for not deleted Busola instances

### DIFF
--- a/prow/scripts/provision-vm-and-start-busola-docker.sh
+++ b/prow/scripts/provision-vm-and-start-busola-docker.sh
@@ -51,7 +51,7 @@ cleanup() {
     #shellcheck disable=SC2088
     utils::receive_from_vm "${ZONE}" "busola-smoke-test-${RANDOM_ID}" "~/busola-tests/cypress/videos" "${ARTIFACTS}"
     
-    gcloud compute instances stop --async --zone="${ZONE}" "busola-smoke-test-${RANDOM_ID}"
+    gcloud compute instances delete --async --zone="${ZONE}" "busola-smoke-test-${RANDOM_ID}"
     log::info "End of cleanup"
 }
 

--- a/prow/scripts/provision-vm-and-start-busola-k3s.sh
+++ b/prow/scripts/provision-vm-and-start-busola-k3s.sh
@@ -41,7 +41,7 @@ cleanup() {
     #shellcheck disable=SC2088
     utils::receive_from_vm "${ZONE}" "busola-integration-test-${RANDOM_ID}" "~/busola-tests/cypress/videos" "${ARTIFACTS}"
     
-    gcloud compute instances stop --async --zone="${ZONE}" "busola-integration-test-${RANDOM_ID}"
+    gcloud compute instances delete --async --zone="${ZONE}" "busola-integration-test-${RANDOM_ID}"
     log::info "End of cleanup"
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changing gcloud compute instances stop to delete. Stopped VMs which are not used, were exhausting our CPUs quota on GCP.
