### PR TITLE
update golang image to 1.17.3 in syncer

### DIFF
--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -10,7 +10,7 @@ images:
 - source: "curlimages/curl:7.78.0"
 - source: "cypress/included:8.6.0"
 - source: "fluent/fluent-bit:1.8.3"
-- source: "golang:1.16.4-alpine"
+- source: "golang:1.17.3-alpine"
 - source: "grafana/loki:2.2.1"
 - source: "grafana/grafana-image-renderer:3.2.1"
 - source: "hudymi/mockice:0.1.3"


### PR DESCRIPTION
Previous golang-runtime 1.16.4 contains vulnerabilities

  CVE-2021-38297
  CVE-2021-33195
  CVE-2021-33194
  CVE-2021-34558