### PR TITLE
Image-url-helper: add external images yaml output to promote command

### DIFF
--- a/development/image-syncer/main.go
+++ b/development/image-syncer/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	imagesyncer "github.com/kyma-project/test-infra/development/image-syncer/pkg"
 	"github.com/pkg/errors"
 	"github.com/sigstore/sigstore/pkg/signature"
 
@@ -23,20 +24,6 @@ import (
 var (
 	log = logrus.New()
 )
-
-// SyncDef stores synchronisation definition
-type SyncDef struct {
-	TargetRepoPrefix string `yaml:"targetRepoPrefix"`
-	Sign             bool   `yaml:"sign"`
-	Images           []Image
-}
-
-// Image stores image location
-type Image struct {
-	Source string
-	Tag    string `yaml:"tag,omitempty"`
-	Sign   *bool  `yaml:"sign,omitempty"`
-}
 
 // Config stores command line arguments
 type Config struct {
@@ -127,7 +114,7 @@ func SyncImage(ctx context.Context, src, dest string, dryRun bool, auth authn.Au
 }
 
 // SyncImages is a main syncing function that takes care of copying and signing/verifying images.
-func SyncImages(ctx context.Context, cfg *Config, images *SyncDef, sv signature.SignerVerifier, authCfg []byte) error {
+func SyncImages(ctx context.Context, cfg *Config, images *imagesyncer.SyncDef, sv signature.SignerVerifier, authCfg []byte) error {
 	auth := &authn.Basic{Username: "_json_key", Password: string(authCfg)}
 	for _, img := range images.Images {
 		target, err := getTarget(img.Source, images.TargetRepoPrefix, img.Tag)

--- a/development/image-syncer/pkg/common.go
+++ b/development/image-syncer/pkg/common.go
@@ -1,0 +1,15 @@
+package pkg
+
+// SyncDef stores synchronisation definition
+type SyncDef struct {
+	TargetRepoPrefix string `yaml:"targetRepoPrefix"`
+	Sign             bool   `yaml:"sign"`
+	Images           []Image
+}
+
+// Image stores image location
+type Image struct {
+	Source string
+	Tag    string `yaml:"tag,omitempty"`
+	Sign   *bool  `yaml:"sign,omitempty"`
+}

--- a/development/image-syncer/util.go
+++ b/development/image-syncer/util.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"strings"
 
+	imagesyncer "github.com/kyma-project/test-infra/development/image-syncer/pkg"
 	"gopkg.in/yaml.v2"
 )
 
@@ -20,12 +21,12 @@ func getTarget(source, targetRepo, targetTag string) (string, error) {
 	return target, nil
 }
 
-func parseImagesFile(file string) (*SyncDef, error) {
+func parseImagesFile(file string) (*imagesyncer.SyncDef, error) {
 	f, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
-	var syncDef SyncDef
+	var syncDef imagesyncer.SyncDef
 	if err := yaml.Unmarshal(f, &syncDef); err != nil {
 		return nil, err
 	}

--- a/development/image-url-helper/cmd/check.go
+++ b/development/image-url-helper/cmd/check.go
@@ -53,8 +53,8 @@ func CheckCmd() *cobra.Command {
 
 			var images []list.Image
 			var testImages []list.Image
-			imageComponents := make(list.ImageComponents)
-			err = filepath.Walk(ResourcesDirectory, list.GetWalkFunc(ResourcesDirectoryClean, &images, &testImages, imageComponents))
+			imageComponentsMap := make(list.ImageToComponents)
+			err = filepath.Walk(ResourcesDirectory, list.GetWalkFunc(ResourcesDirectoryClean, &images, &testImages, imageComponentsMap))
 			if err != nil {
 				fmt.Printf("Cannot traverse directory: %s\n", err)
 				os.Exit(2)
@@ -71,7 +71,7 @@ func CheckCmd() *cobra.Command {
 			if len(inconsistentImages) > 0 {
 				fmt.Printf("\n--------------------\n")
 				fmt.Println("Images with multiple tags:")
-				list.PrintImages(inconsistentImages, imageComponents)
+				list.PrintImages(inconsistentImages, imageComponentsMap)
 			}
 			if len(imagesDefinedOutside) > 0 || len(inconsistentImages) > 0 {
 				os.Exit(3)

--- a/development/image-url-helper/cmd/list.go
+++ b/development/image-url-helper/cmd/list.go
@@ -27,7 +27,7 @@ func ListCmd() *cobra.Command {
 		Example: "image-url-helper list",
 		Args:    cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			imageComponents := make(list.ImageComponents)
+			imageComponentsMap := make(list.ImageToComponents)
 
 			// remove trailing slash to have consistent paths
 			ResourcesDirectoryClean := filepath.Clean(ResourcesDirectory)
@@ -35,7 +35,7 @@ func ListCmd() *cobra.Command {
 			var images []list.Image
 			var testImages []list.Image
 
-			err := filepath.Walk(ResourcesDirectory, list.GetWalkFunc(ResourcesDirectoryClean, &images, &testImages, imageComponents))
+			err := filepath.Walk(ResourcesDirectory, list.GetWalkFunc(ResourcesDirectoryClean, &images, &testImages, imageComponentsMap))
 			if err != nil {
 				fmt.Printf("Cannot traverse directory: %s\n", err)
 				os.Exit(2)
@@ -50,15 +50,15 @@ func ListCmd() *cobra.Command {
 			allImages = list.RemoveDoubles(allImages)
 
 			if options.outputFormat == "" {
-				list.PrintImages(allImages, imageComponents)
+				list.PrintImages(allImages, imageComponentsMap)
 			} else if strings.ToLower(options.outputFormat) == "json" {
-				err = list.PrintImagesJSON(allImages, imageComponents)
+				err = list.PrintImagesJSON(allImages, imageComponentsMap)
 				if err != nil {
 					fmt.Printf("Cannot save JSON: %s\n", err)
 					os.Exit(2)
 				}
 			} else if strings.ToLower(options.outputFormat) == "yaml" {
-				err = list.PrintImagesYAML(allImages, imageComponents)
+				err = list.PrintImagesYAML(allImages, imageComponentsMap)
 				if err != nil {
 					fmt.Printf("Cannot save JSON: %s\n", err)
 					os.Exit(2)

--- a/development/image-url-helper/cmd/promote.go
+++ b/development/image-url-helper/cmd/promote.go
@@ -64,7 +64,7 @@ func addPromoteCmdFlags(cmd *cobra.Command, options *promoteCmdOptions) {
 	cmd.Flags().StringVarP(&options.targetContainerRegistry, "target-container-registry", "c", "", "Name of the target registry")
 	cmd.Flags().StringVarP(&options.targetTag, "target-tag", "t", "", "Name of the target tag")
 	cmd.Flags().BoolVarP(&options.dryRun, "dry-run", "d", true, "Dry run enabled, nothing is changed")
-	cmd.Flags().BoolVarP(&options.sign, "sign", "s", true, "Set sign flag in outputted yaml file")
+	cmd.Flags().BoolVarP(&options.sign, "sign", "s", false, "Set sign flag in outputted yaml file")
 	cmd.MarkFlagRequired("target-container-registry")
 	envy.ParseCobra(cmd, envy.CobraConfig{Persistent: true, Prefix: "IMAGE_URL_HELPER"})
 }

--- a/development/image-url-helper/cmd/promote.go
+++ b/development/image-url-helper/cmd/promote.go
@@ -33,17 +33,21 @@ func PromoteCmd() *cobra.Command {
 			ResourcesDirectoryClean := filepath.Clean(ResourcesDirectory)
 
 			var images []list.Image
+			var testImages []list.Image
 
-			err := filepath.Walk(ResourcesDirectory, promote.GetWalkFunc(ResourcesDirectoryClean, options.targetContainerRegistry, options.targetTag, options.dryRun, &images))
+			err := filepath.Walk(ResourcesDirectory, promote.GetWalkFunc(ResourcesDirectoryClean, options.targetContainerRegistry, options.targetTag, options.dryRun, &images, &testImages))
 			if err != nil {
 				fmt.Printf("Cannot traverse directory: %s\n", err)
 				os.Exit(2)
 			}
 
-			sort.Slice(images, list.GetSortImagesFunc(images))
-			images = list.RemoveDoubles(images)
+			var allImages []list.Image
+			allImages = append(allImages, images...)
+			allImages = append(allImages, testImages...)
+			sort.Slice(allImages, list.GetSortImagesFunc(allImages))
+			allImages = list.RemoveDoubles(allImages)
 
-			err = promote.PrintExternalSyncerYaml(images, options.targetContainerRegistry, options.targetTag, options.sign)
+			err = promote.PrintExternalSyncerYaml(allImages, options.targetContainerRegistry, options.targetTag, options.sign)
 			if err != nil {
 				fmt.Printf("Cannot print list of images: %s\n", err)
 				os.Exit(2)

--- a/development/image-url-helper/cmd/promote.go
+++ b/development/image-url-helper/cmd/promote.go
@@ -41,6 +41,7 @@ func PromoteCmd() *cobra.Command {
 				os.Exit(2)
 			}
 
+			// join and sort both images lists
 			var allImages []list.Image
 			allImages = append(allImages, images...)
 			allImages = append(allImages, testImages...)

--- a/development/image-url-helper/cmd/promote.go
+++ b/development/image-url-helper/cmd/promote.go
@@ -16,6 +16,7 @@ type promoteCmdOptions struct {
 	targetContainerRegistry string
 	targetTag               string
 	dryRun                  bool
+	sign                    bool
 }
 
 // PromoteCmd replaces containerRegistry and image versions with the provided ones
@@ -41,8 +42,8 @@ func PromoteCmd() *cobra.Command {
 
 			sort.Slice(images, list.GetSortImagesFunc(images))
 			images = list.RemoveDoubles(images)
-			// TODO pass "sign" as cli arg
-			err = promote.PrintExternalSyncerYaml(images, options.targetContainerRegistry, options.targetTag, true)
+
+			err = promote.PrintExternalSyncerYaml(images, options.targetContainerRegistry, options.targetTag, options.sign)
 			if err != nil {
 				fmt.Printf("Cannot print list of images: %s\n", err)
 				os.Exit(2)
@@ -58,6 +59,7 @@ func addPromoteCmdFlags(cmd *cobra.Command, options *promoteCmdOptions) {
 	cmd.Flags().StringVarP(&options.targetContainerRegistry, "target-container-registry", "c", "", "Name of the target registry")
 	cmd.Flags().StringVarP(&options.targetTag, "target-tag", "t", "", "Name of the target tag")
 	cmd.Flags().BoolVarP(&options.dryRun, "dry-run", "d", true, "Dry run enabled, nothing is changed")
+	cmd.Flags().BoolVarP(&options.sign, "sign", "s", true, "Set sign flag in outputted yaml file")
 	cmd.MarkFlagRequired("target-container-registry")
 	envy.ParseCobra(cmd, envy.CobraConfig{Persistent: true, Prefix: "IMAGE_URL_HELPER"})
 }

--- a/development/image-url-helper/pkg/check/filecheck.go
+++ b/development/image-url-helper/pkg/check/filecheck.go
@@ -29,15 +29,18 @@ type ImageLine struct {
 	Line       string
 }
 
+// Exclude contains excluded image values for a given file
 type Exclude struct {
 	Filename string   `yaml:"filename"`
 	Images   []string `yaml:"images"`
 }
 
+// excludesList contains a list of excluded image values per each file
 type excludesList struct {
 	Excludes []Exclude `yaml:"excludes"`
 }
 
+// ParseExcludes reads the exclude list file and returns list of excludes
 func ParseExcludes(excludesListFilename string) ([]Exclude, error) {
 	if excludesListFilename == "" {
 		return nil, nil
@@ -113,6 +116,7 @@ func FileHasIncorrectImage(resourcesDirectory, path string, skipComments bool, e
 	return incompatible, nil
 }
 
+// imageInExcludeList checks if the image value in the given line is on the excludes list
 func imageInExcludeList(resourcesDirectory, filename, line string, excludesList []Exclude) bool {
 	for _, exclude := range excludesList {
 		if strings.Replace(filename, resourcesDirectory+"/", "", -1) == exclude.Filename {
@@ -130,7 +134,7 @@ func imageInExcludeList(resourcesDirectory, filename, line string, excludesList 
 	return false
 }
 
-// oldImageFormat checks and prints lines that uses old image: format
+// oldImageFormat checks and prints lines that doesn't use the "imageurl" or "shortimageurl" template
 func oldImageFormat(line string, skipComments bool) bool {
 	// skip all uninteresting lines and just "name:" in its own line
 	if imageRegexp.MatchString(line) {

--- a/development/image-url-helper/pkg/list/imagelister.go
+++ b/development/image-url-helper/pkg/list/imagelister.go
@@ -14,8 +14,8 @@ import (
 // SortFunction is a function type used in slice sorting
 type SortFunction func(i, j int) bool
 
-// ImageComponents is a map that for each image name stores list of components that are using this image
-type ImageComponents map[string][]string
+// ImageToComponents is a map that for each image name stores list of components that are using this image
+type ImageToComponents map[string][]string
 
 // Image contains info about a singular image
 type Image struct {
@@ -78,7 +78,7 @@ type ValueFile struct {
 	Global GlobalKey `yaml:"global,omitempty"`
 }
 
-func GetWalkFunc(resourcesDirectory string, images, testImages *[]Image, imageComponents ImageComponents) filepath.WalkFunc {
+func GetWalkFunc(resourcesDirectory string, images, testImages *[]Image, imageComponentsMap ImageToComponents) filepath.WalkFunc {
 	return func(path string, info os.FileInfo, err error) error {
 		//pass the error further, this shouldn't ever happen
 		if err != nil {
@@ -110,13 +110,13 @@ func GetWalkFunc(resourcesDirectory string, images, testImages *[]Image, imageCo
 		component := strings.Replace(path, resourcesDirectory+"/", "", -1)
 		component = strings.Replace(component, "/values.yaml", "", -1)
 
-		AppendImagesToList(parsedFile, images, testImages, component, imageComponents)
+		AppendImagesToList(parsedFile, images, testImages, component, imageComponentsMap)
 
 		return nil
 	}
 }
 
-func AppendImagesToList(parsedFile ValueFile, images, testImages *[]Image, component string, components ImageComponents) {
+func AppendImagesToList(parsedFile ValueFile, images, testImages *[]Image, component string, components ImageToComponents) {
 	for _, image := range parsedFile.Global.Images {
 		// add registry info directly into the image struct
 		if image.ContainerRegistryPath == "" {
@@ -177,10 +177,10 @@ func GetInconsistentImages(images []Image) []Image {
 }
 
 // PrintImages prints otu list of images and their usage in components
-func PrintImages(images []Image, imageComponents ImageComponents) {
+func PrintImages(images []Image, imageComponentsMap ImageToComponents) {
 	sort.Slice(images, GetSortImagesFunc(images))
 	for _, image := range images {
-		components := imageComponents[image.String()]
+		components := imageComponentsMap[image.String()]
 		fmt.Printf("%s, used by %s\n", image, strings.Join(components, ", "))
 	}
 }

--- a/development/image-url-helper/pkg/list/imagelister.go
+++ b/development/image-url-helper/pkg/list/imagelister.go
@@ -26,8 +26,8 @@ type Image struct {
 	SHA                   string `yaml:"sha,omitempty"`
 }
 
-// String returns complete image URL with version or SHA
-func (i Image) String() string {
+// FullImageURL returns complete image URL with version or SHA
+func (i Image) FullImageURL() string {
 	version := ":" + i.Version
 	if i.SHA != "" {
 		version = "@sha256:" + i.SHA
@@ -57,7 +57,7 @@ func ImageListContains(list []Image, image Image) bool {
 // GetSortImagesFunc returns sorting function for images list
 func GetSortImagesFunc(images []Image) SortFunction {
 	return func(i, j int) bool {
-		return images[i].String() < images[j].String()
+		return images[i].FullImageURL() < images[j].FullImageURL()
 	}
 }
 
@@ -126,7 +126,7 @@ func AppendImagesToList(parsedFile ValueFile, images, testImages *[]Image, compo
 		if !ImageListContains(*images, image) {
 			*images = append(*images, image)
 		}
-		components[image.String()] = append(components[image.String()], component)
+		components[image.FullImageURL()] = append(components[image.FullImageURL()], component)
 	}
 
 	for _, testImage := range parsedFile.Global.TestImages {
@@ -136,7 +136,7 @@ func AppendImagesToList(parsedFile ValueFile, images, testImages *[]Image, compo
 		if !ImageListContains(*testImages, testImage) {
 			*testImages = append(*testImages, testImage)
 		}
-		components[testImage.String()] = append(components[testImage.String()], component)
+		components[testImage.FullImageURL()] = append(components[testImage.FullImageURL()], component)
 	}
 }
 
@@ -180,7 +180,7 @@ func GetInconsistentImages(images []Image) []Image {
 func PrintImages(images []Image, imageComponentsMap ImageToComponents) {
 	sort.Slice(images, GetSortImagesFunc(images))
 	for _, image := range images {
-		components := imageComponentsMap[image.String()]
+		components := imageComponentsMap[image.FullImageURL()]
 		fmt.Printf("%s, used by %s\n", image, strings.Join(components, ", "))
 	}
 }

--- a/development/image-url-helper/pkg/list/imagelister.go
+++ b/development/image-url-helper/pkg/list/imagelister.go
@@ -110,29 +110,33 @@ func GetWalkFunc(resourcesDirectory string, images, testImages *[]Image, imageCo
 		component := strings.Replace(path, resourcesDirectory+"/", "", -1)
 		component = strings.Replace(component, "/values.yaml", "", -1)
 
-		for _, image := range parsedFile.Global.Images {
-			// add registry info directly into the image struct
-			if image.ContainerRegistryPath == "" {
-				image.ContainerRegistryPath = parsedFile.Global.ContainerRegistry.Path
-			}
-			// remove duplicates
-			if !ImageListContains(*images, image) {
-				*images = append(*images, image)
-			}
-			imageComponents[image.String()] = append(imageComponents[image.String()], component)
-		}
-
-		for _, testImage := range parsedFile.Global.TestImages {
-			if testImage.ContainerRegistryPath == "" {
-				testImage.ContainerRegistryPath = parsedFile.Global.ContainerRegistry.Path
-			}
-			if !ImageListContains(*testImages, testImage) {
-				*testImages = append(*testImages, testImage)
-			}
-			imageComponents[testImage.String()] = append(imageComponents[testImage.String()], component)
-		}
+		AppendImagesToList(parsedFile, images, testImages, component, imageComponents)
 
 		return nil
+	}
+}
+
+func AppendImagesToList(parsedFile ValueFile, images, testImages *[]Image, component string, components ImageComponents) {
+	for _, image := range parsedFile.Global.Images {
+		// add registry info directly into the image struct
+		if image.ContainerRegistryPath == "" {
+			image.ContainerRegistryPath = parsedFile.Global.ContainerRegistry.Path
+		}
+		// remove duplicates
+		if !ImageListContains(*images, image) {
+			*images = append(*images, image)
+		}
+		components[image.String()] = append(components[image.String()], component)
+	}
+
+	for _, testImage := range parsedFile.Global.TestImages {
+		if testImage.ContainerRegistryPath == "" {
+			testImage.ContainerRegistryPath = parsedFile.Global.ContainerRegistry.Path
+		}
+		if !ImageListContains(*testImages, testImage) {
+			*testImages = append(*testImages, testImage)
+		}
+		components[testImage.String()] = append(components[testImage.String()], component)
 	}
 }
 

--- a/development/image-url-helper/pkg/list/imagelister.go
+++ b/development/image-url-helper/pkg/list/imagelister.go
@@ -181,6 +181,6 @@ func PrintImages(images []Image, imageComponentsMap ImageToComponents) {
 	sort.Slice(images, GetSortImagesFunc(images))
 	for _, image := range images {
 		components := imageComponentsMap[image.FullImageURL()]
-		fmt.Printf("%s, used by %s\n", image, strings.Join(components, ", "))
+		fmt.Printf("%s, used by %s\n", image.FullImageURL(), strings.Join(components, ", "))
 	}
 }

--- a/development/image-url-helper/pkg/list/outputjson.go
+++ b/development/image-url-helper/pkg/list/outputjson.go
@@ -26,8 +26,8 @@ type OutputImageList struct {
 }
 
 // PrintImagesJSON prints JSON list with names and components for each image
-func PrintImagesJSON(allImages []Image, imageComponents ImageComponents) error {
-	imagesConverted := convertimageslist(allImages, imageComponents)
+func PrintImagesJSON(allImages []Image, imageComponentsMap ImageToComponents) error {
+	imagesConverted := convertimageslist(allImages, imageComponentsMap)
 
 	out, err := json.MarshalIndent(imagesConverted, "", "  ")
 	if err != nil {
@@ -38,8 +38,8 @@ func PrintImagesJSON(allImages []Image, imageComponents ImageComponents) error {
 }
 
 // PrintImagesYAML prints YAML list with names and components for each image
-func PrintImagesYAML(allImages []Image, imageComponents ImageComponents) error {
-	imagesConverted := convertimageslist(allImages, imageComponents)
+func PrintImagesYAML(allImages []Image, imageComponentsMap ImageToComponents) error {
+	imagesConverted := convertimageslist(allImages, imageComponentsMap)
 
 	out, err := yaml.Marshal(imagesConverted)
 	if err != nil {
@@ -49,14 +49,14 @@ func PrintImagesYAML(allImages []Image, imageComponents ImageComponents) error {
 	return nil
 }
 
-func convertimageslist(allImages []Image, imageComponents ImageComponents) OutputImageList {
+func convertimageslist(allImages []Image, imageComponentsMap ImageToComponents) OutputImageList {
 	imagesConverted := OutputImageList{}
 
 	for _, image := range allImages {
 		imageTmp := OutputImage{}
 		imageTmp.Name = image.String()
 		imageTmp.CustomFields.Image = image.String()
-		components := imageComponents[image.String()]
+		components := imageComponentsMap[image.String()]
 		imageTmp.CustomFields.Components = strings.Join(components, ",")
 		imagesConverted.Images = append(imagesConverted.Images, imageTmp)
 	}

--- a/development/image-url-helper/pkg/list/outputjson.go
+++ b/development/image-url-helper/pkg/list/outputjson.go
@@ -49,6 +49,7 @@ func PrintImagesYAML(allImages []Image, imageComponentsMap ImageToComponents) er
 	return nil
 }
 
+// convertImageslist takes in a list of images and image to component mapping and creates an OutputImageList structure that can be later marshalled and used by the security scan tool
 func convertimageslist(allImages []Image, imageComponentsMap ImageToComponents) OutputImageList {
 	imagesConverted := OutputImageList{}
 

--- a/development/image-url-helper/pkg/list/outputjson.go
+++ b/development/image-url-helper/pkg/list/outputjson.go
@@ -54,9 +54,9 @@ func convertimageslist(allImages []Image, imageComponentsMap ImageToComponents) 
 
 	for _, image := range allImages {
 		imageTmp := OutputImage{}
-		imageTmp.Name = image.String()
-		imageTmp.CustomFields.Image = image.String()
-		components := imageComponentsMap[image.String()]
+		imageTmp.Name = image.FullImageURL()
+		imageTmp.CustomFields.Image = image.FullImageURL()
+		components := imageComponentsMap[image.FullImageURL()]
 		imageTmp.CustomFields.Components = strings.Join(components, ",")
 		imagesConverted.Images = append(imagesConverted.Images, imageTmp)
 	}

--- a/development/image-url-helper/pkg/promote/externalsyncer.go
+++ b/development/image-url-helper/pkg/promote/externalsyncer.go
@@ -29,7 +29,7 @@ func convertImageslist(images []list.Image, targetContainerRegistry, targetTag s
 	syncDef.Sign = sign
 	for _, image := range images {
 		tmpImage := imagesyncer.Image{}
-		tmpImage.Source = image.String()
+		tmpImage.Source = image.FullImageURL()
 		if targetTag != "" {
 			tmpImage.Tag = targetTag
 		}

--- a/development/image-url-helper/pkg/promote/externalsyncer.go
+++ b/development/image-url-helper/pkg/promote/externalsyncer.go
@@ -9,7 +9,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// PrintExternalSyncerYaml generates YAML file ready to be used by the image-syncer tool to copy images to new container registry, with option to retag them
+// PrintExternalSyncerYaml prints out a YAML file ready to be used by the image-syncer tool to copy images to new container registry, with option to retag them
 func PrintExternalSyncerYaml(images []list.Image, targetContainerRegistry, targetTag string, sign bool) error {
 	imagesConverted := convertImageslist(images, targetContainerRegistry, targetTag, sign)
 

--- a/development/image-url-helper/pkg/promote/externalsyncer.go
+++ b/development/image-url-helper/pkg/promote/externalsyncer.go
@@ -9,30 +9,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func appendImagesToList(parsedFile list.ValueFile, images *[]list.Image) {
-	for _, image := range parsedFile.Global.Images {
-		// add registry info directly into the image struct
-		if image.ContainerRegistryPath == "" {
-			image.ContainerRegistryPath = parsedFile.Global.ContainerRegistry.Path
-		}
-		// remove duplicates
-		if !list.ImageListContains(*images, image) {
-			*images = append(*images, image)
-		}
-	}
-
-	for _, testImage := range parsedFile.Global.TestImages {
-		if testImage.ContainerRegistryPath == "" {
-			testImage.ContainerRegistryPath = parsedFile.Global.ContainerRegistry.Path
-		}
-		if !list.ImageListContains(*images, testImage) {
-			*images = append(*images, testImage)
-		}
-	}
-}
-
 func PrintExternalSyncerYaml(images []list.Image, targetContainerRegistry, targetTag string, sign bool) error {
-	imagesConverted := convertimageslist(images, targetContainerRegistry, targetTag, sign)
+	imagesConverted := convertImageslist(images, targetContainerRegistry, targetTag, sign)
 
 	var out bytes.Buffer
 	encoder := yaml.NewEncoder(&out)
@@ -45,7 +23,7 @@ func PrintExternalSyncerYaml(images []list.Image, targetContainerRegistry, targe
 	return nil
 }
 
-func convertimageslist(images []list.Image, targetContainerRegistry, targetTag string, sign bool) imagesyncer.SyncDef {
+func convertImageslist(images []list.Image, targetContainerRegistry, targetTag string, sign bool) imagesyncer.SyncDef {
 	syncDef := imagesyncer.SyncDef{}
 	syncDef.TargetRepoPrefix = targetContainerRegistry
 	syncDef.Sign = sign

--- a/development/image-url-helper/pkg/promote/externalsyncer.go
+++ b/development/image-url-helper/pkg/promote/externalsyncer.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// PrintExternalSyncerYaml generates YAML file ready to be used by the image-syncer tool to copy images to new container registry, with option to retag them
 func PrintExternalSyncerYaml(images []list.Image, targetContainerRegistry, targetTag string, sign bool) error {
 	imagesConverted := convertImageslist(images, targetContainerRegistry, targetTag, sign)
 
@@ -23,6 +24,7 @@ func PrintExternalSyncerYaml(images []list.Image, targetContainerRegistry, targe
 	return nil
 }
 
+// convertImageslist takes in a list of images, target repository & tag and creates a SyncDef structure that can be later marshalled and used by the image-syncer tool
 func convertImageslist(images []list.Image, targetContainerRegistry, targetTag string, sign bool) imagesyncer.SyncDef {
 	syncDef := imagesyncer.SyncDef{}
 	syncDef.TargetRepoPrefix = targetContainerRegistry

--- a/development/image-url-helper/pkg/promote/externalsyncer.go
+++ b/development/image-url-helper/pkg/promote/externalsyncer.go
@@ -1,0 +1,62 @@
+package promote
+
+import (
+	"bytes"
+	"fmt"
+
+	imagesyncer "github.com/kyma-project/test-infra/development/image-syncer/pkg"
+	"github.com/kyma-project/test-infra/development/image-url-helper/pkg/list"
+	"gopkg.in/yaml.v3"
+)
+
+func appendImagesToList(parsedFile list.ValueFile, images *[]list.Image) {
+	for _, image := range parsedFile.Global.Images {
+		// add registry info directly into the image struct
+		if image.ContainerRegistryPath == "" {
+			image.ContainerRegistryPath = parsedFile.Global.ContainerRegistry.Path
+		}
+		// remove duplicates
+		if !list.ImageListContains(*images, image) {
+			*images = append(*images, image)
+		}
+	}
+
+	for _, testImage := range parsedFile.Global.TestImages {
+		if testImage.ContainerRegistryPath == "" {
+			testImage.ContainerRegistryPath = parsedFile.Global.ContainerRegistry.Path
+		}
+		if !list.ImageListContains(*images, testImage) {
+			*images = append(*images, testImage)
+		}
+	}
+}
+
+func PrintExternalSyncerYaml(images []list.Image, targetContainerRegistry, targetTag string, sign bool) error {
+	imagesConverted := convertimageslist(images, targetContainerRegistry, targetTag, sign)
+
+	var out bytes.Buffer
+	encoder := yaml.NewEncoder(&out)
+	encoder.SetIndent(2)
+	err := encoder.Encode(imagesConverted)
+	if err != nil {
+		return fmt.Errorf("error while marshalling: %s", err)
+	}
+	fmt.Println(out.String())
+	return nil
+}
+
+func convertimageslist(images []list.Image, targetContainerRegistry, targetTag string, sign bool) imagesyncer.SyncDef {
+	syncDef := imagesyncer.SyncDef{}
+	syncDef.TargetRepoPrefix = targetContainerRegistry
+	syncDef.Sign = sign
+	for _, image := range images {
+		tmpImage := imagesyncer.Image{}
+		tmpImage.Source = image.String()
+		if targetTag != "" {
+			tmpImage.Tag = targetTag
+		}
+		syncDef.Images = append(syncDef.Images, tmpImage)
+	}
+
+	return syncDef
+}

--- a/development/image-url-helper/pkg/promote/promote.go
+++ b/development/image-url-helper/pkg/promote/promote.go
@@ -64,7 +64,7 @@ func GetWalkFunc(ResourcesDirectoryClean, targetContainerRegistry, targetTag str
 			return fmt.Errorf("error while decoding %s file: %s", path, err)
 		}
 
-		list.AppendImagesToList(parsedImagesFile, images, testImages, "", make(list.ImageComponents))
+		list.AppendImagesToList(parsedImagesFile, images, testImages, "", make(list.ImageToComponents))
 
 		globalNode := getYamlNode(parsedFile.Content[0], "global")
 		if globalNode == nil {

--- a/development/image-url-helper/pkg/promote/promote.go
+++ b/development/image-url-helper/pkg/promote/promote.go
@@ -168,7 +168,6 @@ func updateImages(images *yaml.Node, targetTag string, lines []string) error {
 			// loop over values in singular image
 			for key, imageVal := range val.Content {
 				if (imageVal.Value == "version") && (key+1 < len(val.Content)) {
-					val.Content[key+1].Value = targetTag
 					// parse just the version line
 					var versionLineParsed yaml.Node
 					yaml.Unmarshal([]byte(lines[imageVal.Line-1]), &versionLineParsed)

--- a/development/image-url-helper/pkg/promote/promote.go
+++ b/development/image-url-helper/pkg/promote/promote.go
@@ -40,13 +40,14 @@ func GetWalkFunc(ResourcesDirectoryClean, targetContainerRegistry, targetTag str
 		}
 		defer yamlFile.Close()
 
+		// parse the file to a generic YAML struct with most information intact
 		decoder := yaml.NewDecoder(yamlFile)
 		err = decoder.Decode(&parsedFile)
 		if err != nil {
 			return fmt.Errorf("error while unmarshalling %s file: %s", path, err)
 		}
 
-		// rewind and load the file into array of lines
+		// load the file into array of lines
 		yamlFile.Seek(0, 0)
 		scanner := bufio.NewScanner(yamlFile)
 		for scanner.Scan() {
@@ -56,7 +57,7 @@ func GetWalkFunc(ResourcesDirectoryClean, targetContainerRegistry, targetTag str
 			return fmt.Errorf("error while reading %s file: %s", path, scanner.Err())
 		}
 
-		// get list of images
+		// parse the file as an easy to iterate list of images
 		yamlFile.Seek(0, 0)
 		decoder = yaml.NewDecoder(yamlFile)
 		err = decoder.Decode(&parsedImagesFile)
@@ -64,53 +65,29 @@ func GetWalkFunc(ResourcesDirectoryClean, targetContainerRegistry, targetTag str
 			return fmt.Errorf("error while decoding %s file: %s", path, err)
 		}
 
+		// generate list of used images and apprend it to the global list containing images from all values.yaml files
 		list.AppendImagesToList(parsedImagesFile, images, testImages, "", make(list.ImageToComponents))
 
 		globalNode := getYamlNode(parsedFile.Content[0], "global")
 		if globalNode == nil {
-			// skip the whole file
+			//no "global:" key, skip the whole file
 			return nil
 		}
 
-		// promote container registry
+		// promote container registry, this is always true, as this flag is required
 		if targetContainerRegistry != "" {
-			containerRegistryNode := getYamlNode(globalNode, "containerRegistry")
-			if containerRegistryNode == nil {
-				// skip files without images
-				return nil
+			skip, err := promoteContainerRegistry(path, globalNode, targetContainerRegistry, lines)
+			// check if the error was set or if we should skip the file even with the nil error
+			if skip || (err != nil) {
+				return err
 			}
-
-			containerRegistryPathNode := getYamlNode(containerRegistryNode, "path")
-			if containerRegistryPathNode == nil {
-				// raise error if the containerRegistry is defined, but psth is not
-				return fmt.Errorf("error in %s file: could not find global.containerRegistry.path key", path)
-			}
-			containerRegistryPathNode.Value = targetContainerRegistry
-
-			outputLine, err := yamlNodeToString(containerRegistryNode, containerRegistryNode.Content[0].Column)
-			if err != nil {
-				return fmt.Errorf("error while parsing containerRegistry in %s file: %s", path, err)
-			}
-
-			lines[containerRegistryNode.Line-1] = outputLine
 		}
 
-		// retag images
+		// retag images if the --target-tag is set
 		if targetTag != "" {
-			imagesNode := getYamlNode(globalNode, "images")
-			if imagesNode != nil {
-				err = updateImages(imagesNode, targetTag, lines)
-				if err != nil {
-					return fmt.Errorf("error while parsing images in %s file: %s", path, err)
-				}
-			}
-
-			testImagesNode := getYamlNode(globalNode, "testImages")
-			if testImagesNode != nil {
-				err = updateImages(testImagesNode, targetTag, lines)
-				if err != nil {
-					return fmt.Errorf("error while parsing testImages in %s file: %s", path, err)
-				}
+			err = promoteTargetTags(path, globalNode, targetTag, lines)
+			if err != nil {
+				return err
 			}
 		}
 
@@ -126,6 +103,50 @@ func GetWalkFunc(ResourcesDirectoryClean, targetContainerRegistry, targetTag str
 	}
 }
 
+// promoteContainerRegistry promotes container registry and returnsinformation if the file should be skipped and error message
+func promoteContainerRegistry(path string, globalNode *yaml.Node, targetContainerRegistry string, lines []string) (bool, error) {
+	containerRegistryNode := getYamlNode(globalNode, "containerRegistry")
+	if containerRegistryNode == nil {
+		// skip files without "containerRegistry:" key
+		return true, nil
+	}
+
+	containerRegistryPathNode := getYamlNode(containerRegistryNode, "path")
+	if containerRegistryPathNode == nil {
+		// raise error if the containerRegistry key is defined, but path is not, as this key expected to exist
+		return true, fmt.Errorf("error in %s file: could not find global.containerRegistry.path key", path)
+	}
+	containerRegistryPathNode.Value = targetContainerRegistry
+
+	// update the container registry path
+	outputLine, err := yamlNodeToString(containerRegistryNode, containerRegistryNode.Content[0].Column)
+	if err != nil {
+		return true, fmt.Errorf("error while parsing containerRegistry in %s file: %s", path, err)
+	}
+
+	lines[containerRegistryNode.Line-1] = outputLine
+	return false, nil
+}
+
+func promoteTargetTags(path string, globalNode *yaml.Node, targetTag string, lines []string) error {
+	imagesNode := getYamlNode(globalNode, "images")
+	if imagesNode != nil {
+		err := updateImages(imagesNode, targetTag, lines)
+		if err != nil {
+			return fmt.Errorf("error while parsing images in %s file: %s", path, err)
+		}
+	}
+
+	testImagesNode := getYamlNode(globalNode, "testImages")
+	if testImagesNode != nil {
+		err := updateImages(testImagesNode, targetTag, lines)
+		if err != nil {
+			return fmt.Errorf("error while parsing testImages in %s file: %s", path, err)
+		}
+	}
+	return nil
+}
+
 // trimTrailingNewline trims trailing newline character
 func trimTrailingNewline(s string) string {
 	if strings.HasSuffix(s, "\n") {
@@ -134,7 +155,7 @@ func trimTrailingNewline(s string) string {
 	return s
 }
 
-// yamlNodeToString convers YAML node to string, with proper tabulation
+// yamlNodeToString converts YAML node to a string, with proper tabulation
 func yamlNodeToString(yamlNode *yaml.Node, column int) (string, error) {
 	var outputBytes []byte
 	outputBytes, err := yaml.Marshal(yamlNode)
@@ -149,11 +170,11 @@ func yamlNodeToString(yamlNode *yaml.Node, column int) (string, error) {
 	return outputLine, nil
 }
 
-// getYamlNode finda a node with the specified key. If the next node is a map it will be returned.
+// getYamlNode finds a node with the specified key. If the next node is a map it will be returned.
 func getYamlNode(parsedYaml *yaml.Node, wantedKey string) *yaml.Node {
 	for key, val := range parsedYaml.Content {
 		if val.Value == wantedKey {
-			// "name: value" pairs are split into two values in the Content array, this should always be true
+			// "name: value" pairs are split into two nodes in the Content array, this should always be true
 			if key+1 < len(parsedYaml.Content) {
 				return parsedYaml.Content[key+1]
 			}
@@ -162,18 +183,18 @@ func getYamlNode(parsedYaml *yaml.Node, wantedKey string) *yaml.Node {
 	return nil
 }
 
-// updateImages looks for "version" field in each image and replaces its content with a targetTag value
+// updateImages looks for "version" field in each image and updates its content with a targetTag value in the lines slice
 func updateImages(images *yaml.Node, targetTag string, lines []string) error {
 	for _, val := range images.Content {
 		if val.Tag == "!!map" {
 			// loop over values in singular image
 			for key, imageVal := range val.Content {
 				if (imageVal.Value == "version") && (key+1 < len(val.Content)) {
-					// parse just the version line
+					// parse the version line separately
 					var versionLineParsed yaml.Node
 					yaml.Unmarshal([]byte(lines[imageVal.Line-1]), &versionLineParsed)
-
 					versionLineParsed.Content[0].Content[1].Value = targetTag
+
 					outputLines, err := yamlNodeToString(&versionLineParsed, val.Content[0].Column)
 					if err != nil {
 						return err
@@ -187,7 +208,7 @@ func updateImages(images *yaml.Node, targetTag string, lines []string) error {
 	return nil
 }
 
-// saveToFile saves array of lines to a file
+// saveToFile saves array of lines to an existing file, overwriting its content and preserving file permissions
 func saveToFile(path string, lines []string) error {
 	outputData := strings.Join(lines, "\n")
 	outputData += "\n"

--- a/development/image-url-helper/pkg/promote/promote.go
+++ b/development/image-url-helper/pkg/promote/promote.go
@@ -13,7 +13,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func GetWalkFunc(ResourcesDirectoryClean, targetContainerRegistry, targetTag string, dryRun bool, images *[]list.Image) filepath.WalkFunc {
+func GetWalkFunc(ResourcesDirectoryClean, targetContainerRegistry, targetTag string, dryRun bool, images, testImages *[]list.Image) filepath.WalkFunc {
 	return func(path string, info os.FileInfo, err error) error {
 		//pass the error further, this shouldn't ever happen
 		if err != nil {
@@ -63,7 +63,8 @@ func GetWalkFunc(ResourcesDirectoryClean, targetContainerRegistry, targetTag str
 		if err != nil {
 			return fmt.Errorf("error while decoding %s file: %s", path, err)
 		}
-		appendImagesToList(parsedImagesFile, images)
+
+		list.AppendImagesToList(parsedImagesFile, images, testImages, "", make(list.ImageComponents))
 
 		globalNode := getYamlNode(parsedFile.Content[0], "global")
 		if globalNode == nil {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- flags
    - make `target-container-registry` flag mandatory
    - add `dry-run` flag to skip updating `value.yaml` files
    - add `sign` flag for the generated YAML file
- `image-syncer` compatiblity
    - Add YAML generation in format understood by the image-syncer
    - edit image-syncer to be able to have YAML structs as a package
- refactor `image-url-helper` to reuse parts of the `list` subcommand

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#4443