### PR TITLE
Pipeline job to create unstable Kyma CLI upon Reconciler changes

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -731,6 +731,13 @@ presets:
       - name: STABLE
         value: "true"
   - labels:
+      preset-kyma-cli-unstable: "true"
+    env:
+      - name: KYMA_CLI_UNSTABLE_BUCKET
+        value: gs://kyma-cli-unstable
+      - name: STABLE
+        value: "false"
+  - labels:
       preset-stability-checker-slack-notifications: "true"
     env:
       - name: SLACK_CLIENT_WEBHOOK_URL

--- a/prow/jobs/incubator/reconciler/reconciler.yaml
+++ b/prow/jobs/incubator/reconciler/reconciler.yaml
@@ -156,6 +156,7 @@ postsubmits: # runs on main
         preset-bot-github-token: "true"
         preset-docker-push-repository-incubator: "true"
         preset-gc-project-env: "true"
+        preset-kyma-cli-unstable: "true"
         preset-sa-vm-kyma-integration: "true"
       skip_report: false
       decorate: true

--- a/prow/jobs/incubator/reconciler/reconciler.yaml
+++ b/prow/jobs/incubator/reconciler/reconciler.yaml
@@ -141,6 +141,63 @@ postsubmits: # runs on main
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
+    - name: nightly-main-reconciler-publish-unstable-cli
+      annotations:
+        description: "Bump reconciler version used by CLI and publish the unstable CLI binaries"
+        pipeline.clusterprovisioning: "reconciler"
+        pipeline.installer: "reconciler"
+        pipeline.test: "fast-integration"
+        pipeline.trigger: "nightly"
+        testgrid-create-test-group: "false"
+      labels:
+        prow.k8s.io/pubsub.project: "sap-kyma-prow"
+        prow.k8s.io/pubsub.runID: "nightly-main-reconciler-publish-unstable-cli"
+        prow.k8s.io/pubsub.topic: "prowjobs"
+        preset-bot-github-token: "true"
+        preset-docker-push-repository-incubator: "true"
+        preset-gc-project-env: "true"
+        preset-sa-vm-kyma-integration: "true"
+      skip_report: false
+      decorate: true
+      decoration_config:
+        grace_period: 600000000000
+        timeout: 14400000000000
+      cluster: trusted-workload
+      max_concurrency: 10
+      branches:
+        - ^master$
+        - ^main$
+      extra_refs:
+        - org: kyma-project
+          repo: kyma
+          path_alias: github.com/kyma-project/kyma
+          base_ref: main
+        - org: kyma-project
+          repo: cli
+          path_alias: github.com/kyma-project/cli
+          base_ref: main
+        - org: kyma-project
+          repo: test-infra
+          path_alias: github.com/kyma-project/test-infra
+          base_ref: main
+      spec:
+        containers:
+          - image: "eu.gcr.io/kyma-project/test-infra/buildpack-golang:v20211110-ab51bd20"
+            securityContext:
+              privileged: true
+            command:
+              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/reconciler-publish-unstable-cli.sh"
+            resources:
+              requests:
+                memory: 3Gi
+                cpu: 2
+        tolerations:
+          - key: dedicated
+            operator: Equal
+            value: high-cpu
+            effect: NoSchedule
+        nodeSelector:
+            dedicated: "high-cpu"
   
 periodics: # runs on schedule
     - name: periodic-main-kyma-incubator-reconciler-kyma1-kyma2-upgrade

--- a/prow/scripts/reconciler-publish-unstable-cli.sh
+++ b/prow/scripts/reconciler-publish-unstable-cli.sh
@@ -30,7 +30,7 @@ function testCustomImage() {
 cd "${KYMA_PROJECT_DIR}/cli"
 
 log::info "Bump reconciler version used by the Kyma CLI"
-# go get github.com/kyma-incubator/reconciler
+go get github.com/kyma-incubator/reconciler
 
 log::info "Building Kyma CLI"
 make resolve

--- a/prow/scripts/reconciler-publish-unstable-cli.sh
+++ b/prow/scripts/reconciler-publish-unstable-cli.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+
+set -o errexit
+
+readonly SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+KYMA_PROJECT_DIR=${KYMA_PROJECT_DIR:-"/home/prow/go/src/github.com/kyma-project"}
+
+# shellcheck source=prow/scripts/lib/log.sh
+source "${SCRIPT_DIR}/lib/log.sh"
+# shellcheck source=prow/scripts/lib/utils.sh
+source "${SCRIPT_DIR}/lib/utils.sh"
+# shellcheck source=prow/scripts/lib/gcp.sh
+source "$SCRIPT_DIR/lib/gcp.sh"
+
+cleanup() {
+    ARG=$?
+    log::info "Removing instance cli-integration-test-${RANDOM_ID}"
+    date
+    gcloud compute instances delete --zone="${ZONE}" "cli-integration-test-${RANDOM_ID}" || true ### Workaround: not failing the job regardless of the vm deletion result
+    exit $ARG
+}
+
+function testCustomImage() {
+    CUSTOM_IMAGE="$1"
+    IMAGE_EXISTS=$(gcloud compute images list --filter "name:${CUSTOM_IMAGE}" | tail -n +2 | awk '{print $1}')
+    if [[ -z "$IMAGE_EXISTS" ]]; then
+        log::error "${CUSTOM_IMAGE} is invalid, it is not available in GCP images list, the script will terminate ..." && exit 1
+    fi
+}
+
+cd "${KYMA_PROJECT_DIR}/cli"
+
+log::info "Bump reconciler version used by the Kyma CLI"
+go get github.com/kyma-incubator/reconciler
+
+log::info "Building Kyma CLI"
+date
+make resolve
+make test
+make build-linux
+
+gcp::authenticate \
+    -c "${GOOGLE_APPLICATION_CREDENTIALS}"
+
+RANDOM_ID=$(openssl rand -hex 4)
+
+LABELS=""
+if [[ -z "${PULL_NUMBER}" ]]; then
+    LABELS=(--labels "branch=${PULL_BASE_REF/./-},job-name=cli-integration")
+else
+    LABELS=(--labels "pull-number=$PULL_NUMBER,job-name=cli-integration")
+fi
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+
+    key="$1"
+
+    case ${key} in
+        --image|-i)
+            IMAGE="$2"
+            testCustomImage "${IMAGE}"
+            shift 2
+            ;;
+        --kyma-version|-kv)
+            SOURCE="--source $2"
+            shift 2
+            ;;
+        --*)
+            echo "Unknown flag ${1}"
+            exit 1
+            ;;
+        *)    # unknown option
+            POSITIONAL+=("$1") # save it in an array for later
+            shift # past argument
+            ;;
+    esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
+
+if [[ -z "$IMAGE" ]]; then
+    log::info "Provisioning vm using the latest default custom image ..."
+    date
+    IMAGE=$(gcloud compute images list --sort-by "~creationTimestamp" \
+         --filter "family:custom images AND labels.default:yes" --limit=1 | tail -n +2 | awk '{print $1}')
+
+    if [[ -z "$IMAGE" ]]; then
+       log::error "There are no default custom images, the script will exit ..." && exit 1
+    fi
+ fi
+
+ZONE_LIMIT=${ZONE_LIMIT:-5}
+EU_ZONES=$(gcloud compute zones list --filter="name~europe" --limit="${ZONE_LIMIT}" | tail -n +2 | awk '{print $1}')
+
+for ZONE in ${EU_ZONES}; do
+    log::info "Attempting to create a new instance named cli-integration-test-${RANDOM_ID} in zone ${ZONE} using image ${IMAGE}"
+    date
+    gcloud compute instances create "cli-integration-test-${RANDOM_ID}" \
+        --metadata enable-oslogin=TRUE \
+        --image "${IMAGE}" \
+        --machine-type n1-standard-4 \
+        --zone "${ZONE}" \
+        --boot-disk-size 200 "${LABELS[@]}" &&\
+    log::info "Created cli-integration-test-${RANDOM_ID} in zone ${ZONE}" && break
+    log::error "Could not create machine in zone ${ZONE}"
+done || exit 1
+
+trap cleanup exit INT
+
+gcloud compute ssh \
+  --ssh-key-file="${SSH_KEY_FILE_PATH:-/root/.ssh/user/google_compute_engine}" \
+  --verbosity="${GCLOUD_SSH_LOG_LEVEL:-error}" \
+  --quiet --zone="${ZONE}" \
+  "cli-integration-test-${RANDOM_ID}" \
+  --command="mkdir \$HOME/bin"
+
+log::info "Copying Kyma CLI to the instance"
+#shellcheck disable=SC2088
+utils::send_to_vm "${ZONE}" "cli-integration-test-${RANDOM_ID}" "${KYMA_PROJECT_DIR}/cli/bin/kyma-linux" "~/bin/kyma"
+gcloud compute ssh \
+  --ssh-key-file="${SSH_KEY_FILE_PATH:-/root/.ssh/user/google_compute_engine}" \
+  --verbosity="${GCLOUD_SSH_LOG_LEVEL:-error}" \
+  --quiet \
+  --zone="${ZONE}" \
+  "cli-integration-test-${RANDOM_ID}" \
+  --command="sudo cp \$HOME/bin/kyma /usr/local/bin/kyma"
+
+log::info "Provisioning k3d Kubernetes runtime"
+date
+gcloud compute ssh \
+  --ssh-key-file="${SSH_KEY_FILE_PATH:-/root/.ssh/user/google_compute_engine}" \
+  --verbosity="${GCLOUD_SSH_LOG_LEVEL:-error}" \
+  --quiet \
+  --zone="${ZONE}" \
+  "cli-integration-test-${RANDOM_ID}" \
+  --command="yes | sudo kyma provision k3d --ci"
+
+log::info "Installing Kyma"
+date
+gcloud compute ssh \
+  --ssh-key-file="${SSH_KEY_FILE_PATH:-/root/.ssh/user/google_compute_engine}" \
+  --verbosity="${GCLOUD_SSH_LOG_LEVEL:-error}" \
+  --quiet \
+  --zone="${ZONE}" \
+  "cli-integration-test-${RANDOM_ID}" \
+  --command="yes | sudo kyma deploy --ci ${SOURCE}"
+
+# Run test suite
+# shellcheck disable=SC1090,SC1091
+source "${SCRIPT_DIR}/lib/clitests.sh"
+if clitests::testSuiteExists "test-version"; then
+    clitests::execute "test-version" "${ZONE}" "cli-integration-test-${RANDOM_ID}" "$SOURCE"
+else
+    log::error "Test file 'test-version.sh' not found"
+fi
+if clitests::testSuiteExists "test-function"; then
+    clitests::execute "test-function" "${ZONE}" "cli-integration-test-${RANDOM_ID}" "$SOURCE"
+else
+    log::error "Test file 'test-function.sh' not found"
+fi
+
+log::info "Copying Kyma to the instance"
+#shellcheck disable=SC2088
+utils::compress_send_to_vm "${ZONE}" "cli-integration-test-${RANDOM_ID}" "/home/prow/go/src/github.com/kyma-project/kyma" "~/kyma"
+
+log::info "Running fast-integration tests"
+gcloud compute ssh\
+  --ssh-key-file="${SSH_KEY_FILE_PATH:-/root/.ssh/user/google_compute_engine}" \
+  --verbosity="${GCLOUD_SSH_LOG_LEVEL:-error}" \
+  --quiet \
+  --zone="${ZONE}" \
+  --ssh-flag="-o ServerAliveInterval=30" \
+  "cli-integration-test-${RANDOM_ID}" \
+  --command="cd ~/kyma/tests/fast-integration && sudo make ci"
+
+log::info "Uninstalling Kyma"
+date
+gcloud compute ssh \
+  --ssh-key-file="${SSH_KEY_FILE_PATH:-/root/.ssh/user/google_compute_engine}" \
+  --verbosity="${GCLOUD_SSH_LOG_LEVEL:-error}" \
+  --quiet \
+  --zone="${ZONE}" \
+  "cli-integration-test-${RANDOM_ID}" \
+  --command="sudo kyma undeploy --ci"
+
+# TODO: Do we need to verify undeploy?
+
+# TODO: Create the Reconciler bump commit and push it to the CLI repo
+
+# TODO: Publish a new unstable CLI version
+
+log::success "all done"

--- a/templates/data/incubator-buildpack-data.yaml
+++ b/templates/data/incubator-buildpack-data.yaml
@@ -214,6 +214,13 @@ templates:
                   repo: "kyma"
                   path_alias: "github.com/kyma-project/kyma-1.24"
                   base_ref: "release-1.24"
+          extra_refs_kyma_cli:
+            extra_refs:
+              kyma-cli:
+                - org: "kyma-project"
+                  repo: "cli"
+                  path_alias: "github.com/kyma-project/cli"
+                  base_ref: "main"
           reconciler_jobConfig:
             command: "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-generic.sh"
             args:
@@ -247,6 +254,12 @@ templates:
             command: "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/reconciler-gardener-long-lasting.sh"
             annotations:
               pipeline.platform: "gardener_gcp"
+              pipeline.installer: reconciler
+              pipeline.test: "fast-integration"
+              pipeline.clusterprovisioning: reconciler
+          reconciler_publish_unstable_cli_jobConfig:
+            command: "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/reconciler-publish-unstable-cli.sh"
+            annotations:
               pipeline.installer: reconciler
               pipeline.test: "fast-integration"
               pipeline.clusterprovisioning: reconciler
@@ -300,6 +313,31 @@ templates:
                   local:
                     - reconciler_jobConfig
                     - reconciler_jobConfig_args
+              - jobConfig:
+                  name: nightly-main-reconciler-publish-unstable-cli
+                  annotations:
+                    description: Bump reconciler version used by CLI and publish the unstable CLI binaries
+                    pipeline.trigger: "nightly"
+                  decoration_config:
+                    timeout: 14400000000000 # 4h
+                    grace_period: 600000000000 # 10min
+                  cron: "0 0 * * 1-5" # "At 00:00 on every day-of-week from Monday through Friday"
+                  labels:
+                    preset-sa-vm-kyma-integration: "true"
+                    preset-gc-project-env: "true"
+                    preset-bot-github-token: "true"
+                inheritedConfigs:
+                  global:
+                    - jobConfig_default
+                    - jobConfig_postsubmit
+                    - extra_refs_test-infra
+                    - extra_refs_kyma
+                    - disable_testgrid
+                    - image_buildpack-golang
+                    - jobConfig_buildpack_incubator
+                  local:
+                    - extra_refs_kyma_cli
+                    - reconciler_publish_unstable_cli_jobConfig
               - jobConfig:
                   name: periodic-main-kyma-incubator-reconciler-kyma1-kyma2-upgrade
                   annotations:

--- a/templates/data/incubator-buildpack-data.yaml
+++ b/templates/data/incubator-buildpack-data.yaml
@@ -326,6 +326,7 @@ templates:
                     preset-sa-vm-kyma-integration: "true"
                     preset-gc-project-env: "true"
                     preset-bot-github-token: "true"
+                    preset-kyma-cli-unstable: "true"
                 inheritedConfigs:
                   global:
                     - jobConfig_default

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -729,6 +729,13 @@ presets:
       - name: STABLE
         value: "true"
   - labels:
+      preset-kyma-cli-unstable: "true"
+    env:
+      - name: KYMA_CLI_UNSTABLE_BUCKET
+        value: gs://kyma-cli-unstable
+      - name: STABLE
+        value: "false"
+  - labels:
       preset-stability-checker-slack-notifications: "true"
     env:
       - name: SLACK_CLIENT_WEBHOOK_URL

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,6 +1,0 @@
-pjNames:
-  - pjName: nightly-main-reconciler-publish-unstable-cli
-prConfigs:
-  kyma-project:
-    cli:
-      prNumber: 1099

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,2 @@
+pjNames:
+  - pjName: nightly-main-reconciler-publish-unstable-cli

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,2 +1,6 @@
 pjNames:
   - pjName: nightly-main-reconciler-publish-unstable-cli
+prConfigs:
+  kyma-project:
+    cli:
+      prNumber: 1099


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Create CI pipeline to generate nightly CLI builds using the latest reconciler

Changes proposed in this pull request:
- A nightly pipeline job to create unstable Kyma builds

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Closes https://github.com/kyma-incubator/reconciler/issues/283
Requires https://github.com/kyma-project/cli/pull/1099 to be merged first.