### PR TITLE
move compass gke-benchmark overrides in separate file

### DIFF
--- a/prow/scripts/cluster-integration/compass-gke-benchmark.sh
+++ b/prow/scripts/cluster-integration/compass-gke-benchmark.sh
@@ -240,7 +240,7 @@ function applyCompassOverrides() {
     --label "component=compass"
 
 
-  OVERRIDES_FILE="${COMPASS_SOURCES_DIR}/installation/resources/installer-config-gke-integration.yaml.tpl"
+  OVERRIDES_FILE="${COMPASS_SOURCES_DIR}/installation/resources/installer-config-gke-benchmark.yaml.tpl"
   if [[ -f "$OVERRIDES_FILE" ]]; then
     # envsubst requires variables to be exported or to be passed to the process execution in order to work
   CLOUDSDK_CORE_PROJECT=${CLOUDSDK_CORE_PROJECT} CLOUDSDK_COMPUTE_ZONE=${CLOUDSDK_COMPUTE_ZONE} COMMON_NAME=${COMMON_NAME} envsubst < "$OVERRIDES_FILE" | kubectl apply -f -


### PR DESCRIPTION
**move compass gke-benchmark overrides in separate file**

Fixes failing installation for benchmark tests. Compass migration job was failing because no node was available for schedule.
