### PR TITLE
Image-URL-helper: add option to exclude images from being promoted

### DIFF
--- a/development/image-url-helper/cmd/promote.go
+++ b/development/image-url-helper/cmd/promote.go
@@ -71,7 +71,7 @@ func addPromoteCmdFlags(cmd *cobra.Command, options *promoteCmdOptions) {
 	cmd.Flags().StringVarP(&options.targetTag, "target-tag", "t", "", "Name of the target tag")
 	cmd.Flags().BoolVarP(&options.dryRun, "dry-run", "d", true, "Dry run enabled, nothing is changed")
 	cmd.Flags().BoolVarP(&options.sign, "sign", "s", false, "Set sign flag in outputted yaml file")
-	cmd.Flags().StringVarP(&options.excludesList, "excludes-list", "e", "", "List of excluded images")
+	cmd.Flags().StringVarP(&options.excludesList, "excludes-list", "e", "", "Path to the file containing a list of excluded images")
 	cmd.MarkFlagRequired("target-container-registry")
 	envy.ParseCobra(cmd, envy.CobraConfig{Persistent: true, Prefix: "IMAGE_URL_HELPER"})
 }

--- a/development/image-url-helper/cmd/promote.go
+++ b/development/image-url-helper/cmd/promote.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 
 	"github.com/jamiealquiza/envy"
-	"github.com/kyma-project/test-infra/development/image-url-helper/pkg/check"
 	"github.com/kyma-project/test-infra/development/image-url-helper/pkg/list"
 	"github.com/kyma-project/test-infra/development/image-url-helper/pkg/promote"
 	"github.com/spf13/cobra"
@@ -38,7 +37,7 @@ func PromoteCmd() *cobra.Command {
 			images := make(list.ImageMap)
 			testImages := make(list.ImageMap)
 
-			excludes, err := check.ParseExcludes(options.excludesList)
+			excludes, err := promote.ParseExcludes(options.excludesList)
 			if err != nil {
 				fmt.Printf("Cannot parse excludes list: %s\n", err)
 				os.Exit(2)

--- a/development/image-url-helper/cmd/promote.go
+++ b/development/image-url-helper/cmd/promote.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/jamiealquiza/envy"
+	"github.com/kyma-project/test-infra/development/image-url-helper/pkg/check"
 	"github.com/kyma-project/test-infra/development/image-url-helper/pkg/list"
 	"github.com/kyma-project/test-infra/development/image-url-helper/pkg/promote"
 	"github.com/spf13/cobra"
@@ -16,6 +17,7 @@ type promoteCmdOptions struct {
 	targetTag               string
 	dryRun                  bool
 	sign                    bool
+	excludesList            string
 }
 
 // PromoteCmd replaces containerRegistry and image versions with the provided ones
@@ -36,7 +38,13 @@ func PromoteCmd() *cobra.Command {
 			images := make(list.ImageMap)
 			testImages := make(list.ImageMap)
 
-			err := filepath.Walk(ResourcesDirectory, promote.GetWalkFunc(ResourcesDirectoryClean, targetContainerRegistryClean, options.targetTag, options.dryRun, images, testImages))
+			excludes, err := check.ParseExcludes(options.excludesList)
+			if err != nil {
+				fmt.Printf("Cannot parse excludes list: %s\n", err)
+				os.Exit(2)
+			}
+
+			err = filepath.Walk(ResourcesDirectory, promote.GetWalkFunc(ResourcesDirectoryClean, targetContainerRegistryClean, options.targetTag, options.dryRun, images, testImages, excludes))
 			if err != nil {
 				fmt.Printf("Cannot traverse directory: %s\n", err)
 				os.Exit(2)
@@ -64,6 +72,7 @@ func addPromoteCmdFlags(cmd *cobra.Command, options *promoteCmdOptions) {
 	cmd.Flags().StringVarP(&options.targetTag, "target-tag", "t", "", "Name of the target tag")
 	cmd.Flags().BoolVarP(&options.dryRun, "dry-run", "d", true, "Dry run enabled, nothing is changed")
 	cmd.Flags().BoolVarP(&options.sign, "sign", "s", false, "Set sign flag in outputted yaml file")
+	cmd.Flags().StringVarP(&options.excludesList, "excludes-list", "e", "", "List of excluded images")
 	cmd.MarkFlagRequired("target-container-registry")
 	envy.ParseCobra(cmd, envy.CobraConfig{Persistent: true, Prefix: "IMAGE_URL_HELPER"})
 }

--- a/development/image-url-helper/excludes_promote.yaml
+++ b/development/image-url-helper/excludes_promote.yaml
@@ -1,4 +1,2 @@
 excludes:
-  - filename: "istio-configuration/values.yaml"
-    images:
-      - "istio"
+  - "istio-configuration/values.yaml"

--- a/development/image-url-helper/excludes_promote.yaml
+++ b/development/image-url-helper/excludes_promote.yaml
@@ -1,0 +1,4 @@
+excludes:
+  - filename: "istio-configuration/values.yaml"
+    images:
+      - "istio"

--- a/development/image-url-helper/pkg/list/imagelister.go
+++ b/development/image-url-helper/pkg/list/imagelister.go
@@ -118,13 +118,14 @@ func AppendImagesToMap(parsedFile ValueFile, images, testImages ImageMap, compon
 	}
 }
 
-// GetInconsistentImages returns a list of images with the same URl but different versions or hashes
+// GetInconsistentImages returns a list of images with the same URL but different versions or hashes
 func GetInconsistentImages(images ImageMap) ImageMap {
 	inconsistent := make(ImageMap)
 
 	for imageName, image := range images {
 		for image2Name, image2 := range images {
-			if image.ImageURL() == image2.ImageURL() {
+			// if the short image name is the same and full image name is different
+			if image.ImageURL() == image2.ImageURL() && imageName != image2Name {
 				inconsistent[imageName] = image
 				inconsistent[image2Name] = image2
 			}

--- a/development/image-url-helper/pkg/promote/promote.go
+++ b/development/image-url-helper/pkg/promote/promote.go
@@ -75,7 +75,6 @@ func GetWalkFunc(ResourcesDirectoryClean, targetContainerRegistry, targetTag str
 			return fmt.Errorf("error while decoding %s file: %s", path, err)
 		}
 
-		oldContainerRegistry := parsedImagesFile.Global.ContainerRegistry.Path
 		// generate list of used images and apprend it to the global list containing images from all values.yaml files
 		list.AppendImagesToMap(parsedImagesFile, images, testImages, "", make(list.ImageToComponents))
 
@@ -96,7 +95,7 @@ func GetWalkFunc(ResourcesDirectoryClean, targetContainerRegistry, targetTag str
 
 		// retag images if the --target-tag is set
 		if targetTag != "" {
-			err = promoteTargetTags(path, globalNode, targetTag, &lines, oldContainerRegistry)
+			err = promoteTargetTags(path, globalNode, targetTag, &lines)
 			if err != nil {
 				return err
 			}
@@ -148,10 +147,10 @@ func promoteContainerRegistry(path string, globalNode *yaml.Node, targetContaine
 	return false, nil
 }
 
-func promoteTargetTags(path string, globalNode *yaml.Node, targetTag string, lines *[]string, oldContainerRegistry string) error {
+func promoteTargetTags(path string, globalNode *yaml.Node, targetTag string, lines *[]string) error {
 	imagesNode := getYamlNode(globalNode, "images")
 	if imagesNode != nil {
-		err := updateImages(path, imagesNode, targetTag, lines, oldContainerRegistry)
+		err := updateImages(path, imagesNode, targetTag, lines)
 		if err != nil {
 			return fmt.Errorf("error while parsing images in %s file: %s", path, err)
 		}
@@ -159,7 +158,7 @@ func promoteTargetTags(path string, globalNode *yaml.Node, targetTag string, lin
 
 	testImagesNode := getYamlNode(globalNode, "testImages")
 	if testImagesNode != nil {
-		err := updateImages(path, testImagesNode, targetTag, lines, oldContainerRegistry)
+		err := updateImages(path, testImagesNode, targetTag, lines)
 		if err != nil {
 			return fmt.Errorf("error while parsing testImages in %s file: %s", path, err)
 		}
@@ -204,7 +203,7 @@ func getYamlNode(parsedYaml *yaml.Node, wantedKey string) *yaml.Node {
 }
 
 // updateImages looks for "version" field in each image and updates its content with a targetTag value in the lines slice
-func updateImages(path string, images *yaml.Node, targetTag string, lines *[]string, oldContainerRegistry string) error {
+func updateImages(path string, images *yaml.Node, targetTag string, lines *[]string) error {
 	linesPointer := *lines
 	for _, val := range images.Content {
 		if val.Tag == "!!map" {

--- a/development/image-url-helper/pkg/promote/promote.go
+++ b/development/image-url-helper/pkg/promote/promote.go
@@ -9,11 +9,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/kyma-project/test-infra/development/image-url-helper/pkg/check"
 	"github.com/kyma-project/test-infra/development/image-url-helper/pkg/list"
 	"gopkg.in/yaml.v3"
 )
 
-func GetWalkFunc(ResourcesDirectoryClean, targetContainerRegistry, targetTag string, dryRun bool, images, testImages list.ImageMap) filepath.WalkFunc {
+func GetWalkFunc(ResourcesDirectoryClean, targetContainerRegistry, targetTag string, dryRun bool, images, testImages list.ImageMap, excludes []Exclude) filepath.WalkFunc {
 	return func(path string, info os.FileInfo, err error) error {
 		//pass the error further, this shouldn't ever happen
 		if err != nil {
@@ -65,8 +66,12 @@ func GetWalkFunc(ResourcesDirectoryClean, targetContainerRegistry, targetTag str
 			return fmt.Errorf("error while decoding %s file: %s", path, err)
 		}
 
+		oldContainerRegistry := parsedImagesFile.Global.ContainerRegistry.Path
 		// generate list of used images and apprend it to the global list containing images from all values.yaml files
 		list.AppendImagesToMap(parsedImagesFile, images, testImages, "", make(list.ImageToComponents))
+
+		excludeImages(ResourcesDirectoryClean, path, images, excludes)
+		excludeImages(ResourcesDirectoryClean, path, testImages, excludes)
 
 		globalNode := getYamlNode(parsedFile.Content[0], "global")
 		if globalNode == nil {
@@ -85,7 +90,15 @@ func GetWalkFunc(ResourcesDirectoryClean, targetContainerRegistry, targetTag str
 
 		// retag images if the --target-tag is set
 		if targetTag != "" {
-			err = promoteTargetTags(path, globalNode, targetTag, lines)
+			err = promoteTargetTags(ResourcesDirectoryClean, path, globalNode, targetTag, &lines, oldContainerRegistry, excludes)
+			if err != nil {
+				return err
+			}
+		}
+
+		if len(excludes) > 0 {
+			// hardcode container registry path for each image if it's excluded, allowing the rest of images to be promoted
+			err = unpromoteExcludedImages(ResourcesDirectoryClean, path, globalNode, targetTag, &lines, oldContainerRegistry, excludes)
 			if err != nil {
 				return err
 			}
@@ -101,6 +114,16 @@ func GetWalkFunc(ResourcesDirectoryClean, targetContainerRegistry, targetTag str
 
 		return nil
 	}
+}
+
+func excludeImages(resourcesDirectory, path string, images *[]list.Image, excludes []check.Exclude) {
+	var cleanImagesList []list.Image
+	for _, image := range *images {
+		if !imageInExcludeList(resourcesDirectory, path, image.Name, excludes) {
+			cleanImagesList = append(cleanImagesList, image)
+		}
+	}
+	*images = cleanImagesList
 }
 
 // promoteContainerRegistry promotes container registry and returnsinformation if the file should be skipped and error message
@@ -128,10 +151,10 @@ func promoteContainerRegistry(path string, globalNode *yaml.Node, targetContaine
 	return false, nil
 }
 
-func promoteTargetTags(path string, globalNode *yaml.Node, targetTag string, lines []string) error {
+func promoteTargetTags(resourcesDirectory, path string, globalNode *yaml.Node, targetTag string, lines *[]string, oldContainerRegistry string, excludes []check.Exclude) error {
 	imagesNode := getYamlNode(globalNode, "images")
 	if imagesNode != nil {
-		err := updateImages(imagesNode, targetTag, lines)
+		err := updateImages(resourcesDirectory, path, imagesNode, targetTag, lines, oldContainerRegistry, excludes)
 		if err != nil {
 			return fmt.Errorf("error while parsing images in %s file: %s", path, err)
 		}
@@ -139,7 +162,7 @@ func promoteTargetTags(path string, globalNode *yaml.Node, targetTag string, lin
 
 	testImagesNode := getYamlNode(globalNode, "testImages")
 	if testImagesNode != nil {
-		err := updateImages(testImagesNode, targetTag, lines)
+		err := updateImages(resourcesDirectory, path, testImagesNode, targetTag, lines, oldContainerRegistry, excludes)
 		if err != nil {
 			return fmt.Errorf("error while parsing testImages in %s file: %s", path, err)
 		}
@@ -184,15 +207,21 @@ func getYamlNode(parsedYaml *yaml.Node, wantedKey string) *yaml.Node {
 }
 
 // updateImages looks for "version" field in each image and updates its content with a targetTag value in the lines slice
-func updateImages(images *yaml.Node, targetTag string, lines []string) error {
+func updateImages(resourcesDirectory, path string, images *yaml.Node, targetTag string, lines *[]string, oldContainerRegistry string, excludes []check.Exclude) error {
+	linesPointer := *lines
 	for _, val := range images.Content {
 		if val.Tag == "!!map" {
 			// loop over values in singular image
 			for key, imageVal := range val.Content {
+				if (imageVal.Value == "name") && (key+1 < len(val.Content)) {
+					if imageInExcludeList(resourcesDirectory, path, val.Content[key+1].Value, excludes) {
+						break
+					}
+				}
 				if (imageVal.Value == "version") && (key+1 < len(val.Content)) {
 					// parse the version line separately
 					var versionLineParsed yaml.Node
-					yaml.Unmarshal([]byte(lines[imageVal.Line-1]), &versionLineParsed)
+					yaml.Unmarshal([]byte(linesPointer[imageVal.Line-1]), &versionLineParsed)
 					versionLineParsed.Content[0].Content[1].Value = targetTag
 
 					outputLines, err := yamlNodeToString(&versionLineParsed, val.Content[0].Column)
@@ -200,12 +229,77 @@ func updateImages(images *yaml.Node, targetTag string, lines []string) error {
 						return err
 					}
 
-					lines[imageVal.Line-1] = outputLines
+					linesPointer[imageVal.Line-1] = outputLines
 				}
 			}
 		}
 	}
 	return nil
+}
+
+func unpromoteExcludedImages(resourcesDirectory, path string, globalNode *yaml.Node, targetTag string, lines *[]string, oldContainerRegistry string, excludes []check.Exclude) error {
+	imagesNode := getYamlNode(globalNode, "images")
+	if imagesNode != nil {
+		err := updateExcludedImages(resourcesDirectory, path, imagesNode, targetTag, lines, oldContainerRegistry, excludes)
+		if err != nil {
+			return err
+		}
+	}
+
+	testImagesNode := getYamlNode(globalNode, "testImages")
+	if testImagesNode != nil {
+		err := updateExcludedImages(resourcesDirectory, path, testImagesNode, targetTag, lines, oldContainerRegistry, excludes)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func updateExcludedImages(resourcesDirectory, path string, images *yaml.Node, targetTag string, lines *[]string, oldContainerRegistry string, excludes []check.Exclude) error {
+	linesPointer := *lines
+	for _, val := range images.Content {
+		if val.Tag == "!!map" {
+			// loop over values in singular image
+			for key, imageVal := range val.Content {
+				if (imageVal.Value == "name") && (key+1 < len(val.Content)) {
+					if imageInExcludeList(resourcesDirectory, path, val.Content[key+1].Value, excludes) {
+						// add containerregistry
+						containerLine := "containerRegistryPath: " + oldContainerRegistry
+
+						var containerLineParsed yaml.Node
+						yaml.Unmarshal([]byte(containerLine), &containerLineParsed)
+
+						outputLines, err := yamlNodeToString(&containerLineParsed, val.Content[0].Column)
+						if err != nil {
+							return err
+						}
+
+						*lines = append(linesPointer[:val.Content[0].Line+1], linesPointer[val.Content[0].Line:]...)
+						linesPointer[imageVal.Line] = outputLines
+
+						break
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// if !imageInExcludeList(resourcesDirectory, path, )
+// imageInExcludeList checks if the image value in the given line is on the excludes list
+func imageInExcludeList(resourcesDirectory, filename, imageName string, excludesList []check.Exclude) bool {
+	for _, exclude := range excludesList {
+		if strings.Replace(filename, resourcesDirectory+"/", "", -1) == exclude.Filename {
+			for _, excludeImage := range exclude.Images {
+				if imageName == excludeImage {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // saveToFile saves array of lines to an existing file, overwriting its content and preserving file permissions

--- a/development/image-url-helper/pkg/promote/promote.go
+++ b/development/image-url-helper/pkg/promote/promote.go
@@ -287,7 +287,6 @@ func updateExcludedImages(resourcesDirectory, path string, images *yaml.Node, ta
 	return nil
 }
 
-// if !imageInExcludeList(resourcesDirectory, path, )
 // imageInExcludeList checks if the image value in the given line is on the excludes list
 func imageInExcludeList(resourcesDirectory, filename, imageName string, excludesList []check.Exclude) bool {
 	for _, exclude := range excludesList {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add `excludes-list` flag for `promote` command
- join old registry to the new one in `values.yaml` file so the structure reflects promoted images 
- fix map of inconsistent images

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Blocked by #4479