### PR TITLE
Removed copying nbusola

### DIFF
--- a/prow/scripts/cluster-integration/busola-integration-test-k3s.sh
+++ b/prow/scripts/cluster-integration/busola-integration-test-k3s.sh
@@ -118,7 +118,7 @@ kubectl wait \
 --timeout=120s
 
 cp "$PWD/kubeconfig-kyma.yaml" "$PWD/busola-tests/fixtures/kubeconfig.yaml"
-cp "$PWD/kubeconfig-busola.yaml" "$PWD/busola-tests/fixtures/kubeconfig-2.yaml"
+cp "/etc/rancher/k3s/k3s.yaml" "$PWD/busola-tests/fixtures/kubeconfig-2.yaml"
 mkdir -p "$PWD/busola-tests/cypress/screenshots"
 
 echo "STEP: Running Cypress tests inside Docker"

--- a/prow/scripts/cluster-integration/busola-integration-test-k3s.sh
+++ b/prow/scripts/cluster-integration/busola-integration-test-k3s.sh
@@ -118,7 +118,6 @@ kubectl wait \
 --timeout=120s
 
 cp "$PWD/kubeconfig-kyma.yaml" "$PWD/busola-tests/fixtures/kubeconfig.yaml"
-cp "/etc/rancher/k3s/k3s.yaml" "$PWD/busola-tests/fixtures/kubeconfig-2.yaml"
 mkdir -p "$PWD/busola-tests/cypress/screenshots"
 
 echo "STEP: Running Cypress tests inside Docker"

--- a/prow/scripts/provision-vm-and-start-busola-k3s.sh
+++ b/prow/scripts/provision-vm-and-start-busola-k3s.sh
@@ -124,17 +124,9 @@ KYMA_CLUSTER_NAME="nkyma"
 log::info "KYMA_CLUSTER_NAME=${KYMA_CLUSTER_NAME}"
 kubectl get secrets "${KYMA_CLUSTER_NAME}.kubeconfig" -o jsonpath="{.data.kubeconfig}" | base64 -d > "${TMP_DIR}/kubeconfig-${KYMA_CLUSTER_NAME}.yaml"
 
-KYMA_CLUSTER_NAME_SECOND="nbusola"
-log::info "KYMA_CLUSTER_NAME_SECOND=${KYMA_CLUSTER_NAME_SECOND}"
-kubectl get secrets "${KYMA_CLUSTER_NAME_SECOND}.kubeconfig" -o jsonpath="{.data.kubeconfig}" | base64 -d > "${TMP_DIR}/kubeconfig-${KYMA_CLUSTER_NAME_SECOND}.yaml"
-
 log::info "Copying Kyma kubeconfig to the instance"
 #shellcheck disable=SC2088
 utils::send_to_vm "${ZONE}" "busola-integration-test-${RANDOM_ID}" "${TMP_DIR}/kubeconfig-${KYMA_CLUSTER_NAME}.yaml" "~/kubeconfig-kyma.yaml"
-
-log::info "Copying Busola kubeconfig-2 to the instance"
-#shellcheck disable=SC2088
-utils::send_to_vm "${ZONE}" "busola-integration-test-${RANDOM_ID}" "${TMP_DIR}/kubeconfig-${KYMA_CLUSTER_NAME_SECOND}.yaml" "~/kubeconfig-busola.yaml"
 
 log::info "Copying Busola 'tests' folder to the instance"
 #shellcheck disable=SC2088

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,6 @@
+pjNames:
+  - pjName: "pre-busola-integration-test-k3s"
+prConfigs:
+  kyma-project:
+    busola:
+      prNumber: 640

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,6 +1,0 @@
-pjNames:
-  - pjName: "pre-busola-integration-test-k3s"
-prConfigs:
-  kyma-project:
-    busola:
-      prNumber: 640


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
As we were talking yesterday we don't have to copy `nbusola` to `kubeconfig-2` so we have to delete it.
Changes proposed in this pull request:

- Deleted changes from PR #4516

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
