### PR TITLE
Fix RC cluster

### DIFF
--- a/prow/jobs/kyma/releases/kyma-release-20.yaml
+++ b/prow/jobs/kyma/releases/kyma-release-20.yaml
@@ -112,13 +112,17 @@ postsubmits: # runs on main
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
         prow.k8s.io/pubsub.runID: "post-rel20-kyma-release-candidate"
         prow.k8s.io/pubsub.topic: "prowjobs"
+        preset-certificates-bucket: "true"
         preset-cluster-version: "true"
         preset-dind-enabled: "true"
         preset-docker-push-repository-kyma: "true"
         preset-gc-compute-envs: "true"
         preset-gc-project-env: "true"
         preset-gke-kyma-developers-group: "true"
-        preset-kyma-artifacts-bucket: "true"
+        preset-gke-pod-security-policy: "true"
+        preset-kms-gc-project-env: "true"
+        preset-kyma-encryption-key: "true"
+        preset-kyma-keyring: "true"
         preset-sa-gke-kyma-integration: "true"
       skip_report: false
       decorate: true

--- a/prow/jobs/kyma/releases/kyma-release-20.yaml
+++ b/prow/jobs/kyma/releases/kyma-release-20.yaml
@@ -113,6 +113,7 @@ postsubmits: # runs on main
         prow.k8s.io/pubsub.runID: "post-rel20-kyma-release-candidate"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-certificates-bucket: "true"
+        preset-cluster-use-ssd: "true"
         preset-cluster-version: "true"
         preset-dind-enabled: "true"
         preset-docker-push-repository-kyma: "true"
@@ -151,6 +152,10 @@ postsubmits: # runs on main
             env:
               - name: EVENTMESH_SECRET_FILE
                 value: "/etc/credentials/kyma-tunas-release-testing-event-mesh/serviceKey"
+              - name: MACHINE_TYPE
+                value: "n1-highcpu-16"
+              - name: PROVISION_REGIONAL_CLUSTER
+                value: "true"
             resources:
               requests:
                 memory: 200Mi

--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -255,7 +255,11 @@ gcp::provision_k8s_cluster \
         -N "$GCLOUD_NETWORK_NAME" \
         -S "$GCLOUD_SUBNET_NAME" \
         -g "$GCLOUD_SECURITY_GROUP_DOMAIN" \
-        -P "$TEST_INFRA_SOURCES_DIR"
+        -P "$TEST_INFRA_SOURCES_DIR" \
+        -r "$PROVISION_REGIONAL_CLUSTER" \
+        -m "$MACHINE_TYPE" \
+        -D "$CLUSTER_USE_SSD" \
+        -e "$GKE_ENABLE_POD_SECURITY_POLICY" \
 CLEANUP_CLUSTER="true"
 
 kyma::install_cli

--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -41,6 +41,8 @@ source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/log.sh"
 source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/docker.sh"
 # shellcheck source=prow/scripts/lib/gcp.sh
 source "$TEST_INFRA_SOURCES_DIR/prow/scripts/lib/gcp.sh"
+# shellcheck source=prow/scripts/lib/kyma.sh
+source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/kyma.sh"
 
 requiredVars=(
     REPO_OWNER
@@ -255,7 +257,7 @@ gcp::provision_k8s_cluster \
         -P "$TEST_INFRA_SOURCES_DIR"
 CLEANUP_CLUSTER="true"
 
-
+kyma::install_cli
 
 log::info "Install kyma"
 installKyma

--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -14,7 +14,6 @@
 # - CLOUDSDK_DNS_ZONE_NAME - GCP zone name (not its DNS name!)
 # - GOOGLE_APPLICATION_CREDENTIALS - GCP Service Account key file path
 # - GKE_CLUSTER_VERSION - GKE cluster version
-# - KYMA_ARTIFACTS_BUCKET: GCP bucket
 # - MACHINE_TYPE - (optional) GKE machine type
 #
 #Permissions: In order to run this script you need to use a service account with permissions equivalent to the following GCP roles:
@@ -50,8 +49,8 @@ requiredVars=(
     CLOUDSDK_COMPUTE_REGION
     CLOUDSDK_DNS_ZONE_NAME
     GOOGLE_APPLICATION_CREDENTIALS
-    KYMA_ARTIFACTS_BUCKET
     GKE_CLUSTER_VERSION
+    CERTIFICATES_BUCKET
 )
 
 utils::check_required_vars "${requiredVars[@]}"

--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -246,7 +246,7 @@ gcp::provision_k8s_cluster \
         -r "$PROVISION_REGIONAL_CLUSTER" \
         -m "$MACHINE_TYPE" \
         -D "$CLUSTER_USE_SSD" \
-        -e "$GKE_ENABLE_POD_SECURITY_POLICY" \
+        -e "$GKE_ENABLE_POD_SECURITY_POLICY"
 CLEANUP_CLUSTER="true"
 
 kyma::install_cli

--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -126,16 +126,6 @@ cleanupOnError() {
     exit "${EXIT_STATUS}"
 }
 
-test_fast_integration_eventing() {
-    log::info "Running Eventing E2E release tests"
-
-    pushd /home/prow/go/src/github.com/kyma-project/kyma/tests/fast-integration
-    make ci-test-eventing
-    popd
-
-    log::success "Eventing tests completed"
-}
-
 installKyma() {
 
 	kymaUnsetVar=false
@@ -188,9 +178,6 @@ readonly RELEASE_VERSION=$(cat "VERSION")
 log::info "Reading release version from RELEASE_VERSION file, got: ${RELEASE_VERSION}"
 TRIMMED_RELEASE_VERSION=${RELEASE_VERSION//./-}
 COMMON_NAME=$(echo "${COMMON_NAME_PREFIX}-${TRIMMED_RELEASE_VERSION}" | tr "[:upper:]" "[:lower:]")
-
-
-
 
 gcp::set_vars_for_network \
   -n "$JOB_NAME"
@@ -280,8 +267,6 @@ echo "${IMAGES_LIST}" > "${ARTIFACTS}/kyma-images-release-${RELEASE_VERSION}.csv
 # shellcheck disable=SC2016
 IMAGES_LIST=$(kubectl get pods --all-namespaces -o json | jq '{ images: [.items[] | .metadata.ownerReferences[0].name as $owner | (.status.containerStatuses + .status.initContainerStatuses)[] | { name: .imageID, custom_fields: {owner: $owner, image: .image, name: .name }}] | unique | group_by(.name) | map({name: .[0].name, custom_fields: {owner: map(.custom_fields.owner) | unique | join(","), container_name: map(.custom_fields.name) | unique | join(","), image: .[0].custom_fields.image}}) | map(select (.name | startswith("sha256") | not))}' )
 echo "${IMAGES_LIST}" > "${ARTIFACTS}/kyma-images-release-${RELEASE_VERSION}.json"
-
-test_fast_integration_eventing
 
 log::success "Success"
 

--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -169,7 +169,8 @@ installKyma() {
 			--tls-crt "./letsencrypt/live/${DOMAIN}/fullchain.pem" \
 			--tls-key "./letsencrypt/live/${DOMAIN}/privkey.pem" \
 			--value "istio-configuration.components.ingressGateways.config.service.loadBalancerIP=${GATEWAY_IP_ADDRESS}" \
-			--value "global.domainName=${DOMAIN}"
+			--value "global.domainName=${DOMAIN}" \
+			--timeout 60m
 
 	set +x
 

--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -116,17 +116,6 @@ cleanupOnError() {
             -R "$CLOUDSDK_COMPUTE_REGION"
     fi
 
-    if [ -n "${CLEANUP_APISERVER_DNS_RECORD}" ]; then
-        log::info "Delete Apiserver proxy DNS Record"
-        gcp::delete_dns_record \
-            -a "$APISERVER_IP_ADDRESS" \
-            -h "apiserver" \
-            -s "$COMMON_NAME" \
-            -p "$CLOUDSDK_CORE_PROJECT" \
-            -z "$CLOUDSDK_DNS_ZONE_NAME"
-    fi
-
-
     MSG=""
     if [[ ${EXIT_STATUS} -ne 0 ]]; then MSG="(exit status: ${EXIT_STATUS})"; fi
     log::info "Job is finished ${MSG}"
@@ -219,6 +208,9 @@ gcp::authenticate \
     -c "${GOOGLE_APPLICATION_CREDENTIALS}"
 docker::start
 DNS_DOMAIN="$(gcloud dns managed-zones describe "${CLOUDSDK_DNS_ZONE_NAME}" --format="value(dnsName)")"
+export DNS_DOMAIN
+DOMAIN="${DNS_SUBDOMAIN}.${DNS_DOMAIN%?}"
+export DOMAIN
 
 log::info "Reserve IP Address for Ingressgateway"
 GATEWAY_IP_ADDRESS_NAME="${COMMON_NAME}"

--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -163,7 +163,7 @@ installKyma() {
 	kyma deploy \
 			--ci \
 			--source local \
-			--workspace ${KYMA_SOURCES_DIR} \
+			--workspace "${KYMA_SOURCES_DIR}" \
 			--domain "${DOMAIN}" \
 			--profile production \
 			--tls-crt "./letsencrypt/live/${DOMAIN}/fullchain.pem" \

--- a/templates/data/kyma-integration-data.yaml
+++ b/templates/data/kyma-integration-data.yaml
@@ -370,6 +370,7 @@ templates:
               preset-kyma-artifacts-bucket: "true"
               preset-cluster-use-ssd: "true"
               preset-cluster-version: "true"
+              preset-gke-pod-security-policy: "true"
           fast_integration_template:
             command: "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/fast-integration-test.sh"
             annotations:

--- a/templates/data/kyma-release-data.yaml
+++ b/templates/data/kyma-release-data.yaml
@@ -94,13 +94,17 @@ templates:
                     testgrid-days-of-results: "60"
                   labels:
                     preset-dind-enabled: "true"
-                    preset-kyma-artifacts-bucket: "true"
                     preset-sa-gke-kyma-integration: "true"
                     preset-gc-project-env: "true"
                     preset-gke-kyma-developers-group: "true"
                     preset-docker-push-repository-kyma: "true"
                     preset-cluster-version: "true"
                     preset-gc-compute-envs: "true"
+                    preset-certificates-bucket: "true"
+                    preset-kyma-keyring: "true"
+                    preset-kyma-encryption-key: "true"
+                    preset-gke-pod-security-policy: "true"
+                    preset-kms-gc-project-env: "true"
                   env:
                     EVENTMESH_SECRET_FILE: "/etc/credentials/kyma-tunas-release-testing-event-mesh/serviceKey"
                   decoration_config:

--- a/templates/data/kyma-release-data.yaml
+++ b/templates/data/kyma-release-data.yaml
@@ -105,8 +105,11 @@ templates:
                     preset-kyma-encryption-key: "true"
                     preset-gke-pod-security-policy: "true"
                     preset-kms-gc-project-env: "true"
+                    preset-cluster-use-ssd: "true"
                   env:
                     EVENTMESH_SECRET_FILE: "/etc/credentials/kyma-tunas-release-testing-event-mesh/serviceKey"
+                    PROVISION_REGIONAL_CLUSTER: "true"
+                    MACHINE_TYPE: "n1-highcpu-16"
                   decoration_config:
                     timeout: 3600000000000 # 1h
                     grace_period: 600000000000 # 10min

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,2 +1,0 @@
-pjNames:
-- pjName: "presubmit-test-job"

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,2 @@
+pjNames:
+- pjName: "presubmit-test-job"


### PR DESCRIPTION
Updated a kyma-release-candidate.sh script to use `kyma deploy` command and install the version from the new tag.
Additionally after talk with @pxsalehi the ci-eventing fast-integration test was removed. The eventing team will just run the automated test manually.
