### PR TITLE
Scripts: make Kyma version retrieval more universal

### DIFF
--- a/prow/scripts/lib/kyma.sh
+++ b/prow/scripts/lib/kyma.sh
@@ -87,9 +87,15 @@ function kyma::get_last_release_version {
 
     utils::check_empty_arg "$githubToken" "Github token was not provided. Exiting..."
     
+    if [[ -n "${searchedVersion}" ]]; then
+        # shellcheck disable=SC2034
+        kyma_get_last_release_version_return_version=$(curl --silent --fail --show-error -H "Authorization: token $githubToken" "https://api.github.com/repos/kyma-project/kyma/releases" \
+            | jq -r 'del( .[] | select( (.prerelease == true) or (.draft == true) )) | sort_by(.tag_name | split(".") | map(tonumber)) | [.[]| select( .tag_name | match("'"${searchedVersion}"'"))] | .[-1].tag_name')
+    else
     # shellcheck disable=SC2034
-    kyma_get_last_release_version_return_version=$(curl --silent --fail --show-error -H "Authorization: token $githubToken" "https://api.github.com/repos/kyma-project/kyma/releases" \
-        | jq -r 'del( .[] | select( (.prerelease == true) or (.draft == true) )) | sort_by(.tag_name | split(".") | map(tonumber)) | [.[]| select( .tag_name | match("'"${searchedVersion}"'"))] | .[-1].tag_name')
+        kyma_get_last_release_version_return_version=$(curl --silent --fail --show-error -H "Authorization: token $githubToken" "https://api.github.com/repos/kyma-project/kyma/releases" \
+            | jq -r 'del( .[] | select( (.prerelease == true) or (.draft == true) )) | sort_by(.tag_name | split(".") | map(tonumber)) | .[-1].tag_name')
+    fi
 }
 
 kyma::install_cli() {

--- a/prow/scripts/lib/kyma.sh
+++ b/prow/scripts/lib/kyma.sh
@@ -63,7 +63,7 @@ function kyma::undeploy_kyma() {
 #
 # Arguments:
 #   t - GitHub token
-#   v - searched version as a regular expression ("^" is prepended to the regexp), e.g. "1\." (optional)
+#   v - searched version as a regular expression, e.g. "^1\." (optional)
 # Returns:
 #   Last Kyma release version
 function kyma::get_last_release_version {
@@ -89,7 +89,7 @@ function kyma::get_last_release_version {
     
     # shellcheck disable=SC2034
     kyma_get_last_release_version_return_version=$(curl --silent --fail --show-error -H "Authorization: token $githubToken" "https://api.github.com/repos/kyma-project/kyma/releases" \
-        | jq -r 'del( .[] | select( (.prerelease == true) or (.draft == true) )) | sort_by(.tag_name | split(".") | map(tonumber)) | [.[]| select( .tag_name | match("^'"${searchedVersion}"'"))] | .[-1].tag_name')
+        | jq -r 'del( .[] | select( (.prerelease == true) or (.draft == true) )) | sort_by(.tag_name | split(".") | map(tonumber)) | [.[]| select( .tag_name | match("'"${searchedVersion}"'"))] | .[-1].tag_name')
 }
 
 kyma::install_cli() {

--- a/prow/scripts/lib/kyma.sh
+++ b/prow/scripts/lib/kyma.sh
@@ -90,8 +90,8 @@ function kyma::get_last_release_version {
     
     if [[ -n searchedVersion ]]; then
         # shellcheck disable=SC2034
-        kyma_get_last_release_version_return_version=$(curl --silent --fail --show-error  "https://api.github.com/repos/kyma-project/kyma/releases" \
-            | jq -r 'del( .[] | select( (.prerelease == true) or (.draft == true) )) | sort_by(.tag_name | split(".") | map(tonumber)) | [.[]| select( .tag_name | match("^'${searchedVersion}'"))] | .[-1].tag_name')
+        kyma_get_last_release_version_return_version=$(curl --silent --fail --show-error -H "Authorization: token $githubToken" "https://api.github.com/repos/kyma-project/kyma/releases" \
+            | jq -r 'del( .[] | select( (.prerelease == true) or (.draft == true) )) | sort_by(.tag_name | split(".") | map(tonumber)) | [.[]| select( .tag_name | match("^'"${searchedVersion}"'"))] | .[-1].tag_name')
     else
         # shellcheck disable=SC2034
         kyma_get_last_release_version_return_version=$(curl --silent --fail --show-error -H "Authorization: token $githubToken" "https://api.github.com/repos/kyma-project/kyma/releases" \

--- a/prow/scripts/lib/kyma.sh
+++ b/prow/scripts/lib/kyma.sh
@@ -63,7 +63,7 @@ function kyma::undeploy_kyma() {
 #
 # Arguments:
 #   t - GitHub token
-#   v - searched version (optional)
+#   v - searched version as a regular expression ("^" is prepended to the regexp), e.g. "1\." (optional)
 # Returns:
 #   Last Kyma release version
 function kyma::get_last_release_version {

--- a/prow/scripts/lib/kyma.sh
+++ b/prow/scripts/lib/kyma.sh
@@ -87,16 +87,9 @@ function kyma::get_last_release_version {
 
     utils::check_empty_arg "$githubToken" "Github token was not provided. Exiting..."
     
-    
-    if [[ -n searchedVersion ]]; then
-        # shellcheck disable=SC2034
-        kyma_get_last_release_version_return_version=$(curl --silent --fail --show-error -H "Authorization: token $githubToken" "https://api.github.com/repos/kyma-project/kyma/releases" \
-            | jq -r 'del( .[] | select( (.prerelease == true) or (.draft == true) )) | sort_by(.tag_name | split(".") | map(tonumber)) | [.[]| select( .tag_name | match("^'"${searchedVersion}"'"))] | .[-1].tag_name')
-    else
-        # shellcheck disable=SC2034
-        kyma_get_last_release_version_return_version=$(curl --silent --fail --show-error -H "Authorization: token $githubToken" "https://api.github.com/repos/kyma-project/kyma/releases" \
-            | jq -r 'del( .[] | select( (.prerelease == true) or (.draft == true) )) | sort_by(.tag_name | split(".") | map(tonumber)) | .[-1].tag_name')
-    fi
+    # shellcheck disable=SC2034
+    kyma_get_last_release_version_return_version=$(curl --silent --fail --show-error -H "Authorization: token $githubToken" "https://api.github.com/repos/kyma-project/kyma/releases" \
+        | jq -r 'del( .[] | select( (.prerelease == true) or (.draft == true) )) | sort_by(.tag_name | split(".") | map(tonumber)) | [.[]| select( .tag_name | match("^'"${searchedVersion}"'"))] | .[-1].tag_name')
 }
 
 kyma::install_cli() {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Version can be provided, allowing to return release number for a given major version

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Based on observation in #4544, we don't have any way to retrieve a latest release for a given major version