### PR TITLE
Do not make the PV zone node unschedulable

### DIFF
--- a/prow/scripts/cluster-integration/compass-gke-benchmark.sh
+++ b/prow/scripts/cluster-integration/compass-gke-benchmark.sh
@@ -352,7 +352,7 @@ export TLS_CERT="${utils_generate_self_signed_cert_return_tls_cert:?}"
 export TLS_KEY="${utils_generate_self_signed_cert_return_tls_key:?}"
 
 log::info "Choose node for benchmarks execution"
-NODE=$(kubectl get nodes | tail -n 1 | cut -d ' ' -f 1)
+NODE=$(kubectl get nodes -l topology.kubernetes.io/zone!="$CLOUDSDK_COMPUTE_ZONE" | tail -n 1 | cut -d ' ' -f 1)
 
 log::info "Benchmarks will be executed on node: $NODE. Will make it unschedulable."
 kubectl label node "$NODE" benchmark=true


### PR DESCRIPTION
Loki and Prometheus expect the node in `europe-west4-b` to be schedulable as the PVs have nodeAffinity rules. 