### PR TITLE
Remove Piotr from codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,7 +26,7 @@
 /development/tools/jobs/testinfra/ @kyma-project/prow
 
 # Stability checker
-/stability-checker/ @PK85 @piotrmiskiewicz @jasiu001 @adamwalach
+/stability-checker/ @PK85 @piotrmiskiewicz @adamwalach
 
 # The changelog-generator directory
 /changelog-generator/ @akucharska @kyma-project/prow


### PR DESCRIPTION
**Description**

Piotr left Kyma and he's no longer an active contributor so, according to the [guidelines](https://kyma-project.io/community/governance/01-governance/#when-does-a-maintainer-lose-the-maintainer-status), he can be removed from the codeowners.

Changes proposed in this pull request:

- Remove Piotr (`jasiu001 `) from codeowners
