### PR TITLE
Fix kyma1-kyma2-upgrade plan

### DIFF
--- a/prow/scripts/cluster-integration/reconciler-e2e-upgrade-gardener.sh
+++ b/prow/scripts/cluster-integration/reconciler-e2e-upgrade-gardener.sh
@@ -115,9 +115,8 @@ reconciler::wait_until_is_ready
 kyma::install_cli
 
 # Install Kyma using cli with version previously set in KYMA_SOURCE
-log::banner "Installing Kyma $KYMA_SOURCE"
-echo "EXECUTION_PROFILE=$EXECUTION_PROFILE"
 export EXECUTION_PROFILE=evaluation
+log::banner "Installing Kyma $KYMA_SOURCE with profile: \"$EXECUTION_PROFILE\""
 gardener::install_kyma
 
 # run the fast integration test before reconciliation

--- a/prow/scripts/cluster-integration/reconciler-e2e-upgrade-gardener.sh
+++ b/prow/scripts/cluster-integration/reconciler-e2e-upgrade-gardener.sh
@@ -116,6 +116,8 @@ kyma::install_cli
 
 # Install Kyma using cli with version previously set in KYMA_SOURCE
 log::banner "Installing Kyma $KYMA_SOURCE"
+echo "EXECUTION_PROFILE=$EXECUTION_PROFILE"
+export EXECUTION_PROFILE=evaluation
 gardener::install_kyma
 
 # run the fast integration test before reconciliation

--- a/prow/scripts/lib/gardener/gcp.sh
+++ b/prow/scripts/lib/gardener/gcp.sh
@@ -115,10 +115,24 @@ gardener::install_kyma() {
 
     (
     set -x
-    kyma install \
+    if [[ "$EXECUTION_PROFILE" == "evaluation" ]]; then
+        kyma install \
+            --ci \
+            --source "${KYMA_SOURCE}" \
+            --profile evaluation \
+            --timeout 90m
+    elif [[ "$EXECUTION_PROFILE" == "production" ]]; then
+        kyma install \
+            --ci \
+            --source "${KYMA_SOURCE}" \
+            --profile production \
+            --timeout 90m
+    else
+        kyma install \
         --ci \
         --source "${KYMA_SOURCE}" \
         --timeout 90m
+    fi
     )
 }
 

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,3 @@
+pjNames:
+  - pjName: periodic-main-kyma-incubator-reconciler-kyma1-kyma2-upgrade
+

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,3 +1,0 @@
-pjNames:
-  - pjName: periodic-main-kyma-incubator-reconciler-kyma1-kyma2-upgrade
-


### PR DESCRIPTION
**Description**

the kyma1-kyma2 reconciler upgrade pipeline fails.
The reason seems to be that kyma1 is installed without any profile, while kyma2 is installed using evaluation profile.

Changes proposed in this pull request:

- install kyma1 in the pipeline using explicitly configured "evaluation" profile

**Related issue(s)**
https://github.com/kyma-incubator/reconciler/issues/595