### PR TITLE
Disable branch protection for private repo.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -122,6 +122,8 @@ branch-protection:
               required_status_checks:
                 contexts:
                   - "netlify/kyma-project-old/deploy-preview"
+        private-fn-for-e2e-serverless-tests:
+          protect: false
     kyma-incubator:
       protect: true # protect all repos & branches in kyma-incubator org
       exclude:

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -120,6 +120,8 @@ branch-protection:
               required_status_checks:
                 contexts:
                   - "netlify/kyma-project-old/deploy-preview"
+        private-fn-for-e2e-serverless-tests:
+          protect: false
     kyma-incubator:
       protect: true # protect all repos & branches in kyma-incubator org
       exclude:


### PR DESCRIPTION
We cannot protect private repositories created in kyma-project. That breaks branch protection updates. This PR explicitly excludes the private repository from default branch protection.