### PR TITLE
call cleanup on EXIT, HUP and INT

### DIFF
--- a/prow/scripts/provision-vm-and-start-busola-docker.sh
+++ b/prow/scripts/provision-vm-and-start-busola-docker.sh
@@ -104,7 +104,7 @@ while [[ $# -gt 0 ]]; do
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
-trap cleanup 0 1 2
+trap cleanup EXIT HUP INT
 
 if [[ -z "$IMAGE" ]]; then
     log::info "Provisioning vm using the latest default custom image ..."

--- a/prow/scripts/provision-vm-and-start-busola-docker.sh
+++ b/prow/scripts/provision-vm-and-start-busola-docker.sh
@@ -104,6 +104,7 @@ while [[ $# -gt 0 ]]; do
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
+trap cleanup 0 1 2
 
 if [[ -z "$IMAGE" ]]; then
     log::info "Provisioning vm using the latest default custom image ..."
@@ -132,8 +133,6 @@ for ZONE in ${EU_ZONES}; do
 done || exit 1
 ENDTIME=$(date +%s)
 echo "VM creation time: $((ENDTIME - STARTTIME)) seconds."
-
-trap cleanup exit INT
 
 export KUBECONFIG="${GARDENER_KYMA_PROW_KUBECONFIG}"
 KYMA_CLUSTER_NAME="nkyma"

--- a/prow/scripts/provision-vm-and-start-busola-k3s.sh
+++ b/prow/scripts/provision-vm-and-start-busola-k3s.sh
@@ -88,7 +88,7 @@ while [[ $# -gt 0 ]]; do
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
-trap cleanup 0 1 2
+trap cleanup EXIT HUP INT
 
 if [[ -z "$IMAGE" ]]; then
     log::info "Provisioning vm using the latest default custom image ..."

--- a/prow/scripts/provision-vm-and-start-busola-k3s.sh
+++ b/prow/scripts/provision-vm-and-start-busola-k3s.sh
@@ -88,6 +88,7 @@ while [[ $# -gt 0 ]]; do
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
+trap cleanup 0 1 2
 
 if [[ -z "$IMAGE" ]]; then
     log::info "Provisioning vm using the latest default custom image ..."
@@ -116,8 +117,6 @@ for ZONE in ${EU_ZONES}; do
 done || exit 1
 ENDTIME=$(date +%s)
 echo "VM creation time: $((ENDTIME - STARTTIME)) seconds."
-
-trap cleanup exit INT
 
 export KUBECONFIG="${GARDENER_KYMA_PROW_KUBECONFIG}"
 KYMA_CLUSTER_NAME="nkyma"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

We found that prowjob scripts are not calling cleanup function through the trap when prow abort prowjob execution. Testing support for additional signals.

Changes proposed in this pull request:

- Change trap definition to call it for signals 0, 1  and 2.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
