### PR TITLE
Add initial area labels to `label_sync`.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,7 +8,7 @@ filters:
       - area/documentation
   ".*go\..*$": # all go.mod/sum files
     labels:
-      - area/modules
+      - area/dependency
 reviewers:
   - tooling-reviewers
 approvers:

--- a/prow/labels.yaml
+++ b/prow/labels.yaml
@@ -116,3 +116,40 @@ default:
       target: issues
       prowPlugin: help
       addedBy: anyone
+
+    # area labels
+    - color: 0052cc
+      description: Issues or PRs related to dependency changes
+      name: area/dependency
+      target: both
+      addedBy: label
+    - color: 0052cc
+      description: Issues or PRs related to tooling
+      name: area/tooling
+      target: both
+      addedBy: label
+    - color: 0052cc
+      description: Issues or PRs related to documentation
+      name: area/documentation
+      target: both
+      addedBy: label
+    - color: 0052cc
+      description: Issues or PRs related to prow configuration
+      name: area/prow
+      target: both
+      addedBy: label
+    - color: 0052cc
+      description: Issues or PRs related to templates
+      name: area/templates
+      target: both
+      addedBy: label
+    - color: 0052cc
+      description: Issues or PRs related to security
+      name: area/security
+      target: both
+      addedBy: label
+    - color: 0052cc
+      description: Issues or PRs related to CI related topics
+      name: area/ci
+      target: both
+      addedBy: label


### PR DESCRIPTION
Add area labels to sync across all repos. Those labels are used by OWNERS.
Is something is missing it should be added in follow-up PRs.
/hold