### PR TITLE
Add grego952 in OWNERS_ALIASES as a documentation OWNER in `test-infra`

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -21,6 +21,7 @@ aliases:
     - majakurcius
     - alexandra-simeonova
     - NHingerl
+    - grego952
 
   busola-approvers:
     - akucharska


### PR DESCRIPTION
**Description**

As @grego952 has been working with Kyma for over 3 months as a Technical Writer and has gained expertise in this domain, he should be added to the documentation OWNERS.

Changes proposed in this pull request:

- Add @grego952 to `test-infra` documentation OWNERS in OWNERS_ALIASES

**Related issue**
[#13077 ](https://github.com/kyma-project/kyma/issues/13077)
