### PR TITLE
Enable additional useful plug-ins for test-infra

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -21,6 +21,13 @@ plugins:
       - blunderbuss
       - verify-owners
       - owners-label
+      - milestone
+      - override
+      - retitle
+      - pony
+      - lifecycle
+      - transfer-issue
+      - project
   kyma-incubator:
     plugins:
       - cat


### PR DESCRIPTION
`milestone` allows to set milestone for issues and PRs.
`override` allows repo admins to override the github status
`retitle` allows to change PR or issue title
`lifecycle` closes/reopens/flags issue based on the comment
`transfer-issue` transfers issue between repositories on the same org
`projects` allows team members to add issue/PR to the project

More information about plugins: https://status.build.kyma-project.io/plugins