### PR TITLE
Add various kind/ labels.

### DIFF
--- a/prow/labels.yaml
+++ b/prow/labels.yaml
@@ -121,6 +121,8 @@ default:
     - color: 0052cc
       description: Issues or PRs related to dependency changes
       name: area/dependency
+      previously:
+        - dependencies
       target: both
       addedBy: label
     - color: 0052cc

--- a/prow/labels.yaml
+++ b/prow/labels.yaml
@@ -153,3 +153,59 @@ default:
       name: area/ci
       target: both
       addedBy: label
+
+    # kind labels
+    # some of them will replace the current labels across the organizations
+    - color: e11d21
+      description: Categorizes issue or PR as related to a bug.
+      name: kind/bug
+      previously:
+        - name: bug
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: e11d21
+      description: Categorizes issue or PR as related to a consistently or frequently failing test.
+      name: kind/failing-test
+      previously:
+        - test-missing
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: e11d21
+      description: Categorizes issue or PR as related to missing automated tests for scenario.
+      name: kind/missing-test
+      previously:
+        - test-failing
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: c7def8
+      description: Categorizes issue or PR as related to cleaning up code, process, or technical debt.
+      name: kind/cleanup
+      previously:
+        - name: kind/friction
+        - name: kind/technical-debt
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: c7def8
+      description: Categorizes issue or PR as related to a new feature.
+      name: kind/feature
+      previously:
+        - name: enhancement
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: e11d21
+      description: Categorizes issue or PR as related to a feature/enhancement marked for deprecation.
+      name: kind/deprecation
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: f7c6c7
+      description: Categorizes issue or PR as related to a flaky test.
+      name: kind/flake
+      target: both
+      prowPlugin: label
+      addedBy: anyone

--- a/prow/labels.yaml
+++ b/prow/labels.yaml
@@ -170,7 +170,7 @@ default:
       description: Categorizes issue or PR as related to a consistently or frequently failing test.
       name: kind/failing-test
       previously:
-        - test-missing
+        - test-failing
       target: both
       prowPlugin: label
       addedBy: anyone
@@ -178,7 +178,7 @@ default:
       description: Categorizes issue or PR as related to missing automated tests for scenario.
       name: kind/missing-test
       previously:
-        - test-failing
+        - test-missing
       target: both
       prowPlugin: label
       addedBy: anyone


### PR DESCRIPTION
`label` plugin allows managing the labels based on the command.
`/kind` command denotes usage of all `kind/` related labels.
Those define the PR or issue of specific kind. It's useful for Issue/PR management.
