### PR TITLE
Remove requiring GitHub review from test-infra context

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -249,7 +249,6 @@ tide:
         - do-not-merge/missing-docs-review
       repos:
         - kyma-project/test-infra
-      reviewApprovedRequired: true
     - labels:
         - lgtm
       missingLabels:

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -79,7 +79,6 @@ triggers:
     - kyma-incubator
     only_org_members: true
     ignore_ok_to_test: true
-    elide_skipped_contexts: false
 
 lgtm:
   - repos:
@@ -92,6 +91,7 @@ label:
     - tide/merge-method-merge
     - tide/merge-method-rebase
     - tide/merge-method-squash
+    - Epic
 
 size:
   s:   10

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -247,7 +247,6 @@ tide:
         - do-not-merge/missing-docs-review
       repos:
         - kyma-project/test-infra
-      reviewApprovedRequired: true
     - labels:
         - lgtm
       missingLabels:


### PR DESCRIPTION
Since Prow takes cares of approvals and people have write access revoked `reviewApprovedRequired: true` is not needed.
/cc @Halamix2
/kind feature