### PR TITLE
Disable required_pull_request_reviews for test-infra

### DIFF
--- a/development/tools/jobs/testinfra/branchprotector_test.go
+++ b/development/tools/jobs/testinfra/branchprotector_test.go
@@ -25,7 +25,7 @@ func TestBranchProtection(t *testing.T) {
 		approvals    int
 	}{
 		{"kyma-project", "kyma", "main", []string{"license/cla", "tide"}, 1},
-		{"kyma-project", "test-infra", "main", []string{"license/cla", "tide"}, 1},
+		{"kyma-project", "test-infra", "main", []string{"license/cla", "tide"}, 0},
 		{"kyma-project", "website", "main", []string{"license/cla", "netlify/kyma-project/deploy-preview", "tide"}, 1},
 		{"kyma-project", "website", "archive-snapshots", []string{"license/cla", "netlify/kyma-project-old/deploy-preview", "tide"}, 1},
 		{"kyma-project", "community", "main", []string{"license/cla", "tide"}, 1},

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -107,6 +107,11 @@ branch-protection:
       exclude:
         - "^dependabot/"
       repos:
+        test-infra:
+          required_pull_request_reviews:
+            dismiss_stale_reviews: false
+            require_code_owner_reviews: false
+            required_approving_review_count: 0
         kyma:
           branches:
             kyma-2.0-docu:

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -105,6 +105,11 @@ branch-protection:
       exclude:
         - "^dependabot/"
       repos:
+        test-infra:
+          required_pull_request_reviews:
+            dismiss_stale_reviews: false
+            require_code_owner_reviews: false
+            required_approving_review_count: 0
         kyma:
           branches:
             kyma-2.0-docu:


### PR DESCRIPTION
Remove requiring pull request review from code owners on test-infra repo. Not needed since test-infra works with Prow approval flow. 

/area prow
/kind cleanup