### PR TITLE
Recheck CLA Assistant status plugin

### DIFF
--- a/development/external-plugins/cla-assistant/main.go
+++ b/development/external-plugins/cla-assistant/main.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"github.com/kyma-project/test-infra/development/prow/externalplugin"
+	"go.uber.org/zap"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"net/http"
+	"os"
+	"regexp"
+	"time"
+)
+
+const (
+	PluginName = "cla-assistant"
+)
+
+var (
+	CLACheck = regexp.MustCompile(`(?mi)^/cla-recheck\s*$`)
+)
+
+type CLAClient struct {
+	address string
+	client  http.Client
+}
+
+func helpProvider(_ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
+	ph := &pluginhelp.PluginHelp{
+		Description: "Helper plugin that allows quick CLA interactions with CLA Assistant.",
+	}
+	ph.AddCommand(pluginhelp.Command{
+		Usage:       "/cla-recheck",
+		Description: "Force CLA check on Pull Request.",
+		WhoCanUse:   "Anyone.",
+		Examples:    []string{"/cla-recheck"},
+	})
+	return ph, nil
+}
+
+// issueCommentHandler handles all issue_comment webhooks
+func (c CLAClient) issueCommentHandler(_ *externalplugin.Plugin, e externalplugin.Event) {
+	l := externalplugin.NewLogger().With(
+		externalplugin.EventTypeField, e.EventType,
+		github.EventGUID, e.EventGUID,
+	)
+	defer l.Sync()
+	l.Debug("Got issue_comment event")
+	p := github.IssueCommentEvent{}
+	err := json.Unmarshal(e.Payload, &p)
+	if err != nil {
+		l.Errorw("Could not unmarshal event", "error", err)
+	}
+	if err := c.handleIssueCommentEvent(l, p); err != nil {
+		l.Errorw("Error handling event", "error", err)
+	}
+}
+
+// handleIssueCommentEvent handles parsed IssueCommentEvent
+func (c CLAClient) handleIssueCommentEvent(l *zap.SugaredLogger, ic github.IssueCommentEvent) error {
+	if ic.Action != github.IssueCommentActionCreated && !ic.Issue.IsPullRequest() {
+		return nil
+	}
+	if !CLACheck.MatchString(ic.Comment.Body) {
+		return nil
+	}
+	org := ic.Repo.Owner.Login
+	repo := ic.Repo.Name
+	number := ic.Issue.Number
+	l.Debugf("CLA Recheck Request for %s/%s#%d", org, repo, number)
+	// HEAD gets the same response as GET
+	// If this won't work then change it to GET
+	_, err := c.client.Head(fmt.Sprintf("%s/check/%s/%s?pullRequest=%d", c.address, org, repo, number))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func main() {
+	var addr string
+	l := externalplugin.NewLogger()
+	o := externalplugin.Opts{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.IntVar(&o.Port, "port", 8080, "Plugin port to listen on.")
+	fs.BoolVar(&o.DryRun, "dry-run", false, "Run in dry-run mode - no actual changes will be made.")
+	fs.StringVar(&o.WebhookSecretPath, "hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing GitHub HMAC secret")
+	fs.StringVar(&o.LogLevel, "log-level", "info", "Set log level.")
+	fs.StringVar(&addr, "address", "https://cla-assistant.io", "CLA Assistant address.")
+	fs.Parse(os.Args[1:])
+
+	c := CLAClient{
+		address: addr,
+		client:  http.Client{Timeout: time.Minute * 5},
+	}
+
+	s := externalplugin.Plugin{
+		Name: PluginName,
+	}
+	s.WithLogger(l)
+	s.WithWebhookSecret(o.WebhookSecretPath)
+	s.RegisterWebhookHandler("issue_comment", c.issueCommentHandler)
+	l.Infof("Start plugin %s", PluginName)
+	externalplugin.Start(&s, helpProvider, &o)
+}

--- a/development/external-plugins/cla-assistant/main_test.go
+++ b/development/external-plugins/cla-assistant/main_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"fmt"
+	"github.com/kyma-project/test-infra/development/prow/externalplugin"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/github"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type fakeCLAServer struct {
+	org, repo string
+	number    int
+	requested int
+}
+
+func (f *fakeCLAServer) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	// This is roughly based on a response we get from https://cla-assistant.io/check endpoint
+	// It's funny enough because CLA Assistant does not make any checks before running this endpoint.
+	// It just redirects to https://github.com, lol.
+	w.Header().Set("Location", "https://github.com")
+	w.WriteHeader(302)
+	fmt.Fprintf(w, "Found. Redirecting to https://github.com")
+	f.requested++
+}
+
+func Test_handleGenericCommentEvent(t *testing.T) {
+	testcases := []struct {
+		name             string
+		expectedRequests int
+		event            github.IssueCommentEvent
+	}{
+		{
+			name:             "Non-PR comment created, skip CLA recheck",
+			expectedRequests: 0,
+			event: github.IssueCommentEvent{
+				Action: github.IssueCommentActionCreated,
+				Issue:  github.Issue{PullRequest: nil},
+			},
+		},
+		{
+			name:             "Non-created event received, skip CLA recheck",
+			expectedRequests: 0,
+			event: github.IssueCommentEvent{
+				Action: github.IssueCommentActionEdited,
+				Issue:  github.Issue{PullRequest: &struct{}{}},
+			},
+		},
+		{
+			name:             "PR comment created, without /cla-recheck, skip CLA recheck",
+			expectedRequests: 0,
+			event: github.IssueCommentEvent{
+				Action:  github.IssueCommentActionCreated,
+				Issue:   github.Issue{PullRequest: &struct{}{}},
+				Comment: github.IssueComment{Body: ""},
+			},
+		},
+		{
+			name:             "PR comment created, /cla-recheck, request CLA check",
+			expectedRequests: 1,
+			event: github.IssueCommentEvent{
+				Action:  github.IssueCommentActionCreated,
+				Issue:   github.Issue{PullRequest: &struct{}{}, Number: 101},
+				Comment: github.IssueComment{Body: "/cla-recheck"},
+				Repo: github.Repo{
+					Name:  "repo",
+					Owner: github.User{Login: "org"},
+				},
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			fclas := fakeCLAServer{}
+			s := httptest.NewServer(&fclas)
+			defer s.Close()
+			clac := CLAClient{
+				address: s.URL,
+				client:  http.Client{Timeout: time.Minute * 5},
+			}
+			l := externalplugin.NewLogger().With("test", tc.name)
+			if err := clac.handleIssueCommentEvent(l, tc.event); err != nil {
+				t.Errorf("Unexpected error from handleIssueCommentEvent: %v", err)
+			}
+			if fclas.requested != tc.expectedRequests {
+				t.Errorf("Wrong number of requested CLA rechecks. Got %d, Wanted %d", fclas.requested, tc.expectedRequests)
+			}
+		})
+	}
+}
+
+func Test_helpProvider(t *testing.T) {
+	th, err := helpProvider([]config.OrgRepo{})
+	if err != nil {
+		t.Errorf("unexpected error from helpProvider %v", err)
+	}
+	expCmds := 1
+	if len(th.Commands) != expCmds {
+		t.Errorf("Number of commands does not match Got %d Wanted %d", len(th.Commands), expCmds)
+	}
+}

--- a/prow/cluster/components/cla-assistant_external-plugin.yaml
+++ b/prow/cluster/components/cla-assistant_external-plugin.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: cla-assistant
+  labels:
+    app: cla-assistant
+spec:
+  selector:
+    matchLabels:
+      app: cla-assistant
+  template:
+    metadata:
+      labels:
+        app: cla-assistant
+    spec:
+      containers:
+      - name: cla-assistant
+        image: eu.gcr.io/sap-kyma-neighbors-dev/cla-assistant-plugin:v20220130-54e1f7f39-dirty-2
+        args:
+        - --dry-run=false
+        - --hmac-secret-file=/etc/webhook/hmac
+        ports:
+          - name: http
+            containerPort: 8080
+        volumeMounts:
+          - name: hmac
+            mountPath: /etc/webhook
+            readOnly: true
+      volumes:
+        - name: hmac
+          secret:
+            secretName: hmac-token
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cla-assistant
+  namespace: default
+spec:
+  selector:
+    app: cla-assistant
+  ports:
+  - port: 80
+    targetPort: 8080

--- a/prow/images/cla-assistant-external-plugin/Dockerfile
+++ b/prow/images/cla-assistant-external-plugin/Dockerfile
@@ -1,0 +1,16 @@
+# This dockerfile is meant to use on externally built binary using command
+# in development/tools/external-plugins/cla-assistant:
+# GOOS=linux GOARCH=amd64 go build -o ./plugin .
+# Move the compiled binary file to this directory and execute:
+# docker build -t cla-assistant .
+# NOT MEANT FOR AUTOBUILDS
+
+FROM alpine:3.15.0
+
+ARG commit
+ENV IMAGE_COMMIT=$commit
+LABEL io.kyma-project.test-infra.commit=$commit
+COPY ./plugin /
+RUN apk add --no-cache ca-certificates git && \
+	chmod a+x /plugin
+ENTRYPOINT ["/plugin"]

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -46,6 +46,9 @@ plugins:
 
 external_plugins:
   kyma-project/test-infra:
+    - name: cla-assistant
+      events:
+        - issue_comment
     - name: needs-tws
       events:
         - pull_request


### PR DESCRIPTION
This plugin allows easy CLA recheck once it gets stuck on `Expected - Waiting for status to be reported`. It only works on comments made in PRs.

Fixes #4624
