### PR TITLE
Fix Upgrade Gardener Pipelines

### DIFF
--- a/prow/scripts/cluster-integration/kyma-upgrade-gardener-kyma-to-kyma2.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-gardener-kyma-to-kyma2.sh
@@ -121,7 +121,8 @@ kyma::get_last_release_version -t "${BOT_GITHUB_TOKEN}"
 export KYMA_SOURCE="${kyma_get_last_release_version_return_version:?}"
 log::info "### Reading release version from RELEASE_VERSION file, got: ${KYMA_SOURCE}"
 
-kyma::deploy_kyma -s "$KYMA_SOURCE" -d "$KYMA_SOURCES_DIR" -u "true"
+kyma2_install_dir="$KYMA_SOURCES_DIR/kyma2"
+kyma::deploy_kyma -s "$KYMA_SOURCE" -d "$kyma2_install_dir" -u "true"
 
 log::info "### Run post-upgrade tests"
 gardener::post_upgrade_test_fast_integration_kyma

--- a/prow/scripts/cluster-integration/kyma-upgrade-gardener-kyma2-to-main.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-gardener-kyma2-to-main.sh
@@ -104,7 +104,8 @@ gardener::provision_cluster
 
 log::info "### Installing Kyma $KYMA_SOURCE"
 
-kyma::deploy_kyma -s "$KYMA_SOURCE" -d "$KYMA_SOURCES_DIR" -u "true"
+kyma2_install_dir="$KYMA_SOURCES_DIR/kyma2"
+kyma::deploy_kyma -s "$KYMA_SOURCE" -d "$kyma2_install_dir" -u "true"
 
 # generate pod-security-policy list in json
 utils::save_psp_list "${ARTIFACTS}/kyma-psp.json"
@@ -116,7 +117,8 @@ gardener::pre_upgrade_test_fast_integration_kyma
 export KYMA_SOURCE="main"
 log::info "### Installing Kyma $KYMA_SOURCE"
 
-kyma::deploy_kyma -s "$KYMA_SOURCE" -d "$KYMA_SOURCES_DIR" -u "true"
+kymaMain_install_dir="$KYMA_SOURCES_DIR/kymaMain"
+kyma::deploy_kyma -s "$KYMA_SOURCE" -d "$kymaMain_install_dir" -u "true"
 
 
 log::info "### Run post-upgrade tests"

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,7 @@
+pjNames:
+  - pjName: "kyma-upgrade-gardener-kyma-to-kyma2"
+  - pjName: "kyma-upgrade-gardener-kyma2-to-main"
+prConfigs:
+  kyma-project:
+    test-infra:
+      prNumber:

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,7 +1,0 @@
-pjNames:
-  - pjName: "kyma-upgrade-gardener-kyma-to-kyma2"
-  - pjName: "kyma-upgrade-gardener-kyma2-to-main"
-prConfigs:
-  kyma-project:
-    test-infra:
-      prNumber: 4884

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -4,4 +4,4 @@ pjNames:
 prConfigs:
   kyma-project:
     test-infra:
-      prNumber:
+      prNumber: 4884


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The working directory needs to be differenet than the extra_Ref directory - Because when using `--source` flag with anything different than `local`, it cleans up the directory afterwards. 
In those two pipeline we need multiple versions of Kyma, due to the upgrade scenario, plus we need the fast-integration tests. Thus, we will use source flag for the Kyma version and the external_refs for the fast-integration test.

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
