### PR TITLE
Adjust whiteource unified agent config for scan language `golang-mod`

### DIFF
--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -17,8 +17,8 @@ export TEST_INFRA_SOURCES_DIR="/home/prow/go/src/github.com/kyma-project/test-in
 source "$TEST_INFRA_SOURCES_DIR/prow/scripts/lib/gcp.sh"
 
 # whitesource config
-GO_CONFIG_PATH="/home/prow/go/src/github.com/kyma-project/test-infra/prow/images/whitesource-scanner/go-wss-unified-agent.config"
-JAVASCRIPT_CONFIG_PATH="/home/prow/go/src/github.com/kyma-project/test-infra/prow/images/whitesource-scanner/javascript-wss-unified-agent.config"
+GO_CONFIG_PATH="$TEST_INFRA_SOURCES_DIR/prow/images/whitesource-scanner/go-wss-unified-agent.config"
+JAVASCRIPT_CONFIG_PATH="$TEST_INFRA_SOURCES_DIR/prow/images/whitesource-scanner/javascript-wss-unified-agent.config"
 
 # authenticate gcloud client
 gcp::authenticate \
@@ -79,8 +79,10 @@ golang-mod)
   go version
   CONFIG_PATH=$GO_CONFIG_PATH
   export GO111MODULE=on
-  sed -i.bak "s|go.dependencyManager=|go.dependencyManager=modules|g" $CONFIG_PATH
-  sed -i.bak "s|go.collectDependenciesAtRuntime=true|go.collectDependenciesAtRuntime=false|g" $CONFIG_PATH
+  sed -i.bak "s|go.dependencyManager=|#go.dependencyManager=|g" $CONFIG_PATH
+  sed -i.bak "s|go.collectDependenciesAtRuntime=true|#go.collectDependenciesAtRuntime=true|g" $CONFIG_PATH
+  sed -i.bak "s|go.resolveDependencies=true|go.modules.resolveDependencies=true|g" $CONFIG_PATH
+  sed -i.bak "s|go.ignoreSourceFiles=true|go.modules.ignoreSourceFiles=true|g" $CONFIG_PATH
   sed -i.bak '/^excludes=/d' $CONFIG_PATH
   echo "scanComment=$(date)" >> $CONFIG_PATH
   # exclude godep based folders


### PR DESCRIPTION
- The `modules` option  for the unified agent config property `go.dependencyManager=` is not supported anymore
- Since [Whitesource Unified Agent version 21.3.2](https://whitesource.atlassian.net/wiki/spaces/WD/pages/33718455/WhiteSource+Server+Release+Notes#Version-21.3.2-(11-April-2021)) there are dedicated `go.modules.*` config properties:
   - go.modules.resolveDependencies
   - go.modules.ignoreSourceFiles
   - go.modules.removeDuplicateDependencies
   - go.modules.includeTestDependecies

The variables `GO_CONFIG_PATH` and `JAVASCRIPT_CONFIG_PATH` were adjusted to use pre-configured `TEST_INFRA_SOURCES_DIR`
