### PR TITLE
Fix labels.yaml unmarshal issue

### DIFF
--- a/prow/labels.yaml
+++ b/prow/labels.yaml
@@ -134,7 +134,7 @@ default:
       description: Issues or PRs related to dependency changes
       name: area/dependency
       previously:
-        - dependencies
+        - name: dependencies
       target: both
       addedBy: label
     - color: 0052cc
@@ -182,7 +182,7 @@ default:
       description: Categorizes issue or PR as related to a consistently or frequently failing test.
       name: kind/failing-test
       previously:
-        - test-failing
+        - name: test-failing
       target: both
       prowPlugin: label
       addedBy: anyone
@@ -190,7 +190,7 @@ default:
       description: Categorizes issue or PR as related to missing automated tests for scenario.
       name: kind/missing-test
       previously:
-        - test-missing
+        - name: test-missing
       target: both
       prowPlugin: label
       addedBy: anyone


### PR DESCRIPTION
The list should contain field marshal able to Label struct, not string.

https://status.build.kyma-project.io/view/gs/kyma-prow-logs/logs/ci-prow-label-sync/1491008381987590144

/cc @Halamix2 