### PR TITLE
Adjust go.modules configurations for WS Unified Agent

### DIFF
--- a/prow/scripts/cluster-integration/helpers/start-wssagent.sh
+++ b/prow/scripts/cluster-integration/helpers/start-wssagent.sh
@@ -81,9 +81,10 @@ golang-mod)
   export GO111MODULE=on
   sed -i.bak "s|go.dependencyManager=|#go.dependencyManager=|g" $CONFIG_PATH
   sed -i.bak "s|go.collectDependenciesAtRuntime=true|#go.collectDependenciesAtRuntime=true|g" $CONFIG_PATH
-  sed -i.bak "s|go.resolveDependencies=true|go.modules.resolveDependencies=true|g" $CONFIG_PATH
+  sed -i.bak "s|go.resolveDependencies=true|go.resolveDependencies=false|g" $CONFIG_PATH
   sed -i.bak "s|go.ignoreSourceFiles=true|go.modules.ignoreSourceFiles=true|g" $CONFIG_PATH
   sed -i.bak '/^excludes=/d' $CONFIG_PATH
+  echo "go.modules.resolveDependencies=true" >> $CONFIG_PATH
   echo "scanComment=$(date)" >> $CONFIG_PATH
   # exclude godep based folders
   filterFolders gopkg.toml "${KYMA_SRC}" >>${CONFIG_PATH}


### PR DESCRIPTION
According to the [WS documentation](https://whitesource.atlassian.net/wiki/spaces/WD/pages/33718455/WhiteSource+Server+Release+Notes#Version-21.3.2-(11-April-2021)):
>To use the enhanced Modules dependencies detection, it is recommended to turn on the new resolver by setting go.modules.resolveDependencies=true and disable the current Go resolver by setting go.resolveDependencies=false
