### PR TITLE
Update jobs to use the 1.21 k8s server version

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -297,11 +297,11 @@ presets:
       preset-cluster-version: "true"
     env:
       - name: AKS_CLUSTER_VERSION
-        value: "1.20"
+        value: "1.21"
       - name: GKE_CLUSTER_VERSION
-        value: "1.20"
+        value: "1.21"
       - name: GARDENER_CLUSTER_VERSION
-        value: "1.20"
+        value: "1.21"
   # test clusters log collector
   - labels:
       preset-log-collector-slack-token: "true"

--- a/prow/images/bootstrap/Dockerfile
+++ b/prow/images/bootstrap/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install gcloud
-ENV CLOUD_SDK_VERSION=373.0.0
+ENV CLOUD_SDK_VERSION=358.0.0
 ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
     CLOUDSDK_CORE_DISABLE_PROMPTS=1
 
@@ -52,7 +52,7 @@ RUN curl -fLSs -o gc-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid
     gcloud info | tee /workspace/gcloud-info.txt
 
 # Cluster Version
-ENV CLUSTER_VERSION=1.21.9
+ENV CLUSTER_VERSION=1.21
 
 # Kubectl 1.21
 RUN mv /google-cloud-sdk/bin/kubectl.${CLUSTER_VERSION} /google-cloud-sdk/bin/kubectl

--- a/prow/images/bootstrap/Dockerfile
+++ b/prow/images/bootstrap/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install gcloud
-ENV CLOUD_SDK_VERSION=358.0.0
+ENV CLOUD_SDK_VERSION=373.0.0
 ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
     CLOUDSDK_CORE_DISABLE_PROMPTS=1
 

--- a/prow/images/bootstrap/Dockerfile
+++ b/prow/images/bootstrap/Dockerfile
@@ -52,9 +52,9 @@ RUN curl -fLSs -o gc-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid
     gcloud info | tee /workspace/gcloud-info.txt
 
 # Cluster Version
-ENV CLUSTER_VERSION=1.20
+ENV CLUSTER_VERSION=1.21.9
 
-# Kubectl 1.20
+# Kubectl 1.21
 RUN mv /google-cloud-sdk/bin/kubectl.${CLUSTER_VERSION} /google-cloud-sdk/bin/kubectl
 
 # Docker-in-docker

--- a/prow/scripts/resources/busola/cluster-busola.yaml
+++ b/prow/scripts/resources/busola/cluster-busola.yaml
@@ -9,7 +9,7 @@ spec:
     allowPrivilegedContainers: true
     kubeAPIServer:
       enableBasicAuthentication: false
-    version: 1.20.12
+    version: 1.21.8
   provider:
     controlPlaneConfig:
       apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1

--- a/prow/scripts/resources/busola/cluster-kyma.yaml
+++ b/prow/scripts/resources/busola/cluster-kyma.yaml
@@ -29,7 +29,7 @@ spec:
           - RS256
         usernameClaim: sub
         usernamePrefix: '-'
-    version: 1.20.12
+    version: 1.21.8
   networking:
     nodes: 10.250.0.0/16
     pods: 100.96.0.0/11

--- a/prow/scripts/resources/reconciler/shoot-template.yaml
+++ b/prow/scripts/resources/reconciler/shoot-template.yaml
@@ -9,7 +9,7 @@ spec:
     allowPrivilegedContainers: true
     kubeAPIServer:
       enableBasicAuthentication: false
-    version: 1.20.12
+    version: 1.21.8
   provider:
     controlPlaneConfig:
       apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -295,11 +295,11 @@ presets:
       preset-cluster-version: "true"
     env:
       - name: AKS_CLUSTER_VERSION
-        value: "1.20"
+        value: "1.21"
       - name: GKE_CLUSTER_VERSION
-        value: "1.20"
+        value: "1.21"
       - name: GARDENER_CLUSTER_VERSION
-        value: "1.20"
+        value: "1.21"
   # test clusters log collector
   - labels:
       preset-log-collector-slack-token: "true"

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,3 @@
+pjNames:
+  - pjName: "kyma-weekly-gardener-gcp-busola-kyma"
+  - pjName: "pre-main-control-plane-reconciler-e2e"

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,3 +1,5 @@
 pjNames:
   - pjName: "kyma-weekly-gardener-gcp-busola-kyma"
   - pjName: "pre-main-control-plane-reconciler-e2e"
+  - pjName: "pre-main-kyma-gardener-gcp-eventing"
+  - pjName: "pre-main-compass-gke-integration"

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,5 +1,0 @@
-pjNames:
-  - pjName: "kyma-weekly-gardener-gcp-busola-kyma"
-  - pjName: "pre-main-control-plane-reconciler-e2e"
-  - pjName: "pre-main-kyma-gardener-gcp-eventing"
-  - pjName: "pre-main-compass-gke-integration"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- All hyperscaler should use 1.21 as the base version k8s api server version

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
