### PR TITLE
Hardcode last release version to 1.24.10

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-upgrade.sh
@@ -224,7 +224,7 @@ function getLastRCVersion() {
 function installKyma() {
   kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user="$(gcloud config get-value account)"
   mkdir -p /tmp/kyma-gke-upgradeability
-  LAST_RELEASE_VERSION=$(kyma::get_last_release_version "${BOT_GITHUB_TOKEN}")
+  LAST_RELEASE_VERSION="1.24.10"
   if [ -z "$LAST_RELEASE_VERSION" ]; then
     log::error "Couldn't grab latest version from GitHub API, stopping."
     exit 1


### PR DESCRIPTION
The `kyma::get_last_release_version` script is incorrectly picking up 1.23.1 as last released version. This is incorrect.
The usual way of upgrading should be latest release, eg. 1.24.10 to latest version to be released, eg 1.24.11.

As a workaround hardcode release version until possibly we backport the changes to this function from main branch.
Need manual approved label.

/cc @Halamix2 
/cc @dekiel 