### PR TITLE
Exclude recon wkly from cleaner job

### DIFF
--- a/development/tools/jobs/kyma/kyma_gardener_cleanup_test.go
+++ b/development/tools/jobs/kyma/kyma_gardener_cleanup_test.go
@@ -28,7 +28,7 @@ func TestKymaGardenerCleanupJobPeriodics(t *testing.T) {
 	tester.AssertThatHasExtraRepoRefCustom(t, job.JobBase.UtilityConfig, []string{"test-infra"}, []string{"main"})
 	assert.Equal(t, tester.ImageKymaIntegrationLatest, job.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/helpers/cleanup-gardener.sh"}, job.Spec.Containers[0].Command)
-	assert.Equal(t, []string{"--excluded-clusters", "(nbusola|nkyma|rec-night)"}, job.Spec.Containers[0].Args)
+	assert.Equal(t, []string{"--excluded-clusters", "(nbusola|nkyma|rec-night|rec-wkly-lt)"}, job.Spec.Containers[0].Args)
 	tester.AssertThatContainerHasEnv(t, job.Spec.Containers[0], "KYMA_PROJECT_DIR", "/home/prow/go/src/github.com/kyma-project")
 	tester.AssertThatSpecifiesResourceRequests(t, job.JobBase)
 }

--- a/prow/jobs/kyma/kyma-gardener-cleanup.yaml
+++ b/prow/jobs/kyma/kyma-gardener-cleanup.yaml
@@ -32,7 +32,7 @@ periodics: # runs on schedule
               - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/helpers/cleanup-gardener.sh"
             args:
               - "--excluded-clusters"
-              - "(nbusola|nkyma|rec-night)"
+              - "(nbusola|nkyma|rec-night|rec-wkly-lt)"
             env:
               - name: KYMA_PROJECT_DIR
                 value: "/home/prow/go/src/github.com/kyma-project"

--- a/templates/data/kyma-gardener-cleanup-data.yaml
+++ b/templates/data/kyma-gardener-cleanup-data.yaml
@@ -7,7 +7,7 @@ templates:
             command: "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/helpers/cleanup-gardener.sh"
             args:
               - "--excluded-clusters"
-              - '(nbusola|nkyma|rec-night)'
+              - '(nbusola|nkyma|rec-night|rec-wkly-lt)'
             labels:
               preset-gardener-gcp-kyma-integration: "true"
             env:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Due to some load tests, we have a long running cluster which should not be deleted by the Gardener Cleaner job.


Changes proposed in this pull request:

- Exclude `rec-wkly-lt` from cleaner
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
