### PR TITLE
Specify k8s version for compass gke tests cluster

### DIFF
--- a/development/tools/jobs/incubator/compass/compass_gke_integration_test.go
+++ b/development/tools/jobs/incubator/compass/compass_gke_integration_test.go
@@ -39,7 +39,6 @@ func TestCompassGKEIntegrationPresubmit(t *testing.T) {
 		preset.GardenerAzureIntegration,
 		preset.BuildPr,
 		"preset-kyma-development-artifacts-bucket",
-		preset.ClusterVersion,
 	)
 	tester.AssertThatHasExtraRefTestInfra(t, actualJob.JobBase.UtilityConfig, "main")
 	require.Len(t, actualJob.Spec.Containers, 1)
@@ -50,6 +49,7 @@ func TestCompassGKEIntegrationPresubmit(t *testing.T) {
 	assert.Equal(t, "-c", compassCont.Args[0])
 	assert.Equal(t, "${KYMA_PROJECT_DIR}/test-infra/prow/scripts/cluster-integration/compass-gke-integration.sh", compassCont.Args[1])
 	tester.AssertThatContainerHasEnv(t, compassCont, "CLOUDSDK_COMPUTE_ZONE", "europe-west4-b")
+	tester.AssertThatContainerHasEnv(t, compassCont, "GKE_CLUSTER_VERSION", "1.20")
 	tester.AssertThatSpecifiesResourceRequests(t, actualJob.JobBase)
 }
 
@@ -80,7 +80,6 @@ func TestCompassGKEIntegrationJobsReleases(t *testing.T) {
 				preset.GardenerAzureIntegration,
 				preset.BuildRelease,
 				"preset-kyma-development-artifacts-bucket",
-				preset.ClusterVersion,
 			)
 			assert.False(t, actualPresubmit.AlwaysRun)
 			assert.Len(t, actualPresubmit.Spec.Containers, 1)
@@ -121,7 +120,6 @@ func TestCompassGKEIntegrationPostsubmit(t *testing.T) {
 		preset.GardenerAzureIntegration,
 		preset.BuildMaster,
 		"preset-kyma-development-artifacts-bucket",
-		preset.ClusterVersion,
 	)
 	tester.AssertThatHasExtraRefTestInfra(t, actualJob.JobBase.UtilityConfig, "main")
 	require.Len(t, actualJob.Spec.Containers, 1)
@@ -132,5 +130,6 @@ func TestCompassGKEIntegrationPostsubmit(t *testing.T) {
 	assert.Equal(t, "-c", compassCont.Args[0])
 	assert.Equal(t, "${KYMA_PROJECT_DIR}/test-infra/prow/scripts/cluster-integration/compass-gke-integration.sh", compassCont.Args[1])
 	tester.AssertThatContainerHasEnv(t, compassCont, "CLOUDSDK_COMPUTE_ZONE", "europe-west4-b")
+	tester.AssertThatContainerHasEnv(t, compassCont, "GKE_CLUSTER_VERSION", "1.20")
 	tester.AssertThatSpecifiesResourceRequests(t, actualJob.JobBase)
 }

--- a/prow/jobs/incubator/compass/compass-gke-integration.yaml
+++ b/prow/jobs/incubator/compass/compass-gke-integration.yaml
@@ -11,7 +11,6 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-main-compass-gke-integration"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-pr: "true"
-        preset-cluster-version: "true"
         preset-dind-enabled: "true"
         preset-docker-push-repository-gke-integration: "true"
         preset-gardener-azure-kyma-integration: "true"
@@ -52,6 +51,8 @@ presubmits: # runs on PRs
             env:
               - name: CLOUDSDK_COMPUTE_ZONE
                 value: "europe-west4-b"
+              - name: GKE_CLUSTER_VERSION
+                value: "1.20"
               - name: KYMA_MAJOR_VERSION
                 value: "1"
               - name: MACHINE_TYPE
@@ -79,7 +80,6 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-rel20-compass-gke-integration"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-release: "true"
-        preset-cluster-version: "true"
         preset-dind-enabled: "true"
         preset-docker-push-repository-gke-integration: "true"
         preset-gardener-azure-kyma-integration: "true"
@@ -118,6 +118,8 @@ presubmits: # runs on PRs
             env:
               - name: CLOUDSDK_COMPUTE_ZONE
                 value: "europe-west4-b"
+              - name: GKE_CLUSTER_VERSION
+                value: "1.20"
               - name: KYMA_MAJOR_VERSION
                 value: "1"
               - name: MACHINE_TYPE
@@ -145,7 +147,6 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-rel124-compass-gke-integration"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-release: "true"
-        preset-cluster-version: "true"
         preset-dind-enabled: "true"
         preset-docker-push-repository-gke-integration: "true"
         preset-gardener-azure-kyma-integration: "true"
@@ -184,6 +185,8 @@ presubmits: # runs on PRs
             env:
               - name: CLOUDSDK_COMPUTE_ZONE
                 value: "europe-west4-b"
+              - name: GKE_CLUSTER_VERSION
+                value: "1.20"
               - name: KYMA_MAJOR_VERSION
                 value: "1"
               - name: MACHINE_TYPE
@@ -211,7 +214,6 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-rel123-compass-gke-integration"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-release: "true"
-        preset-cluster-version: "true"
         preset-dind-enabled: "true"
         preset-docker-push-repository-gke-integration: "true"
         preset-gardener-azure-kyma-integration: "true"
@@ -250,6 +252,8 @@ presubmits: # runs on PRs
             env:
               - name: CLOUDSDK_COMPUTE_ZONE
                 value: "europe-west4-b"
+              - name: GKE_CLUSTER_VERSION
+                value: "1.20"
               - name: KYMA_MAJOR_VERSION
                 value: "1"
               - name: MACHINE_TYPE
@@ -282,7 +286,6 @@ postsubmits: # runs on main
         prow.k8s.io/pubsub.runID: "post-main-compass-gke-integration"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-main: "true"
-        preset-cluster-version: "true"
         preset-dind-enabled: "true"
         preset-docker-push-repository-gke-integration: "true"
         preset-gardener-azure-kyma-integration: "true"
@@ -324,6 +327,8 @@ postsubmits: # runs on main
             env:
               - name: CLOUDSDK_COMPUTE_ZONE
                 value: "europe-west4-b"
+              - name: GKE_CLUSTER_VERSION
+                value: "1.20"
               - name: KYMA_MAJOR_VERSION
                 value: "1"
               - name: MACHINE_TYPE

--- a/templates/data/compass-gke-integration-data.yaml
+++ b/templates/data/compass-gke-integration-data.yaml
@@ -15,6 +15,7 @@ templates:
               NODES_PER_ZONE: "1"
               MACHINE_TYPE: "n1-highcpu-16"
               KYMA_MAJOR_VERSION: "1"
+              GKE_CLUSTER_VERSION: "1.20"
             request_memory: 200Mi
             request_cpu: 80m
             labels:
@@ -30,7 +31,6 @@ templates:
               preset-kyma-artifacts-bucket: "true"
               preset-gardener-azure-kyma-integration: "true"
               preset-kyma-development-artifacts-bucket: "true"
-              preset-cluster-version: "true"
         jobConfigs:
           - repoName: kyma-incubator/compass
             jobs:

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,7 +1,0 @@
-pjNames:
-  - pjName: "pre-main-compass-gke-integration"
-    pjPath: "test-infra/prow/jobs/incubator/compass/"
-prConfigs:
-  kyma-incubator:
-    compass:
-      prNumber: 2215

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,7 @@
+pjNames:
+  - pjName: "pre-main-compass-gke-integration"
+    pjPath: "test-infra/prow/jobs/incubator/compass/"
+prConfigs:
+  kyma-incubator:
+    compass:
+      prNumber: 2215


### PR DESCRIPTION
Changes proposed in this pull request:
- Specify kubernetes version used when creating gke cluster for compass e2e tests 