### PR TITLE
Specify k8s version for benchmark tests

### DIFF
--- a/prow/jobs/incubator/compass/compass-gke-benchmark.yaml
+++ b/prow/jobs/incubator/compass/compass-gke-benchmark.yaml
@@ -11,7 +11,6 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-main-compass-gke-benchmark"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-pr: "true"
-        preset-cluster-version: "true"
         preset-dind-enabled: "true"
         preset-docker-push-repository-gke-integration: "true"
         preset-gardener-azure-kyma-integration: "true"
@@ -52,6 +51,8 @@ presubmits: # runs on PRs
             env:
               - name: CLOUDSDK_COMPUTE_ZONE
                 value: "europe-west4-b"
+              - name: GKE_CLUSTER_VERSION
+                value: "1.20"
               - name: KYMA_MAJOR_VERSION
                 value: "1"
               - name: MACHINE_TYPE
@@ -79,7 +80,6 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-rel20-compass-gke-benchmark"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-release: "true"
-        preset-cluster-version: "true"
         preset-dind-enabled: "true"
         preset-docker-push-repository-gke-integration: "true"
         preset-gardener-azure-kyma-integration: "true"
@@ -118,6 +118,8 @@ presubmits: # runs on PRs
             env:
               - name: CLOUDSDK_COMPUTE_ZONE
                 value: "europe-west4-b"
+              - name: GKE_CLUSTER_VERSION
+                value: "1.20"
               - name: KYMA_MAJOR_VERSION
                 value: "1"
               - name: MACHINE_TYPE
@@ -145,7 +147,6 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-rel124-compass-gke-benchmark"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-release: "true"
-        preset-cluster-version: "true"
         preset-dind-enabled: "true"
         preset-docker-push-repository-gke-integration: "true"
         preset-gardener-azure-kyma-integration: "true"
@@ -184,6 +185,8 @@ presubmits: # runs on PRs
             env:
               - name: CLOUDSDK_COMPUTE_ZONE
                 value: "europe-west4-b"
+              - name: GKE_CLUSTER_VERSION
+                value: "1.20"
               - name: KYMA_MAJOR_VERSION
                 value: "1"
               - name: MACHINE_TYPE
@@ -211,7 +214,6 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-rel123-compass-gke-benchmark"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-release: "true"
-        preset-cluster-version: "true"
         preset-dind-enabled: "true"
         preset-docker-push-repository-gke-integration: "true"
         preset-gardener-azure-kyma-integration: "true"
@@ -250,6 +252,8 @@ presubmits: # runs on PRs
             env:
               - name: CLOUDSDK_COMPUTE_ZONE
                 value: "europe-west4-b"
+              - name: GKE_CLUSTER_VERSION
+                value: "1.20"
               - name: KYMA_MAJOR_VERSION
                 value: "1"
               - name: MACHINE_TYPE

--- a/templates/data/compass-gke-benchmark-data.yaml
+++ b/templates/data/compass-gke-benchmark-data.yaml
@@ -15,6 +15,7 @@ templates:
               NODES_PER_ZONE: "1"
               MACHINE_TYPE: "n1-highcpu-16"
               KYMA_MAJOR_VERSION: "1"
+              GKE_CLUSTER_VERSION: "1.20"
             request_memory: 200Mi
             request_cpu: 80m
             labels:
@@ -30,7 +31,6 @@ templates:
               preset-kyma-artifacts-bucket: "true"
               preset-gardener-azure-kyma-integration: "true"
               preset-kyma-development-artifacts-bucket: "true"
-              preset-cluster-version: "true"
         jobConfigs:
           - repoName: kyma-incubator/compass
             jobs:

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,7 @@
+pjNames:
+  - pjName: "pre-main-compass-gke-benchmark"
+    pjPath: "test-infra/prow/jobs/incubator/compass/"
+prConfigs:
+  kyma-incubator:
+    compass:
+      prNumber: 2207

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,7 +1,0 @@
-pjNames:
-  - pjName: "pre-main-compass-gke-benchmark"
-    pjPath: "test-infra/prow/jobs/incubator/compass/"
-prConfigs:
-  kyma-incubator:
-    compass:
-      prNumber: 2207


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix kubernetes version used for compass benchmark tests to 1.20
