### PR TITLE
Revert fixed k8s version for compass gke and benchmark tests

### DIFF
--- a/development/tools/jobs/incubator/compass/compass_gke_integration_test.go
+++ b/development/tools/jobs/incubator/compass/compass_gke_integration_test.go
@@ -39,6 +39,7 @@ func TestCompassGKEIntegrationPresubmit(t *testing.T) {
 		preset.GardenerAzureIntegration,
 		preset.BuildPr,
 		"preset-kyma-development-artifacts-bucket",
+		preset.ClusterVersion,
 	)
 	tester.AssertThatHasExtraRefTestInfra(t, actualJob.JobBase.UtilityConfig, "main")
 	require.Len(t, actualJob.Spec.Containers, 1)
@@ -49,7 +50,6 @@ func TestCompassGKEIntegrationPresubmit(t *testing.T) {
 	assert.Equal(t, "-c", compassCont.Args[0])
 	assert.Equal(t, "${KYMA_PROJECT_DIR}/test-infra/prow/scripts/cluster-integration/compass-gke-integration.sh", compassCont.Args[1])
 	tester.AssertThatContainerHasEnv(t, compassCont, "CLOUDSDK_COMPUTE_ZONE", "europe-west4-b")
-	tester.AssertThatContainerHasEnv(t, compassCont, "GKE_CLUSTER_VERSION", "1.20")
 	tester.AssertThatSpecifiesResourceRequests(t, actualJob.JobBase)
 }
 
@@ -80,6 +80,7 @@ func TestCompassGKEIntegrationJobsReleases(t *testing.T) {
 				preset.GardenerAzureIntegration,
 				preset.BuildRelease,
 				"preset-kyma-development-artifacts-bucket",
+				preset.ClusterVersion,
 			)
 			assert.False(t, actualPresubmit.AlwaysRun)
 			assert.Len(t, actualPresubmit.Spec.Containers, 1)
@@ -120,6 +121,7 @@ func TestCompassGKEIntegrationPostsubmit(t *testing.T) {
 		preset.GardenerAzureIntegration,
 		preset.BuildMaster,
 		"preset-kyma-development-artifacts-bucket",
+		preset.ClusterVersion,
 	)
 	tester.AssertThatHasExtraRefTestInfra(t, actualJob.JobBase.UtilityConfig, "main")
 	require.Len(t, actualJob.Spec.Containers, 1)
@@ -130,6 +132,5 @@ func TestCompassGKEIntegrationPostsubmit(t *testing.T) {
 	assert.Equal(t, "-c", compassCont.Args[0])
 	assert.Equal(t, "${KYMA_PROJECT_DIR}/test-infra/prow/scripts/cluster-integration/compass-gke-integration.sh", compassCont.Args[1])
 	tester.AssertThatContainerHasEnv(t, compassCont, "CLOUDSDK_COMPUTE_ZONE", "europe-west4-b")
-	tester.AssertThatContainerHasEnv(t, compassCont, "GKE_CLUSTER_VERSION", "1.20")
 	tester.AssertThatSpecifiesResourceRequests(t, actualJob.JobBase)
 }

--- a/prow/jobs/incubator/compass/compass-gke-benchmark.yaml
+++ b/prow/jobs/incubator/compass/compass-gke-benchmark.yaml
@@ -11,6 +11,7 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-main-compass-gke-benchmark"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-pr: "true"
+        preset-cluster-version: "true"
         preset-dind-enabled: "true"
         preset-docker-push-repository-gke-integration: "true"
         preset-gardener-azure-kyma-integration: "true"
@@ -51,8 +52,6 @@ presubmits: # runs on PRs
             env:
               - name: CLOUDSDK_COMPUTE_ZONE
                 value: "europe-west4-b"
-              - name: GKE_CLUSTER_VERSION
-                value: "1.20"
               - name: KYMA_MAJOR_VERSION
                 value: "1"
               - name: MACHINE_TYPE
@@ -80,6 +79,7 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-rel20-compass-gke-benchmark"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-release: "true"
+        preset-cluster-version: "true"
         preset-dind-enabled: "true"
         preset-docker-push-repository-gke-integration: "true"
         preset-gardener-azure-kyma-integration: "true"
@@ -118,8 +118,6 @@ presubmits: # runs on PRs
             env:
               - name: CLOUDSDK_COMPUTE_ZONE
                 value: "europe-west4-b"
-              - name: GKE_CLUSTER_VERSION
-                value: "1.20"
               - name: KYMA_MAJOR_VERSION
                 value: "1"
               - name: MACHINE_TYPE
@@ -147,6 +145,7 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-rel124-compass-gke-benchmark"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-release: "true"
+        preset-cluster-version: "true"
         preset-dind-enabled: "true"
         preset-docker-push-repository-gke-integration: "true"
         preset-gardener-azure-kyma-integration: "true"
@@ -185,8 +184,6 @@ presubmits: # runs on PRs
             env:
               - name: CLOUDSDK_COMPUTE_ZONE
                 value: "europe-west4-b"
-              - name: GKE_CLUSTER_VERSION
-                value: "1.20"
               - name: KYMA_MAJOR_VERSION
                 value: "1"
               - name: MACHINE_TYPE
@@ -214,6 +211,7 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-rel123-compass-gke-benchmark"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-release: "true"
+        preset-cluster-version: "true"
         preset-dind-enabled: "true"
         preset-docker-push-repository-gke-integration: "true"
         preset-gardener-azure-kyma-integration: "true"
@@ -252,8 +250,6 @@ presubmits: # runs on PRs
             env:
               - name: CLOUDSDK_COMPUTE_ZONE
                 value: "europe-west4-b"
-              - name: GKE_CLUSTER_VERSION
-                value: "1.20"
               - name: KYMA_MAJOR_VERSION
                 value: "1"
               - name: MACHINE_TYPE

--- a/prow/jobs/incubator/compass/compass-gke-integration.yaml
+++ b/prow/jobs/incubator/compass/compass-gke-integration.yaml
@@ -11,6 +11,7 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-main-compass-gke-integration"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-pr: "true"
+        preset-cluster-version: "true"
         preset-dind-enabled: "true"
         preset-docker-push-repository-gke-integration: "true"
         preset-gardener-azure-kyma-integration: "true"
@@ -51,8 +52,6 @@ presubmits: # runs on PRs
             env:
               - name: CLOUDSDK_COMPUTE_ZONE
                 value: "europe-west4-b"
-              - name: GKE_CLUSTER_VERSION
-                value: "1.20"
               - name: KYMA_MAJOR_VERSION
                 value: "1"
               - name: MACHINE_TYPE
@@ -80,6 +79,7 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-rel20-compass-gke-integration"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-release: "true"
+        preset-cluster-version: "true"
         preset-dind-enabled: "true"
         preset-docker-push-repository-gke-integration: "true"
         preset-gardener-azure-kyma-integration: "true"
@@ -118,8 +118,6 @@ presubmits: # runs on PRs
             env:
               - name: CLOUDSDK_COMPUTE_ZONE
                 value: "europe-west4-b"
-              - name: GKE_CLUSTER_VERSION
-                value: "1.20"
               - name: KYMA_MAJOR_VERSION
                 value: "1"
               - name: MACHINE_TYPE
@@ -147,6 +145,7 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-rel124-compass-gke-integration"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-release: "true"
+        preset-cluster-version: "true"
         preset-dind-enabled: "true"
         preset-docker-push-repository-gke-integration: "true"
         preset-gardener-azure-kyma-integration: "true"
@@ -185,8 +184,6 @@ presubmits: # runs on PRs
             env:
               - name: CLOUDSDK_COMPUTE_ZONE
                 value: "europe-west4-b"
-              - name: GKE_CLUSTER_VERSION
-                value: "1.20"
               - name: KYMA_MAJOR_VERSION
                 value: "1"
               - name: MACHINE_TYPE
@@ -214,6 +211,7 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-rel123-compass-gke-integration"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-release: "true"
+        preset-cluster-version: "true"
         preset-dind-enabled: "true"
         preset-docker-push-repository-gke-integration: "true"
         preset-gardener-azure-kyma-integration: "true"
@@ -252,8 +250,6 @@ presubmits: # runs on PRs
             env:
               - name: CLOUDSDK_COMPUTE_ZONE
                 value: "europe-west4-b"
-              - name: GKE_CLUSTER_VERSION
-                value: "1.20"
               - name: KYMA_MAJOR_VERSION
                 value: "1"
               - name: MACHINE_TYPE
@@ -286,6 +282,7 @@ postsubmits: # runs on main
         prow.k8s.io/pubsub.runID: "post-main-compass-gke-integration"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-build-main: "true"
+        preset-cluster-version: "true"
         preset-dind-enabled: "true"
         preset-docker-push-repository-gke-integration: "true"
         preset-gardener-azure-kyma-integration: "true"
@@ -327,8 +324,6 @@ postsubmits: # runs on main
             env:
               - name: CLOUDSDK_COMPUTE_ZONE
                 value: "europe-west4-b"
-              - name: GKE_CLUSTER_VERSION
-                value: "1.20"
               - name: KYMA_MAJOR_VERSION
                 value: "1"
               - name: MACHINE_TYPE

--- a/templates/data/compass-gke-benchmark-data.yaml
+++ b/templates/data/compass-gke-benchmark-data.yaml
@@ -15,7 +15,6 @@ templates:
               NODES_PER_ZONE: "1"
               MACHINE_TYPE: "n1-highcpu-16"
               KYMA_MAJOR_VERSION: "1"
-              GKE_CLUSTER_VERSION: "1.20"
             request_memory: 200Mi
             request_cpu: 80m
             labels:
@@ -31,6 +30,7 @@ templates:
               preset-kyma-artifacts-bucket: "true"
               preset-gardener-azure-kyma-integration: "true"
               preset-kyma-development-artifacts-bucket: "true"
+              preset-cluster-version: "true"
         jobConfigs:
           - repoName: kyma-incubator/compass
             jobs:

--- a/templates/data/compass-gke-integration-data.yaml
+++ b/templates/data/compass-gke-integration-data.yaml
@@ -15,7 +15,6 @@ templates:
               NODES_PER_ZONE: "1"
               MACHINE_TYPE: "n1-highcpu-16"
               KYMA_MAJOR_VERSION: "1"
-              GKE_CLUSTER_VERSION: "1.20"
             request_memory: 200Mi
             request_cpu: 80m
             labels:
@@ -31,6 +30,7 @@ templates:
               preset-kyma-artifacts-bucket: "true"
               preset-gardener-azure-kyma-integration: "true"
               preset-kyma-development-artifacts-bucket: "true"
+              preset-cluster-version: "true"
         jobConfigs:
           - repoName: kyma-incubator/compass
             jobs:


### PR DESCRIPTION
**Description**
With this [PR in CMP](https://github.com/kyma-incubator/compass/pull/2226) the k8s version of the tests cluster no longer needs to be fixed so this PR enables back automatic use of the latest k8s version.

Changes proposed in this pull request:
- Revert #5008 
- Revert #5011 