### PR TITLE
bug fixing: nightly main reconciler e2e can't connect to cluster

### DIFF
--- a/prow/scripts/cluster-integration/helpers/reconciler.sh
+++ b/prow/scripts/cluster-integration/helpers/reconciler.sh
@@ -6,6 +6,11 @@ readonly RECONCILER_TIMEOUT=1200 # in secs
 readonly RECONCILER_DELAY=15 # in secs
 readonly LOCAL_KUBECONFIG="$HOME/.kube/config"
 
+function reconciler::export_nightly_cluster_name(){
+  day=$(echo $(date +%a) | tr "[:upper:]" "[:lower:]" | cut -c1-2)
+  export INPUT_CLUSTER_NAME="${INPUT_CLUSTER_NAME}-${day}"
+}
+
 function reconciler::delete_cluster_if_exists(){
   export KUBECONFIG="${GARDENER_KYMA_PROW_KUBECONFIG}"
   for i in mo tu we th fr sa su

--- a/prow/scripts/cluster-integration/helpers/reconciler.sh
+++ b/prow/scripts/cluster-integration/helpers/reconciler.sh
@@ -7,6 +7,8 @@ readonly RECONCILER_DELAY=15 # in secs
 readonly LOCAL_KUBECONFIG="$HOME/.kube/config"
 
 function reconciler::export_nightly_cluster_name(){
+  # shellcheck disable=SC2046
+  # shellcheck disable=SC2005
   day=$(echo $(date +%a) | tr "[:upper:]" "[:lower:]" | cut -c1-2)
   export INPUT_CLUSTER_NAME="${INPUT_CLUSTER_NAME}-${day}"
 }

--- a/prow/scripts/cluster-integration/reconciler-e2e-nightly-gardener.sh
+++ b/prow/scripts/cluster-integration/reconciler-e2e-nightly-gardener.sh
@@ -78,8 +78,7 @@ fi
 # Checks required vars and initializes gcloud/docker if necessary
 gardener::init
 
-numeric_day=$(date +%u)
-export INPUT_CLUSTER_NAME="${INPUT_CLUSTER_NAME}${numeric_day}"
+reconciler::export_nightly_cluster_name
 
 log::banner "Connecting to nightly cluster"
 

--- a/prow/scripts/cluster-integration/reconciler-gardener-long-lasting.sh
+++ b/prow/scripts/cluster-integration/reconciler-gardener-long-lasting.sh
@@ -57,8 +57,7 @@ reconciler::delete_cluster_if_exists
 # Generate new cluster name
 # shellcheck disable=SC2046
 # shellcheck disable=SC2005
-day=$(echo $(date +%a) | tr "[:upper:]" "[:lower:]" | cut -c1-2)
-export INPUT_CLUSTER_NAME="${INPUT_CLUSTER_NAME}-${day}"
+reconciler::export_nightly_cluster_name
 
 # Provisioning gardener long lasting cluster
 reconciler::provision_cluster

--- a/prow/scripts/cluster-integration/reconciler-gardener-long-lasting.sh
+++ b/prow/scripts/cluster-integration/reconciler-gardener-long-lasting.sh
@@ -55,8 +55,6 @@ utils::check_required_vars "${requiredVars[@]}"
 reconciler::delete_cluster_if_exists
 
 # Generate new cluster name
-# shellcheck disable=SC2046
-# shellcheck disable=SC2005
 reconciler::export_nightly_cluster_name
 
 # Provisioning gardener long lasting cluster

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,3 +1,0 @@
-pjNames:
-  - pjName: "nightly-main-reconciler-e2e"
-    report: true

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,3 @@
+pjNames:
+  - pjName: "nightly-main-reconciler-e2e"
+    report: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Currently,[nightly-main-reconciler-e2e](https://status.build.kyma-project.io/?job=nightly-main-reconciler-e2e) job failed due to can't find cluster which created by [nightly-main-reconciler](https://status.build.kyma-project.io/?job=nightly-main-reconciler), the reason is recent change brings inconsistent naming issue.