### PR TITLE
Install yq in bootstrap image

### DIFF
--- a/prow/images/bootstrap/Dockerfile
+++ b/prow/images/bootstrap/Dockerfile
@@ -105,3 +105,8 @@ RUN curl -fLSs -o shellcheck.tar.xz https://github.com/koalaman/shellcheck/relea
 
 RUN curl -fLSs -o /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.7.0/hadolint-Linux-x86_64 && \
     chmod +x /usr/local/bin/hadolint
+
+#Install yq
+ENV YQ_VERSION=v4.2.0 \
+    YQ_BINARY=yq_linux_amd64
+RUN curl -fLS -o /usr/bin/yq https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY} && chmod +x /usr/bin/yq


### PR DESCRIPTION
**Description:**

With one of our latest changes, we need the yq tool in our installation scripts in [compass](https://github.com/kyma-incubator/compass). Since there are quite a few tools in the bootstrap image I think that yq will be a good fit for it and can also be useful in other places