### PR TITLE
Synchronize stale labels

### DIFF
--- a/prow/labels.yaml
+++ b/prow/labels.yaml
@@ -223,12 +223,13 @@ default:
       target: both
       prowPlugin: label
       addedBy: anyone
-    
+
+    # lifecycle labels
     - color: d3e2f0
       description: Indicates that an issue or PR should not be auto-closed due to staleness.
       name: lifecycle/frozen
-#       previously:
-#       - name: ci/future
+      previously:
+        - name: ci/future
       target: both
       prowPlugin: lifecycle
       addedBy: anyone
@@ -236,7 +237,7 @@ default:
       description: Indicates that an issue or PR is actively being worked on by a contributor.
       name: lifecycle/active
       previously:
-      - name: active
+        - name: active
       target: both
       prowPlugin: lifecycle
       addedBy: anyone
@@ -249,8 +250,8 @@ default:
     - color: "795548"
       description: Denotes an issue or PR has remained open with no activity and has become stale.
       name: lifecycle/stale
-#       previously:
-#         - name: stale
+      previously:
+        - name: stale
       target: both
       prowPlugin: lifecycle
       addedBy: anyone or [@kyma-stale-bot[bot]](https://github.com/apps/kyma-stale-bot)


### PR DESCRIPTION
We do not need `stale` and `ci/future` labels anymore. Those are replaced by `lifecycle/stale` and `lifecycle/frozen` so those can work with lifecycle plugin.

Closes #4779