### PR TITLE
Set the debug mode on the periodic kyma-integration-k3d job

### DIFF
--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -1446,10 +1446,10 @@ periodics: # runs on schedule
             command:
               - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-and-start-kyma-k3d.sh"
             env:
-              - name: KYMA_MAJOR_VERSION
-                value: "2"
               - name: DEBUG
                 value: "true"
+              - name: KYMA_MAJOR_VERSION
+                value: "2"
             resources:
               requests:
                 memory: 100Mi

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -1448,6 +1448,8 @@ periodics: # runs on schedule
             env:
               - name: KYMA_MAJOR_VERSION
                 value: "2"
+              - name: DEBUG
+                value: "test"
             resources:
               requests:
                 memory: 100Mi

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -1449,7 +1449,7 @@ periodics: # runs on schedule
               - name: KYMA_MAJOR_VERSION
                 value: "2"
               - name: DEBUG
-                value: "test"
+                value: "true"
             resources:
               requests:
                 memory: 100Mi

--- a/templates/data/kyma-integration-data.yaml
+++ b/templates/data/kyma-integration-data.yaml
@@ -762,6 +762,8 @@ templates:
                   cron: "5 * * * *"
                   labels:
                     preset-build-main: "true"
+                  env:
+                    DEBUG: "true"
                 inheritedConfigs:
                   global:
                     - "jobConfig_default"


### PR DESCRIPTION
**Description**
I need to change the logging level on the periodic `kyma-integration-k3d` job because I can not reproduce or trace the error using pjtester.

Changes proposed in this pull request:

- set the environmental variable `DEBUG=true`


**Related issue(s)**
See also [this](https://github.com/kyma-project/kyma/issues/13563) related issue