### PR TITLE
Delete the debug mode on the periodic kyma-integration-k3d job

### DIFF
--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -1446,8 +1446,6 @@ periodics: # runs on schedule
             command:
               - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-and-start-kyma-k3d.sh"
             env:
-              - name: DEBUG
-                value: "true"
               - name: KYMA_MAJOR_VERSION
                 value: "2"
             resources:

--- a/templates/data/kyma-integration-data.yaml
+++ b/templates/data/kyma-integration-data.yaml
@@ -762,8 +762,6 @@ templates:
                   cron: "5 * * * *"
                   labels:
                     preset-build-main: "true"
-                  env:
-                    DEBUG: "true"
                 inheritedConfigs:
                   global:
                     - "jobConfig_default"


### PR DESCRIPTION
**Description**
I no longer need the verbose logging level on the periodic kyma-integration-k3d job.

Changes proposed in this pull request:

- delete the environmental variable `DEBUG=true`
