### PR TITLE
Enable additional plugins for Kyma organizations

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -14,11 +14,6 @@ plugins:
       - shrug
       - invalidcommitmsg
       - help
-  kyma-project/test-infra:
-    plugins:
-      - config-updater
-      - approve
-      - blunderbuss
       - verify-owners
       - owners-label
       - milestone
@@ -27,7 +22,11 @@ plugins:
       - pony
       - lifecycle
       - transfer-issue
-      - project
+  kyma-project/test-infra:
+    plugins:
+      - config-updater
+      - approve
+      - blunderbuss
   kyma-incubator:
     plugins:
       - cat
@@ -43,6 +42,14 @@ plugins:
       - shrug
       - invalidcommitmsg
       - help
+      - verify-owners
+      - owners-label
+      - milestone
+      - override
+      - retitle
+      - pony
+      - lifecycle
+      - transfer-issue
 
 external_plugins:
   kyma-project/test-infra:


### PR DESCRIPTION
This is small feat. which enables some of the plugins we tested on the test-infra for all orgs.This will not affect the usual workflow. Generally these changes allow to add labels based on OWNERS files, use lifecycle plugin which recently had updates to work with stalebot and verify owners files.
