### PR TITLE
Enable approve plugin for kyma-incubator/compass

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -241,8 +241,10 @@ tide:
         - do-not-merge/invalid-commit-message
       orgs:
         - kyma-project
+        - kyma-incubator
       excludedRepos:
         - kyma-project/test-infra # handled in separate query specifically for approve plugin
+        - kyma-incubator/compass # handled in separate query specifically for approve plugin
       reviewApprovedRequired: true
     - labels:
         - lgtm
@@ -256,20 +258,9 @@ tide:
         - do-not-merge/missing-docs-review
       repos:
         - kyma-project/test-infra
-    - labels:
-        - lgtm
-      missingLabels:
-        - needs-rebase
-        - do-not-merge/hold
-        - do-not-merge/work-in-progress
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/invalid-commit-message
-      orgs:
-        - kyma-incubator
-      reviewApprovedRequired: true
+        - kyma-incubator/compass
   context_options:
     from-branch-protection: true
-#    skip-unknown-contexts: true
 
 presets:
   - labels:

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -27,6 +27,10 @@ plugins:
       - config-updater
       - approve
       - blunderbuss
+  kyma-incubator/compass:
+    plugins:
+      - approve
+      - blunderbuss
   kyma-incubator:
     plugins:
       - cat

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -239,8 +239,10 @@ tide:
         - do-not-merge/invalid-commit-message
       orgs:
         - kyma-project
+        - kyma-incubator
       excludedRepos:
         - kyma-project/test-infra # handled in separate query specifically for approve plugin
+        - kyma-incubator/compass # handled in separate query specifically for approve plugin
       reviewApprovedRequired: true
     - labels:
         - lgtm
@@ -254,20 +256,9 @@ tide:
         - do-not-merge/missing-docs-review
       repos:
         - kyma-project/test-infra
-    - labels:
-        - lgtm
-      missingLabels:
-        - needs-rebase
-        - do-not-merge/hold
-        - do-not-merge/work-in-progress
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/invalid-commit-message
-      orgs:
-        - kyma-incubator
-      reviewApprovedRequired: true
+        - kyma-incubator/compass
   context_options:
     from-branch-protection: true
-#    skip-unknown-contexts: true
 
 presets:
   - labels:


### PR DESCRIPTION
Since kyma-incubator/compass already doesn't CODEOWNERS we need to enable Prow approval flow there https://github.com/kyma-incubator/compass/pull/2262. @NickyMateev please confirm.

Additionally I've consolidated 2 redundant queries for the organisations. 

/cc @dekiel