### PR TITLE
Fix istio configuration in kyma GKE RC and long-running clusters

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -162,7 +162,7 @@ function installKyma() {
 			--profile production \
 			--tls-crt "./letsencrypt/live/${DOMAIN}/fullchain.pem" \
 			--tls-key "./letsencrypt/live/${DOMAIN}/privkey.pem" \
-			--value "istio-configuration.components.ingressGateways.config.service.loadBalancerIP=${GATEWAY_IP_ADDRESS}" \
+			--value "istio.components.ingressGateways.config.service.loadBalancerIP=${GATEWAY_IP_ADDRESS}" \
 			--value "global.domainName=${DOMAIN}"
 
 	set +x

--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -158,7 +158,7 @@ installKyma() {
 			--profile production \
 			--tls-crt "./letsencrypt/live/${DOMAIN}/fullchain.pem" \
 			--tls-key "./letsencrypt/live/${DOMAIN}/privkey.pem" \
-			--value "istio-configuration.components.ingressGateways.config.service.loadBalancerIP=${GATEWAY_IP_ADDRESS}" \
+			--value "istio.components.ingressGateways.config.service.loadBalancerIP=${GATEWAY_IP_ADDRESS}" \
 			--value "global.domainName=${DOMAIN}" \
 			--timeout 60m
 

--- a/prow/scripts/cluster-integration/reconciler-component-integration.sh
+++ b/prow/scripts/cluster-integration/reconciler-component-integration.sh
@@ -77,11 +77,7 @@ EOF
 function istio::prepare_components_file() {
   log::info "Preparing Kyma installation with Ory and prerequisites"
 
-  if [[ $KYMA_VERSION == main ]]; then
-    export ISTIO_COMPONENT_NAME="istio"
-  else
-    export ISTIO_COMPONENT_NAME="istio-configuration"
-  fi
+  export ISTIO_COMPONENT_NAME="istio"
 
 cat << EOF > "$PWD/istio.yaml"
 defaultNamespace: kyma-system


### PR DESCRIPTION
In 2.1 Istio-configuration got renamed to just istio, making the current overrides not working anymore for RC and long-running GKE clusters. This PR fixes the logic and makes the overrides working with new naming.

@jeremyharisch please confirm if this behaviour needs to be changed also for reconciler. If not the I will revert the changes in the script.

/kind bug
/assign @jeremyharisch
/hold