### PR TITLE
Cp fix istio pipeline

### DIFF
--- a/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-long-lasting.sh
@@ -162,7 +162,7 @@ function installKyma() {
 			--profile production \
 			--tls-crt "./letsencrypt/live/${DOMAIN}/fullchain.pem" \
 			--tls-key "./letsencrypt/live/${DOMAIN}/privkey.pem" \
-			--value "istio-configuration.components.ingressGateways.config.service.loadBalancerIP=${GATEWAY_IP_ADDRESS}" \
+			--value "istio.components.ingressGateways.config.service.loadBalancerIP=${GATEWAY_IP_ADDRESS}" \
 			--value "global.domainName=${DOMAIN}"
 
 	set +x

--- a/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
+++ b/prow/scripts/cluster-integration/kyma-gke-release-candidate.sh
@@ -158,7 +158,7 @@ installKyma() {
 			--profile production \
 			--tls-crt "./letsencrypt/live/${DOMAIN}/fullchain.pem" \
 			--tls-key "./letsencrypt/live/${DOMAIN}/privkey.pem" \
-			--value "istio-configuration.components.ingressGateways.config.service.loadBalancerIP=${GATEWAY_IP_ADDRESS}" \
+			--value "istio.components.ingressGateways.config.service.loadBalancerIP=${GATEWAY_IP_ADDRESS}" \
 			--value "global.domainName=${DOMAIN}" \
 			--timeout 60m
 

--- a/prow/scripts/cluster-integration/reconciler-component-integration.sh
+++ b/prow/scripts/cluster-integration/reconciler-component-integration.sh
@@ -77,11 +77,7 @@ EOF
 function istio::prepare_components_file() {
   log::info "Preparing Kyma installation with Ory and prerequisites"
 
-  if [[ $KYMA_VERSION == main ]]; then
-    export ISTIO_COMPONENT_NAME="istio"
-  else
-    export ISTIO_COMPONENT_NAME="istio-configuration"
-  fi
+  export ISTIO_COMPONENT_NAME="istio"
 
 cat << EOF > "$PWD/istio.yaml"
 defaultNamespace: kyma-system

--- a/prow/scripts/cluster-integration/reconciler-component-integration.sh
+++ b/prow/scripts/cluster-integration/reconciler-component-integration.sh
@@ -77,7 +77,11 @@ EOF
 function istio::prepare_components_file() {
   log::info "Preparing Kyma installation with Ory and prerequisites"
 
-  export ISTIO_COMPONENT_NAME="istio"
+  if [[ $KYMA_VERSION == main ]]; then
+    export ISTIO_COMPONENT_NAME="istio"
+  else
+    export ISTIO_COMPONENT_NAME="istio-configuration"
+  fi
 
 cat << EOF > "$PWD/istio.yaml"
 defaultNamespace: kyma-system


### PR DESCRIPTION
Since 2.1 `Istio-configuration` is renamed to `Istio`. That broke the overrides in GKE scripts. Cherry-picked fixes from main.

/kind bug
/label tide/merge-method-merge