### PR TITLE
Add `approve` configuration for kyma and compass

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -56,10 +56,20 @@ plugins:
       - transfer-issue
 
 external_plugins:
-  kyma-project/test-infra:
+  kyma-project:
     - name: cla-assistant
       events:
         - issue_comment
+  kyma-incubator:
+    - name: cla-assistant
+      events:
+        - issue_comment
+  kyma-project/test-infra:
+    - name: needs-tws
+      events:
+        - pull_request
+        - pull_request_review
+  kyma-incubator/compass:
     - name: needs-tws
       events:
         - pull_request
@@ -120,6 +130,11 @@ blunderbuss:
 
 approve:
   - repos:
-      - kubernetes/test-infra
+      - kyma-project/test-infra
     require_self_approval: false
+    ignore_review_state: false
+  - repos:
+      - kyma-project/kyma
+      - kyma-incubator/compass
+    require_self_approval: true # ignore authors of the PRs to be able to auto-approve their PR if they are owners
     ignore_review_state: false


### PR DESCRIPTION
`require_self_approval` enforces that the author must explicitly approve their PR. That means if approver of the repo creates a PR their PR will not be auto-approved and would require separate approve from the other approver.