### PR TITLE
Remove obsolete migration script

### DIFF
--- a/prow/scripts/cluster-integration/kyma-upgrade-gardener-kyma2-to-main.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-gardener-kyma2-to-main.sh
@@ -123,9 +123,6 @@ log::info "### Installing Kyma $KYMA_SOURCE"
 kymaMain_install_dir="$KYMA_SOURCES_DIR/kymaMain"
 kyma::deploy_kyma -s "$KYMA_SOURCE" -d "$kymaMain_install_dir" -u "true"
 
-# run migration script
-curl https://raw.githubusercontent.com/kyma-project/kyma/main/docs/assets/2.0-2.1-fix-upgraded-resources.sh | sh
-
 log::info "### Run post-upgrade tests"
 gardener::post_upgrade_test_fast_integration_kyma
 

--- a/prow/scripts/cluster-integration/kyma-upgrade-k3d-kyma2-to-main.sh
+++ b/prow/scripts/cluster-integration/kyma-upgrade-k3d-kyma2-to-main.sh
@@ -89,9 +89,6 @@ function upgrade_kyma() {
     log::info "### Upgrade Kyma to ${KYMA_SOURCE}"
     kyma deploy --ci --source "${KYMA_SOURCE}" --timeout 20m
 
-    # run migration script
-    curl https://raw.githubusercontent.com/kyma-project/kyma/main/docs/assets/2.0-2.1-fix-upgraded-resources.sh | sh
-
     if [[ $? -eq 0 ]];then
         log::success "Upgrade completed"
     else

--- a/prow/scripts/cluster-integration/reconciler-upgrade-kyma2-latest-to-main-gardener.sh
+++ b/prow/scripts/cluster-integration/reconciler-upgrade-kyma2-latest-to-main-gardener.sh
@@ -161,10 +161,6 @@ reconciler::trigger_kyma_reconcile
 # Wait until reconciliation is complete
 reconciler::wait_until_kyma_reconciled
 
-# Execute migration script
-log::banner "Execute migration script 2.0->2.1"
-curl https://raw.githubusercontent.com/kyma-project/kyma/main/docs/assets/2.0-2.1-fix-upgraded-resources.sh | sh
-
 # run the fast integration test after reconciliation
 log::banner "Executing post-upgrade test"
 gardener::post_upgrade_test_fast_integration_kyma


### PR DESCRIPTION
**Description**

Remove obsolete migration script from reconciler pipelines
This script was required for upgrade scenarios between Kyma 2.0 and Kyma 2.1, but the pipelines now install Kyma 2.1 first, and the script is failing, causing entire plan to fail.

Changes proposed in this pull request:

- Remove obsolete migration script from reconciler pipelines

**Links to failed pipelines**
- https://storage.googleapis.com/kyma-prow-logs/logs/kyma-upgrade-gardener-kyma2-to-main-reconciler-main/1508413740670783488/build-log.txt
- https://storage.googleapis.com/kyma-prow-logs/logs/kyma-upgrade-k3d-kyma2-to-main/1508413740792418304/build-log.txt