### PR TITLE
Add a prow-job to run JetStream E2E fast integration tests

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1240,9 +1240,3 @@ presets:
         value: "https://mothership-reconciler.cp.dev.kyma.cloud.sap/v1"
       - name: KCP_OIDC_ISSUER_URL
         value: "https://kymatest.accounts400.ondemand.com"
-  - labels:
-      # Allows setting the feature flag in Eventing Charts to enable the NATS JetStream Backend.
-      preset-eventing-enable-jetstream: "true"
-    env:
-      - name: EVENTING_ENABLE_JETSTREAM
-        value: "true"

--- a/prow/jobs/kyma/kyma-integration-gardener.yaml
+++ b/prow/jobs/kyma/kyma-integration-gardener.yaml
@@ -300,6 +300,83 @@ presubmits: # runs on PRs
           - name: kyma-tunas-prow-event-mesh
             secret:
               secretName: kyma-tunas-prow-event-mesh
+    - name: pre-main-kyma-gardener-gcp-eventing-js
+      annotations:
+        pipeline.clusterprovisioning: "kyma cli"
+        pipeline.installer: "kyma deploy"
+        pipeline.platform: "gardener_gcp"
+        pipeline.test: "fast-integration"
+        pipeline.trigger: "pr-submit"
+      labels:
+        prow.k8s.io/pubsub.project: "sap-kyma-prow"
+        prow.k8s.io/pubsub.runID: "pre-main-kyma-gardener-gcp-eventing-js"
+        prow.k8s.io/pubsub.topic: "prowjobs"
+        preset-build-pr: "true"
+        preset-cluster-version: "true"
+        preset-debug-commando-oom: "true"
+        preset-gardener-gcp-kyma-integration: "true"
+        preset-kyma-cli-stable: "true"
+      run_if_changed: '^((tests/fast-integration\S+|resources/eventing\S+)(\.[^.][^.][^.]+$|\.[^.][^dD]$|\.[^mM][^.]$|\.[^.]$|/[^.]+$))'
+      optional: true
+      skip_report: false
+      decorate: true
+      decoration_config:
+        grace_period: 600000000000
+        timeout: 14400000000000
+      path_alias: github.com/kyma-project/kyma
+      cluster: untrusted-workload
+      max_concurrency: 10
+      branches:
+        - ^master$
+        - ^main$
+      extra_refs:
+        - org: kyma-project
+          repo: test-infra
+          path_alias: github.com/kyma-project/test-infra
+          base_ref: main
+      spec:
+        containers:
+          - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20220411-a5159710"
+            securityContext:
+              privileged: true
+            command:
+              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/kyma-integration-gardener-eventing.sh"
+            env:
+              - name: BACKEND
+                value: "nats_jetstream"
+              - name: CREDENTIALS_DIR
+                value: "/etc/credentials/kyma-tunas-prow-event-mesh"
+              - name: EXECUTION_PROFILE
+                value: "evaluation"
+              - name: GARDENER_REGION
+                value: "europe-west4"
+              - name: GARDENER_ZONES
+                value: "europe-west4-b"
+              - name: KYMA_MAJOR_VERSION
+                value: "2"
+              - name: KYMA_PROJECT_DIR
+                value: "/home/prow/go/src/github.com/kyma-project"
+              - name: STORAGE
+                value: "file"
+            resources:
+              requests:
+                memory: 1Gi
+                cpu: 400m
+            volumeMounts:
+              - name: kyma-tunas-prow-event-mesh
+                mountPath: /etc/credentials/kyma-tunas-prow-event-mesh
+                readOnly: true
+        tolerations:
+          - key: dedicated
+            operator: Equal
+            value: high-cpu
+            effect: NoSchedule
+        nodeSelector:
+            dedicated: "high-cpu"
+        volumes:
+          - name: kyma-tunas-prow-event-mesh
+            secret:
+              secretName: kyma-tunas-prow-event-mesh
     - name: pre-main-kyma-skr-eventing
       annotations:
         pipeline.clusterprovisioning: "keb"

--- a/prow/scripts/lib/gardener/gcp.sh
+++ b/prow/scripts/lib/gardener/gcp.sh
@@ -137,15 +137,7 @@ gardener::install_kyma() {
 }
 
 gardener::deploy_kyma() {
-    (
-    set -x
-    if [[ $EVENTING_ENABLE_JETSTREAM == "true" ]]; then
-      log::info "### JetStream feature flag set to true"
-      kyma deploy --ci --timeout 90m --value global.features.enableJetStream=true "$@"
-    else
-      kyma deploy --ci --timeout 90m "$@"
-    fi
-    )
+    kyma deploy --ci --timeout 90m "$@"
 }
 
 gardener::hibernate_kyma() {

--- a/templates/data/kyma-integration-gardener-data.yaml
+++ b/templates/data/kyma-integration-gardener-data.yaml
@@ -298,6 +298,36 @@ templates:
                     - gardener_gcp_job_eventing
                     - command_integration_eventing
               - jobConfig:
+                  name: pre-main-kyma-gardener-gcp-eventing-js
+                  optional: true
+                  decoration_config:
+                    timeout: 14400000000000 # 4h
+                    grace_period: 600000000000 # 10min
+                  run_if_changed: "^((tests/fast-integration\\S+|resources/eventing\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
+                  env:
+                    EXECUTION_PROFILE: "evaluation"
+                    BACKEND: "nats_jetstream"
+                    STORAGE: "file"
+                  volumes:
+                    - name: kyma-tunas-prow-event-mesh
+                      secretName: kyma-tunas-prow-event-mesh
+                  volumeMounts:
+                    - name: kyma-tunas-prow-event-mesh
+                      mountPath: /etc/credentials/kyma-tunas-prow-event-mesh
+                      readOnly: true
+                inheritedConfigs:
+                  global:
+                    - jobConfig_default
+                    - jobConfig_presubmit
+                    - extra_refs_test-infra
+                    - image_kyma-integration
+                    - kyma_major_version_2
+                  local:
+                    - jobConfig_default
+                    - jobConfig_presubmit
+                    - gardener_gcp_job_eventing
+                    - command_integration_eventing
+              - jobConfig:
                   name: pre-main-kyma-skr-eventing
                   # temporarily make the job optional
                   optional: true

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -1238,9 +1238,3 @@ presets:
         value: "https://mothership-reconciler.cp.dev.kyma.cloud.sap/v1"
       - name: KCP_OIDC_ISSUER_URL
         value: "https://kymatest.accounts400.ondemand.com"
-  - labels:
-      # Allows setting the feature flag in Eventing Charts to enable the NATS JetStream Backend.
-      preset-eventing-enable-jetstream: "true"
-    env:
-      - name: EVENTING_ENABLE_JETSTREAM
-        value: "true"

--- a/test-inventory-integration.md
+++ b/test-inventory-integration.md
@@ -30,6 +30,7 @@
 | post-main-kyma-gardener-azure-alpha-eval | gardener_azure | kyma cli | kyma deploy | evaluation | pr-merge |  fast-integration  |
 | post-main-kyma-gardener-azure-alpha-prod | gardener_azure | kyma cli | kyma deploy | production | pr-merge |  fast-integration  |
 | pre-main-kyma-gardener-gcp-eventing | gardener_gcp | kyma cli | kyma deploy |  | pr-submit |  fast-integration  |
+| pre-main-kyma-gardener-gcp-eventing-js | gardener_gcp | kyma cli | kyma deploy |  | pr-submit |  fast-integration  |
 | pre-main-kyma-skr-eventing | gardener_aws | keb | keb |  | pr-submit |  fast-integration  |
 | pre-main-kyma-gardener-gcp-eventing-upgrade | gardener_gcp | kyma cli | kyma deploy |  | pr-submit |  fast-integration  |
 | kyma-alpha-integration-evaluation-gardener-azure | gardener_azure | kyma cli | kyma deploy | evaluation | periodic |  fast-integration  |

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,6 +1,0 @@
-pjNames:
-  - pjName: "pre-main-kyma-gardener-gcp-eventing-js"
-prConfigs:
-  kyma-project:
-    kyma:
-      prNumber: 13779

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,6 @@
+pjNames:
+  - pjName: "pre-main-kyma-gardener-gcp-eventing-js"
+prConfigs:
+  kyma-project:
+    kyma:
+      prNumber: 13779


### PR DESCRIPTION
**Description**

Add a prow-job to run JetStream E2E fast integration tests.

**Successful runs**

- https://status.build.kyma-project.io/view/gs/kyma-prow-logs/pr-logs/pull/kyma-project_kyma/13779/marcobebway_test_of_prowjob_pre-main-kyma-gardener-gcp-eventing/1513920647124750336
- https://status.build.kyma-project.io/view/gs/kyma-prow-logs/pr-logs/pull/kyma-project_kyma/13779/marcobebway_test_of_prowjob_pre-main-kyma-gardener-gcp-eventing/1513910509819138048

**Related issue(s)**

- https://github.com/kyma-project/kyma/issues/13739
- https://github.com/kyma-project/kyma/pull/13779