### PR TITLE
Enable approve for kyma-project/kyma

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -35,6 +35,10 @@ plugins:
     plugins:
       - approve
       - blunderbuss
+  kyma-project/kyma:
+    plugins:
+      - approve
+      - blunderbuss
   kyma-project/cli:
     plugins:
       - approve


### PR DESCRIPTION
Forgot to add actual approve and blunderbuss plugins to kyma