### PR TITLE
Increase timeout for protecode guard

### DIFF
--- a/prow/scripts/cluster-integration/protecode-guard.sh
+++ b/prow/scripts/cluster-integration/protecode-guard.sh
@@ -67,7 +67,7 @@ do
         fi
     fi
 
-    sleep 15
+    sleep 30
 done
 
 log::error "Timeout reached - job failed"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Right now the `protecode-guard` pipeline is often failing because of timeout ([example](https://status.build.kyma-project.io/view/gs/kyma-prow-logs/pr-logs/pull/kyma-project_kyma/13708/pre-main-kyma-protecode-guard/1509480329897840640)) to avoid situations like this, I'd like to propose increasing the timeout.