### PR TITLE
Bumped NATS prometheus exporter image 0.9.0 on image-syncer

### DIFF
--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -49,5 +49,5 @@ images:
 - source: "natsio/nats-server-config-reloader:0.6.3"
 - source: "natsio/prometheus-nats-exporter:0.9.1"
 - source: "natsio/prometheus-nats-exporter@sha256:3392c3852e2c10070157eb0550e45bd102a999eabd241a720350eda0063260fc"
-  tag: "0.9.0"
+  tag: "0.9.0-2022-04-07"
 - source: "mockserver/mockserver:mockserver-5.11.2"

--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -48,4 +48,6 @@ images:
   tag: "2.7.4-alpine-2022-04-05"
 - source: "natsio/nats-server-config-reloader:0.6.3"
 - source: "natsio/prometheus-nats-exporter:0.9.1"
+- source: "natsio/prometheus-nats-exporter@sha256:3392c3852e2c10070157eb0550e45bd102a999eabd241a720350eda0063260fc"
+  tag: "0.9.0"
 - source: "mockserver/mockserver:mockserver-5.11.2"

--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -47,7 +47,6 @@ images:
 - source: "nats@sha256:bed4f10253c279b665399962dd8a61466115c3e1e9acd74470e29f955c4dc923"
   tag: "2.7.4-alpine-2022-04-05"
 - source: "natsio/nats-server-config-reloader:0.6.3"
-- source: "natsio/prometheus-nats-exporter:0.9.1"
 - source: "natsio/prometheus-nats-exporter@sha256:3392c3852e2c10070157eb0550e45bd102a999eabd241a720350eda0063260fc"
   tag: "0.9.0-2022-04-07"
 - source: "mockserver/mockserver:mockserver-5.11.2"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Bumped NATS prometheus exporter image 0.9.0 to a specific SHA.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
