### PR TITLE
Fix missing tide queries

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -267,9 +267,13 @@ tide:
         - do-not-merge/work-in-progress
         - do-not-merge/invalid-owners-file
         - do-not-merge/invalid-commit-message
-      orgs:
-        - kyma-incubator
-      reviewApprovedRequired: true
+        - do-not-merge/missing-docs-review
+      repos:
+        - kyma-project/test-infra
+        - kyma-project/third-party-images
+        - kyma-project/cli
+        - kyma-project/kyma
+        - kyma-incubator/compass
     - author: kyma-bot
       labels:
         - skip-review

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -265,9 +265,13 @@ tide:
         - do-not-merge/work-in-progress
         - do-not-merge/invalid-owners-file
         - do-not-merge/invalid-commit-message
-      orgs:
-        - kyma-incubator
-      reviewApprovedRequired: true
+        - do-not-merge/missing-docs-review
+      repos:
+        - kyma-project/test-infra
+        - kyma-project/third-party-images
+        - kyma-project/cli
+        - kyma-project/kyma
+        - kyma-incubator/compass
     - author: kyma-bot
       labels:
         - skip-review


### PR DESCRIPTION
We need to have 2 default queries in Tide:
```
    - labels:
        - lgtm
      missingLabels:
        - needs-rebase
        - do-not-merge/hold
        - do-not-merge/work-in-progress
        - do-not-merge/invalid-owners-file
        - do-not-merge/invalid-commit-message
      orgs:
        - kyma-project
        - kyma-incubator
      excludedRepos:
        - kyma-project/test-infra # handled in separate query specifically for approve plugin
        - kyma-project/third-party-images
        - kyma-project/cli
        - kyma-project/kyma
        - kyma-incubator/compass # handled in separate query specifically for approve plugin
      reviewApprovedRequired: true
    - labels:
        - lgtm
        - approved
      missingLabels:
        - needs-rebase
        - do-not-merge/hold
        - do-not-merge/work-in-progress
        - do-not-merge/invalid-owners-file
        - do-not-merge/invalid-commit-message
        - do-not-merge/missing-docs-review
      repos:
        - kyma-project/test-infra
        - kyma-project/third-party-images
        - kyma-project/cli
        - kyma-project/kyma
        - kyma-incubator/compass
```

THis PR fixes the merge changes which got incorrectly added in #4730