### PR TITLE
Add file name to rendertemplates YAML parsing error message

### DIFF
--- a/development/tools/cmd/rendertemplates/main.go
+++ b/development/tools/cmd/rendertemplates/main.go
@@ -98,7 +98,7 @@ func main() {
 				log.Fatalf("Cannot render data template: %v", err)
 			}
 			if err := yaml.Unmarshal(cfg.Bytes(), &dataFileConfig); err != nil {
-				log.Fatalf("Cannot parse data file yaml: %s\n", err)
+				log.Fatalf("Cannot parse data file %s%s: %s\n", dataFilesDir, dataFile, err)
 			}
 			dataFilesTemplates = append(dataFilesTemplates, dataFileConfig.Templates...)
 		}


### PR DESCRIPTION
**Description**

Fix for #5260 

Changes proposed in this pull request:

- Add file name to rendertemplates YAML parsing error message

**Related issue(s)**
#5260 