### PR TITLE
pre-main-reconciler-integration-k3d trigger on go.mod or go.sum changes

### DIFF
--- a/development/tools/jobs/incubator/reconciler/reconciler_test.go
+++ b/development/tools/jobs/incubator/reconciler/reconciler_test.go
@@ -70,7 +70,7 @@ func TestReconcilerMainIntegrationJobsPresubmit(t *testing.T) {
 	assert.False(t, actualPresubmit.SkipReport)
 	assert.False(t, actualPresubmit.Optional)
 	assert.False(t, actualPresubmit.AlwaysRun)
-	assert.Equal(t, actualPresubmit.RunIfChanged, "^((cmd\\S+|configs\\S+|internal\\S+|pkg\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))")
+	assert.Equal(t, actualPresubmit.RunIfChanged, "^(go.mod$|go.sum$)|((cmd\\S+|configs\\S+|internal\\S+|pkg\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))")
 	tester.AssertThatHasExtraRefTestInfra(t, actualPresubmit.JobBase.UtilityConfig, "main")
 	assert.Equal(t, tester.ImageKymaIntegrationLatest, actualPresubmit.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/provision-vm-and-start-reconciler-k3d.sh"}, actualPresubmit.Spec.Containers[0].Command)

--- a/prow/jobs/incubator/reconciler/reconciler.yaml
+++ b/prow/jobs/incubator/reconciler/reconciler.yaml
@@ -15,7 +15,7 @@ presubmits: # runs on PRs
         preset-gc-project-env: "true"
         preset-kyma-guard-bot-github-token: "true"
         preset-sa-vm-kyma-integration: "true"
-      run_if_changed: '^((cmd\S+|configs\S+|internal\S+|pkg\S+)(\.[^.][^.][^.]+$|\.[^.][^dD]$|\.[^mM][^.]$|\.[^.]$|/[^.]+$))'
+      run_if_changed: '^(go.mod$|go.sum$)|((cmd\S+|configs\S+|internal\S+|pkg\S+)(\.[^.][^.][^.]+$|\.[^.][^dD]$|\.[^mM][^.]$|\.[^.]$|/[^.]+$))'
       skip_report: false
       decorate: true
       cluster: untrusted-workload

--- a/templates/data/incubator-buildpack-data.yaml
+++ b/templates/data/incubator-buildpack-data.yaml
@@ -313,7 +313,7 @@ templates:
               - jobConfig:
                   name: "pre-main-reconciler-integration-k3d"
                   # following regexp won't start build if only Markdown files were changed
-                  run_if_changed: "^((cmd\\S+|configs\\S+|internal\\S+|pkg\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
+                  run_if_changed: "^(go.mod$|go.sum$)|((cmd\\S+|configs\\S+|internal\\S+|pkg\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
                   labels:
                     preset-build-pr: "true"
                     preset-kyma-guard-bot-github-token: "true"


### PR DESCRIPTION
**Description**
fixes #5263 

Changes proposed in this pull request:

- The `pre-main-reconciler-integration-k3d` job should run when the go.mod or go.sum files change.

**Related issue(s)**
#5263 