### PR TITLE
Fix a broken anchor to GitHub documentation on creating a release

### DIFF
--- a/development/tools/cmd/githubrelease/README.md
+++ b/development/tools/cmd/githubrelease/README.md
@@ -27,7 +27,7 @@ See the list of available flags:
 
 | Name                             | Required | Description                                                                                          |
 | :-----------------------------   | :------: | :--------------------------------------------------------------------------------------------------- |
-| **--targetCommit**               |   Yes    | The string which specifies the [commitish value](https://docs.github.com/en/rest/reference/releases#create-a-release) that the GitHub tag refers to.
+| **--targetCommit**               |   Yes    | The string which specifies the [commitish value](https://docs.github.com/en/rest/releases/releases#create-a-release) that the GitHub tag refers to.
 | **--bucketName**                 |    No    | The string value with the name of the Google bucket containing release artifacts. It defaults to `kyma-prow-artifacts`.
 | **--kymaInstallerCRCluster**     |    No    | The string value with the name of the file with list of components installed by the installer for cluster. It defaults to `kyma-installer-cr-cluster.yaml`.
 | **--kymaConfigLocal**            |    No    | The string value with the name of the Kyma local configuration file. It defaults to `kyma-config-local.yaml`.


### PR DESCRIPTION
**Description**

Our [governance job](https://status.build.kyma-project.io/view/gs/kyma-prow-logs/logs/test-infra-governance-nightly/1517005402045157376) detected a broken anchor in a link to GitHub documentation on creating a release. This PR is fixing the link. 

Changes proposed in this pull request:

- Fix a broken anchor to GitHub documentation on creating a release in the [README](https://github.com/kyma-project/test-infra/blob/main/development/tools/cmd/githubrelease/README.md).

**Related issue(s)**
https://status.build.kyma-project.io/view/gs/kyma-prow-logs/logs/test-infra-governance-nightly/1517005402045157376