### PR TITLE
Disable automerging without review

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -274,38 +274,6 @@ tide:
         - kyma-project/cli
         - kyma-project/kyma
         - kyma-incubator/compass
-    - author: kyma-bot
-      labels:
-        - skip-review
-      missingLabels:
-        - needs-rebase
-        - do-not-merge/hold
-        - do-not-merge/work-in-progress
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/invalid-commit-message
-        - do-not-merge/missing-docs-review
-      repos:
-        - kyma-project/test-infra
-        - kyma-project/third-party-images
-        - kyma-project/cli
-        - kyma-project/kyma
-        - kyma-incubator/compass
-    - author: dependabot[bot]
-      labels:
-        - skip-review
-      missingLabels:
-        - needs-rebase
-        - do-not-merge/hold
-        - do-not-merge/work-in-progress
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/invalid-commit-message
-        - do-not-merge/missing-docs-review
-      repos:
-        - kyma-project/test-infra
-        - kyma-project/third-party-images
-        - kyma-project/cli
-        - kyma-project/kyma
-        - kyma-incubator/compass
   context_options:
     from-branch-protection: true
 

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -272,38 +272,6 @@ tide:
         - kyma-project/cli
         - kyma-project/kyma
         - kyma-incubator/compass
-    - author: kyma-bot
-      labels:
-        - skip-review
-      missingLabels:
-        - needs-rebase
-        - do-not-merge/hold
-        - do-not-merge/work-in-progress
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/invalid-commit-message
-        - do-not-merge/missing-docs-review
-      repos:
-        - kyma-project/test-infra
-        - kyma-project/third-party-images
-        - kyma-project/cli
-        - kyma-project/kyma
-        - kyma-incubator/compass
-    - author: dependabot[bot]
-      labels:
-        - skip-review
-      missingLabels:
-        - needs-rebase
-        - do-not-merge/hold
-        - do-not-merge/work-in-progress
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/invalid-commit-message
-        - do-not-merge/missing-docs-review
-      repos:
-        - kyma-project/test-infra
-        - kyma-project/third-party-images
-        - kyma-project/cli
-        - kyma-project/kyma
-        - kyma-incubator/compass
   context_options:
     from-branch-protection: true
 


### PR DESCRIPTION
Auto merging without human review for bots must be disabled. This feature together with write access would allow anyone in organisation to push changes without review.

Parent: #5312