### PR TITLE
Revert prow approval flow in compass

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -256,7 +256,6 @@ tide:
         - kyma-project/third-party-images
         - kyma-project/cli
         - kyma-project/kyma
-        - kyma-incubator/compass # handled in separate query specifically for approve plugin
       reviewApprovedRequired: true
     - labels:
         - lgtm
@@ -273,7 +272,6 @@ tide:
         - kyma-project/third-party-images
         - kyma-project/cli
         - kyma-project/kyma
-        - kyma-incubator/compass
     - author: kyma-bot
       labels:
         - skip-review

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -27,10 +27,6 @@ plugins:
       - config-updater
       - approve
       - blunderbuss
-  kyma-incubator/compass:
-    plugins:
-      - approve
-      - blunderbuss
   kyma-project/third-party-images:
     plugins:
       - approve
@@ -92,11 +88,6 @@ external_plugins:
         - pull_request
         - pull_request_review
   kyma-project/cli:
-    - name: needs-tws
-      events:
-        - pull_request
-        - pull_request_review
-  kyma-incubator/compass:
     - name: needs-tws
       events:
         - pull_request
@@ -167,7 +158,6 @@ approve:
     ignore_review_state: false
   - repos:
       - kyma-project/kyma
-      - kyma-incubator/compass
       - kyma-project/cli
     require_self_approval: true # ignore authors of the PRs to be able to auto-approve their PR if they are owners
     ignore_review_state: false

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -254,7 +254,6 @@ tide:
         - kyma-project/third-party-images
         - kyma-project/cli
         - kyma-project/kyma
-        - kyma-incubator/compass # handled in separate query specifically for approve plugin
       reviewApprovedRequired: true
     - labels:
         - lgtm
@@ -271,7 +270,6 @@ tide:
         - kyma-project/third-party-images
         - kyma-project/cli
         - kyma-project/kyma
-        - kyma-incubator/compass
     - author: kyma-bot
       labels:
         - skip-review


### PR DESCRIPTION
Removed settings for prow approval flow in kyma repository.

See: #5314