### PR TITLE
Revert prow approval flow in test-infra

### DIFF
--- a/development/tools/jobs/testinfra/branchprotector_test.go
+++ b/development/tools/jobs/testinfra/branchprotector_test.go
@@ -25,7 +25,7 @@ func TestBranchProtection(t *testing.T) {
 		approvals    int
 	}{
 		{"kyma-project", "kyma", "main", []string{"license/cla", "tide"}, 0},
-		{"kyma-project", "test-infra", "main", []string{"license/cla", "tide"}, 0},
+		{"kyma-project", "test-infra", "main", []string{"license/cla", "tide"}, 1},
 		{"kyma-project", "website", "main", []string{"license/cla", "netlify/kyma-project/deploy-preview", "tide"}, 1},
 		{"kyma-project", "website", "archive-snapshots", []string{"license/cla", "netlify/kyma-project-old/deploy-preview", "tide"}, 1},
 		{"kyma-project", "community", "main", []string{"license/cla", "tide"}, 1},

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -237,7 +237,6 @@ tide:
         - kyma-project
         - kyma-incubator
       excludedRepos:
-        - kyma-project/test-infra # handled in separate query specifically for approve plugin
         - kyma-project/kyma
         - kyma-incubator/compass # handled in separate query specifically for approve plugin
       reviewApprovedRequired: true
@@ -252,7 +251,6 @@ tide:
         - do-not-merge/invalid-commit-message
         - do-not-merge/missing-docs-review
       repos:
-        - kyma-project/test-infra
         - kyma-project/kyma
         - kyma-incubator/compass
   context_options:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -108,11 +108,6 @@ branch-protection:
       exclude:
         - "^dependabot/"
       repos:
-        test-infra:
-          required_pull_request_reviews:
-            dismiss_stale_reviews: false
-            require_code_owner_reviews: false
-            required_approving_review_count: 0
         kyma:
           required_pull_request_reviews:
             dismiss_stale_reviews: false
@@ -252,7 +247,6 @@ tide:
         - kyma-project
         - kyma-incubator
       excludedRepos:
-        - kyma-project/test-infra # handled in separate query specifically for approve plugin
         - kyma-project/third-party-images
         - kyma-project/cli
         - kyma-project/kyma
@@ -269,7 +263,6 @@ tide:
         - do-not-merge/invalid-commit-message
         - do-not-merge/missing-docs-review
       repos:
-        - kyma-project/test-infra
         - kyma-project/third-party-images
         - kyma-project/cli
         - kyma-project/kyma

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -25,8 +25,6 @@ plugins:
   kyma-project/test-infra:
     plugins:
       - config-updater
-      - approve
-      - blunderbuss
   kyma-incubator/compass:
     plugins:
       - approve
@@ -76,11 +74,6 @@ external_plugins:
     - name: cla-assistant
       events:
         - issue_comment
-  kyma-project/test-infra:
-    - name: needs-tws
-      events:
-        - pull_request
-        - pull_request_review
   kyma-project/kyma:
     - name: needs-tws
       events:
@@ -161,7 +154,6 @@ blunderbuss:
 
 approve:
   - repos:
-      - kyma-project/test-infra
       - kyma-project/third-party-images
     require_self_approval: false
     ignore_review_state: false

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -132,10 +132,6 @@ blunderbuss:
 
 approve:
   - repos:
-      - kyma-project/test-infra
-    require_self_approval: false
-    ignore_review_state: false
-  - repos:
       - kyma-project/kyma
       - kyma-incubator/compass
     require_self_approval: true # ignore authors of the PRs to be able to auto-approve their PR if they are owners

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -235,7 +235,6 @@ tide:
         - kyma-project
         - kyma-incubator
       excludedRepos:
-        - kyma-project/test-infra # handled in separate query specifically for approve plugin
         - kyma-project/kyma
         - kyma-incubator/compass # handled in separate query specifically for approve plugin
       reviewApprovedRequired: true
@@ -250,7 +249,6 @@ tide:
         - do-not-merge/invalid-commit-message
         - do-not-merge/missing-docs-review
       repos:
-        - kyma-project/test-infra
         - kyma-project/kyma
         - kyma-incubator/compass
   context_options:

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -106,11 +106,6 @@ branch-protection:
       exclude:
         - "^dependabot/"
       repos:
-        test-infra:
-          required_pull_request_reviews:
-            dismiss_stale_reviews: false
-            require_code_owner_reviews: false
-            required_approving_review_count: 0
         kyma:
           required_pull_request_reviews:
             dismiss_stale_reviews: false
@@ -250,7 +245,6 @@ tide:
         - kyma-project
         - kyma-incubator
       excludedRepos:
-        - kyma-project/test-infra # handled in separate query specifically for approve plugin
         - kyma-project/third-party-images
         - kyma-project/cli
         - kyma-project/kyma
@@ -267,7 +261,6 @@ tide:
         - do-not-merge/invalid-commit-message
         - do-not-merge/missing-docs-review
       repos:
-        - kyma-project/test-infra
         - kyma-project/third-party-images
         - kyma-project/cli
         - kyma-project/kyma


### PR DESCRIPTION
Removed settings for prow approval flow in kyma repository.

See: #5323