### PR TITLE
Revert prow approval flow in third-party-images

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -118,11 +118,6 @@ branch-protection:
             dismiss_stale_reviews: false
             require_code_owner_reviews: false
             required_approving_review_count: 0
-        third-party-images:
-          required_pull_request_reviews:
-            dismiss_stale_reviews: false
-            require_code_owner_reviews: false
-            required_approving_review_count: 0
         website:
           branches:
             main:
@@ -248,7 +243,6 @@ tide:
         - kyma-incubator
       excludedRepos:
         - kyma-project/test-infra # handled in separate query specifically for approve plugin
-        - kyma-project/third-party-images
         - kyma-project/kyma
         - kyma-incubator/compass # handled in separate query specifically for approve plugin
       reviewApprovedRequired: true
@@ -264,7 +258,6 @@ tide:
         - do-not-merge/missing-docs-review
       repos:
         - kyma-project/test-infra
-        - kyma-project/third-party-images
         - kyma-project/kyma
         - kyma-incubator/compass
   context_options:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -123,11 +123,6 @@ branch-protection:
             dismiss_stale_reviews: false
             require_code_owner_reviews: false
             required_approving_review_count: 0
-        third-party-images:
-          required_pull_request_reviews:
-            dismiss_stale_reviews: false
-            require_code_owner_reviews: false
-            required_approving_review_count: 0
         website:
           branches:
             main:
@@ -253,7 +248,6 @@ tide:
         - kyma-incubator
       excludedRepos:
         - kyma-project/test-infra # handled in separate query specifically for approve plugin
-        - kyma-project/third-party-images
         - kyma-project/cli
         - kyma-project/kyma
         - kyma-incubator/compass # handled in separate query specifically for approve plugin
@@ -270,7 +264,6 @@ tide:
         - do-not-merge/missing-docs-review
       repos:
         - kyma-project/test-infra
-        - kyma-project/third-party-images
         - kyma-project/cli
         - kyma-project/kyma
         - kyma-incubator/compass

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -78,20 +78,11 @@ external_plugins:
       events:
         - pull_request
         - pull_request_review
-  kyma-project/third-party-images:
-    - name: needs-tws
-      events:
-        - pull_request
-        - pull_request_review
   kyma-incubator/compass:
     - name: needs-tws
       events:
         - pull_request
         - pull_request_review
-  kyma-project:
-    - name: automerge-notification
-      events:
-        - pull_request
 
 config_updater:
   maps:

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -31,10 +31,6 @@ plugins:
     plugins:
       - approve
       - blunderbuss
-  kyma-project/third-party-images:
-    plugins:
-      - approve
-      - blunderbuss
   kyma-project/kyma:
     plugins:
       - approve
@@ -82,11 +78,6 @@ external_plugins:
         - pull_request
         - pull_request_review
   kyma-project/kyma:
-    - name: needs-tws
-      events:
-        - pull_request
-        - pull_request_review
-  kyma-project/third-party-images:
     - name: needs-tws
       events:
         - pull_request
@@ -162,7 +153,6 @@ blunderbuss:
 approve:
   - repos:
       - kyma-project/test-infra
-      - kyma-project/third-party-images
     require_self_approval: false
     ignore_review_state: false
   - repos:

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -121,11 +121,6 @@ branch-protection:
             dismiss_stale_reviews: false
             require_code_owner_reviews: false
             required_approving_review_count: 0
-        third-party-images:
-          required_pull_request_reviews:
-            dismiss_stale_reviews: false
-            require_code_owner_reviews: false
-            required_approving_review_count: 0
         website:
           branches:
             main:
@@ -251,7 +246,6 @@ tide:
         - kyma-incubator
       excludedRepos:
         - kyma-project/test-infra # handled in separate query specifically for approve plugin
-        - kyma-project/third-party-images
         - kyma-project/cli
         - kyma-project/kyma
         - kyma-incubator/compass # handled in separate query specifically for approve plugin
@@ -268,7 +262,6 @@ tide:
         - do-not-merge/missing-docs-review
       repos:
         - kyma-project/test-infra
-        - kyma-project/third-party-images
         - kyma-project/cli
         - kyma-project/kyma
         - kyma-incubator/compass

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -116,11 +116,6 @@ branch-protection:
             dismiss_stale_reviews: false
             require_code_owner_reviews: false
             required_approving_review_count: 0
-        third-party-images:
-          required_pull_request_reviews:
-            dismiss_stale_reviews: false
-            require_code_owner_reviews: false
-            required_approving_review_count: 0
         website:
           branches:
             main:
@@ -246,7 +241,6 @@ tide:
         - kyma-incubator
       excludedRepos:
         - kyma-project/test-infra # handled in separate query specifically for approve plugin
-        - kyma-project/third-party-images
         - kyma-project/kyma
         - kyma-incubator/compass # handled in separate query specifically for approve plugin
       reviewApprovedRequired: true
@@ -262,7 +256,6 @@ tide:
         - do-not-merge/missing-docs-review
       repos:
         - kyma-project/test-infra
-        - kyma-project/third-party-images
         - kyma-project/kyma
         - kyma-incubator/compass
   context_options:


### PR DESCRIPTION
Removed settings for prow approval flow in kyma repository.

See: #5324