### PR TITLE
fix cleanup for pre-main-control-plane-reconciler-e2e

### DIFF
--- a/prow/scripts/cluster-integration/reconciler-e2e-gardener.sh
+++ b/prow/scripts/cluster-integration/reconciler-e2e-gardener.sh
@@ -82,6 +82,8 @@ readonly COMMON_NAME_PREFIX="grd"
 utils::generate_commonName -n "${COMMON_NAME_PREFIX}"
 
 export INPUT_CLUSTER_NAME="${utils_generate_commonName_return_commonName:?}"
+# This is needed for the gardener::cleanup function
+export CLUSTER_NAME="${INPUT_CLUSTER_NAME}"
 
 # set Kyma version to reconcile
 if [[ $KYMA_TEST_SOURCE == "latest-release" ]]; then

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,2 +1,0 @@
-pjNames:
-  - pjName: pre-main-control-plane-reconciler-e2e

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,2 @@
+pjNames:
+  - pjName: pre-main-control-plane-reconciler-e2e


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- create a new variable based on cluster name for access in the cleanup script

**Related issue(s)**

- relates to a change made in https://github.com/kyma-project/test-infra/pull/5332 which enables the actual cleanup
- part of https://github.com/kyma-project/kyma/issues/13855
