### PR TITLE
Run kyma-integration-k3d-telemetry jobs if chart or crds changed

### DIFF
--- a/development/tools/jobs/kyma/kyma_integration_test.go
+++ b/development/tools/jobs/kyma/kyma_integration_test.go
@@ -76,13 +76,13 @@ func TestKymaIntegrationJobsPresubmit(t *testing.T) {
 				preset.GCProjectEnv, preset.KymaGuardBotGithubToken, preset.BuildPr, "preset-sa-vm-kyma-integration", "preset-kyma-integration-telemetry-enabled",
 			},
 
-			expRunIfChangedRegex: "^components/telemetry-operator/|^resources/telemetry/",
+			expRunIfChangedRegex: "^resources/telemetry/",
 			expRunIfChangedPaths: []string{
-				"components/telemetry-operator/main.go",
 				"resources/telemetry/charts/operator/values.yaml",
 				"resources/telemetry/charts/fluent-bit/values.yaml",
 			},
 			expNotRunIfChangedPaths: []string{
+				"components/telemetry-operator/main.go",
 				"installation/README.md",
 				"installation/test/test/README.MD",
 			},
@@ -151,7 +151,7 @@ func TestKymaIntegrationJobsPostsubmit(t *testing.T) {
 		},
 		"Should contain the kyma-integration k3d with telemetry job": {
 			givenJobName: "post-main-kyma-integration-k3d-telemetry",
-			runIfChanged: "^components/telemetry-operator/|^resources/telemetry/",
+			runIfChanged: "^resources/telemetry/",
 
 			expPresets: []preset.Preset{
 				preset.GCProjectEnv, preset.KymaGuardBotGithubToken, "preset-sa-vm-kyma-integration", "preset-kyma-integration-telemetry-enabled",

--- a/development/tools/jobs/kyma/kyma_integration_test.go
+++ b/development/tools/jobs/kyma/kyma_integration_test.go
@@ -76,10 +76,11 @@ func TestKymaIntegrationJobsPresubmit(t *testing.T) {
 				preset.GCProjectEnv, preset.KymaGuardBotGithubToken, preset.BuildPr, "preset-sa-vm-kyma-integration", "preset-kyma-integration-telemetry-enabled",
 			},
 
-			expRunIfChangedRegex: "^resources/telemetry/",
+			expRunIfChangedRegex: "^resources/telemetry/|^installation/resources/crds/telemetry",
 			expRunIfChangedPaths: []string{
 				"resources/telemetry/charts/operator/values.yaml",
 				"resources/telemetry/charts/fluent-bit/values.yaml",
+				"installation/resources/crds/telemetry/logpipelines.crd.yaml",
 			},
 			expNotRunIfChangedPaths: []string{
 				"components/telemetry-operator/main.go",
@@ -151,7 +152,7 @@ func TestKymaIntegrationJobsPostsubmit(t *testing.T) {
 		},
 		"Should contain the kyma-integration k3d with telemetry job": {
 			givenJobName: "post-main-kyma-integration-k3d-telemetry",
-			runIfChanged: "^resources/telemetry/",
+			runIfChanged: "^resources/telemetry/|^installation/resources/crds/telemetry",
 
 			expPresets: []preset.Preset{
 				preset.GCProjectEnv, preset.KymaGuardBotGithubToken, "preset-sa-vm-kyma-integration", "preset-kyma-integration-telemetry-enabled",

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -299,7 +299,7 @@ presubmits: # runs on PRs
         preset-kyma-guard-bot-github-token: "true"
         preset-kyma-integration-telemetry-enabled: "true"
         preset-sa-vm-kyma-integration: "true"
-      run_if_changed: '^components/telemetry-operator/|^resources/telemetry/'
+      run_if_changed: '^resources/telemetry/'
       skip_report: false
       decorate: true
       path_alias: github.com/kyma-project/kyma
@@ -589,7 +589,7 @@ postsubmits: # runs on main
         preset-kyma-guard-bot-github-token: "true"
         preset-kyma-integration-telemetry-enabled: "true"
         preset-sa-vm-kyma-integration: "true"
-      run_if_changed: '^components/telemetry-operator/|^resources/telemetry/'
+      run_if_changed: '^resources/telemetry/'
       skip_report: false
       decorate: true
       path_alias: github.com/kyma-project/kyma

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -299,7 +299,7 @@ presubmits: # runs on PRs
         preset-kyma-guard-bot-github-token: "true"
         preset-kyma-integration-telemetry-enabled: "true"
         preset-sa-vm-kyma-integration: "true"
-      run_if_changed: '^resources/telemetry/'
+      run_if_changed: '^resources/telemetry/|^installation/resources/crds/telemetry'
       skip_report: false
       decorate: true
       path_alias: github.com/kyma-project/kyma
@@ -589,7 +589,7 @@ postsubmits: # runs on main
         preset-kyma-guard-bot-github-token: "true"
         preset-kyma-integration-telemetry-enabled: "true"
         preset-sa-vm-kyma-integration: "true"
-      run_if_changed: '^resources/telemetry/'
+      run_if_changed: '^resources/telemetry/|^installation/resources/crds/telemetry'
       skip_report: false
       decorate: true
       path_alias: github.com/kyma-project/kyma

--- a/templates/data/kyma-integration-data.yaml
+++ b/templates/data/kyma-integration-data.yaml
@@ -577,7 +577,7 @@ templates:
                     - "vm_job_labels_template"
               - jobConfig:
                   name: "pre-main-kyma-integration-k3d-telemetry"
-                  run_if_changed: '^components/telemetry-operator/|^resources/telemetry/'
+                  run_if_changed: '^resources/telemetry/'
                   labels:
                     preset-build-pr: "true"
                     preset-kyma-integration-telemetry-enabled: "true"
@@ -686,7 +686,7 @@ templates:
                     - "extra_refs_kyma-local"
               - jobConfig:
                   name: "post-main-kyma-integration-k3d-telemetry"
-                  run_if_changed: '^components/telemetry-operator/|^resources/telemetry/'
+                  run_if_changed: '^resources/telemetry/'
                   labels:
                     preset-build-main: "true"
                     preset-kyma-integration-telemetry-enabled: "true"
@@ -725,7 +725,7 @@ templates:
                     - "vm_job_template_k3d"
                     - "vm_job_labels_template"
                     - "extra_refs_kyma-local"
-                  
+
               # periodics
 
               - jobConfig:

--- a/templates/data/kyma-integration-data.yaml
+++ b/templates/data/kyma-integration-data.yaml
@@ -577,7 +577,7 @@ templates:
                     - "vm_job_labels_template"
               - jobConfig:
                   name: "pre-main-kyma-integration-k3d-telemetry"
-                  run_if_changed: '^resources/telemetry/'
+                  run_if_changed: '^resources/telemetry/|^installation/resources/crds/telemetry'
                   labels:
                     preset-build-pr: "true"
                     preset-kyma-integration-telemetry-enabled: "true"
@@ -686,7 +686,7 @@ templates:
                     - "extra_refs_kyma-local"
               - jobConfig:
                   name: "post-main-kyma-integration-k3d-telemetry"
-                  run_if_changed: '^resources/telemetry/'
+                  run_if_changed: '^resources/telemetry/|^installation/resources/crds/telemetry'
                   labels:
                     preset-build-main: "true"
                     preset-kyma-integration-telemetry-enabled: "true"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The kyma-integration-k3d-telemetry jobs were executed on component and chart change. However, only changing the component would still run the job with the old telemetry-operator image. Changing the CRD did not trigger the job and was added.

Changes proposed in this pull request:

- Remove components/telemetry-operator from run_if_changed list
- Add telemetry CRDs to trigger job

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
