### PR TITLE
Normalize GitHub names and safe expand OWNERS_ALIASES

### DIFF
--- a/development/external-plugins/needs-tws/plugin_test.go
+++ b/development/external-plugins/needs-tws/plugin_test.go
@@ -13,6 +13,8 @@ import (
 
 type fakeAliases struct {
 	ownersAliases
+	// This has to be normalized list of aliases
+	// lowercase and without any GitHub prefixes
 	Aliases repoowners.RepoAliases
 }
 
@@ -381,7 +383,7 @@ func Test_HandlePullRequestReview(t *testing.T) {
 				Action: github.ReviewActionSubmitted,
 				Review: github.Review{
 					State: github.ReviewStateApproved,
-					User:  github.User{Login: "reviewer"},
+					User:  github.User{Login: "Reviewer"},
 				},
 				Repo: github.Repo{
 					Name:  "repo",
@@ -437,7 +439,7 @@ func Test_HandlePullRequestReview(t *testing.T) {
 				Action: github.ReviewActionSubmitted,
 				Review: github.Review{
 					State: github.ReviewStateChangesRequested,
-					User:  github.User{Login: "reviewer"},
+					User:  github.User{Login: "Reviewer"},
 				},
 				Repo: github.Repo{
 					Name:  "repo",
@@ -457,7 +459,7 @@ func Test_HandlePullRequestReview(t *testing.T) {
 				Action: github.ReviewActionSubmitted,
 				Review: github.Review{
 					State: github.ReviewStateChangesRequested,
-					User:  github.User{Login: "reviewer"},
+					User:  github.User{Login: "Reviewer"},
 				},
 				Repo: github.Repo{
 					Name:  "repo",
@@ -481,7 +483,7 @@ func Test_HandlePullRequestReview(t *testing.T) {
 				Action: github.ReviewActionSubmitted,
 				Review: github.Review{
 					State: github.ReviewStateApproved,
-					User:  github.User{Login: "reviewer"},
+					User:  github.User{Login: "Reviewer"},
 				},
 				Repo: github.Repo{
 					Name:  "repo",


### PR DESCRIPTION
The problem is that working code for loading repo aliases already performs normalization when the file gets loaded. That means all usernames in the `RepoAliases` map are lower-cased and stripped from unnecessary prefixes. That means all usernames in the `handlePullRequestReview` function have to be normalized beforehand.

This behaviour was not visible through the test because fakes implement the struct as-is, so explanation comment was added on how the fake OwnersAliases struct should look like to make the test relevant.

/kind bug
/area tooling

Closes #5037