### PR TITLE
One verbose attempt for gardener provisioning

### DIFF
--- a/prow/scripts/lib/gardener/aws.sh
+++ b/prow/scripts/lib/gardener/aws.sh
@@ -99,7 +99,7 @@ gardener::provision_cluster() {
         --scaler-max 4 \
         --scaler-min 2 \
         --kube-version="${GARDENER_CLUSTER_VERSION}" \
-        --attempts 1
+        --attempts 1 \
         --verbose
     # trap cleanup we want other errors fail pipeline immediately
     trap - ERR

--- a/prow/scripts/lib/gardener/aws.sh
+++ b/prow/scripts/lib/gardener/aws.sh
@@ -99,7 +99,8 @@ gardener::provision_cluster() {
         --scaler-max 4 \
         --scaler-min 2 \
         --kube-version="${GARDENER_CLUSTER_VERSION}" \
-        --attempts 2
+        --attempts 1
+        --verbose
     # trap cleanup we want other errors fail pipeline immediately
     trap - ERR
     if [ "$DEBUG_COMMANDO_OOM" = "true" ]; then

--- a/prow/scripts/lib/gardener/azure.sh
+++ b/prow/scripts/lib/gardener/azure.sh
@@ -122,7 +122,8 @@ gardener::provision_cluster() {
                 --scaler-max 1 --scaler-min 1 \
                 --disk-type StandardSSD_LRS \
                 --kube-version="${GARDENER_CLUSTER_VERSION}" \
-                --attempts 2
+                --attempts 1
+                --verbose
     else
             # enable trap to catch kyma provision failures
             trap gardener::reprovision_cluster ERR
@@ -137,7 +138,8 @@ gardener::provision_cluster() {
                 -t "${MACHINE_TYPE}" \
                 --disk-type StandardSSD_LRS \
                 --kube-version="${GARDENER_CLUSTER_VERSION}" \
-                --attempts 2
+                --attempts 1
+                --verbose
     fi
     # trap cleanup we want other errors fail pipeline immediately
     trap - ERR

--- a/prow/scripts/lib/gardener/azure.sh
+++ b/prow/scripts/lib/gardener/azure.sh
@@ -122,7 +122,7 @@ gardener::provision_cluster() {
                 --scaler-max 1 --scaler-min 1 \
                 --disk-type StandardSSD_LRS \
                 --kube-version="${GARDENER_CLUSTER_VERSION}" \
-                --attempts 1
+                --attempts 1 \
                 --verbose
     else
             # enable trap to catch kyma provision failures
@@ -138,7 +138,7 @@ gardener::provision_cluster() {
                 -t "${MACHINE_TYPE}" \
                 --disk-type StandardSSD_LRS \
                 --kube-version="${GARDENER_CLUSTER_VERSION}" \
-                --attempts 1
+                --attempts 1 \
                 --verbose
     fi
     # trap cleanup we want other errors fail pipeline immediately

--- a/prow/scripts/lib/gardener/gcp.sh
+++ b/prow/scripts/lib/gardener/gcp.sh
@@ -101,7 +101,8 @@ gardener::provision_cluster() {
         --scaler-max 4 \
         --scaler-min 2 \
         --kube-version="${GARDENER_CLUSTER_VERSION}" \
-        --attempts 2
+        --attempts 1
+        --verbose
     # trap cleanup we want other errors fail pipeline immediately
     trap - ERR
     if [ "$DEBUG_COMMANDO_OOM" = "true" ]; then

--- a/prow/scripts/lib/gardener/gcp.sh
+++ b/prow/scripts/lib/gardener/gcp.sh
@@ -101,7 +101,7 @@ gardener::provision_cluster() {
         --scaler-max 4 \
         --scaler-min 2 \
         --kube-version="${GARDENER_CLUSTER_VERSION}" \
-        --attempts 1
+        --attempts 1 \
         --verbose
     # trap cleanup we want other errors fail pipeline immediately
     trap - ERR


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add verbose option to the provisioning command
- skip second attempt as the proper cleanup is not in place

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/13855