### PR TITLE
Fix utils.sh script

### DIFF
--- a/prow/scripts/lib/utils.sh
+++ b/prow/scripts/lib/utils.sh
@@ -329,7 +329,7 @@ function utils::deprovision_gardener_cluster() {
 # Arguments
 # $1 - Name of the output json file
 function utils::save_psp_list() {
-  log:: info "generates pod-security-policy list and saves it to json file"
+  log::info "generates pod-security-policy list and saves it to json file"
   log::info "json file name: $1"
   if [ -z "$1" ]; then
     echo "File name is empty. Exiting..."


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
Remove unintended white space in utils.sh.
Introduced in https://github.com/kyma-project/test-infra/pull/5374

**Related issue(s)**
Following prow jobs are affected by this script:
- [gardener-gcp-eventing](https://status.build.kyma-project.io/job-history/gs/kyma-prow-logs/pr-logs/directory/pre-main-kyma-gardener-gcp-eventing)
-  [gardener-gcp-eventing-js](https://status.build.kyma-project.io/job-history/gs/kyma-prow-logs/pr-logs/directory/pre-main-kyma-gardener-gcp-eventing-js)
- [gardener-gcp-eventing-upgrade](https://status.build.kyma-project.io/job-history/gs/kyma-prow-logs/pr-logs/directory/pre-main-kyma-gardener-gcp-eventing-upgrade)