### PR TITLE
Added fi cleanup part to pre-main-kyma-gardener-gcp-eventing-upgrade

### DIFF
--- a/prow/scripts/cluster-integration/kyma-integration-gardener-eventing-upgrade.sh
+++ b/prow/scripts/cluster-integration/kyma-integration-gardener-eventing-upgrade.sh
@@ -74,8 +74,17 @@ else
     exit 1
 fi
 
+function cleanupJobAssets() {
+    log::banner "Running cleanup"
+    # clean up fast-integration assets from cluster
+    eventing::fast_integration_test_cleanup
+
+    # clean up gardener
+    gardener::cleanup
+}
+
 # nice cleanup on exit, be it successful or on fail
-trap gardener::cleanup EXIT INT
+trap cleanupJobAssets EXIT INT
 
 #Used to detect errors for logging purposes
 ERROR_LOGGING_GUARD="true"

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,7 @@
+pjNames:
+  - pjName: "pre-main-kyma-gardener-gcp-eventing-upgrade"
+    report: false
+prConfigs:
+  kyma-project:
+    kyma:
+      prNumber: 14241


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Added fi cleanup part to pre-main-kyma-gardener-gcp-eventing-upgrade
- Running the the cleanup target for eventing-fi tests before deleting the gardener cluster, because sometimes gardener stucks in deleting the cluster because of some assets created by the fi tests.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
