### PR TITLE
Do not require up-to-date branch for compass repo

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -134,7 +134,6 @@ branch-protection:
           branches:
             main:
               protect: true
-              required_status_checks:
         compass-console:
           protect: false
           branches:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -134,8 +134,6 @@ branch-protection:
           branches:
             main:
               protect: true
-              required_status_checks:
-                strict: false
         compass-console:
           protect: false
           branches:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -134,6 +134,8 @@ branch-protection:
           branches:
             main:
               protect: true
+              required_status_checks:
+                strict: false
         compass-console:
           protect: false
           branches:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -135,7 +135,6 @@ branch-protection:
             main:
               protect: true
               required_status_checks:
-                strict: true
         compass-console:
           protect: false
           branches:

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -132,7 +132,6 @@ branch-protection:
           branches:
             main:
               protect: true
-              required_status_checks:
         compass-console:
           protect: false
           branches:

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -132,8 +132,6 @@ branch-protection:
           branches:
             main:
               protect: true
-              required_status_checks:
-                strict: false
         compass-console:
           protect: false
           branches:

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -132,6 +132,8 @@ branch-protection:
           branches:
             main:
               protect: true
+              required_status_checks:
+                strict: false
         compass-console:
           protect: false
           branches:

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -133,7 +133,6 @@ branch-protection:
             main:
               protect: true
               required_status_checks:
-                strict: true
         compass-console:
           protect: false
           branches:


### PR DESCRIPTION
We want to disable the strict requirement for an up-to-date main branch in order to speed up our contributions, since if there are no conflicts the changes were in different components. (We have versions that are bumped)