### PR TITLE
Add new job regex for release candidate

### DIFF
--- a/prow/jobs/incubator/compass/compass-development-artifacts.yaml
+++ b/prow/jobs/incubator/compass/compass-development-artifacts.yaml
@@ -83,6 +83,7 @@ postsubmits: # runs on main
         - ^master$
         - ^main$
         - ^v\d+\.\d+\.\d+$
+        - ^v\d+\.\d+\.\d-rc\d$
       extra_refs:
         - org: kyma-project
           repo: test-infra

--- a/templates/data/compass-development-artifacts-data.yaml
+++ b/templates/data/compass-development-artifacts-data.yaml
@@ -47,6 +47,7 @@ templates:
                     - ^master$
                     - ^main$
                     - "^v\\d+\\.\\d+\\.\\d+$" # release tags
+                    - "^v\\d+\\.\\d+\\.\\d-rc\\d$" # release candidate tags
                   labels:
                     preset-build-artifacts-main: "true"
                   slack_channel: "kyma-prow-dev-null"


### PR DESCRIPTION
**Description**
In CMP(UCL) we want to use github pre-releases and for that we need additional regex to match the tags

Changes proposed in this pull request:
- add new pre-release regex