### PR TITLE
Bumped NATS config reloader image tag to 0.7.0 in image-syncer

### DIFF
--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -43,6 +43,6 @@ images:
 - source: "quay.io/service-manager/sb-proxy-k8s:v0.9.1"
 - source: "nats@sha256:3dfa6b8def0d3c784ef7827f0c21b17afd01be56773c68d5950e9f29172ae796"
   tag: "2.8.2-alpine"
-- source: "natsio/nats-server-config-reloader:0.6.3"
+- source: "natsio/nats-server-config-reloader:0.7.0"
 - source: "natsio/prometheus-nats-exporter:0.9.3"
 - source: "mockserver/mockserver:mockserver-5.11.2"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Bumped NATS config reloader image tag

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
