### PR TITLE
bump golang image to alpine-3.16

### DIFF
--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -12,8 +12,8 @@ images:
 - source: "fluent/fluent-bit:1.8.3"
 - source: "gcr.io/google-containers/pause-amd64:3.2"
 # Golang image is pinned because it is force updated in the upstream
-- source: "golang@sha256:3765360960a954c24b215518a41b0bf8e9e2fe3bd142b6f782fa56f8e00b8d21"
-  tag: "1.18.2-alpine3.15"
+- source: "golang@sha256:76dfe4aee4c0bf1ecd9666d29d22087eae592f697f449a88c0c7fc81a82faa01"
+  tag: "1.18.2-alpine3.16"
 - source: "grafana/loki:2.2.1"
 - source: "grafana/grafana-image-renderer:3.2.1"
 - source: "hudymi/mockice:0.1.3"


### PR DESCRIPTION
bumps the golang image to alpine-3.16 (golang 1.18.2) 

https://hub.docker.com/layers/golang/library/golang/alpine3.16/images/sha256-76dfe4aee4c0bf1ecd9666d29d22087eae592f697f449a88c0c7fc81a82faa01?context=explore