### PR TITLE
Make the Eventing upgrade job required

### DIFF
--- a/prow/jobs/kyma/kyma-integration-gardener.yaml
+++ b/prow/jobs/kyma/kyma-integration-gardener.yaml
@@ -469,7 +469,6 @@ presubmits: # runs on PRs
         preset-gardener-gcp-kyma-integration: "true"
         preset-kyma-cli-stable: "true"
       run_if_changed: '^((tests/fast-integration\S+|resources/eventing\S+)(\.[^.][^.][^.]+$|\.[^.][^dD]$|\.[^mM][^.]$|\.[^.]$|/[^.]+$))'
-      optional: true
       skip_report: false
       decorate: true
       decoration_config:

--- a/templates/data/kyma-integration-gardener-data.yaml
+++ b/templates/data/kyma-integration-gardener-data.yaml
@@ -356,6 +356,7 @@ templates:
                     - command_integration_skr_eventing
               - jobConfig:
                   name: pre-main-kyma-gardener-gcp-eventing-upgrade
+                  optional: false
                   decoration_config:
                     timeout: 14400000000000 # 4h
                     grace_period: 600000000000 # 10min

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,6 +1,0 @@
-pjNames:
-  - pjName: "pre-main-kyma-gardener-gcp-eventing-upgrade"
-#prConfigs:
-#  kyma-project:
-#    kyma:
-#      prNumber: 14492

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,6 @@
+pjNames:
+  - pjName: "pre-main-kyma-gardener-gcp-eventing-upgrade"
+#prConfigs:
+#  kyma-project:
+#    kyma:
+#      prNumber: 14492


### PR DESCRIPTION
**Description**

Make the `pre-main-kyma-gardener-gcp-eventing-upgrade` job required:

- https://status.build.kyma-project.io/view/gs/kyma-prow-logs/pr-logs/pull/kyma-project_kyma/14399/marcobebway_test_of_prowjob_pre-main-kyma-gardener-gcp-eventing/1534154833542516736
- https://status.build.kyma-project.io/view/gs/kyma-prow-logs/pr-logs/pull/kyma-project_kyma/14481/marcobebway_test_of_prowjob_pre-main-kyma-gardener-gcp-eventing/1534143096349003776
- https://status.build.kyma-project.io/view/gs/kyma-prow-logs/pr-logs/pull/kyma-project_kyma/14481/marcobebway_test_of_prowjob_pre-main-kyma-gardener-gcp-eventing/1534119950170460160
- https://status.build.kyma-project.io/view/gs/kyma-prow-logs/pr-logs/pull/kyma-project_kyma/14481/marcobebway_test_of_prowjob_pre-main-kyma-gardener-gcp-eventing/1534091602652303360

The job was reporting invalid success status even when the test or provisioning failed, now this behaviour is fix:

- https://status.build.kyma-project.io/view/gs/kyma-prow-logs/pr-logs/pull/kyma-project_kyma/14492/marcobebway_test_of_prowjob_pre-main-kyma-gardener-gcp-eventing/1534139119309950976
- https://status.build.kyma-project.io/view/gs/kyma-prow-logs/pr-logs/pull/kyma-project_kyma/14481/marcobebway_test_of_prowjob_pre-main-kyma-gardener-gcp-eventing/1534106875979632640
- https://status.build.kyma-project.io/view/gs/kyma-prow-logs/pr-logs/pull/kyma-project_kyma/14334/marcobebway_test_of_prowjob_pre-main-kyma-gardener-gcp-eventing/1534082588417724416
- https://status.build.kyma-project.io/view/gs/kyma-prow-logs/pr-logs/pull/kyma-project_kyma/14492/marcobebway_test_of_prowjob_pre-main-kyma-gardener-gcp-eventing/1534074953597456384

**Related issue(s)**

- https://github.com/kyma-project/kyma/issues/13395#issuecomment-1139385523
