### PR TITLE
Enable Prow secret censoring

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -19,6 +19,10 @@ plank:
     '*':
       timeout: 3h
       grace_period: 10m
+      censor_secrets: true
+      censoring_options:
+        censoring_concurrency: 2 # 2 concurrent censoring
+        censoring_buffer_size: 3092 # 3kB
       utility_images:
         clonerefs: gcr.io/k8s-prow/clonerefs:v20220606-f46fefa333
         initupload: gcr.io/k8s-prow/initupload:v20220606-f46fefa333

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -17,6 +17,10 @@ plank:
     '*':
       timeout: 3h
       grace_period: 10m
+      censor_secrets: true
+      censoring_options:
+        censoring_concurrency: 2 # 2 concurrent censoring
+        censoring_buffer_size: 3092 # 3kB
       utility_images:
         clonerefs: gcr.io/k8s-prow/clonerefs:v20220606-f46fefa333
         initupload: gcr.io/k8s-prow/initupload:v20220606-f46fefa333


### PR DESCRIPTION
Part of secret security hardening for compliance with SLC-29. Initial configuration, we might want to fine-tune it per ProwJob.

Closes #5250