### PR TITLE
make pre-main-control-plane-reconciler-e2e optional

### DIFF
--- a/development/tools/jobs/control-plane/control_plane_reconciler_integration_test.go
+++ b/development/tools/jobs/control-plane/control_plane_reconciler_integration_test.go
@@ -24,7 +24,7 @@ func TestReconcilerJobsPresubmitE2E(t *testing.T) {
 	assert.Equal(t, []string{"^master$", "^main$"}, actualPresubmit.Branches)
 	assert.Equal(t, 10, actualPresubmit.MaxConcurrency)
 	assert.False(t, actualPresubmit.SkipReport)
-	assert.False(t, actualPresubmit.Optional)
+	//assert.False(t, actualPresubmit.Optional)
 	assert.False(t, actualPresubmit.AlwaysRun)
 	assert.Equal(t, actualPresubmit.RunIfChanged, "^resources/kcp/values.yaml|^resources/kcp/charts/mothership-reconciler/|^resources/kcp/charts/component-reconcilers/")
 	tester.AssertThatHasExtraRefTestInfra(t, actualPresubmit.JobBase.UtilityConfig, "main")

--- a/prow/jobs/control-plane/control-plane-reconciler-integration.yaml
+++ b/prow/jobs/control-plane/control-plane-reconciler-integration.yaml
@@ -15,6 +15,7 @@ presubmits: # runs on PRs
         preset-gardener-gcp-kyma-integration: "true"
         preset-kyma-cli-stable: "true"
       run_if_changed: '^resources/kcp/values.yaml|^resources/kcp/charts/mothership-reconciler/|^resources/kcp/charts/component-reconcilers/'
+      optional: true
       skip_report: false
       decorate: true
       cluster: untrusted-workload

--- a/templates/data/control-plane-integration-data.yaml
+++ b/templates/data/control-plane-integration-data.yaml
@@ -163,7 +163,7 @@ templates:
               - jobConfig:
                   name: pre-main-control-plane-reconciler-e2e
                   run_if_changed: "^resources/kcp/values.yaml|^resources/kcp/charts/mothership-reconciler/|^resources/kcp/charts/component-reconcilers/"
-                  optional: false
+                  optional: true
                 inheritedConfigs:
                   global:
                     - jobConfig_default


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

make pre-main-control-plane-reconciler-e2e optional temporarily so that not block other component release on control-plane https://github.com/kyma-project/control-plane/pull/1782

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
