### PR TITLE
Enable skip plugin on all repos

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -21,6 +21,7 @@ plugins:
       - cat
       - shrug
       - pony
+      - skip
   kyma-project/test-infra:
     plugins:
       - config-updater
@@ -50,6 +51,7 @@ plugins:
       - cat
       - shrug
       - pony
+      - skip
 
 external_plugins:
   kyma-project:


### PR DESCRIPTION
The skip plugin allows users to clean up GitHub stale commit statuses for non-blocking jobs on a PR.
Command: `/skip`
