### PR TITLE
Using body template for Kyma2.4.x

### DIFF
--- a/prow/scripts/cluster-integration/helpers/reconciler.sh
+++ b/prow/scripts/cluster-integration/helpers/reconciler.sh
@@ -198,10 +198,14 @@ function reconciler::initialize_test_pod() {
     sed -i "s/example.com/$domain/" ./e2e-test/template-kyma-2-0-x.json
     # shellcheck disable=SC2016
     jq --arg kubeconfig "${kc}" --arg version "${KYMA_UPGRADE_SOURCE}" '.kubeconfig = $kubeconfig | .kymaConfig.version = $version' ./e2e-test/template-kyma-2-0-x.json > body.json
-  elif [[ "$KYMA_UPGRADE_SOURCE" =~ ^2\.[1-9]\.[0-9]+$ ]] ; then
+  elif [[ "$KYMA_UPGRADE_SOURCE" =~ ^2\.[1-3]\.[0-9]+$ ]] ; then
     sed -i "s/example.com/$domain/" ./e2e-test/template-kyma-2-1-x.json
     # shellcheck disable=SC2016
     jq --arg kubeconfig "${kc}" --arg version "${KYMA_UPGRADE_SOURCE}" '.kubeconfig = $kubeconfig | .kymaConfig.version = $version' ./e2e-test/template-kyma-2-1-x.json > body.json
+  elif [[ "$KYMA_UPGRADE_SOURCE" =~ ^2\.[4-9]\.[0-9]+$ ]] ; then
+      sed -i "s/example.com/$domain/" ./e2e-test/template-kyma-2-4-x.json
+      # shellcheck disable=SC2016
+      jq --arg kubeconfig "${kc}" --arg version "${KYMA_UPGRADE_SOURCE}" '.kubeconfig = $kubeconfig | .kymaConfig.version = $version' ./e2e-test/template-kyma-2-4-x.json > body.json
   else
     log::error "Unsupported Kyma Version: $KYMA_UPGRADE_SOURCE"
     exit 1


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The pipeline `pre-main-control-plane-reconciler-e2e-latest-release` is failing since Kyma 2.4.0 release - Due to the reason that `helm-broker`, `service-catalogue`, and `service-catalogue-addons` have been removed. The PR https://github.com/kyma-project/control-plane/pull/1829 introduces a new template for Kyma versions >= 2.4.x. This PR makes use of the new template.

Please first merge https://github.com/kyma-project/control-plane/pull/1829

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
