### PR TITLE
Remove kyma_major_version_1 from skr related tests

### DIFF
--- a/prow/jobs/kyma/skr-aws-upgrade-integration-dev.yaml
+++ b/prow/jobs/kyma/skr-aws-upgrade-integration-dev.yaml
@@ -48,8 +48,6 @@ periodics: # runs on schedule
             env:
               - name: KEB_PLAN_ID
                 value: "361c511f-f939-4621-b228-d0fb79a1fe15"
-              - name: KYMA_MAJOR_VERSION
-                value: "1"
               - name: KYMA_PROJECT_DIR
                 value: "/home/prow/go/src/github.com/kyma-project"
               - name: SKIP_CLEANUP

--- a/prow/jobs/kyma/skr-integration.yaml
+++ b/prow/jobs/kyma/skr-integration.yaml
@@ -50,8 +50,6 @@ periodics: # runs on schedule
                 value: "4deee563-e5ec-4731-b9b1-53b42d855f0c"
               - name: KEB_SUBACCOUNT_ID
                 value: "kyma-skr-nightly"
-              - name: KYMA_MAJOR_VERSION
-                value: "1"
             resources:
               requests:
                 memory: 100Mi
@@ -107,8 +105,6 @@ periodics: # runs on schedule
                 value: "4deee563-e5ec-4731-b9b1-53b42d855f0c"
               - name: KEB_SUBACCOUNT_ID
                 value: "prow-keb-integration"
-              - name: KYMA_MAJOR_VERSION
-                value: "1"
             resources:
               requests:
                 memory: 100Mi
@@ -165,8 +161,6 @@ periodics: # runs on schedule
                 value: "8cb22518-aa26-44c5-91a0-e669ec9bf443"
               - name: KEB_SUBACCOUNT_ID
                 value: "prow-keb-integration"
-              - name: KYMA_MAJOR_VERSION
-                value: "1"
             resources:
               requests:
                 memory: 100Mi
@@ -223,8 +217,6 @@ periodics: # runs on schedule
                 value: "361c511f-f939-4621-b228-d0fb79a1fe15"
               - name: KEB_SUBACCOUNT_ID
                 value: "prow-keb-integration"
-              - name: KYMA_MAJOR_VERSION
-                value: "1"
             resources:
               requests:
                 memory: 100Mi
@@ -281,8 +273,6 @@ periodics: # runs on schedule
                 value: "7d55d31d-35ae-4438-bf13-6ffdfa107d9f"
               - name: KEB_SUBACCOUNT_ID
                 value: "prow-keb-integration"
-              - name: KYMA_MAJOR_VERSION
-                value: "1"
             resources:
               requests:
                 memory: 100Mi
@@ -341,8 +331,6 @@ periodics: # runs on schedule
                 value: "cf-eu10"
               - name: KEB_SUBACCOUNT_ID
                 value: "prow-keb-integration"
-              - name: KYMA_MAJOR_VERSION
-                value: "1"
             resources:
               requests:
                 memory: 100Mi

--- a/templates/data/skr-aws-upgrade-integration-dev-data.yaml
+++ b/templates/data/skr-aws-upgrade-integration-dev-data.yaml
@@ -47,7 +47,6 @@ templates:
                     - "extra_refs_test-infra"
                     - "extra_refs_kyma"
                     - "disable_testgrid"
-                    - "kyma_major_version_1"
                     - "kyma_project_dir"
                   local:
                     - "jobConfig_default"

--- a/templates/data/skr-integration-data.yaml
+++ b/templates/data/skr-integration-data.yaml
@@ -94,7 +94,6 @@ templates:
                     - "extra_refs_test-infra"
                     - "extra_refs_kyma"
                     - "disable_testgrid"
-                    - "kyma_major_version_1"
                   local:
                     - "jobConfig_default"
                     - "keb_plan_azure"
@@ -110,7 +109,6 @@ templates:
                     - "extra_refs_test-infra"
                     - "extra_refs_kyma"
                     - "disable_testgrid"
-                    - "kyma_major_version_1"
                   local:
                     - "jobConfig_default"
                     - "keb_plan_azure"
@@ -126,7 +124,6 @@ templates:
                     - "extra_refs_test-infra"
                     - "extra_refs_kyma"
                     - "disable_testgrid"
-                    - "kyma_major_version_1"
                   local:
                     - "jobConfig_default"
                     - "keb_plan_azure_lite"
@@ -144,7 +141,6 @@ templates:
                     - "extra_refs_test-infra"
                     - "extra_refs_kyma"
                     - "disable_testgrid"
-                    - "kyma_major_version_1"
                   local:
                     - "jobConfig_default"
                     - "keb_plan_aws"
@@ -160,7 +156,6 @@ templates:
                     - "extra_refs_test-infra"
                     - "extra_refs_kyma"
                     - "disable_testgrid"
-                    - "kyma_major_version_1"
                   local:
                     - "jobConfig_default"
                     - "keb_plan_trial"
@@ -176,7 +171,6 @@ templates:
                     - "extra_refs_test-infra"
                     - "extra_refs_kyma"
                     - "disable_testgrid"
-                    - "kyma_major_version_1"
                   local:
                     - "jobConfig_default"
                     - "keb_plan_free_aws"

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,10 @@
+pjNames:
+  - pjName: "skr-aws-integration-dev"
+  - pjName: "skr-aws-upgrade-integration-dev"
+  - pjName: "skr-free-aws-integration-dev"
+  - pjName: "skr-azure-integration-dev"
+  - pjName: "skr-azure-nightly"
+prConfigs:
+  kyma-project:
+    kyma:
+      prNumber: 14747

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,9 +1,9 @@
 pjNames:
   - pjName: "skr-aws-integration-dev"
-  - pjName: "skr-aws-upgrade-integration-dev"
-  - pjName: "skr-free-aws-integration-dev"
-  - pjName: "skr-azure-integration-dev"
-  - pjName: "skr-azure-nightly"
+  # - pjName: "skr-aws-upgrade-integration-dev"
+  # - pjName: "skr-free-aws-integration-dev"
+  # - pjName: "skr-azure-integration-dev"
+  # - pjName: "skr-azure-nightly"
 prConfigs:
   kyma-project:
     kyma:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- The environnment variable `KYMA_MAJOR_VERSION` is set to 1 for skr related FIT tests
- Those tests don't need this variable anymore
- Pjtester:
  - https://status.build.kyma-project.io/?job=dennis-ge_test_of_prowjob_skr-free-aws-integration-dev ✅
  - https://status.build.kyma-project.io/?job=dennis-ge_test_of_prowjob_skr-aws-upgrade-integration-dev ❌ (currently failing because of other issue)
  - https://status.build.kyma-project.io/?job=dennis-ge_test_of_prowjob_skr-azure-nightly ❌ (currently failing because of other issue)
  - https://status.build.kyma-project.io/?job=dennis-ge_test_of_prowjob_skr-aws-integration-dev
  - https://status.build.kyma-project.io/?job=dennis-ge_test_of_prowjob_skr-azure-integration-dev ❌ (currently failing because of other issue)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
