### PR TITLE
Fix pjtester running from repo other than test-infra

### DIFF
--- a/prow/jobs/test-infra/pjtester.yaml
+++ b/prow/jobs/test-infra/pjtester.yaml
@@ -129,6 +129,11 @@ presubmits: # runs on PRs
       max_concurrency: 10
       branches:
         - ^.*$
+      extra_refs:
+        - org: kyma-project
+          repo: test-infra
+          path_alias: github.com/kyma-project/test-infra
+          base_ref: main
       spec:
         containers:
           - image: "eu.gcr.io/kyma-project/test-infra/pr/prow-tools:PR-5544"

--- a/templates/data/pjtester-data.yaml
+++ b/templates/data/pjtester-data.yaml
@@ -94,5 +94,6 @@ templates:
                   inheritedConfigs:
                     global:
                       - "jobConfig_default"
+                      - "extra_refs_test-infra"
                     local:
                       - "jobConfig_default"


### PR DESCRIPTION
pjtester must have access to test-infra to load prow config and static prowjobs defined in test-infra.