### PR TITLE
Make pre-main-kyma-integration-k3d-central-app-connectivity-compass job optional

### DIFF
--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -257,6 +257,7 @@ presubmits: # runs on PRs
         preset-kyma-integration-compass-enabled: "true"
         preset-sa-vm-kyma-integration: "true"
       run_if_changed: '^((tests/fast-integration\S+|resources\S+|installation\S+|tools/kyma-installer\S+)(\.[^.][^.][^.]+$|\.[^.][^dD]$|\.[^mM][^.]$|\.[^.]$|/[^.]+$))'
+      optional: true
       skip_report: false
       decorate: true
       path_alias: github.com/kyma-project/kyma

--- a/templates/data/kyma-integration-data.yaml
+++ b/templates/data/kyma-integration-data.yaml
@@ -447,6 +447,7 @@ templates:
                   name: "pre-main-kyma-integration-k3d-central-app-connectivity-compass"
                   # following regexp won't start build if only Markdown files were changed
                   run_if_changed: "^((tests/fast-integration\\S+|resources\\S+|installation\\S+|tools/kyma-installer\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
+                  optional: "true"
                   labels:
                     preset-build-pr: "true"
                     preset-kyma-integration-compass-dev: "true"


### PR DESCRIPTION
There are constant problems with random errors reported by this job.  It seems we cannot merge anything without running it few dozens times.

The fast way to mitigate this problem to deliver important fixes is to make it optional.

In the future we will either fix this job or we will replace it with component tests for more granular verification of `application-connectivity` components. 

