### PR TITLE
Disabling set-e option for reconciler e2e pipeline

### DIFF
--- a/prow/scripts/cluster-integration/reconciler-e2e-gardener.sh
+++ b/prow/scripts/cluster-integration/reconciler-e2e-gardener.sh
@@ -20,7 +20,7 @@
 ## ---------------------------------------------------------------------------------------
 
 # exit on error, and raise error when variable is not set when used
-set -e
+#set -e
 
 ENABLE_TEST_LOG_COLLECTOR=false
 


### PR DESCRIPTION
**Description**

Disabling the defensive error handling for the E2E test of reconciler as we have failing pipelines.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
