### PR TITLE
Bump `nats-config-reloader` and `nats-prometheus-exporter` images

### DIFF
--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -42,6 +42,6 @@ images:
 - source: "quay.io/prometheus/alertmanager:v0.24.0"
 - source: "quay.io/prometheus/prometheus:v2.35.0"
 - source: "nats:2.8.4-alpine3.15"
-- source: "natsio/nats-server-config-reloader:0.7.0"
+- source: "natsio/nats-server-config-reloader:0.7.2"
 - source: "natsio/prometheus-nats-exporter:0.9.3"
 - source: "mockserver/mockserver:mockserver-5.11.2"

--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -43,5 +43,5 @@ images:
 - source: "quay.io/prometheus/prometheus:v2.35.0"
 - source: "nats:2.8.4-alpine3.15"
 - source: "natsio/nats-server-config-reloader:0.7.2"
-- source: "natsio/prometheus-nats-exporter:0.9.3"
+- source: "natsio/prometheus-nats-exporter:0.10.0"
 - source: "mockserver/mockserver:mockserver-5.11.2"


### PR DESCRIPTION
bump `nats-config-reloader` to [`0.7.2`](https://hub.docker.com/layers/nats-server-config-reloader/natsio/nats-server-config-reloader/0.7.2/images/sha256-7e660b7c8e7dd54b982e38c3d3440a46fa60e9505e9164fd26d5515129e84cd9?context=explore) and `nats-prometheus-exporter` to [`0.10.0`](https://hub.docker.com/layers/prometheus-nats-exporter/natsio/prometheus-nats-exporter/0.10.0/images/sha256-5400de7cf9cd9fbda4ef3d6f5d236560e43bc6d1bf09b021ce4611d0dc4ff21a?context=explore) to prevent potential security vulnerabilities. 