### PR TITLE
Bump Compass E2E tests component job timeout

### DIFF
--- a/prow/jobs/incubator/compass/tests/compass-e2e-tests/compass-e2e-tests.yaml
+++ b/prow/jobs/incubator/compass/tests/compass-e2e-tests/compass-e2e-tests.yaml
@@ -19,7 +19,7 @@ presubmits: # runs on PRs
       decorate: true
       decoration_config:
         grace_period: 1m
-        timeout: 20m
+        timeout: 30m
       path_alias: github.com/kyma-incubator/compass
       cluster: untrusted-workload
       max_concurrency: 10
@@ -72,7 +72,7 @@ postsubmits: # runs on main
       decorate: true
       decoration_config:
         grace_period: 1m
-        timeout: 20m
+        timeout: 30m
       path_alias: github.com/kyma-incubator/compass
       cluster: trusted-workload
       max_concurrency: 10

--- a/templates/data/generic_component_compass_data.yaml
+++ b/templates/data/generic_component_compass_data.yaml
@@ -396,7 +396,7 @@ templates:
                   args:
                     - "/home/prow/go/src/github.com/kyma-incubator/compass/tests"
                   decoration_config:
-                    timeout: 20m
+                    timeout: 30m
                     grace_period: 1m
                   run_if_changed: "^tests/|^scripts/"
                   release_since: "1.17"


### PR DESCRIPTION
# Bump Compass E2E tests component job timeout

**Description**

Changes proposed in this pull request:

- 20 minutes seems not to be enough sometimes: https://status.build.kyma-project.io/view/gs/kyma-prow-logs/pr-logs/pull/kyma-incubator_compass/2570/pre-compass-tests/1560516977976414208

**Related issue(s)**
https://status.build.kyma-project.io/view/gs/kyma-prow-logs/pr-logs/pull/kyma-incubator_compass/2570/pre-compass-tests/1560516977976414208