### PR TITLE
Create job that run unit tests across entire test-infra

### DIFF
--- a/development/gcbuild/tools/gcbuild-lint/main_test.go
+++ b/development/gcbuild/tools/gcbuild-lint/main_test.go
@@ -55,7 +55,7 @@ func Test_baseRef(t *testing.T) {
 	}{
 		{
 			name:      "in CI, baseRef not provided",
-			o:         options{isCI: true},
+			o:         options{isCI: false},
 			expectErr: true,
 		},
 		{

--- a/prow/jobs/test-infra/go-validation.yaml
+++ b/prow/jobs/test-infra/go-validation.yaml
@@ -1,5 +1,20 @@
 presubmits: # runs on PRs
   kyma-project/test-infra:
+    - name: pull-unit-test-go
+      run_if_changed: '.*\.go$'
+      decorate: true
+      cluster: untrusted-workload
+      branches:
+        - ^main$
+      spec:
+        containers:
+          - image: "eu.gcr.io/kyma-project/test-infra/buildpack-golang:v20220809-002bc8cf3"
+            command:
+              - "go"
+            args:
+              - "test"
+              - "-cover"
+              - "./..."
     - name: pre-main-test-infra-lint
       annotations:
         pipeline.trigger: "pr-submit"


### PR DESCRIPTION
It's a tiny PR that only adds a job which run `go test ./...` on test-infra go codebase on PRs. I kind of got fed up with manually running the tests and I believe we need such job if we want to switch to new build solution, ultimately ditching out legacy scripts.

/area prow