### PR TITLE
Revert "Do not cleanup defective Gardener cluster - Analysis of VPN seed issue"

### DIFF
--- a/prow/scripts/cluster-integration/reconciler-e2e-gardener.sh
+++ b/prow/scripts/cluster-integration/reconciler-e2e-gardener.sh
@@ -72,8 +72,7 @@ else
 fi
 
 # nice cleanup on exit, be it succesful or on fail
-# temporarily disabled to provide Gardener test-cluster - https://github.com/gardener/gardener/issues/6588
-#trap gardener::cleanup EXIT INT
+trap gardener::cleanup EXIT INT
 
 # Used to detect errors for logging purposes
 ERROR_LOGGING_GUARD="true"
@@ -133,5 +132,3 @@ gardener::test_fast_integration_kyma
 
 #!!! Must be at the end of the script !!!
 ERROR_LOGGING_GUARD="false"
-
-gardener::cleanup


### PR DESCRIPTION
Reverts kyma-project/test-infra#5959

Analysis is finished and clusters can be cleaned up again.