### PR TITLE
Updating makefile calls for app connector tests

### DIFF
--- a/prow/scripts/cluster-integration/kyma-integration-k3d.sh
+++ b/prow/scripts/cluster-integration/kyma-integration-k3d.sh
@@ -122,11 +122,11 @@ function run_tests() {
       go install github.com/jstemmer/go-junit-report/v2@latest
 
       if [[ -v APPLICATION_CONNECTOR_COMPONENT_TESTS_ENABLED_GATEWAY ]]; then
-        make test-gateway
+        make test -f Makefile.test-application-gateway
       elif [ -v APPLICATION_CONNECTOR_COMPONENT_TESTS_ENABLED_VALIDATOR ]; then
-        make test-validator
+        make test -f Makefile.test-application-conn-validator
       elif [ -v APPLICATION_CONNECTOR_COMPONENT_TESTS_ENABLED_RUNTIME_AGENT ]; then
-        make test-compass-runtime-agent
+        make test -f Makefile.test-compass-runtime-agent
       fi
 
       popd

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,6 +1,0 @@
-pjNames:
-  - pjName: "pre-main-kyma-integration-k3d-app-gateway"
-prConfigs:
-  kyma-project:
-    kyma:
-      prNumber: 15380

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,6 @@
+pjNames:
+  - pjName: "pre-main-kyma-integration-k3d-app-gateway"
+prConfigs:
+  kyma-project:
+    kyma:
+      prNumber: 15380


### PR DESCRIPTION
Change of entry point for execution of all application connector component tests: 

Adjustments to new makefile structure updates made in [Kyma PR 15380 ](https://github.com/kyma-project/kyma/pull/15380) 