### PR TITLE
Fix naming in kaniko-build config.go

### DIFF
--- a/development/kaniko-build/config.go
+++ b/development/kaniko-build/config.go
@@ -8,11 +8,11 @@ import (
 
 type Config struct {
 	// Registry is URL where clean build should land.
-	Registry string `yaml:"directory"`
+	Registry string `yaml:"registry"`
 	// DevRegistry is Registry URL where development/dirty images should land.
 	// If not set then the Registry field is used.
 	// This field is only valid when running in CI (CI env variable is set to `true`)
-	DevRegistry string `yaml:"dev-directory"`
+	DevRegistry string `yaml:"dev-registry"`
 	// Cache options that are directly related to kaniko flags
 	Cache CacheConfig `yaml:"cache"`
 	// TagTemplate is go-template field that defines the format of the $_TAG substitution.

--- a/development/kaniko-build/config_test.go
+++ b/development/kaniko-build/config_test.go
@@ -15,10 +15,10 @@ func Test_ParseConfig(t *testing.T) {
 	}{
 		{
 			name: "parsed full config",
-			config: `dev-directory: dev.kyma-project.io/dev-directory
+			config: `dev-registry: dev.kyma-project.io/dev-registry
 tag-template: v{{ .Date }}-{{ .ShortSHA }}`,
 			expectedConfig: Config{
-				DevRegistry: "dev.kyma-project.io/dev-directory",
+				DevRegistry: "dev.kyma-project.io/dev-registry",
 				TagTemplate: `v{{ .Date }}-{{ .ShortSHA }}`,
 			},
 		},

--- a/prow/jobs/test-infra/buildpack.yaml
+++ b/prow/jobs/test-infra/buildpack.yaml
@@ -19,7 +19,7 @@ presubmits: # runs on PRs
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -52,7 +52,7 @@ presubmits: # runs on PRs
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -85,7 +85,7 @@ presubmits: # runs on PRs
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -118,7 +118,7 @@ presubmits: # runs on PRs
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -151,7 +151,7 @@ presubmits: # runs on PRs
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -184,7 +184,7 @@ presubmits: # runs on PRs
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -217,7 +217,7 @@ presubmits: # runs on PRs
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -250,7 +250,7 @@ presubmits: # runs on PRs
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -283,7 +283,7 @@ presubmits: # runs on PRs
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -316,7 +316,7 @@ presubmits: # runs on PRs
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -349,7 +349,7 @@ presubmits: # runs on PRs
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -382,7 +382,7 @@ presubmits: # runs on PRs
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -415,7 +415,7 @@ presubmits: # runs on PRs
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -453,7 +453,7 @@ postsubmits: # runs on main
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -487,7 +487,7 @@ postsubmits: # runs on main
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -522,7 +522,7 @@ postsubmits: # runs on main
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -557,7 +557,7 @@ postsubmits: # runs on main
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -592,7 +592,7 @@ postsubmits: # runs on main
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -627,7 +627,7 @@ postsubmits: # runs on main
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -662,7 +662,7 @@ postsubmits: # runs on main
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -697,7 +697,7 @@ postsubmits: # runs on main
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -732,7 +732,7 @@ postsubmits: # runs on main
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -767,7 +767,7 @@ postsubmits: # runs on main
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -802,7 +802,7 @@ postsubmits: # runs on main
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -837,7 +837,7 @@ postsubmits: # runs on main
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:
@@ -872,7 +872,7 @@ postsubmits: # runs on main
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615"
             command:
               - "/kaniko-build"
             args:

--- a/templates/data/buildpack-data.yaml
+++ b/templates/data/buildpack-data.yaml
@@ -12,7 +12,7 @@ templates:
                   - "^main$"
                 pubsub_project: "sap-kyma-prow"
                 pubsub_topic: "prowjobs"
-                image: eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220905-0070bb40f
+                image: eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-ee6d5e615
                 command: /kaniko-build
                 labels:
                   preset-sa-gcr-push: "true"


### PR DESCRIPTION
During refactoring and moving registry to the cluster config, one value unintentionally got renamed.

/area ci
/kind bug
