### PR TITLE
Update cluster version

### DIFF
--- a/prow/scripts/cluster-integration/compass-gke-benchmark.sh
+++ b/prow/scripts/cluster-integration/compass-gke-benchmark.sh
@@ -111,7 +111,7 @@ function createCluster() {
   gcp::provision_k8s_cluster \
         -c "$COMMON_NAME" \
         -p "$CLOUDSDK_CORE_PROJECT" \
-        -v "1.21.12" \
+        -v "1.21.14" \
         -j "$JOB_NAME" \
         -J "$PROW_JOB_ID" \
         -z "$CLOUDSDK_COMPUTE_ZONE" \


### PR DESCRIPTION
**Description**
Since September 2022 the 1.21.12 version is no longer provided by GCP.

Changes proposed in this pull request:
- Adjust version to latest supported: https://cloud.google.com/kubernetes-engine/docs/release-notes

