### PR TITLE
Run application connector pipelines tests after istio changes

### DIFF
--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -77,7 +77,7 @@ presubmits: # runs on PRs
         preset-kyma-integration-app-connector-tests-app-gateway: "true"
         preset-kyma-integration-central-app-connectivity-enabled: "true"
         preset-sa-vm-kyma-integration: "true"
-      run_if_changed: '^((resources/application-connector\S+|installation\S+|tests/components/application-connector\S+)(\.[^.][^.][^.]+$|\.[^.][^dD]$|\.[^mM][^.]$|\.[^.]$|/[^.]+$))'
+      run_if_changed: '^((resources/application-connector\S+|installation\S+|tests/components/application-connector\S+|resources/istio\S+|resources/istio-resources\S+)(\.[^.][^.][^.]+$|\.[^.][^dD]$|\.[^mM][^.]$|\.[^.]$|/[^.]+$))'
       optional: true
       skip_report: false
       decorate: true
@@ -137,7 +137,7 @@ presubmits: # runs on PRs
         preset-kyma-integration-app-connector-tests-app-validator: "true"
         preset-kyma-integration-central-app-connectivity-enabled: "true"
         preset-sa-vm-kyma-integration: "true"
-      run_if_changed: '^((resources/application-connector\S+|installation\S+|tests/components/application-connector\S+)(\.[^.][^.][^.]+$|\.[^.][^dD]$|\.[^mM][^.]$|\.[^.]$|/[^.]+$))'
+      run_if_changed: '^((resources/application-connector\S+|installation\S+|tests/components/application-connector\S+|resources/istio\S+|resources/istio-resources\S+)(\.[^.][^.][^.]+$|\.[^.][^dD]$|\.[^mM][^.]$|\.[^.]$|/[^.]+$))'
       optional: true
       skip_report: false
       decorate: true

--- a/templates/data/kyma-integration-data.yaml
+++ b/templates/data/kyma-integration-data.yaml
@@ -374,7 +374,7 @@ templates:
               - jobConfig:
                   name: "pre-main-kyma-integration-k3d-app-gateway"
                   # following regexp won't start build if only Markdown files were changed
-                  run_if_changed: "^((resources/application-connector\\S+|installation\\S+|tests/components/application-connector\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
+                  run_if_changed: "^((resources/application-connector\\S+|installation\\S+|tests/components/application-connector\\S+|resources/istio\\S+|resources/istio-resources\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
                   optional: "true"
                   labels:
                     preset-build-pr: "true"
@@ -398,7 +398,7 @@ templates:
               - jobConfig:
                   name: "pre-main-kyma-integration-k3d-app-conn-validator"
                   # following regexp won't start build if only Markdown files were changed
-                  run_if_changed: "^((resources/application-connector\\S+|installation\\S+|tests/components/application-connector\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
+                  run_if_changed: "^((resources/application-connector\\S+|installation\\S+|tests/components/application-connector\\S+|resources/istio\\S+|resources/istio-resources\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
                   optional: "true"
                   labels:
                     preset-build-pr: "true"


### PR DESCRIPTION
This is implementation of #5906 

Following jobs will be triggered after changes in Kyma istio configuration

- pre-main-kyma-integration-k3d-app-conn-validator
- post-main-kyma-integration-k3d-app-conn-validator