### PR TITLE
Implement using multiple repos to push in kaniko-build

### DIFF
--- a/development/kaniko-build/config_test.go
+++ b/development/kaniko-build/config_test.go
@@ -14,11 +14,28 @@ func Test_ParseConfig(t *testing.T) {
 		expectErr      bool
 	}{
 		{
-			name: "parsed full config",
-			config: `dev-registry: dev.kyma-project.io/dev-registry
+			name: "parsed full config one repo",
+			config: `registry: kyma-project.io/prod-registry
+dev-registry: dev.kyma-project.io/dev-registry
 tag-template: v{{ .Date }}-{{ .ShortSHA }}`,
 			expectedConfig: Config{
-				DevRegistry: "dev.kyma-project.io/dev-registry",
+				Registry:    []string{"kyma-project.io/prod-registry"},
+				DevRegistry: []string{"dev.kyma-project.io/dev-registry"},
+				TagTemplate: `v{{ .Date }}-{{ .ShortSHA }}`,
+			},
+		},
+		{
+			name: "parsed full config with multiple repos",
+			config: `registry:
+- kyma-project.io/prod-registry
+- kyma-project.io/second-registry
+dev-registry:
+- dev.kyma-project.io/dev-registry
+- dev.kyma-project.io/second-registry
+tag-template: v{{ .Date }}-{{ .ShortSHA }}`,
+			expectedConfig: Config{
+				Registry:    []string{"kyma-project.io/prod-registry", "kyma-project.io/second-registry"},
+				DevRegistry: []string{"dev.kyma-project.io/dev-registry", "dev.kyma-project.io/second-registry"},
 				TagTemplate: `v{{ .Date }}-{{ .ShortSHA }}`,
 			},
 		},

--- a/development/kaniko-build/main.go
+++ b/development/kaniko-build/main.go
@@ -109,7 +109,7 @@ func runBuildJob(o options, vs Variants) error {
 	if o.isCI {
 		presubmit := os.Getenv("JOB_TYPE") == "presubmit"
 		if presubmit {
-			if o.DevRegistry != "" {
+			if len(o.Registry) > 0 {
 				repo = o.DevRegistry
 			}
 			if n := os.Getenv("PULL_NUMBER"); n != "" {
@@ -189,11 +189,13 @@ func getTags(pr, sha, tagTemplate string, additionalTags []string) ([]string, er
 	return tags, nil
 }
 
-func gatherDestinations(repo, directory, name string, tags []string) []string {
+func gatherDestinations(repo []string, directory, name string, tags []string) []string {
 	var dst []string
 	for _, t := range tags {
-		image := path.Join(repo, directory, name)
-		dst = append(dst, image+":"+strings.ReplaceAll(t, " ", "-"))
+		for _, r := range repo {
+			image := path.Join(r, directory, name)
+			dst = append(dst, image+":"+strings.ReplaceAll(t, " ", "-"))
+		}
 	}
 	return dst
 }

--- a/development/kaniko-build/main_test.go
+++ b/development/kaniko-build/main_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_gatherDestinations(t *testing.T) {
-	repo := "dev.kyma.io"
+	repo := []string{"dev.kyma.io", "dev2.kyma.io"}
 	directory := "subdirectory"
 	name := "test-image"
 	tags := []string{
@@ -18,8 +18,11 @@ func Test_gatherDestinations(t *testing.T) {
 	}
 	expected := []string{
 		"dev.kyma.io/subdirectory/test-image:20222002-abcd1234",
+		"dev2.kyma.io/subdirectory/test-image:20222002-abcd1234",
 		"dev.kyma.io/subdirectory/test-image:latest",
+		"dev2.kyma.io/subdirectory/test-image:latest",
 		"dev.kyma.io/subdirectory/test-image:cookie",
+		"dev2.kyma.io/subdirectory/test-image:cookie",
 	}
 	got := gatherDestinations(repo, directory, name, tags)
 	if len(expected) != len(got) {


### PR DESCRIPTION
/kind feature
/area ci
This small update addresses an issue where it is required to push one image to multiple destinations under the same tag. 
Add ability to define `registry` and `dev-registry` field in the config as either *string*, or *sequence* to define multiple registry addresses to push the image. It will not break current config.yaml and will give transitioning to artifact registry desired grace period without any additional tooling.