### PR TITLE
prefer local changelog file githubrelease

### DIFF
--- a/development/tools/pkg/release/options.go
+++ b/development/tools/pkg/release/options.go
@@ -3,6 +3,7 @@ package release
 import (
 	"bytes"
 	"context"
+	"os"
 
 	"github.com/pkg/errors"
 )
@@ -34,9 +35,22 @@ func NewOptions(ctx context.Context, storage StorageAPI, releaseVersionFilePath,
 	}
 
 	//Changelog
-	releaseChangelogData, err := relOpts.readReleaseBody(ctx, releaseVersion, releaseChangelogName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "while reading %s file", releaseChangelogName)
+	var releaseChangelogData string
+	if _, err := os.Stat(releaseChangelogName); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, errors.Wrapf(err, "while reading %s file", releaseChangelogName)
+		}
+		// use try to use GCP to fetch the changelog
+		releaseChangelogData, err = relOpts.readReleaseBody(ctx, releaseVersion, releaseChangelogName)
+		if err != nil {
+			return nil, errors.Wrapf(err, "while reading %s file", releaseChangelogName)
+		}
+	} else {
+		clb, err := os.ReadFile(releaseChangelogName)
+		if err != nil {
+			return nil, errors.Wrapf(err, "while reading %s file", releaseChangelogName)
+		}
+		releaseChangelogData = string(clb)
 	}
 
 	relOpts.Version = releaseVersion


### PR DESCRIPTION
Program checks if given release changelog name is present as a file if it's not then uses old logic of getting changelog from GCS as fallback. If changelog is present in local filesystem, use this file instead of fetching it from GCS.

/kind feature
/area ci
