### PR TITLE
Disable timestamp stripping when building images

### DIFF
--- a/configs/kaniko-build-config.yaml
+++ b/configs/kaniko-build-config.yaml
@@ -1,5 +1,5 @@
 registry: eu.gcr.io/kyma-project
-reproducible: true
+reproducible: false
 log-format: json
 cache:
   enabled: true


### PR DESCRIPTION
This makes some problems with generic-autobumper. It requires more investigation. Probably we will have to remove all images that contain timestamps so our current autobumper solution works

/area ci
/kind bug