### PR TITLE
kaniko-build: make directory option optional

### DIFF
--- a/development/kaniko-build/main.go
+++ b/development/kaniko-build/main.go
@@ -203,9 +203,6 @@ func gatherDestinations(repo []string, directory, name string, tags []string) []
 // validateOptions handles options validation. All checks should be provided here
 func validateOptions(o options) error {
 	var errs []error
-	if o.directory == "" {
-		errs = append(errs, fmt.Errorf("flag '--directory' is missing"))
-	}
 	if o.context == "" {
 		errs = append(errs, fmt.Errorf("flag '--context' is missing"))
 	}


### PR DESCRIPTION
It's never intended for it to be required, as it only defines the subpath of the image on registry. Remove the check and update tests