### PR TITLE
setup kaniko for module manager and runtime watcher

### DIFF
--- a/prow/jobs/lifecycle-manager/lifecycle-manager.yaml
+++ b/prow/jobs/lifecycle-manager/lifecycle-manager.yaml
@@ -91,7 +91,6 @@ presubmits: # runs on PRs
       cluster: untrusted-workload
       max_concurrency: 10
       branches:
-        - ^master$
         - ^main$
       spec:
         containers:
@@ -103,7 +102,6 @@ presubmits: # runs on PRs
               - "--config=/config/kaniko-build-config.yaml"
               - "--context=operator"
               - "--dockerfile=Dockerfile"
-              - "--directory=."
             volumeMounts:
               - name: config
                 mountPath: /config
@@ -129,7 +127,6 @@ postsubmits: # runs on main
       cluster: trusted-workload
       max_concurrency: 10
       branches:
-        - ^master$
         - ^main$
       spec:
         containers:
@@ -141,7 +138,6 @@ postsubmits: # runs on main
               - "--config=/config/kaniko-build-config.yaml"
               - "--context=operator"
               - "--dockerfile=Dockerfile"
-              - "--directory=."
             volumeMounts:
               - name: config
                 mountPath: /config

--- a/prow/jobs/lifecycle-manager/lifecycle-manager.yaml
+++ b/prow/jobs/lifecycle-manager/lifecycle-manager.yaml
@@ -94,7 +94,7 @@ presubmits: # runs on PRs
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-566f916e6"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220923-cdc39230b"
             command:
               - "/kaniko-build"
             args:
@@ -130,7 +130,7 @@ postsubmits: # runs on main
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-566f916e6"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220923-cdc39230b"
             command:
               - "/kaniko-build"
             args:

--- a/prow/jobs/module-manager/module-manager.yaml
+++ b/prow/jobs/module-manager/module-manager.yaml
@@ -94,9 +94,6 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
         prow.k8s.io/pubsub.runID: "pull-build"
         prow.k8s.io/pubsub.topic: "prowjobs"
-        preset-dind-enabled: "true"
-        preset-docker-push-repository-kyma: "true"
-        preset-kyma-kms-sign-key: "true"
         preset-sa-gcr-push: "true"
       always_run: true
       skip_report: false
@@ -105,33 +102,24 @@ presubmits: # runs on PRs
       max_concurrency: 10
       branches:
         - ^main$
-      extra_refs:
-        - org: kyma-project
-          repo: test-infra
-          path_alias: github.com/kyma-project/test-infra
-          base_ref: main
       spec:
         containers:
-          - image: "eu.gcr.io/kyma-project/test-infra/buildpack-golang:v20220926-fbffe961"
-            securityContext:
-              privileged: true
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-566f916e6"
             command:
-              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-generic.sh"
+              - "/kaniko-build"
             args:
-              - "/home/prow/go/src/github.com/kyma-project/module-manager/operator"
-              - "docker-build"
-              - "docker-push"
-            resources:
-              requests:
-                memory: 3Gi
-                cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
+              - "--name=module-manager"
+              - "--config=/config/kaniko-build-config.yaml"
+              - "--context=operator"
+              - "--dockerfile=Dockerfile"
+            volumeMounts:
+              - name: config
+                mountPath: /config
+                readOnly: true
+        volumes:
+          - name: config
+            configMap:
+              name: kaniko-build-config
   
 postsubmits: # runs on main
   kyma-project/module-manager:
@@ -142,9 +130,6 @@ postsubmits: # runs on main
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
         prow.k8s.io/pubsub.runID: "main-build"
         prow.k8s.io/pubsub.topic: "prowjobs"
-        preset-dind-enabled: "true"
-        preset-docker-push-repository-kyma: "true"
-        preset-kyma-kms-sign-key: "true"
         preset-sa-gcr-push: "true"
       always_run: true
       skip_report: false
@@ -153,31 +138,22 @@ postsubmits: # runs on main
       max_concurrency: 10
       branches:
         - ^main$
-      extra_refs:
-        - org: kyma-project
-          repo: test-infra
-          path_alias: github.com/kyma-project/test-infra
-          base_ref: main
       spec:
         containers:
-          - image: "eu.gcr.io/kyma-project/test-infra/buildpack-golang:v20220926-fbffe961"
-            securityContext:
-              privileged: true
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-566f916e6"
             command:
-              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-generic.sh"
+              - "/kaniko-build"
             args:
-              - "/home/prow/go/src/github.com/kyma-project/module-manager/operator"
-              - "docker-build"
-              - "docker-push"
-            resources:
-              requests:
-                memory: 3Gi
-                cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
+              - "--name=module-manager"
+              - "--config=/config/kaniko-build-config.yaml"
+              - "--context=operator"
+              - "--dockerfile=Dockerfile"
+            volumeMounts:
+              - name: config
+                mountPath: /config
+                readOnly: true
+        volumes:
+          - name: config
+            configMap:
+              name: kaniko-build-config
   

--- a/prow/jobs/module-manager/module-manager.yaml
+++ b/prow/jobs/module-manager/module-manager.yaml
@@ -104,7 +104,7 @@ presubmits: # runs on PRs
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-566f916e6"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220923-cdc39230b"
             command:
               - "/kaniko-build"
             args:
@@ -140,7 +140,7 @@ postsubmits: # runs on main
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-566f916e6"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220923-cdc39230b"
             command:
               - "/kaniko-build"
             args:

--- a/prow/jobs/runtime-watcher/runtime-watcher.yaml
+++ b/prow/jobs/runtime-watcher/runtime-watcher.yaml
@@ -3,12 +3,12 @@
 
 presubmits: # runs on PRs
   kyma-project/runtime-watcher:
-    - name: pull-skr-lint
+    - name: pull-lint-skr
       annotations:
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pull-skr-lint"
+        prow.k8s.io/pubsub.runID: "pull-lint-skr"
         prow.k8s.io/pubsub.topic: "prowjobs"
       run_if_changed: '^skr/(go.mod|go.sum)$|^skr/*/(.*.go|Makefile|.*.sh)'
       skip_report: false
@@ -38,12 +38,12 @@ presubmits: # runs on PRs
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
-    - name: pull-skr-tests
+    - name: pull-tests-skr
       annotations:
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pull-skr-tests"
+        prow.k8s.io/pubsub.runID: "pull-tests-skr"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-dind-enabled: "true"
         preset-docker-push-repository-kyma: "true"
@@ -76,12 +76,12 @@ presubmits: # runs on PRs
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
-    - name: pull-kcp-lint
+    - name: pull-lint-kcp
       annotations:
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pull-kcp-lint"
+        prow.k8s.io/pubsub.runID: "pull-lint-kcp"
         prow.k8s.io/pubsub.topic: "prowjobs"
       run_if_changed: '^kcp/(go.mod|go.sum)$|^kcp/*/(.*.go|Makefile|.*.sh)'
       skip_report: false
@@ -111,12 +111,12 @@ presubmits: # runs on PRs
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
-    - name: pull-kcp-tests
+    - name: pull-tests-kcp
       annotations:
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pull-kcp-tests"
+        prow.k8s.io/pubsub.runID: "pull-tests-kcp"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-dind-enabled: "true"
         preset-docker-push-repository-kyma: "true"
@@ -149,12 +149,12 @@ presubmits: # runs on PRs
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
-    - name: pull-listener-lint
+    - name: pull-lint-listener
       annotations:
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pull-listener-lint"
+        prow.k8s.io/pubsub.runID: "pull-lint-listener"
         prow.k8s.io/pubsub.topic: "prowjobs"
       run_if_changed: '^listener/(go.mod|go.sum)$|^listener/*/(.*.go|Makefile|.*.sh)'
       skip_report: false
@@ -184,12 +184,12 @@ presubmits: # runs on PRs
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
-    - name: pull-listener-tests
+    - name: pull-tests-listener
       annotations:
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pull-listener-tests"
+        prow.k8s.io/pubsub.runID: "pull-tests-listener"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-dind-enabled: "true"
         preset-docker-push-repository-kyma: "true"

--- a/prow/jobs/runtime-watcher/runtime-watcher.yaml
+++ b/prow/jobs/runtime-watcher/runtime-watcher.yaml
@@ -222,16 +222,13 @@ presubmits: # runs on PRs
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
-    - name: pull-kcp-build
+    - name: pull-build-kcp
       annotations:
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pull-kcp-build"
+        prow.k8s.io/pubsub.runID: "pull-build-kcp"
         prow.k8s.io/pubsub.topic: "prowjobs"
-        preset-dind-enabled: "true"
-        preset-docker-push-repository-kyma: "true"
-        preset-kyma-kms-sign-key: "true"
         preset-sa-gcr-push: "true"
       run_if_changed: '^kcp/'
       skip_report: false
@@ -240,43 +237,31 @@ presubmits: # runs on PRs
       max_concurrency: 10
       branches:
         - ^main$
-      extra_refs:
-        - org: kyma-project
-          repo: test-infra
-          path_alias: github.com/kyma-project/test-infra
-          base_ref: main
       spec:
         containers:
-          - image: "eu.gcr.io/kyma-project/test-infra/buildpack-golang:v20220926-fbffe961"
-            securityContext:
-              privileged: true
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-566f916e6"
             command:
-              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-generic.sh"
+              - "/kaniko-build"
             args:
-              - "/home/prow/go/src/github.com/kyma-project/runtime-watcher/kcp"
-              - "docker-build"
-              - "docker-push"
-            resources:
-              requests:
-                memory: 3Gi
-                cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
-    - name: pull-skr-build
+              - "--name=runtime-watcher-kcp"
+              - "--config=/config/kaniko-build-config.yaml"
+              - "--context=kcp"
+              - "--dockerfile=Dockerfile"
+            volumeMounts:
+              - name: config
+                mountPath: /config
+                readOnly: true
+        volumes:
+          - name: config
+            configMap:
+              name: kaniko-build-config
+    - name: pull-build-skr
       annotations:
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pull-skr-build"
+        prow.k8s.io/pubsub.runID: "pull-build-skr"
         prow.k8s.io/pubsub.topic: "prowjobs"
-        preset-dind-enabled: "true"
-        preset-docker-push-repository-kyma: "true"
-        preset-kyma-kms-sign-key: "true"
         preset-sa-gcr-push: "true"
       run_if_changed: '^skr/'
       skip_report: false
@@ -285,124 +270,91 @@ presubmits: # runs on PRs
       max_concurrency: 10
       branches:
         - ^main$
-      extra_refs:
-        - org: kyma-project
-          repo: test-infra
-          path_alias: github.com/kyma-project/test-infra
-          base_ref: main
       spec:
         containers:
-          - image: "eu.gcr.io/kyma-project/test-infra/buildpack-golang:v20220926-fbffe961"
-            securityContext:
-              privileged: true
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-566f916e6"
             command:
-              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-generic.sh"
+              - "/kaniko-build"
             args:
-              - "/home/prow/go/src/github.com/kyma-project/runtime-watcher/skr"
-              - "docker-build"
-              - "docker-push"
-            resources:
-              requests:
-                memory: 3Gi
-                cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
+              - "--name=runtime-watcher-skr"
+              - "--config=/config/kaniko-build-config.yaml"
+              - "--context=skr"
+              - "--dockerfile=Dockerfile"
+            volumeMounts:
+              - name: config
+                mountPath: /config
+                readOnly: true
+        volumes:
+          - name: config
+            configMap:
+              name: kaniko-build-config
   
 postsubmits: # runs on main
   kyma-project/runtime-watcher:
-    - name: main-kcp-build
+    - name: main-build-kcp
       annotations:
         pipeline.trigger: "pr-merge"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "main-kcp-build"
+        prow.k8s.io/pubsub.runID: "main-build-kcp"
         prow.k8s.io/pubsub.topic: "prowjobs"
-        preset-dind-enabled: "true"
-        preset-docker-push-repository-kyma: "true"
-        preset-kyma-kms-sign-key: "true"
         preset-sa-gcr-push: "true"
-      run_if_changed: '^kcp/'
+      always_run: true
       skip_report: false
       decorate: true
       cluster: trusted-workload
       max_concurrency: 10
       branches:
         - ^main$
-      extra_refs:
-        - org: kyma-project
-          repo: test-infra
-          path_alias: github.com/kyma-project/test-infra
-          base_ref: main
       spec:
         containers:
-          - image: "eu.gcr.io/kyma-project/test-infra/buildpack-golang:v20220926-fbffe961"
-            securityContext:
-              privileged: true
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-566f916e6"
             command:
-              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-generic.sh"
+              - "/kaniko-build"
             args:
-              - "/home/prow/go/src/github.com/kyma-project/runtime-watcher/kcp"
-              - "docker-build"
-              - "docker-push"
-            resources:
-              requests:
-                memory: 3Gi
-                cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
-    - name: main-skr-build
+              - "--name=runtime-watcher-kcp"
+              - "--config=/config/kaniko-build-config.yaml"
+              - "--context=kcp"
+              - "--dockerfile=Dockerfile"
+            volumeMounts:
+              - name: config
+                mountPath: /config
+                readOnly: true
+        volumes:
+          - name: config
+            configMap:
+              name: kaniko-build-config
+    - name: main-build-skr
       annotations:
         pipeline.trigger: "pr-merge"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "main-skr-build"
+        prow.k8s.io/pubsub.runID: "main-build-skr"
         prow.k8s.io/pubsub.topic: "prowjobs"
-        preset-dind-enabled: "true"
-        preset-docker-push-repository-kyma: "true"
-        preset-kyma-kms-sign-key: "true"
         preset-sa-gcr-push: "true"
-      run_if_changed: '^skr/'
+      always_run: true
       skip_report: false
       decorate: true
       cluster: trusted-workload
       max_concurrency: 10
       branches:
         - ^main$
-      extra_refs:
-        - org: kyma-project
-          repo: test-infra
-          path_alias: github.com/kyma-project/test-infra
-          base_ref: main
       spec:
         containers:
-          - image: "eu.gcr.io/kyma-project/test-infra/buildpack-golang:v20220926-fbffe961"
-            securityContext:
-              privileged: true
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-566f916e6"
             command:
-              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-generic.sh"
+              - "/kaniko-build"
             args:
-              - "/home/prow/go/src/github.com/kyma-project/runtime-watcher/skr"
-              - "docker-build"
-              - "docker-push"
-            resources:
-              requests:
-                memory: 3Gi
-                cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
+              - "--name=runtime-watcher-skr"
+              - "--config=/config/kaniko-build-config.yaml"
+              - "--context=skr"
+              - "--dockerfile=Dockerfile"
+            volumeMounts:
+              - name: config
+                mountPath: /config
+                readOnly: true
+        volumes:
+          - name: config
+            configMap:
+              name: kaniko-build-config
   

--- a/prow/jobs/runtime-watcher/runtime-watcher.yaml
+++ b/prow/jobs/runtime-watcher/runtime-watcher.yaml
@@ -239,7 +239,7 @@ presubmits: # runs on PRs
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-566f916e6"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220923-cdc39230b"
             command:
               - "/kaniko-build"
             args:
@@ -272,7 +272,7 @@ presubmits: # runs on PRs
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-566f916e6"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220923-cdc39230b"
             command:
               - "/kaniko-build"
             args:
@@ -308,7 +308,7 @@ postsubmits: # runs on main
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-566f916e6"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220923-cdc39230b"
             command:
               - "/kaniko-build"
             args:
@@ -341,7 +341,7 @@ postsubmits: # runs on main
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-566f916e6"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220923-cdc39230b"
             command:
               - "/kaniko-build"
             args:

--- a/templates/data/lifecycle-manager-data.yaml
+++ b/templates/data/lifecycle-manager-data.yaml
@@ -14,7 +14,7 @@ templates:
               - "^main$"
             pubsub_project: "sap-kyma-prow"
             pubsub_topic: "prowjobs"
-            image: eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-566f916e6
+            image: eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220923-cdc39230b
             command: /kaniko-build
             labels:
               preset-sa-gcr-push: "true"

--- a/templates/data/lifecycle-manager-data.yaml
+++ b/templates/data/lifecycle-manager-data.yaml
@@ -11,7 +11,6 @@ templates:
             max_concurrency: "10"
             decorate: "true"
             branches:
-              - "^master$"
               - "^main$"
             pubsub_project: "sap-kyma-prow"
             pubsub_topic: "prowjobs"
@@ -68,7 +67,6 @@ templates:
                     - "--config=/config/kaniko-build-config.yaml"
                     - "--context=operator"
                     - "--dockerfile=Dockerfile"
-                    - "--directory=."
                 inheritedConfigs:
                   local:
                     - default
@@ -82,7 +80,6 @@ templates:
                     - "--config=/config/kaniko-build-config.yaml"
                     - "--context=operator"
                     - "--dockerfile=Dockerfile"
-                    - "--directory=."
                 inheritedConfigs:
                   local:
                     - default

--- a/templates/data/module-manager-data.yaml
+++ b/templates/data/module-manager-data.yaml
@@ -14,7 +14,7 @@ templates:
               - "^main$"
             pubsub_project: "sap-kyma-prow"
             pubsub_topic: "prowjobs"
-            image: eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-566f916e6
+            image: eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220923-cdc39230b
             command: /kaniko-build
             labels:
               preset-sa-gcr-push: "true"

--- a/templates/data/module-manager-data.yaml
+++ b/templates/data/module-manager-data.yaml
@@ -2,6 +2,29 @@ templates:
   - from: generic.tmpl
     render:
       - to: ../../prow/jobs/module-manager/module-manager.yaml
+        localSets:
+          jobConfig_default:
+            imagePullPolicy: "Always"
+            privileged: "false"
+          default:
+            skip_report: "false"
+            max_concurrency: "10"
+            decorate: "true"
+            branches:
+              - "^main$"
+            pubsub_project: "sap-kyma-prow"
+            pubsub_topic: "prowjobs"
+            image: eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-566f916e6
+            command: /kaniko-build
+            labels:
+              preset-sa-gcr-push: "true"
+            volumes:
+              - name: config
+                configMapName: kaniko-build-config
+            volumeMounts:
+              - name: config
+                mountPath: /config
+                readOnly: true
         jobConfigs:
           - repoName: kyma-project/module-manager
             jobs:
@@ -42,42 +65,28 @@ templates:
                     - "jobConfig_presubmit"
                     - "build_labels" # default labels
               - jobConfig:
-                  labels:
-                    preset-docker-push-repository-kyma: "true" # sets GCR Registry through DOCKER_PUSH_REPOSITORY
-                  name: "pull-build"
+                  name: pull-build
                   always_run: true
-                  command: "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-generic.sh"
                   args:
-                    - "/home/prow/go/src/github.com/kyma-project/module-manager/operator"
-                    - "docker-build"
-                    - "docker-push"
-                  branches:
-                    - ^main$
+                    - "--name=module-manager"
+                    - "--config=/config/kaniko-build-config.yaml"
+                    - "--context=operator"
+                    - "--dockerfile=Dockerfile"
                 inheritedConfigs:
+                  local:
+                    - default
                   global:
-                    - jobConfig_default
                     - jobConfig_presubmit
-                    - extra_refs_test-infra
-                    - image_buildpack-golang
-                    - jobConfig_generic_component
-                    - "build_labels" # default labels
               - jobConfig:
-                  labels:
-                    preset-docker-push-repository-kyma: "true" # sets GCR Registry through DOCKER_PUSH_REPOSITORY
-                  name: "main-build"
+                  name: main-build
                   always_run: true
-                  command: "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-generic.sh"
                   args:
-                    - "/home/prow/go/src/github.com/kyma-project/module-manager/operator"
-                    - "docker-build"
-                    - "docker-push"
-                  branches:
-                    - ^main$
+                    - "--name=module-manager"
+                    - "--config=/config/kaniko-build-config.yaml"
+                    - "--context=operator"
+                    - "--dockerfile=Dockerfile"
                 inheritedConfigs:
+                  local:
+                    - default
                   global:
-                    - jobConfig_default
                     - jobConfig_postsubmit
-                    - extra_refs_test-infra
-                    - image_buildpack-golang
-                    - jobConfig_generic_component
-                    - "build_labels" # default labels

--- a/templates/data/runtime-watcher-data.yaml
+++ b/templates/data/runtime-watcher-data.yaml
@@ -14,7 +14,7 @@ templates:
               - "^main$"
             pubsub_project: "sap-kyma-prow"
             pubsub_topic: "prowjobs"
-            image: eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-566f916e6
+            image: eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220923-cdc39230b
             command: /kaniko-build
             labels:
               preset-sa-gcr-push: "true"

--- a/templates/data/runtime-watcher-data.yaml
+++ b/templates/data/runtime-watcher-data.yaml
@@ -2,13 +2,36 @@ templates:
   - from: generic.tmpl
     render:
       - to: ../../prow/jobs/runtime-watcher/runtime-watcher.yaml
+        localSets:
+          jobConfig_default:
+            imagePullPolicy: "Always"
+            privileged: "false"
+          default:
+            skip_report: "false"
+            max_concurrency: "10"
+            decorate: "true"
+            branches:
+              - "^main$"
+            pubsub_project: "sap-kyma-prow"
+            pubsub_topic: "prowjobs"
+            image: eu.gcr.io/sap-kyma-neighbors-dev/kaniko-build:v20220907-566f916e6
+            command: /kaniko-build
+            labels:
+              preset-sa-gcr-push: "true"
+            volumes:
+              - name: config
+                configMapName: kaniko-build-config
+            volumeMounts:
+              - name: config
+                mountPath: /config
+                readOnly: true
         jobConfigs:
           - repoName: kyma-project/runtime-watcher
             jobs:
               - jobConfig:
                   run_if_changed: "^skr/(go.mod|go.sum)$|^skr/*/(.*.go|Makefile|.*.sh)"
                   image: "eu.gcr.io/kyma-project/test-infra/golangci-lint:v20220830-7bf905118"
-                  name: "pull-skr-lint"
+                  name: pull-lint-skr
                   command: "bash"
                   args:
                     - "-c"
@@ -21,7 +44,7 @@ templates:
                     - jobConfig_presubmit
               - jobConfig:
                   run_if_changed: "^skr/(go.mod|go.sum)$|^skr/*/(.*.go|Makefile|.*.sh)"
-                  name: pull-skr-tests
+                  name: pull-tests-skr
                   command: "bash"
                   args:
                     - "-c"
@@ -37,7 +60,7 @@ templates:
               - jobConfig:
                   run_if_changed: "^kcp/(go.mod|go.sum)$|^kcp/*/(.*.go|Makefile|.*.sh)"
                   image: "eu.gcr.io/kyma-project/test-infra/golangci-lint:v20220830-7bf905118"
-                  name: "pull-kcp-lint"
+                  name: pull-lint-kcp
                   command: "bash"
                   args:
                     - "-c"
@@ -50,7 +73,7 @@ templates:
                     - jobConfig_presubmit
               - jobConfig:
                   run_if_changed: "^kcp/(go.mod|go.sum)$|^kcp/*/(.*.go|Makefile|.*.sh)"
-                  name: pull-kcp-tests
+                  name: pull-tests-kcp
                   command: "bash"
                   args:
                     - "-c"
@@ -66,7 +89,7 @@ templates:
               - jobConfig:
                   run_if_changed: "^listener/(go.mod|go.sum)$|^listener/*/(.*.go|Makefile|.*.sh)"
                   image: "eu.gcr.io/kyma-project/test-infra/golangci-lint:v20220830-7bf905118"
-                  name: "pull-listener-lint"
+                  name: "pull-lint-listener"
                   command: "bash"
                   args:
                     - "-c"
@@ -79,7 +102,7 @@ templates:
                     - jobConfig_presubmit
               - jobConfig:
                   run_if_changed: "^listener/(go.mod|go.sum)$|^listener/*/(.*.go|Makefile|.*.sh)"
-                  name: pull-listener-tests
+                  name: pull-tests-listener
                   command: "bash"
                   args:
                     - "-c"
@@ -93,82 +116,54 @@ templates:
                     - "jobConfig_presubmit"
                     - "build_labels" # default labels
               - jobConfig:
-                  labels:
-                    preset-docker-push-repository-kyma: "true" # sets GCR Registry through DOCKER_PUSH_REPOSITORY
-                  name: "pull-kcp-build"
+                  name: pull-build-kcp
                   run_if_changed: "^kcp/"
-                  command: "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-generic.sh"
                   args:
-                    - "/home/prow/go/src/github.com/kyma-project/runtime-watcher/kcp"
-                    - "docker-build"
-                    - "docker-push"
-                  branches:
-                    - ^main$
+                    - "--name=runtime-watcher-kcp"
+                    - "--config=/config/kaniko-build-config.yaml"
+                    - "--context=kcp"
+                    - "--dockerfile=Dockerfile"
                 inheritedConfigs:
+                  local:
+                    - default
                   global:
-                    - jobConfig_default
                     - jobConfig_presubmit
-                    - extra_refs_test-infra
-                    - image_buildpack-golang
-                    - jobConfig_generic_component
-                    - "build_labels" # default labels
               - jobConfig:
-                  labels:
-                    preset-docker-push-repository-kyma: "true" # sets GCR Registry through DOCKER_PUSH_REPOSITORY
-                  name: "main-kcp-build"
-                  run_if_changed: "^kcp/"
-                  command: "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-generic.sh"
+                  name: main-build-kcp
+                  always_run: true
                   args:
-                    - "/home/prow/go/src/github.com/kyma-project/runtime-watcher/kcp"
-                    - "docker-build"
-                    - "docker-push"
-                  branches:
-                    - ^main$
+                    - "--name=runtime-watcher-kcp"
+                    - "--config=/config/kaniko-build-config.yaml"
+                    - "--context=kcp"
+                    - "--dockerfile=Dockerfile"
                 inheritedConfigs:
+                  local:
+                    - default
                   global:
-                    - jobConfig_default
                     - jobConfig_postsubmit
-                    - extra_refs_test-infra
-                    - image_buildpack-golang
-                    - jobConfig_generic_component
-                    - "build_labels" # default labels
               - jobConfig:
-                  labels:
-                    preset-docker-push-repository-kyma: "true" # sets GCR Registry through DOCKER_PUSH_REPOSITORY
-                  name: "pull-skr-build"
+                  name: pull-build-skr
                   run_if_changed: "^skr/"
-                  command: "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-generic.sh"
                   args:
-                    - "/home/prow/go/src/github.com/kyma-project/runtime-watcher/skr"
-                    - "docker-build"
-                    - "docker-push"
-                  branches:
-                    - ^main$
+                    - "--name=runtime-watcher-skr"
+                    - "--config=/config/kaniko-build-config.yaml"
+                    - "--context=skr"
+                    - "--dockerfile=Dockerfile"
                 inheritedConfigs:
+                  local:
+                    - default
                   global:
-                    - jobConfig_default
                     - jobConfig_presubmit
-                    - extra_refs_test-infra
-                    - image_buildpack-golang
-                    - jobConfig_generic_component
-                    - "build_labels" # default labels
               - jobConfig:
-                  labels:
-                    preset-docker-push-repository-kyma: "true" # sets GCR Registry through DOCKER_PUSH_REPOSITORY
-                  name: "main-skr-build"
-                  run_if_changed: "^skr/"
-                  command: "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/build-generic.sh"
+                  name: main-build-skr
+                  always_run: true
                   args:
-                    - "/home/prow/go/src/github.com/kyma-project/runtime-watcher/skr"
-                    - "docker-build"
-                    - "docker-push"
-                  branches:
-                    - ^main$
+                    - "--name=runtime-watcher-skr"
+                    - "--config=/config/kaniko-build-config.yaml"
+                    - "--context=skr"
+                    - "--dockerfile=Dockerfile"
                 inheritedConfigs:
+                  local:
+                    - default
                   global:
-                    - jobConfig_default
                     - jobConfig_postsubmit
-                    - extra_refs_test-infra
-                    - image_buildpack-golang
-                    - jobConfig_generic_component
-                    - "build_labels" # default labels

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,4 @@
+pjNames:
+  - pjName: "main-build-skr"
+  - pjName: "main-build-kcp"
+  - pjName: "main-build"

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,4 +1,0 @@
-pjNames:
-  - pjName: "main-build-skr"
-  - pjName: "main-build-kcp"
-  - pjName: "main-build"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- changes module-manager to only use kaniko builds
- changes runtime-watcher (skr & kcp operators) to only use kaniko builds
- unifies naming of runtime watcher jobs to be suffix based

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
