### PR TITLE
bump to go image to golang:1.19.2-alpine3.16

### DIFF
--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -12,7 +12,7 @@ images:
 - source: "fluent/fluent-bit:1.8.3"
 - source: "gcr.io/google-containers/pause-amd64:3.2"
 # Golang image is pinned because it is force updated in the upstream
-- source: "golang@sha256:2a949686d9886ac7c10582a6c29116fd29d3077d02755e87e111870d63607725"
+- source: "golang@sha256:45d14bdb069fd5e1fee50160a3e15752038f0fabf339a5ed7f342b84701ed3d6"
   tag: "1.19.2-alpine3.16"
 - source: "grafana/loki:2.2.1"
 - source: "grafana/grafana-image-renderer:3.2.1"

--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -12,8 +12,8 @@ images:
 - source: "fluent/fluent-bit:1.8.3"
 - source: "gcr.io/google-containers/pause-amd64:3.2"
 # Golang image is pinned because it is force updated in the upstream
-- source: "golang@sha256:ca4f0513119dfbdc65ae7b76b69688f0723ed00d9ecf9de68abbf6ed01ef11bf"
-  tag: "1.19.1-alpine3.16"
+- source: "golang@sha256:2a949686d9886ac7c10582a6c29116fd29d3077d02755e87e111870d63607725"
+  tag: "1.19.2-alpine3.16"
 - source: "grafana/loki:2.2.1"
 - source: "grafana/grafana-image-renderer:3.2.1"
 - source: "hudymi/mockice:0.1.3"


### PR DESCRIPTION
go 1.19.2 was released.
this is the new alpine image: https://hub.docker.com/layers/library/golang/1.19.2-alpine3.16/images/sha256-45d14bdb069fd5e1fee50160a3e15752038f0fabf339a5ed7f342b84701ed3d6?context=explore