### PR TITLE
Disable batch_size_limit for all repos in Kyma

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -270,7 +270,7 @@ branch-protection:
 tide:
   sync_period: 2m
   batch_size_limit:
-    kyma-project/kyma: -1 # disable batch merging for Kyma repo
+    '*': -1 # disable batch merging for all repos
   merge_method:
     kyma-project/kyma: squash
     kyma-project/website: squash

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -268,7 +268,7 @@ branch-protection:
 tide:
   sync_period: 2m
   batch_size_limit:
-    kyma-project/kyma: -1 # disable batch merging for Kyma repo
+    '*': -1 # disable batch merging for all repos
   merge_method:
     kyma-project/kyma: squash
     kyma-project/website: squash


### PR DESCRIPTION
Builds don't work because batches aren't considered as presubmits for tide when it merges PRs. That breaks image building, because it relies on JOB_TYPE=presubmit env variable This will slow down merging a bit, but will fix problem of not merging batches

