### PR TITLE
Remove `--directory` flag in favour of using `--name`

### DIFF
--- a/development/image-builder/README.md
+++ b/development/image-builder/README.md
@@ -73,8 +73,6 @@ Usage of image-builder:
         Path to application config file (default "/config/image-builder-config.yaml")
   -context string
         Path to build directory context (default ".")
-  -directory string
-        Destination directory where the image is be pushed. This flag will be ignored if running in presubmit job and devRegistry is provided in config.yaml
   -dockerfile string
         Path to Dockerfile file relative to context (default "Dockerfile")
   -log-dir string

--- a/development/image-builder/main.go
+++ b/development/image-builder/main.go
@@ -19,7 +19,6 @@ type options struct {
 	configPath     string
 	context        string
 	dockerfile     string
-	directory      string
 	name           string
 	variant        string
 	logDir         string
@@ -203,7 +202,7 @@ func runBuildJob(o options, vs Variants) error {
 
 	if len(vs) == 0 {
 		// variants.yaml file not present or either empty. Run single build.
-		destinations := gatherDestinations(repo, o.directory, o.name, tags)
+		destinations := gatherDestinations(repo, o.name, tags)
 		fmt.Println("Starting build for image: ", strings.Join(destinations, ", "))
 		err = runFunc(o, "build", destinations, o.platforms, make(map[string]string))
 		if err != nil {
@@ -218,7 +217,7 @@ func runBuildJob(o options, vs Variants) error {
 		for _, tag := range tags {
 			variantTags = append(variantTags, tag+"-"+variant)
 		}
-		destinations := gatherDestinations(repo, o.directory, o.name, variantTags)
+		destinations := gatherDestinations(repo, o.name, variantTags)
 		fmt.Println("Starting build for image: ", strings.Join(destinations, ", "))
 		if err := runFunc(o, variant, destinations, o.platforms, env); err != nil {
 			errs = append(errs, fmt.Errorf("job %s ended with error: %w", variant, err))
@@ -260,11 +259,11 @@ func getTags(pr, sha, tagTemplate string, additionalTags []string) ([]string, er
 	return tags, nil
 }
 
-func gatherDestinations(repo []string, directory, name string, tags []string) []string {
+func gatherDestinations(repo []string, name string, tags []string) []string {
 	var dst []string
 	for _, t := range tags {
 		for _, r := range repo {
-			image := path.Join(r, directory, name)
+			image := path.Join(r, name)
 			dst = append(dst, image+":"+strings.ReplaceAll(t, " ", "-"))
 		}
 	}
@@ -290,7 +289,6 @@ func (o *options) gatherOptions(fs *flag.FlagSet) *flag.FlagSet {
 	fs.BoolVar(&o.silent, "silent", false, "Do not push build logs to stdout")
 	fs.StringVar(&o.configPath, "config", "/config/image-builder-config.yaml", "Path to application config file")
 	fs.StringVar(&o.context, "context", ".", "Path to build directory context")
-	fs.StringVar(&o.directory, "directory", "", "Destination directory where the image is be pushed. This flag will be ignored if running in presubmit job and devRegistry is provided in config.yaml")
 	fs.StringVar(&o.name, "name", "", "Name of the image to be built")
 	fs.StringVar(&o.dockerfile, "dockerfile", "Dockerfile", "Path to Dockerfile file relative to context")
 	fs.StringVar(&o.variant, "variant", "", "If variants.yaml file is present, define which variant should be built. If variants.yaml is not present, this flag will be ignored")

--- a/development/image-builder/main_test.go
+++ b/development/image-builder/main_test.go
@@ -9,16 +9,14 @@ import (
 
 func Test_gatherDestinations(t *testing.T) {
 	tc := []struct {
-		name      string
-		directory string
-		repos     []string
-		tags      []string
-		expected  []string
+		name     string
+		repos    []string
+		tags     []string
+		expected []string
 	}{
 		{
-			name:      "test-image",
-			repos:     []string{"dev.kyma.io", "dev2.kyma.io"},
-			directory: "subdirectory",
+			name:  "subdirectory/test-image",
+			repos: []string{"dev.kyma.io", "dev2.kyma.io"},
 			tags: []string{
 				"20222002-abcd1234",
 				"latest",
@@ -42,7 +40,7 @@ func Test_gatherDestinations(t *testing.T) {
 	}
 	for _, c := range tc {
 		t.Run(c.name, func(t *testing.T) {
-			got := gatherDestinations(c.repos, c.directory, c.name, c.tags)
+			got := gatherDestinations(c.repos, c.name, c.tags)
 			if len(c.expected) != len(got) {
 				t.Errorf("result length mismatch. wanted %v, got %v", len(c.expected), len(got))
 			}
@@ -95,7 +93,6 @@ func Test_validateOptions(t *testing.T) {
 			name:      "parsed config",
 			expectErr: false,
 			opts: options{
-				directory:  "kyma.dev",
 				context:    "directory/",
 				name:       "test-image",
 				dockerfile: "Dockerfile",
@@ -105,7 +102,6 @@ func Test_validateOptions(t *testing.T) {
 			name:      "context missing",
 			expectErr: true,
 			opts: options{
-				directory:  "kyma.dev",
 				name:       "test-image",
 				dockerfile: "Dockerfile",
 			},
@@ -114,7 +110,6 @@ func Test_validateOptions(t *testing.T) {
 			name:      "name missing",
 			expectErr: true,
 			opts: options{
-				directory:  "kyma.dev",
 				context:    "directory/",
 				dockerfile: "Dockerfile",
 			},
@@ -123,9 +118,8 @@ func Test_validateOptions(t *testing.T) {
 			name:      "dockerfile missing",
 			expectErr: true,
 			opts: options{
-				directory: "kyma.dev",
-				context:   "directory/",
-				name:      "test-image",
+				context: "directory/",
+				name:    "test-image",
 			},
 		},
 	}
@@ -167,7 +161,6 @@ func TestFlags(t *testing.T) {
 			expectedErr: false,
 			expectedOpts: options{
 				name:           "test-image",
-				directory:      "subdirectory",
 				additionalTags: []string{"latest", "cookie"},
 				context:        "prow/build",
 				configPath:     "config.yaml",
@@ -178,7 +171,6 @@ func TestFlags(t *testing.T) {
 			args: []string{
 				"--config=config.yaml",
 				"--dockerfile=Dockerfile",
-				"--directory=subdirectory",
 				"--name=test-image",
 				"--tag=latest",
 				"--tag=cookie",


### PR DESCRIPTION
Closes #6130 

/area ci
/kind deprecation

Remove `--directory` flag to avoid confusion and treat `--name` as go-to flag to define image name with full subpath to image.
