### PR TITLE
Move kubebuilder path to end of PATH in go-builder

### DIFF
--- a/prow/images/buildpack-golang/Dockerfile
+++ b/prow/images/buildpack-golang/Dockerfile
@@ -42,8 +42,8 @@ RUN curl -fLSs -o go.tar.gz "https://dl.google.com/go/go${GO_VERSION}.linux-${AR
     mkdir -p "${GOPATH}/src" && \
     curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 
-# Install kubebuilder
 ENV PATH /home/prow/go/bin:$PATH
+# Install kubebuilder
 # Do not alter base image tools path with kubebuilder
 ENV PATH=$PATH:/usr/local/kubebuilder/bin
 

--- a/prow/images/buildpack-golang/Dockerfile
+++ b/prow/images/buildpack-golang/Dockerfile
@@ -43,8 +43,9 @@ RUN curl -fLSs -o go.tar.gz "https://dl.google.com/go/go${GO_VERSION}.linux-${AR
     curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 
 # Install kubebuilder
-ENV PATH /usr/local/kubebuilder/bin:$PATH
 ENV PATH /home/prow/go/bin:$PATH
+# Do not alter base image tools path with kubebuilder
+ENV PATH=$PATH:/usr/local/kubebuilder/bin
 
 RUN curl -fLSs -o kubebuilder.tar.gz "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_${KUBEBUILDER_VERSION}_linux_${ARCH}.tar.gz" && \
     tar -zxvf kubebuilder.tar.gz && \


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Place kubebuilder path at the end of PATH env variable to prevent overriding paths of base image tools

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- Resolves #5441 