### PR TITLE
bump image nats-config-reloader to v0.7.4

### DIFF
--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -46,6 +46,6 @@ images:
 - source: "quay.io/prometheus/prometheus:v2.38.0"
 - source: "nats@sha256:bf9cae35d4496a6557faaaa46222bc55961ffdea0f6d833968a7fe798581a289"
   tag: "2.9.3-alpine3.16"
-- source: "natsio/nats-server-config-reloader:0.7.2"
+- source: "natsio/nats-server-config-reloader:0.7.4"
 - source: "natsio/prometheus-nats-exporter:0.10.0"
 - source: "mockserver/mockserver:mockserver-5.11.2"


### PR DESCRIPTION
bump the image of `nats-config-reloader` to `v0.7.4`

https://hub.docker.com/layers/natsio/nats-server-config-reloader/0.7.4/images/sha256-b8c42f0dc7cb4de5749bd1a3040f2e298cbf961397ec85f29c39ad098508faf1?context=explore

