### PR TITLE
Remove reviewers for markdown files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -56,6 +56,3 @@
 
 /templates @kyma-project/prow
 /templates/templates @kyma-project/prow
-
-# All .md files
-*.md @mmitoraj @majakurcius @NHingerl @grego952 @IwonaLanger  


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Remove codeowners for markdown files. Markdown files are generated by the script, no need to review them.

