### PR TITLE
Fix buildkit export-cache ref

### DIFF
--- a/development/image-builder/main.go
+++ b/development/image-builder/main.go
@@ -75,7 +75,7 @@ func runInBuildKit(o options, name string, destinations, platforms []string, bui
 		// TODO (@Ressetkk): Implement multiple caches, see https://github.com/moby/buildkit#export-cache
 		args = append(args,
 			"--export-cache", "type=registry,ref="+o.Cache.CacheRepo,
-			"--import-cache", "type=registry,"+o.Cache.CacheRepo)
+			"--import-cache", "type=registry,ref="+o.Cache.CacheRepo)
 	}
 
 	cmd := exec.Command("buildctl-daemonless.sh", args...)


### PR DESCRIPTION
/area tooling
/kind bug

Add missing ref parameter to import-cache buildkit flag.

This should resolve error
```
error: invalid value europe-docker.pkg.dev/kyma-project/cache/cache
build encountered error: exit status 1
```