### PR TITLE
Allow scheduling inrepo prowjobs on untrusted cluster only.

### DIFF
--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -190,7 +190,7 @@ in_repo_config:
   enabled:
     "*": true
   allowed_clusters:
-    "*": ["default", "untrusted-workload", "trusted-workload"]
+    "*": ["untrusted-workload"]
 
 branch-protection:
   enforce_admins: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Restrict inrepo config defined prowjobs to be scheduled on unstrusted cluster only.

Solution for allowing dedicated inrepo config projobs to run on trusted cluster is not ready yet. At this moment trusted cluster must be allowed for static prowjobs only.
