### PR TITLE
bump image of prometheus-nats-exporter to v0.10.1

### DIFF
--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -47,5 +47,5 @@ images:
 - source: "nats@sha256:bf9cae35d4496a6557faaaa46222bc55961ffdea0f6d833968a7fe798581a289"
   tag: "2.9.3-alpine3.16"
 - source: "natsio/nats-server-config-reloader:0.7.4"
-- source: "natsio/prometheus-nats-exporter:0.10.0"
+- source: "natsio/prometheus-nats-exporter:0.10.1"
 - source: "mockserver/mockserver:mockserver-5.11.2"


### PR DESCRIPTION
Title says it all.

docker repo: https://hub.docker.com/layers/natsio/prometheus-nats-exporter/0.10.1/images/sha256-37a39c6aa042b203af7e55c5cf7db3858f93f3236b8ad4b66d93769652fdcdc0?context=explore

release notes: https://github.com/nats-io/prometheus-nats-exporter/releases/tag/v0.10.1