### PR TITLE
bump nats server to v2.9.5-alpine3.16

### DIFF
--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -45,7 +45,7 @@ images:
 - source: "quay.io/prometheus/alertmanager:v0.24.0"
 - source: "quay.io/prometheus/prometheus:v2.39.1"
 - source: "nats@sha256:bf9cae35d4496a6557faaaa46222bc55961ffdea0f6d833968a7fe798581a289"
-  tag: "2.9.3-alpine3.16"
+  tag: "2.9.5-alpine3.16"
 - source: "natsio/nats-server-config-reloader:0.7.4"
 - source: "natsio/prometheus-nats-exporter:0.10.1"
 - source: "mockserver/mockserver:mockserver-5.11.2"

--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -44,7 +44,7 @@ images:
 - source: "quay.io/prometheus-operator/prometheus-operator:v0.60.1"
 - source: "quay.io/prometheus/alertmanager:v0.24.0"
 - source: "quay.io/prometheus/prometheus:v2.39.1"
-- source: "nats@sha256:bf9cae35d4496a6557faaaa46222bc55961ffdea0f6d833968a7fe798581a289"
+- source: "nats@sha256:b961cb563a3c05e116ece911ad75c0dca8580521e1dc744f63fa78b2543e0aa8"
   tag: "2.9.5-alpine3.16"
 - source: "natsio/nats-server-config-reloader:0.7.4"
 - source: "natsio/prometheus-nats-exporter:0.10.1"


### PR DESCRIPTION
docker repo: https://hub.docker.com/_/nats/

release notes: https://github.com/nats-io/nats-server/releases/tag/v2.9.5