### PR TITLE
Wrap error returned by function and pass it up. It was not clear from…

### DIFF
--- a/development/tools/pkg/pjtester/pjtester.go
+++ b/development/tools/pkg/pjtester/pjtester.go
@@ -290,11 +290,11 @@ func (pjopts *testProwJobOptions) genJobSpec(o options, conf *config.Config, pjC
 			})
 			pjs, err = pjopts.setProwJobSpecRefs(pjs, o)
 			if err != nil {
-				return config.JobBase{}, prowapi.ProwJobSpec{}, fmt.Errorf("failed generate presubmit refs")
+				return config.JobBase{}, prowapi.ProwJobSpec{}, fmt.Errorf("failed generate presubmit refs, error: %w", err)
 			}
 			pjs, err = pjopts.setProwJobSpecExtraRefs(pjs, o)
 			if err != nil {
-				return config.JobBase{}, prowapi.ProwJobSpec{}, fmt.Errorf("failed generate presubmit extrarefs")
+				return config.JobBase{}, prowapi.ProwJobSpec{}, fmt.Errorf("failed generate presubmit extrarefs, error: %w", err)
 			}
 			return p.JobBase, pjs, nil
 		}
@@ -311,11 +311,11 @@ func (pjopts *testProwJobOptions) genJobSpec(o options, conf *config.Config, pjC
 			})
 			pjs, err = pjopts.setProwJobSpecRefs(pjs, o)
 			if err != nil {
-				return config.JobBase{}, prowapi.ProwJobSpec{}, fmt.Errorf("failed generate presubmit refs")
+				return config.JobBase{}, prowapi.ProwJobSpec{}, fmt.Errorf("failed generate postsubmit refs, error: %w", err)
 			}
 			pjs, err = pjopts.setProwJobSpecExtraRefs(pjs, o)
 			if err != nil {
-				return config.JobBase{}, prowapi.ProwJobSpec{}, fmt.Errorf("failed generate presubmit extrarefs")
+				return config.JobBase{}, prowapi.ProwJobSpec{}, fmt.Errorf("failed generate postsubmit extrarefs, error: %w", err)
 			}
 			return p.JobBase, pjs, nil
 		}
@@ -329,7 +329,7 @@ func (pjopts *testProwJobOptions) genJobSpec(o options, conf *config.Config, pjC
 			pjs := pjutil.PeriodicSpec(p)
 			pjs, err = pjopts.setProwJobSpecExtraRefs(pjs, o)
 			if err != nil {
-				return config.JobBase{}, prowapi.ProwJobSpec{}, fmt.Errorf("failed generate presubmit extrarefs")
+				return config.JobBase{}, prowapi.ProwJobSpec{}, fmt.Errorf("failed generate periodic extrarefs, error: %w", err)
 			}
 			return p.JobBase, pjs, nil
 		}


### PR DESCRIPTION
… logs why generating presubmit refs failed.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Added missing error wrap returned by functions setting refs and extra refs on prowjob specs. Returned error message didn't provide details why setting refs or extrarefs failed.
- Fixed error message to provide correct prowjob type.