### PR TITLE
Make reconciler-cli-kyma-prev-to-last-release-upgrade-k3d optional

### DIFF
--- a/prow/jobs/incubator/reconciler/reconciler.yaml
+++ b/prow/jobs/incubator/reconciler/reconciler.yaml
@@ -213,6 +213,7 @@ presubmits: # runs on PRs
         preset-kyma-guard-bot-github-token: "true"
         preset-sa-vm-kyma-integration: "true"
       run_if_changed: '^((cmd\S+|configs\S+|internal\S+|pkg\S+)(\.[^.][^.][^.]+$|\.[^.][^dD]$|\.[^mM][^.]$|\.[^.]$|/[^.]+$))'
+      optional: true
       skip_report: false
       decorate: true
       cluster: untrusted-workload

--- a/templates/data/incubator-buildpack-data.yaml
+++ b/templates/data/incubator-buildpack-data.yaml
@@ -311,6 +311,7 @@ templates:
                     - reconciler_cli_integration_jobConfig
               - jobConfig:
                   name: "pre-main-reconciler-cli-kyma-prev-to-last-release-upgrade-k3d"
+                  optional: true
                   # following regexp won't start build if only Markdown files were changed
                   run_if_changed: "^((cmd\\S+|configs\\S+|internal\\S+|pkg\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
                   labels:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Make the failing test optional until the fix arrives

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/15994