### PR TITLE
Introduce template operator pipeline

### DIFF
--- a/prow/jobs/lifecycle-manager/lifecycle-manager.yaml
+++ b/prow/jobs/lifecycle-manager/lifecycle-manager.yaml
@@ -113,12 +113,12 @@ presubmits: # runs on PRs
   
 postsubmits: # runs on main
   kyma-project/lifecycle-manager:
-    - name: main-lifecycle-build
+    - name: main-lifecycle-mgr-build
       annotations:
         pipeline.trigger: "pr-merge"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "main-lifecycle-build"
+        prow.k8s.io/pubsub.runID: "main-lifecycle-mgr-build"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
       always_run: true

--- a/prow/jobs/module-manager/module-manager.yaml
+++ b/prow/jobs/module-manager/module-manager.yaml
@@ -3,13 +3,13 @@
 
 presubmits: # runs on PRs
   kyma-project/module-manager:
-    - name: pull-lint
+    - name: pull-module-mgr-lint
       annotations:
         description: "executes the 'make lint' command in the module-manager 'operator' directory before any pull request."
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pull-lint"
+        prow.k8s.io/pubsub.runID: "pull-module-mgr-lint"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-dind-enabled: "true"
         preset-docker-push-repository-kyma: "true"
@@ -45,13 +45,13 @@ presubmits: # runs on PRs
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
-    - name: pull-tests
+    - name: pull-module-mgr-tests
       annotations:
         description: "executes the 'make test' command in the module-manager 'operator' directory before any pull request."
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pull-tests"
+        prow.k8s.io/pubsub.runID: "pull-module-mgr-tests"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-dind-enabled: "true"
         preset-docker-push-repository-kyma: "true"
@@ -87,12 +87,12 @@ presubmits: # runs on PRs
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
-    - name: pull-build
+    - name: pull-module-mgr-build
       annotations:
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pull-build"
+        prow.k8s.io/pubsub.runID: "pull-module-mgr-build"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
       always_run: true
@@ -123,12 +123,12 @@ presubmits: # runs on PRs
   
 postsubmits: # runs on main
   kyma-project/module-manager:
-    - name: main-build
+    - name: main-module-mgr-build
       annotations:
         pipeline.trigger: "pr-merge"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "main-build"
+        prow.k8s.io/pubsub.runID: "main-module-mgr-build"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
       always_run: true

--- a/prow/jobs/template-operator/template-operator.yaml
+++ b/prow/jobs/template-operator/template-operator.yaml
@@ -2,16 +2,16 @@
 
 
 presubmits: # runs on PRs
-  kyma-project/lifecycle-manager:
-    - name: pull-lifecycle-mgr-lint
+  kyma-project/template-operator:
+    - name: pull-template-op-lint
       annotations:
-        description: "executes the 'golangci-lint lint' command in the lifecycle-manager 'operator' directory before any pull request."
+        description: "executes the 'golangci-lint lint' command in the template-operator repository before any pull request."
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pull-lifecycle-mgr-lint"
+        prow.k8s.io/pubsub.runID: "pull-template-op-lint"
         prow.k8s.io/pubsub.topic: "prowjobs"
-      run_if_changed: '^operator/(go.mod|go.sum)$|^operator/*/(.*.go|Makefile|.*.sh)'
+      run_if_changed: '^.*.go|^.*.sh|^go.mod|^go.sum|^Makefile'
       skip_report: false
       decorate: true
       cluster: untrusted-workload
@@ -39,17 +39,17 @@ presubmits: # runs on PRs
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
-    - name: pull-lifecycle-mgr-tests
+    - name: pull-template-op-tests
       annotations:
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pull-lifecycle-mgr-tests"
+        prow.k8s.io/pubsub.runID: "pull-template-op-tests"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-dind-enabled: "true"
         preset-docker-push-repository-kyma: "true"
         preset-sa-gcr-push: "true"
-      run_if_changed: '^operator/(go.mod|go.sum)$|^operator/*/(.*.go|Makefile|.*.sh)'
+      run_if_changed: '^.*.go|^.*.sh|^go.mod|^go.sum|^Makefile'
       skip_report: false
       decorate: true
       cluster: untrusted-workload
@@ -77,12 +77,12 @@ presubmits: # runs on PRs
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
-    - name: pull-lifecycle-mgr-build
+    - name: pull-build-template-operator
       annotations:
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pull-lifecycle-mgr-build"
+        prow.k8s.io/pubsub.runID: "pull-build-template-operator"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
       always_run: true
@@ -98,7 +98,7 @@ presubmits: # runs on PRs
             command:
               - "/image-builder"
             args:
-              - "--name=lifecycle-manager"
+              - "--name=template-operator"
               - "--config=/config/kaniko-build-config.yaml"
               - "--context=operator"
               - "--dockerfile=Dockerfile"
@@ -112,13 +112,13 @@ presubmits: # runs on PRs
               name: kaniko-build-config
   
 postsubmits: # runs on main
-  kyma-project/lifecycle-manager:
-    - name: main-lifecycle-build
+  kyma-project/template-operator:
+    - name: main-template-op-build
       annotations:
         pipeline.trigger: "pr-merge"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "main-lifecycle-build"
+        prow.k8s.io/pubsub.runID: "main-template-op-build"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
       always_run: true
@@ -134,7 +134,7 @@ postsubmits: # runs on main
             command:
               - "/image-builder"
             args:
-              - "--name=lifecycle-manager"
+              - "--name=template-operator"
               - "--config=/config/kaniko-build-config.yaml"
               - "--context=operator"
               - "--dockerfile=Dockerfile"

--- a/prow/jobs/template-operator/template-operator.yaml
+++ b/prow/jobs/template-operator/template-operator.yaml
@@ -27,7 +27,7 @@ presubmits: # runs on PRs
               - "bash"
             args:
               - "-c"
-              - "cd operator && golangci-lint run"
+              - "make lint"
             resources:
               requests:
                 memory: 3Gi
@@ -65,7 +65,7 @@ presubmits: # runs on PRs
               - "bash"
             args:
               - "-c"
-              - "cd operator && make test"
+              - "make test"
             resources:
               requests:
                 memory: 3Gi

--- a/templates/data/lifecycle-manager-data.yaml
+++ b/templates/data/lifecycle-manager-data.yaml
@@ -73,7 +73,7 @@ templates:
                   global:
                     - jobConfig_presubmit
               - jobConfig:
-                  name: main-lifecycle-build
+                  name: main-lifecycle-mgr-build
                   always_run: true
                   args:
                     - "--name=lifecycle-manager"

--- a/templates/data/module-manager-data.yaml
+++ b/templates/data/module-manager-data.yaml
@@ -31,7 +31,7 @@ templates:
               - jobConfig:
                   run_if_changed: "^operator/(go.mod|go.sum)$|^operator/*/(.*.go|Makefile|.*.sh)"
                   image: "eu.gcr.io/kyma-project/test-infra/golangci-lint:v20221025-25ddc121"
-                  name: "pull-lint"
+                  name: "pull-module-mgr-lint"
                   annotations:
                     description: executes the 'make lint' command in the module-manager 'operator' directory before any pull request.
                   command: "bash"
@@ -48,7 +48,7 @@ templates:
                     - "build_labels" # default labels
               - jobConfig:
                   run_if_changed: "^operator/(go.mod|go.sum)$|^operator/*/(.*.go|Makefile|.*.sh)"
-                  name: pull-tests
+                  name: pull-module-mgr-tests
                   annotations:
                     description: executes the 'make test' command in the module-manager 'operator' directory before any pull request.
                   command: "bash"
@@ -65,7 +65,7 @@ templates:
                     - "jobConfig_presubmit"
                     - "build_labels" # default labels
               - jobConfig:
-                  name: pull-build
+                  name: pull-module-mgr-build
                   always_run: true
                   args:
                     - "--name=module-manager"
@@ -78,7 +78,7 @@ templates:
                   global:
                     - jobConfig_presubmit
               - jobConfig:
-                  name: main-build
+                  name: main-module-mgr-build
                   always_run: true
                   args:
                     - "--name=module-manager"

--- a/templates/data/template-operator-data.yaml
+++ b/templates/data/template-operator-data.yaml
@@ -1,7 +1,7 @@
 templates:
   - from: generic.tmpl
     render:
-      - to: ../../prow/jobs/lifecycle-manager/lifecycle-manager.yaml
+      - to: ../../prow/jobs/template-operator/template-operator.yaml
         localSets:
           jobConfig_default:
             imagePullPolicy: "Always"
@@ -26,14 +26,14 @@ templates:
                 mountPath: /config
                 readOnly: true
         jobConfigs:
-          - repoName: kyma-project/lifecycle-manager
+          - repoName: kyma-project/template-operator
             jobs:
               - jobConfig:
                   image: "eu.gcr.io/kyma-project/test-infra/golangci-lint:v20221025-25ddc121"
-                  name: pull-lifecycle-mgr-lint
-                  run_if_changed: "^operator/(go.mod|go.sum)$|^operator/*/(.*.go|Makefile|.*.sh)"
+                  name: pull-template-op-lint
+                  run_if_changed: "^.*.go|^.*.sh|^go.mod|^go.sum|^Makefile"
                   annotations:
-                    description: executes the 'golangci-lint lint' command in the lifecycle-manager 'operator' directory before any pull request.
+                    description: executes the 'golangci-lint lint' command in the template-operator repository before any pull request.
                   command: "bash"
                   args:
                     - "-c"
@@ -45,8 +45,8 @@ templates:
                     - jobConfig_default
                     - jobConfig_presubmit
               - jobConfig:
-                  run_if_changed: "^operator/(go.mod|go.sum)$|^operator/*/(.*.go|Makefile|.*.sh)"
-                  name: pull-lifecycle-mgr-tests # pre-main-lifecycle-manager-tests
+                  run_if_changed: "^.*.go|^.*.sh|^go.mod|^go.sum|^Makefile"
+                  name: pull-template-op-tests
                   command: "bash"
                   args:
                     - "-c"
@@ -60,10 +60,10 @@ templates:
                     - "jobConfig_presubmit"
                     - "build_labels" # default labels
               - jobConfig:
-                  name: pull-lifecycle-mgr-build
+                  name: pull-build-template-operator
                   always_run: true
                   args:
-                    - "--name=lifecycle-manager"
+                    - "--name=template-operator"
                     - "--config=/config/kaniko-build-config.yaml"
                     - "--context=operator"
                     - "--dockerfile=Dockerfile"
@@ -73,10 +73,10 @@ templates:
                   global:
                     - jobConfig_presubmit
               - jobConfig:
-                  name: main-lifecycle-build
+                  name: main-template-op-build
                   always_run: true
                   args:
-                    - "--name=lifecycle-manager"
+                    - "--name=template-operator"
                     - "--config=/config/kaniko-build-config.yaml"
                     - "--context=operator"
                     - "--dockerfile=Dockerfile"

--- a/templates/data/template-operator-data.yaml
+++ b/templates/data/template-operator-data.yaml
@@ -37,7 +37,7 @@ templates:
                   command: "bash"
                   args:
                     - "-c"
-                    - "cd operator && golangci-lint run"
+                    - "make lint"
                   branches:
                     - ^main$
                 inheritedConfigs:
@@ -50,7 +50,7 @@ templates:
                   command: "bash"
                   args:
                     - "-c"
-                    - "cd operator && make test" # run test make target of operator
+                    - "make test" # run test make target of operator
                   branches:
                     - ^main$ # any pr against main triggers this
                 inheritedConfigs:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Introduce pipelines for template operator
- Rename pipelines of lifecycle- and module-manager
    - Since prow does not distinguish between Repositories in the job history if the y have the same naming
    - Example: https://status.build.kyma-project.io/job-history/gs/kyma-prow-logs/pr-logs/directory/pull-lint
    This history includes jobs for lifecycle-manager, module-manager, as well as runtime-watcher, because the jobs have the same name

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
