### PR TITLE
Disable branch protection for admins for kyma-dashboard repo

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -227,6 +227,10 @@ branch-protection:
               required_status_checks:
                 contexts:
                   - "netlify/kyma-project-old/deploy-preview"
+        kyma-dashboard:
+            branches:
+              main:
+                enforce_admins: false
         private-fn-for-e2e-serverless-tests:
           protect: false
         organization-and-operations:

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -225,6 +225,10 @@ branch-protection:
               required_status_checks:
                 contexts:
                   - "netlify/kyma-project-old/deploy-preview"
+        kyma-dashboard:
+            branches:
+              main:
+                enforce_admins: false
         private-fn-for-e2e-serverless-tests:
           protect: false
         organization-and-operations:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- I assume "enforce_admins=false" is the same as having this option unchecked.
<img width="818" alt="image" src="https://user-images.githubusercontent.com/10504661/201868852-2b2fd5d4-d32c-4f90-9334-69f67d4ed016.png">


