### PR TITLE
Migrate Prow to workload identity

### DIFF
--- a/prow/cluster/components/crier_deployment.yaml
+++ b/prow/cluster/components/crier_deployment.yaml
@@ -34,9 +34,6 @@ spec:
       containers:
       - name: crier
         image: gcr.io/k8s-prow/crier:v20221111-fe4f3e2158
-        env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: "/etc/credentials/service-account.json"
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml
@@ -50,7 +47,6 @@ spec:
         - --pubsub-workers=5
         - --slack-token-file=/etc/slack/token
         - --slack-workers=1
-        - --gcs-credentials-file=/etc/credentials/service-account.json
         volumeMounts:
         - mountPath: /etc/kubeconfig
           name: kubeconfig
@@ -66,9 +62,6 @@ spec:
           readOnly: true
         - name: slack
           mountPath: /etc/slack
-          readOnly: true
-        - name: gcs-service-account
-          mountPath: /etc/credentials
           readOnly: true
       volumes:
       - name: config
@@ -87,6 +80,3 @@ spec:
         secret:
           defaultMode: 420
           secretName: workload-clusters-kubeconfig
-      - name: gcs-service-account
-        secret:
-          secretName: sa-crier

--- a/prow/cluster/components/crier_rbac.yaml
+++ b/prow/cluster/components/crier_rbac.yaml
@@ -17,7 +17,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   annotations:
-    iam.gke.io/gcp-service-account: control-plane@k8s-prow.iam.gserviceaccount.com
+    iam.gke.io/gcp-service-account: sa-crier@sap-kyma-prow.iam.gserviceaccount.com 
   name: crier
   namespace: default
 ---

--- a/prow/cluster/components/crier_rbac.yaml
+++ b/prow/cluster/components/crier_rbac.yaml
@@ -17,7 +17,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   annotations:
-    iam.gke.io/gcp-service-account: sa-crier@sap-kyma-prow.iam.gserviceaccount.com 
+    iam.gke.io/gcp-service-account: control-plane@sap-kyma-prow.iam.gserviceaccount.com 
   name: crier
   namespace: default
 ---

--- a/prow/cluster/components/deck_rbac.yaml
+++ b/prow/cluster/components/deck_rbac.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   namespace: default
   annotations:
-    iam.gke.io/gcp-service-account: control-plane@k8s-prow.iam.gserviceaccount.com
+    iam.gke.io/gcp-service-account: control-plane@sap-kyma-prow.iam.gserviceaccount.com
   name: deck
 ---
 kind: Role

--- a/prow/cluster/components/halogen.yaml
+++ b/prow/cluster/components/halogen.yaml
@@ -39,8 +39,8 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-#  annotations:
-#    iam.gke.io/gcp-service-account: control-plane@k8s-prow.iam.gserviceaccount.com
+  annotations:
+    iam.gke.io/gcp-service-account: control-plane@sap-kyma-prow.iam.gserviceaccount.com
   namespace: default
   name: halogen
 ---

--- a/prow/cluster/components/tide_rbac.yaml
+++ b/prow/cluster/components/tide_rbac.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    iam.gke.io/gcp-service-account: control-plane@k8s-prow.iam.gserviceaccount.com
+    iam.gke.io/gcp-service-account: control-plane@sap-kyma-prow.iam.gserviceaccount.com
   namespace: default
   name: tide
 ---

--- a/prow/cluster/resources/external-secrets/external_secrets_prow.yaml
+++ b/prow/cluster/resources/external-secrets/external_secrets_prow.yaml
@@ -53,19 +53,6 @@ spec:
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
-  name: sa-crier # name of the k8s external secret and the k8s secret
-  namespace: default
-spec:
-  backendType: gcpSecretsManager
-  projectId: sap-kyma-prow
-  data:
-    - key: prow_default_sa-crier # name of the GCP secret
-      name: service-account.json # key name in the k8s secret
-      version: latest # version of the GCP secret
----
-apiVersion: kubernetes-client.io/v1
-kind: ExternalSecret
-metadata:
   name: sap-slack-bot-token # name of the k8s external secret and the k8s secret
   namespace: default
 spec:

--- a/prow/cluster/resources/external-secrets/values_prow.yaml
+++ b/prow/cluster/resources/external-secrets/values_prow.yaml
@@ -27,7 +27,6 @@ env:
   #VAULT_ADDR: http://127.0.0.1:8200
   # Set a role to be used when assuming roles specified in external secret (AWS only)
   # AWS_INTERMEDIATE_ROLE_ARN:
-  GOOGLE_APPLICATION_CREDENTIALS: /etc/credentials/sa-secret-manager-prow/service-account.json
   # Use custom endpoints for FIPS compliance
   # AWS_STS_ENDPOINT: https://sts-fips.us-east-1.amazonaws.com
   # AWS_SSM_ENDPOINT: http://ssm-fips.us-east-1.amazonaws.com
@@ -100,13 +99,6 @@ envFrom: {}
 # - secretRef:
 #     name: special-config
 
-
-# Create files from existing k8s secrets
-filesFromSecret:
-  sa-secret-manager-prow:
-    secret: sa-secret-manager-prow
-    mountPath: /etc/credentials/sa-secret-manager-prow
-
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
@@ -115,10 +107,11 @@ serviceAccount:
   # Specifies whether a service account should be created
   create: true
   # Specifies annotations for this service account
-  annotations: {}
+  annotations:
+    iam.gke.io/gcp-service-account: secret-manager-prow@sap-kyma-prow.iam.gserviceaccount.com
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name:
+  name: secret-manager-prow
 
 # Using multiple replicas is not recommended as there is no coordination between replicas.
 # Replicas will try to create and update secrets concurrently which might lead to race conditions.
@@ -165,7 +158,8 @@ resources:
   #   cpu: 100m
   #   memory: 128Mi
 
-nodeSelector: {}
+nodeSelector:
+  iam.gke.io/gke-metadata-server-enabled: "true"
 
 tolerations: []
 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -15,8 +15,8 @@ plank:
   allow_cancellations: true # AllowCancellations enables aborting presubmit jobs for commits that have been superseded by newer commits in Github pull requests.
   max_concurrency: 100 # Limit of concurrent ProwJobs. Need to be adjusted depending of the cluster size.
   pod_pending_timeout: 60m
-  default_decoration_configs:
-    "*":
+  default_decoration_config_entries:
+  - config:
       timeout: 3h
       grace_period: 10m
       censor_secrets: true
@@ -31,7 +31,16 @@ plank:
       gcs_configuration:
         bucket: kyma-prow-logs
         path_strategy: "explicit"
-      gcs_credentials_secret: "sa-gcs-plank" # Service account with "Object Admin" role
+      gcs_credentials_secret: ""
+      default_service_account_name: prow-controller-manager
+  - cluster: "untrusted-workload"
+    config:
+      gcs_credentials_secret: ""
+      default_service_account_name: prow-controller-manager
+  - cluster: "trusted-workload"
+    config:
+      gcs_credentials_secret: ""
+      default_service_account_name: prow-controller-manager
 
 deck:
   spyglass:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -32,7 +32,7 @@ plank:
         bucket: kyma-prow-logs
         path_strategy: "explicit"
       gcs_credentials_secret: ""
-      default_service_account_name: prow-controller-manager
+      default_service_account_name: prowjob-default-sa
   - cluster: "untrusted-workload"
     config:
       gcs_credentials_secret: ""

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -36,11 +36,11 @@ plank:
   - cluster: "untrusted-workload"
     config:
       gcs_credentials_secret: ""
-      default_service_account_name: prow-controller-manager
+      default_service_account_name: prowjob-default-sa
   - cluster: "trusted-workload"
     config:
       gcs_credentials_secret: ""
-      default_service_account_name: prow-controller-manager
+      default_service_account_name: prowjob-default-sa
 
 deck:
   spyglass:

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -34,11 +34,11 @@ plank:
   - cluster: "untrusted-workload"
     config:
       gcs_credentials_secret: ""
-      default_service_account_name: prow-controller-manager
+      default_service_account_name: prowjob-default-sa
   - cluster: "trusted-workload"
     config:
       gcs_credentials_secret: ""
-      default_service_account_name: prow-controller-manager
+      default_service_account_name: prowjob-default-sa
 
 deck:
   spyglass:

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -30,7 +30,7 @@ plank:
         bucket: kyma-prow-logs
         path_strategy: "explicit"
       gcs_credentials_secret: ""
-      default_service_account_name: prow-controller-manager
+      default_service_account_name: prowjob-default-sa
   - cluster: "untrusted-workload"
     config:
       gcs_credentials_secret: ""

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -13,8 +13,8 @@ plank:
   allow_cancellations: true # AllowCancellations enables aborting presubmit jobs for commits that have been superseded by newer commits in Github pull requests.
   max_concurrency: 100 # Limit of concurrent ProwJobs. Need to be adjusted depending of the cluster size.
   pod_pending_timeout: 60m
-  default_decoration_configs:
-    "*":
+  default_decoration_config_entries:
+  - config:
       timeout: 3h
       grace_period: 10m
       censor_secrets: true
@@ -29,7 +29,16 @@ plank:
       gcs_configuration:
         bucket: kyma-prow-logs
         path_strategy: "explicit"
-      gcs_credentials_secret: "sa-gcs-plank" # Service account with "Object Admin" role
+      gcs_credentials_secret: ""
+      default_service_account_name: prow-controller-manager
+  - cluster: "untrusted-workload"
+    config:
+      gcs_credentials_secret: ""
+      default_service_account_name: prow-controller-manager
+  - cluster: "trusted-workload"
+    config:
+      gcs_credentials_secret: ""
+      default_service_account_name: prow-controller-manager
 
 deck:
   spyglass:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Bound `crier`, `deck`, `halogen`, `tide` to the `control-plane` GCP service-account
- removed GCP service account credentials from `crier` deployment


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
