### PR TITLE
Bring back the kyma-upgrade-gardener-kyma2-minor-versions pipeline

### DIFF
--- a/prow/jobs/kyma/kyma-integration-gardener.yaml
+++ b/prow/jobs/kyma/kyma-integration-gardener.yaml
@@ -869,4 +869,77 @@ periodics: # runs on schedule
             effect: NoSchedule
         nodeSelector:
             dedicated: "high-cpu"
+    - name: kyma-upgrade-gardener-kyma2-minor-versions
+      annotations:
+        description: "Azure Kyma 2 previous minor versions."
+        pipeline.clusterprovisioning: "kyma cli"
+        pipeline.installer: "kyma deploy"
+        pipeline.platform: "gardener_azure"
+        pipeline.test: "upgrade-fast-integration"
+        pipeline.trigger: "periodic"
+        testgrid-dashboards: "kyma_integration"
+      labels:
+        prow.k8s.io/pubsub.project: "sap-kyma-prow"
+        prow.k8s.io/pubsub.runID: "kyma-upgrade-gardener-kyma2-minor-versions"
+        prow.k8s.io/pubsub.topic: "prowjobs"
+        preset-az-kyma-prow-credentials: "true"
+        preset-bot-github-token: "true"
+        preset-cluster-version-previous: "true"
+        preset-debug-commando-oom: "true"
+        preset-dind-enabled: "true"
+        preset-docker-push-repository-gke-integration: "true"
+        preset-gardener-azure-kyma-integration: "true"
+        preset-gc-compute-envs: "true"
+        preset-gc-project-env: "true"
+        preset-kyma-cli-stable: "true"
+        preset-sa-gardener-logs: "true"
+        preset-sa-test-gcr-push: "true"
+      cron: "0 8 * * 1-5"
+      skip_report: false
+      decorate: true
+      decoration_config:
+        grace_period: 600000000000
+        timeout: 7200000000000
+      path_alias: github.com/kyma-project/kyma
+      cluster: untrusted-workload
+      extra_refs:
+        - org: kyma-project
+          repo: kyma
+          path_alias: github.com/kyma-project/kyma
+          base_ref: main
+        - org: kyma-project
+          repo: test-infra
+          path_alias: github.com/kyma-project/test-infra
+          base_ref: main
+      spec:
+        containers:
+          - image: "eu.gcr.io/kyma-project/test-infra/kyma-integration:v20221216-14ab5da8"
+            securityContext:
+              privileged: true
+            command:
+              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/kyma-upgrade-gardener-kyma2-minor-versions.sh"
+            env:
+              - name: GARDENER_REGION
+                value: "northeurope"
+              - name: GARDENER_ZONES
+                value: "1"
+              - name: KYMA_PROJECT_DIR
+                value: "/home/prow/go/src/github.com/kyma-project"
+              - name: PREVIOUS_MINOR_VERSION_COUNT
+                value: "1"
+              - name: REGION
+                value: "northeurope"
+              - name: RS_GROUP
+                value: "kyma-gardener-azure"
+            resources:
+              requests:
+                memory: 1Gi
+                cpu: 400m
+        tolerations:
+          - key: dedicated
+            operator: Equal
+            value: high-cpu
+            effect: NoSchedule
+        nodeSelector:
+            dedicated: "high-cpu"
   

--- a/templates/data/kyma-integration-gardener-data.yaml
+++ b/templates/data/kyma-integration-gardener-data.yaml
@@ -486,3 +486,26 @@ templates:
                     - jobConfig_default
                     - gardener_azure_job
                     - command_upgrade_gardener_kyma2_to_main
+              - jobConfig:
+                  name: kyma-upgrade-gardener-kyma2-minor-versions
+                  annotations:
+                    testgrid-dashboards: kyma_integration
+                    description: Azure Kyma 2 previous minor versions.
+                  decoration_config:
+                    timeout: 7200000000000 # 2h
+                    grace_period: 600000000000 # 10min
+                  cron: "0 8 * * 1-5"
+                  labels:
+                    preset-bot-github-token: "true"
+                inheritedConfigs:
+                  global:
+                    - jobConfig_default
+                    - jobConfig_periodic
+                    - extra_refs_test-infra
+                    - extra_refs_kyma
+                    - image_kyma-integration
+                    - kyma_minor_upgrade
+                  local:
+                    - jobConfig_default
+                    - gardener_azure_job_old_version
+                    - command_upgrade_gardener_kyma2_minor_versions

--- a/test-inventory-integration.md
+++ b/test-inventory-integration.md
@@ -40,6 +40,7 @@
 | kyma-alpha-integration-production-gardener-azure | gardener_azure | kyma cli | kyma deploy | production | periodic |  fast-integration  |
 | kyma-weekly-gardener-gcp-busola-kyma | gardener_gcp | kubectl shootspec | kyma deploy |  | periodic |    |
 | kyma-upgrade-gardener-kyma2-to-main-reconciler-main | gardener_azure | kyma cli | kyma deploy |  | periodic |  upgrade-fast-integration  |
+| kyma-upgrade-gardener-kyma2-minor-versions | gardener_azure | kyma cli | kyma deploy |  | periodic |  upgrade-fast-integration  |
 | skr-azure-nightly | gardener_azure | keb | keb |  | periodic |  fast-integration  |
 | skr-azure-integration-dev | gardener_azure | keb | keb |  | periodic |  fast-integration  |
 | skr-azure-lite-integration-dev | gardener_azure | keb | keb | evaluation | periodic |  fast-integration  |


### PR DESCRIPTION
**Description**

Bring back the periodical job, which got removed due to [this issue](https://github.com/kyma-project/kyma/issues/16059). 

NOTE: this PR should be merged, after this [PR](https://github.com/kyma-project/kyma/pull/16278) gets into the last release.