### PR TITLE
Make gcp-eventing and gcp-eventing-upgrade tests optional

### DIFF
--- a/prow/jobs/kyma/kyma-integration-gardener.yaml
+++ b/prow/jobs/kyma/kyma-integration-gardener.yaml
@@ -238,6 +238,7 @@ presubmits: # runs on PRs
         preset-gardener-gcp-kyma-integration: "true"
         preset-kyma-cli-stable: "true"
       run_if_changed: '^((tests/fast-integration\S+|resources/eventing\S+)(\.[^.][^.][^.]+$|\.[^.][^dD]$|\.[^mM][^.]$|\.[^.]$|/[^.]+$))'
+      optional: true
       skip_report: false
       decorate: true
       decoration_config:
@@ -443,6 +444,7 @@ presubmits: # runs on PRs
         preset-gardener-gcp-kyma-integration: "true"
         preset-kyma-cli-stable: "true"
       run_if_changed: '^((tests/fast-integration\S+|resources/eventing\S+)(\.[^.][^.][^.]+$|\.[^.][^dD]$|\.[^mM][^.]$|\.[^.]$|/[^.]+$))'
+      optional: true
       skip_report: false
       decorate: true
       decoration_config:

--- a/templates/data/kyma-integration-gardener-data.yaml
+++ b/templates/data/kyma-integration-gardener-data.yaml
@@ -265,7 +265,7 @@ templates:
                     - command_integration
               - jobConfig:
                   name: pre-main-kyma-gardener-gcp-eventing
-                  optional: false
+                  optional: true
                   decoration_config:
                     timeout: 14400000000000 # 4h
                     grace_period: 600000000000 # 10min
@@ -342,7 +342,7 @@ templates:
                     - command_integration
               - jobConfig:
                   name: pre-main-kyma-gardener-gcp-eventing-upgrade
-                  optional: false
+                  optional: true
                   decoration_config:
                     timeout: 14400000000000 # 4h
                     grace_period: 600000000000 # 10min


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

These tests are flaky but are blocking e.g. changes in skr-tests (see https://github.com/kyma-project/kyma/pull/16048) despite only ski-tests are changed and eventing test do not provision any SKR.

Changes proposed in this pull request:

- `pre-main-kyma-gardener-gcp-eventing` optional
- `pre-main-kyma-gardener-gcp-eventing-upgrade` optional


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
