### PR TITLE
refactor: remove module-manager 'operator' folder

### DIFF
--- a/prow/jobs/module-manager/module-manager.yaml
+++ b/prow/jobs/module-manager/module-manager.yaml
@@ -5,7 +5,7 @@ presubmits: # runs on PRs
   kyma-project/module-manager:
     - name: pull-module-mgr-lint
       annotations:
-        description: "executes the 'make lint' command in the module-manager 'operator' directory before any pull request."
+        description: "executes the 'golangci-lint lint' command before any pull request."
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
@@ -14,7 +14,7 @@ presubmits: # runs on PRs
         preset-dind-enabled: "true"
         preset-docker-push-repository-kyma: "true"
         preset-sa-gcr-push: "true"
-      run_if_changed: '^operator/(go.mod|go.sum)$|^operator/*/(.*.go|Makefile|.*.sh)'
+      run_if_changed: '^(go.mod|go.sum)$|^*/(.*.go|Makefile|.*.sh)'
       skip_report: false
       decorate: true
       cluster: untrusted-workload
@@ -33,7 +33,7 @@ presubmits: # runs on PRs
               - "bash"
             args:
               - "-c"
-              - "cd operator && golangci-lint run"
+              - "golangci-lint run"
             resources:
               requests:
                 memory: 3Gi
@@ -47,7 +47,7 @@ presubmits: # runs on PRs
             dedicated: "high-cpu"
     - name: pull-module-mgr-tests
       annotations:
-        description: "executes the 'make test' command in the module-manager 'operator' directory before any pull request."
+        description: "executes the 'make test' command in the module-manager before any pull request."
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
@@ -56,7 +56,7 @@ presubmits: # runs on PRs
         preset-dind-enabled: "true"
         preset-docker-push-repository-kyma: "true"
         preset-sa-gcr-push: "true"
-      run_if_changed: '^operator/(go.mod|go.sum)$|^operator/*/(.*.go|Makefile|.*.sh)'
+      run_if_changed: '^(go.mod|go.sum)$|^*/(.*.go|Makefile|.*.sh)'
       skip_report: false
       decorate: true
       cluster: untrusted-workload
@@ -75,7 +75,7 @@ presubmits: # runs on PRs
               - "bash"
             args:
               - "-c"
-              - "cd operator && make test"
+              - "make test"
             resources:
               requests:
                 memory: 3Gi
@@ -110,7 +110,6 @@ presubmits: # runs on PRs
             args:
               - "--name=module-manager"
               - "--config=/config/kaniko-build-config.yaml"
-              - "--context=operator"
               - "--dockerfile=Dockerfile"
             volumeMounts:
               - name: config
@@ -146,7 +145,6 @@ postsubmits: # runs on main
             args:
               - "--name=module-manager"
               - "--config=/config/kaniko-build-config.yaml"
-              - "--context=operator"
               - "--dockerfile=Dockerfile"
               - "--tag=latest"
             volumeMounts:

--- a/templates/data/module-manager-data.yaml
+++ b/templates/data/module-manager-data.yaml
@@ -29,15 +29,15 @@ templates:
           - repoName: kyma-project/module-manager
             jobs:
               - jobConfig:
-                  run_if_changed: "^operator/(go.mod|go.sum)$|^operator/*/(.*.go|Makefile|.*.sh)"
+                  run_if_changed: "^(go.mod|go.sum)$|^*/(.*.go|Makefile|.*.sh)"
                   image: "eu.gcr.io/kyma-project/test-infra/golangci-lint:v20221025-25ddc121"
-                  name: "pull-module-mgr-lint"
+                  name: pull-module-mgr-lint
                   annotations:
-                    description: executes the 'make lint' command in the module-manager 'operator' directory before any pull request.
+                    description: executes the 'golangci-lint lint' command before any pull request.
                   command: "bash"
                   args:
                     - "-c"
-                    - "cd operator && golangci-lint run"
+                    - "golangci-lint run"
                   branches:
                     - ^main$
                   slack_channel: jellyfish-notifications
@@ -47,14 +47,14 @@ templates:
                     - jobConfig_presubmit
                     - "build_labels" # default labels
               - jobConfig:
-                  run_if_changed: "^operator/(go.mod|go.sum)$|^operator/*/(.*.go|Makefile|.*.sh)"
+                  run_if_changed: "^(go.mod|go.sum)$|^*/(.*.go|Makefile|.*.sh)"
                   name: pull-module-mgr-tests
                   annotations:
-                    description: executes the 'make test' command in the module-manager 'operator' directory before any pull request.
+                    description: executes the 'make test' command in the module-manager before any pull request.
                   command: "bash"
                   args:
                     - "-c"
-                    - "cd operator && make test" # run test make target of operator
+                    - "make test" # run test make target
                   branches:
                     - ^main$ # any pr against main trig
                   slack_channel: jellyfish-notifications
@@ -70,7 +70,6 @@ templates:
                   args:
                     - "--name=module-manager"
                     - "--config=/config/kaniko-build-config.yaml"
-                    - "--context=operator"
                     - "--dockerfile=Dockerfile"
                 inheritedConfigs:
                   local:
@@ -83,7 +82,6 @@ templates:
                   args:
                     - "--name=module-manager"
                     - "--config=/config/kaniko-build-config.yaml"
-                    - "--context=operator"
                     - "--dockerfile=Dockerfile"
                     - "--tag=latest"
                 inheritedConfigs:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Move module-manager up by one level by removing the 'operator' folder

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/module-manager/issues/156
