### PR TITLE
Increase test run interval for telemetry-integration-k3d

### DIFF
--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -1623,7 +1623,7 @@ periodics: # runs on schedule
         preset-kyma-integration-telemetry-enabled: "true"
         preset-kyma-integration-telemetry-tracing-enabled: "true"
         preset-sa-vm-kyma-integration: "true"
-      cron: "0 7,13 * * *"
+      cron: "0 */2 * * *"
       skip_report: false
       decorate: true
       path_alias: github.com/kyma-project/kyma

--- a/templates/data/kyma-integration-data.yaml
+++ b/templates/data/kyma-integration-data.yaml
@@ -823,7 +823,7 @@ templates:
                     - "extra_refs_kyma-local"
               - jobConfig:
                   name: "kyma-integration-k3d-telemetry"
-                  cron: "0 7,13 * * *"
+                  cron: "0 */2 * * *"
                   labels:
                     preset-build-main: "true"
                     preset-kyma-integration-telemetry-enabled: "true"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- We want to increase the interval for telemetry integration test runs to "every 2 hours" for a couple of weeks to analyse flakiness

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
