### PR TITLE
Make compass checks explicitly non strict

### DIFF
--- a/development/tools/pkg/pjtester/test_artifacts/test-prow-config.yaml
+++ b/development/tools/pkg/pjtester/test_artifacts/test-prow-config.yaml
@@ -238,6 +238,8 @@ branch-protection:
           branches:
             main:
               protect: true
+              required_status_checks:
+                strict: false
         compass-console:
           protect: false
           branches:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -254,6 +254,8 @@ branch-protection:
           branches:
             main:
               protect: true
+              required_status_checks:
+                strict: false
         compass-console:
           protect: false
           branches:

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -252,6 +252,8 @@ branch-protection:
           branches:
             main:
               protect: true
+              required_status_checks:
+                strict: false
         compass-console:
           protect: false
           branches:


### PR DESCRIPTION
**Description**

We have a problem that when a PR is ready to be merged (approved with all checks passing, no merge conflicts), when we remove the hold label for it to be merged and the base (main) branch is not up-to-date, the tests are retriggered again. Which slows our development significantly. We have different mechanics (PR numbers with conflicts) that guards us of problems with not up-to-date bases.