### PR TITLE
bump golang image to 1.19.4-alpine1.17

### DIFF
--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -13,8 +13,8 @@ images:
 - source: "gcr.io/google-containers/pause-amd64:3.2"
 - source: "goreleaser/goreleaser:v1.11.5"
 # Golang image is pinned because it is force updated in the upstream
-- source: "golang@sha256:4e2a54594cfe7002a98c483c28f6f3a78e5c7f4010c355a8cf960292a3fdecfe"
-  tag: "1.19.3-alpine3.16"
+- source: "golang@sha256:f33331e12ca70192c0dbab2d0a74a52e1dd344221507d88aaea605b0219a212f"
+  tag: "1.19.4-alpine3.17"
 - source: "grafana/loki:2.2.1"
 - source: "grafana/grafana-image-renderer:3.2.1"
 - source: "hudymi/mockice:0.1.3"


### PR DESCRIPTION
[image](https://hub.docker.com/layers/library/golang/1.19.4-alpine3.17/images/sha256-f33331e12ca70192c0dbab2d0a74a52e1dd344221507d88aaea605b0219a212f?context=explore)

[rel notes go 1.19.4](https://go.dev/doc/devel/release#go1.19.minor)