### PR TITLE
Switch Debian 11 back to cgroups v1

### DIFF
--- a/development/custom-image/install-deps-debian.sh
+++ b/development/custom-image/install-deps-debian.sh
@@ -64,7 +64,7 @@ wget https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO
 # install minikube
 curl -Lo /tmp/minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64 && \
 chmod +x /tmp/minikube && \
-sudo mv /tmp/minikube /usr/local/bin/minikube
+sudo install /tmp/minikube /usr/local/bin/minikube
 
 
 # install postgres and migrate tool

--- a/development/custom-image/install-deps-debian.sh
+++ b/development/custom-image/install-deps-debian.sh
@@ -105,3 +105,7 @@ echo 'export PATH="$PATH:/usr/local/go/bin"' | sudo tee -a /etc/profile
 # pre-fetch-docker-images
 sudo docker pull eu.gcr.io/kyma-project/external/cypress/included:8.7.0
 sudo docker pull eu.gcr.io/kyma-project/test-infra/docker-registry-2:20200202
+
+sudo sed -i 's/\(GRUB_CMDLINE_LINUX_DEFAULT="\)\(.*\)\("\)/\1\2 systemd.legacy_systemd_cgroup_controller=false systemd.unified_cgroup_hierarchy=false\3/' /etc/default/grub
+sudo sed -i 's/\(GRUB_CMDLINE_LINUX="\)\(.*\)\("\)/\1\2 systemd.legacy_systemd_cgroup_controller=false systemd.unified_cgroup_hierarchy=false\3/' /etc/default/grub
+sudo update-grub


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Switch back Debian 11 to use cgroups v1. Minikube is not compatible with cgroups v2 which is a default version for debian 11.

**Related issue(s)**
See #6596
