### PR TITLE
Add ability to run prebuild step with tag as argument

### DIFF
--- a/development/image-builder/README.md
+++ b/development/image-builder/README.md
@@ -130,5 +130,7 @@ Usage of image-builder:
         Additional tag that the image will be tagged
   -variant string
         If variants.yaml file is present, define which variant should be built. If variants.yaml is not present, this flag will be ignored
+  -pre-build-script string
+        Path to script that will be run before build. It will receive docker tag in format provided via TagTemplate in config as first argument. Output from script isn't used in build process, but build will fail on script failure.
 
 ```

--- a/development/image-builder/config.go
+++ b/development/image-builder/config.go
@@ -29,7 +29,7 @@ type Config struct {
 	// as well as org/repo mapping of enabled signers in specific repository
 	SignConfig SignConfig `yaml:"sign-config" json:"sign-config"`
 	// PreBuildScript contains path to custom script that will be executed before build
-	// As first parameter it will recieve docker tag generated from TagTemplate
+	// As first parameter it will receive docker tag generated from TagTemplate
 	PreBuildScript string `yaml:"pre-build-script" json:"pre-build-script"`
 }
 

--- a/development/image-builder/config.go
+++ b/development/image-builder/config.go
@@ -28,9 +28,6 @@ type Config struct {
 	// SignConfig contains custom configuration of signers
 	// as well as org/repo mapping of enabled signers in specific repository
 	SignConfig SignConfig `yaml:"sign-config" json:"sign-config"`
-	// PreBuildScript contains path to custom script that will be executed before build
-	// As first parameter it will receive docker tag generated from TagTemplate
-	PreBuildScript string `yaml:"pre-build-script" json:"pre-build-script"`
 }
 
 type SignConfig struct {

--- a/development/image-builder/config.go
+++ b/development/image-builder/config.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/kyma-project/test-infra/development/image-builder/sign"
 	"gopkg.in/yaml.v3"
-	"os"
 )
 
 type Config struct {
@@ -27,6 +28,9 @@ type Config struct {
 	// SignConfig contains custom configuration of signers
 	// as well as org/repo mapping of enabled signers in specific repository
 	SignConfig SignConfig `yaml:"sign-config" json:"sign-config"`
+	// PreBuildScript contains path to custom script that will be executed before build
+	// As first parameter it will recieve docker tag generated from TagTemplate
+	PreBuildScript string `yaml:"pre-build-script" json:"pre-build-script"`
 }
 
 type SignConfig struct {

--- a/development/image-builder/config_test.go
+++ b/development/image-builder/config_test.go
@@ -45,19 +45,6 @@ tag-template: v{{ .Date }}-{{ .ShortSHA }}`,
 			expectedConfig: Config{},
 			expectErr:      true,
 		},
-		{
-			name: "Parsed config with tag export",
-			config: `registry: kyma-project.io/prod-registry
-dev-registry: dev.kyma-project.io/dev-registry
-tag-template: v{{ .Date }}-{{ .ShortSHA }}
-pre-build-script: scripts/custom.sh`,
-			expectedConfig: Config{
-				Registry:       []string{"kyma-project.io/prod-registry"},
-				DevRegistry:    []string{"dev.kyma-project.io/dev-registry"},
-				TagTemplate:    `v{{ .Date }}-{{ .ShortSHA }}`,
-				PreBuildScript: "scripts/custom.sh",
-			},
-		},
 	}
 	for _, c := range tc {
 		t.Run(c.name, func(t *testing.T) {

--- a/development/image-builder/config_test.go
+++ b/development/image-builder/config_test.go
@@ -45,6 +45,19 @@ tag-template: v{{ .Date }}-{{ .ShortSHA }}`,
 			expectedConfig: Config{},
 			expectErr:      true,
 		},
+		{
+			name: "Parsed config with tag export",
+			config: `registry: kyma-project.io/prod-registry
+dev-registry: dev.kyma-project.io/dev-registry
+tag-template: v{{ .Date }}-{{ .ShortSHA }}
+pre-build-script: scripts/custom.sh`,
+			expectedConfig: Config{
+				Registry:       []string{"kyma-project.io/prod-registry"},
+				DevRegistry:    []string{"dev.kyma-project.io/dev-registry"},
+				TagTemplate:    `v{{ .Date }}-{{ .ShortSHA }}`,
+				PreBuildScript: "scripts/custom.sh",
+			},
+		},
 	}
 	for _, c := range tc {
 		t.Run(c.name, func(t *testing.T) {

--- a/development/image-builder/main.go
+++ b/development/image-builder/main.go
@@ -200,6 +200,7 @@ func runBuildJob(o options, vs Variants, envs map[string]string) error {
 		return err
 	}
 
+	// (@KacperMalachowski): Consider refactoring for better flexibility
 	if o.Config.PreBuildScript != "" && len(parsedTags) > 0 {
 		cmd := exec.Command(o.Config.PreBuildScript, parsedTags[len(parsedTags)-1])
 		err := cmd.Run()


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
As Busola team requested the ability to provide them an evaluated docker tag, this change introduces it to image-builder.
It's easiest possible solution, we should consider refactor it in feature to better solution which will be more flexible.

Changes proposed in this pull request:

- Add configuration to provide custom script that should be run before build to image-builder
- Add ability to run that script before build and provide evaluated docker tag (based on TagTemplate) to script.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #6252 