### PR TITLE
Add gencred jobs for workload clusters

### DIFF
--- a/configs/gencred-config.yaml
+++ b/configs/gencred-config.yaml
@@ -1,0 +1,19 @@
+clusters:
+  - gke: projects/sap-kyma-prow/locations/europe-west4/clusters/tekton
+    duration: 48h
+    name: tekton-pipelines
+    gsm:
+      name: tekton-pipelines-kubeconfig
+      project: sap-kyma-prow
+  - gke: projects/sap-kyma-prow/locations/europe-west3/clusters/untrusted-workload-kyma-prow
+    duration: 48h
+    name: untrusted-workload-kyma-prow
+    gsm:
+      name: untrusted-workload-kubeconfig
+      project: sap-kyma-prow
+  - gke: projects/sap-kyma-prow/locations/europe-west3/clusters/trusted-workload-kyma-prow
+    duration: 48h
+    name: trusted-workload-kyma-prow
+    gsm:
+      name: trusted-workload-kubeconfig
+      project: sap-kyma-prow

--- a/prow/jobs/test-infra/test-infra-trusted-jobs.yaml
+++ b/prow/jobs/test-infra/test-infra-trusted-jobs.yaml
@@ -1,0 +1,38 @@
+postsubmits:
+  kyma-project/test-infra:
+    - name: post-gencred-refresh-kubeconfigs
+      cluster: trusted-workload
+      run_if_changed: '^configs/gencred-config.yaml'
+      decorate: true
+      branches:
+        - ^main$
+      spec:
+        serviceAccountName: gencred-refresher
+        containers:
+          - name: gencred
+            image: gcr.io/k8s-prow/gencred:v20230109-8245463f64
+            command:
+              - gencred
+            args:
+              - --config=./configs/gencred-config.yaml
+      annotations:
+        testgrid-create-test-group: "false"
+
+periodics:
+  - cron: "17 */6 * * *"  # Every 6 hours at 17 minutes past the hour
+    name: ci-gencred-refresh-kubeconfigs
+    cluster: trusted-workload
+    extra_refs:
+      - org: kyma-project
+        repo: test-infra
+        base_ref: main
+    decorate: true
+    spec:
+      serviceAccountName: gencred-refresher
+      containers:
+        - name: gencred
+          image: gcr.io/k8s-prow/gencred:v20230109-8245463f64
+          command:
+            - gencred
+          args:
+            - --config=./configs/gencred-config.yaml

--- a/prow/workload-cluster/trusted-workload/gencred-refresher_serviceaccount.yaml
+++ b/prow/workload-cluster/trusted-workload/gencred-refresher_serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gencred-refresher
+  namespace: default
+  annotations:
+    iam.gke.io/gcp-service-account: gencred-refresher@sap-kyma-prow.iam.gserviceaccount.com


### PR DESCRIPTION
Part 1 of #6622

* Add new jobs that rotate kubeconfigs every 6 hours
* Add trusted workload serviceacount with workload identity mapping
* Add configuration file for all workload clusters - trusted, untrusted and nekton that pushes new kubeconfigs as secrets to the secret manager 