### PR TITLE
Add Prow connection to workload clusters with gencred configs

### DIFF
--- a/configs/gencred-config.yaml
+++ b/configs/gencred-config.yaml
@@ -7,13 +7,13 @@ clusters:
       project: sap-kyma-prow
   - gke: projects/sap-kyma-prow/locations/europe-west3/clusters/untrusted-workload-kyma-prow
     duration: 48h
-    name: untrusted-workload-kyma-prow
+    name: untrusted-workload
     gsm:
       name: untrusted-workload-kubeconfig
       project: sap-kyma-prow
   - gke: projects/sap-kyma-prow/locations/europe-west3/clusters/trusted-workload-kyma-prow
     duration: 48h
-    name: trusted-workload-kyma-prow
+    name: trusted-workload
     gsm:
       name: trusted-workload-kubeconfig
       project: sap-kyma-prow

--- a/prow/cluster/components/crier_deployment.yaml
+++ b/prow/cluster/components/crier_deployment.yaml
@@ -42,14 +42,22 @@ spec:
         - --github-token-path=/etc/github/oauth
         - --github-workers=5
         - --job-config-path=/etc/job-config
-        - --kubeconfig=/etc/kubeconfig/config
         - --kubernetes-blob-storage-workers=1
         - --pubsub-workers=5
         - --slack-token-file=/etc/slack/token
         - --slack-workers=1
+        env:
+        - name: KUBECONFIG
+          value: "/etc/untrusted-workload-kubeconfig/config:/etc/trusted-workload-kubeconfig/config:/etc/tekton-pipelines-kubeconfig/config"
         volumeMounts:
-        - mountPath: /etc/kubeconfig
-          name: kubeconfig
+        - mountPath: /etc/untrusted-workload-kubeconfig
+          name: untrusted-workload-kubeconfig
+          readOnly: true
+        - mountPath: /etc/trusted-workload-kubeconfig
+          name: trusted-workload-kubeconfig
+          readOnly: true
+        - mountPath: /etc/tekton-pipelines-kubeconfig
+          name: tekton-pipelines-kubeconfig
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -76,7 +84,15 @@ spec:
       - name: slack
         secret:
           secretName: slack-token
-      - name: kubeconfig
+      - name: untrusted-workload-kubeconfig
         secret:
           defaultMode: 420
-          secretName: workload-clusters-kubeconfig
+          secretName: untrusted-workload-kubeconfig
+      - name: trusted-workload-kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: trusted-workload-kubeconfig
+      - name: tekton-pipelines-kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: tekton-pipelines-kubeconfig

--- a/prow/cluster/components/deck_deployment.yaml
+++ b/prow/cluster/components/deck_deployment.yaml
@@ -44,7 +44,6 @@ spec:
           - name: http
             containerPort: 8080
         args:
-        - --kubeconfig=/etc/kubeconfig/config
         - --tide-url=http://tide/
         - --hook-url=http://hook:8888/plugin-help
         - --redirect-http-to=status.build.kyma-project.io
@@ -59,6 +58,9 @@ spec:
         - --github-oauth-config-file=/etc/githuboauth/secret
         - --cookie-secret=/etc/cookie/secret
         - --plugin-config=/etc/plugins/plugins.yaml
+        env:
+          - name: KUBECONFIG
+            value: "/etc/untrusted-workload-kubeconfig/config:/etc/trusted-workload-kubeconfig/config:/etc/tekton-pipelines-kubeconfig/config"
         volumeMounts:
         - name: oauth-config
           mountPath: /etc/githuboauth
@@ -66,8 +68,14 @@ spec:
         - name: cookie-secret
           mountPath: /etc/cookie
           readOnly: true
-        - mountPath: /etc/kubeconfig
-          name: kubeconfig
+        - mountPath: /etc/untrusted-workload-kubeconfig
+          name: untrusted-workload-kubeconfig
+          readOnly: true
+        - mountPath: /etc/trusted-workload-kubeconfig
+          name: trusted-workload-kubeconfig
+          readOnly: true
+        - mountPath: /etc/tekton-pipelines-kubeconfig
+          name: tekton-pipelines-kubeconfig
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -107,10 +115,18 @@ spec:
       - name: cookie-secret
         secret:
           secretName: cookie
-      - name: kubeconfig
+      - name: untrusted-workload-kubeconfig
         secret:
           defaultMode: 420
-          secretName: workload-clusters-kubeconfig
+          secretName: untrusted-workload-kubeconfig
+      - name: trusted-workload-kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: trusted-workload-kubeconfig
+      - name: tekton-pipelines-kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: tekton-pipelines-kubeconfig
       - name: config
         configMap:
           name: config

--- a/prow/cluster/components/hook_deployment.yaml
+++ b/prow/cluster/components/hook_deployment.yaml
@@ -33,7 +33,9 @@ spec:
         - --github-token-path=/etc/github/oauth
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
-        - --kubeconfig=/etc/kubeconfig/config
+        env:
+          - name: KUBECONFIG
+            value: "/etc/untrusted-workload-kubeconfig/config:/etc/trusted-workload-kubeconfig/config:/etc/tekton-pipelines-kubeconfig/config"
         ports:
           - name: http
             containerPort: 8888
@@ -53,8 +55,14 @@ spec:
         - name: plugins
           mountPath: /etc/plugins
           readOnly: true
-        - name: kubeconfig
-          mountPath: /etc/kubeconfig
+        - mountPath: /etc/untrusted-workload-kubeconfig
+          name: untrusted-workload-kubeconfig
+          readOnly: true
+        - mountPath: /etc/trusted-workload-kubeconfig
+          name: trusted-workload-kubeconfig
+          readOnly: true
+        - mountPath: /etc/tekton-pipelines-kubeconfig
+          name: tekton-pipelines-kubeconfig
           readOnly: true
         livenessProbe:
           httpGet:
@@ -76,9 +84,18 @@ spec:
       - name: oauth
         secret:
           secretName: oauth-token
-      - name: kubeconfig
+      - name: untrusted-workload-kubeconfig
         secret:
-          secretName: workload-clusters-kubeconfig
+          defaultMode: 420
+          secretName: untrusted-workload-kubeconfig
+      - name: trusted-workload-kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: trusted-workload-kubeconfig
+      - name: tekton-pipelines-kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: tekton-pipelines-kubeconfig
       - name: config
         configMap:
           name: config

--- a/prow/cluster/components/prow_controller_manager_deployment.yaml
+++ b/prow/cluster/components/prow_controller_manager_deployment.yaml
@@ -40,11 +40,18 @@ spec:
         - --dry-run=false
         - --enable-controller=plank
         - --job-config-path=/etc/job-config
-        - --kubeconfig=/etc/kubeconfig/config
+        env:
+          - name: KUBECONFIG
+            value: "/etc/untrusted-workload-kubeconfig/config:/etc/trusted-workload-kubeconfig/config:/etc/tekton-pipelines-kubeconfig/config"
         volumeMounts:
-        - mountPath: /etc/kubeconfig
-          name: kubeconfig
+        - mountPath: /etc/untrusted-workload-kubeconfig
+          name: untrusted-workload-kubeconfig
           readOnly: true
+        - mountPath: /etc/trusted-workload-kubeconfig
+          name: trusted-workload-kubeconfig
+          readOnly: true
+        - mountPath: /etc/tekton-pipelines-kubeconfig
+          name: tekton-pipelines-kubeconfig
         - name: config
           mountPath: /etc/config
           readOnly: true
@@ -52,10 +59,18 @@ spec:
           mountPath: /etc/job-config
           readOnly: true
       volumes:
-      - name: kubeconfig
+      - name: untrusted-workload-kubeconfig
         secret:
           defaultMode: 420
-          secretName: workload-clusters-kubeconfig
+          secretName: untrusted-workload-kubeconfig
+      - name: trusted-workload-kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: trusted-workload-kubeconfig
+      - name: tekton-pipelines-kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: tekton-pipelines-kubeconfig
       - name: config
         configMap:
           name: config

--- a/prow/cluster/components/sinker_deployment.yaml
+++ b/prow/cluster/components/sinker_deployment.yaml
@@ -19,15 +19,22 @@ spec:
       containers:
       - name: sinker
         args:
-        - --kubeconfig=/etc/kubeconfig/config
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
         image: gcr.io/k8s-prow/sinker:v20230111-f89d0e1985
+        env:
+          - name: KUBECONFIG
+            value: "/etc/untrusted-workload-kubeconfig/config:/etc/trusted-workload-kubeconfig/config:/etc/tekton-pipelines-kubeconfig/config"
         volumeMounts:
-        - mountPath: /etc/kubeconfig
-          name: kubeconfig
+        - mountPath: /etc/untrusted-workload-kubeconfig
+          name: untrusted-workload-kubeconfig
           readOnly: true
+        - mountPath: /etc/trusted-workload-kubeconfig
+          name: trusted-workload-kubeconfig
+          readOnly: true
+        - mountPath: /etc/tekton-pipelines-kubeconfig
+          name: tekton-pipelines-kubeconfig
         - name: config
           mountPath: /etc/config
           readOnly: true
@@ -35,10 +42,18 @@ spec:
           mountPath: /etc/job-config
           readOnly: true
       volumes:
-      - name: kubeconfig
+      - name: untrusted-workload-kubeconfig
         secret:
           defaultMode: 420
-          secretName: workload-clusters-kubeconfig
+          secretName: untrusted-workload-kubeconfig
+      - name: trusted-workload-kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: trusted-workload-kubeconfig
+      - name: tekton-pipelines-kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: tekton-pipelines-kubeconfig
       - name: config
         configMap:
           name: config

--- a/prow/cluster/resources/external-secrets/external_secrets_prow.yaml
+++ b/prow/cluster/resources/external-secrets/external_secrets_prow.yaml
@@ -127,6 +127,60 @@ spec:
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
+  name: untrusted-workload-kubeconfig # name of the k8s external secret and the k8s secret
+  namespace: default
+spec:
+  secretStoreRef:
+    name: gcp-secretstore
+    kind: ClusterSecretStore
+  refreshInterval: "10m"
+  target:
+    deletionPolicy: "Delete" # delete secret when External Secret is deleted
+  data:
+    - secretKey: config # k8s key name
+      remoteRef:
+        key: untrusted-workload-kubeconfig # GCP secret name
+        version: latest
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: trusted-workload-kubeconfig # name of the k8s external secret and the k8s secret
+  namespace: default
+spec:
+  secretStoreRef:
+    name: gcp-secretstore
+    kind: ClusterSecretStore
+  refreshInterval: "10m"
+  target:
+    deletionPolicy: "Delete" # delete secret when External Secret is deleted
+  data:
+    - secretKey: config # k8s key name
+      remoteRef:
+        key: trusted-workload-kubeconfig # GCP secret name
+        version: latest
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: tekton-pipelines-kubeconfig # name of the k8s external secret and the k8s secret
+  namespace: default
+spec:
+  secretStoreRef:
+    name: gcp-secretstore
+    kind: ClusterSecretStore
+  refreshInterval: "10m"
+  target:
+    deletionPolicy: "Delete" # delete secret when External Secret is deleted
+  data:
+    - secretKey: config # k8s key name
+      remoteRef:
+        key: tekton-pipelines-kubeconfig # GCP secret name
+        version: latest
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
   name: probot-stale-oss # name of the k8s external secret and the k8s secret
   namespace: probot-stale-oss
 spec:


### PR DESCRIPTION
#6622 

* Split one kubeconfig for workload cluster into multiple kubeconfigs
* use KUBECONFIG env for defining path to all kubeconfigs
* update external secrets
* fix gencred-config.yaml naming to follow old names for workloads