### PR TITLE
bump golang image

### DIFF
--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -13,7 +13,7 @@ images:
 - source: "goreleaser/goreleaser:v1.11.5"
 # Golang image is pinned because it is force updated in the upstream
 - source: "golang@sha256:3183b343d01a6e8c9bee7b7c4eb7208518e68dc0cdac8623e1575820342472ed"
-  tag: "1.19.5-alpine3.17"
+  tag: "1.19.5-alpine3.17-v1"
 - source: "grafana/loki:2.2.1"
 - source: "grafana/grafana-image-renderer:3.2.1"
   amd64Only: true

--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -12,8 +12,8 @@ images:
 - source: "gcr.io/google-containers/pause:3.2"
 - source: "goreleaser/goreleaser:v1.11.5"
 # Golang image is pinned because it is force updated in the upstream
-- source: "golang@sha256:a9b24b67dc83b3383d22a14941c2b2b2ca6a103d805cac6820fd1355943beaf1"
-  tag: "1.19.4-alpine3.17-v1"
+- source: "golang@sha256:3183b343d01a6e8c9bee7b7c4eb7208518e68dc0cdac8623e1575820342472ed"
+  tag: "1.19.5-alpine3.17"
 - source: "grafana/loki:2.2.1"
 - source: "grafana/grafana-image-renderer:3.2.1"
   amd64Only: true


### PR DESCRIPTION
bumping golang image

[docker image](https://hub.docker.com/layers/library/golang/1.19.5-alpine3.17/images/sha256-3183b343d01a6e8c9bee7b7c4eb7208518e68dc0cdac8623e1575820342472ed?context=explore)
[release notes](https://go.dev/doc/devel/release#go1.19)