### PR TITLE
ARM build for schema migrator

### DIFF
--- a/prow/jobs/incubator/compass/components/schema-migrator/schema-migrator-generic.yaml
+++ b/prow/jobs/incubator/compass/components/schema-migrator/schema-migrator-generic.yaml
@@ -36,6 +36,7 @@ presubmits: # runs on PRs
               - "--context=components/schema-migrator"
               - "--dockerfile=Dockerfile"
               - "--platform=linux/amd64"
+              - "--platform=linux/arm64"
             env:
               - name: BUILDKITD_FLAGS
                 value: "--oci-worker-no-process-sandbox"

--- a/templates/data/generic_component_compass_data.yaml
+++ b/templates/data/generic_component_compass_data.yaml
@@ -573,6 +573,7 @@ templates:
                     - "--context=components/schema-migrator"
                     - "--dockerfile=Dockerfile"
                     - "--platform=linux/amd64"
+                    - "--platform=linux/arm64"
                   decoration_config:
                     timeout: 20m
                     grace_period: 1m


### PR DESCRIPTION
**Description**
So far Schema Migrator build was only for architecture AMD64 due to used binaries in docker build. We now introduce ARM build for this component.

Changes proposed in this pull request:
- ARM build for schema migrator
