### PR TITLE
Bump golagn image to v1.19.5 multiplatform

### DIFF
--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -12,8 +12,8 @@ images:
 - source: "gcr.io/google-containers/pause:3.2"
 - source: "goreleaser/goreleaser:v1.11.5"
 # Golang image is pinned because it is force updated in the upstream
-- source: "golang@sha256:a9b24b67dc83b3383d22a14941c2b2b2ca6a103d805cac6820fd1355943beaf1"
-  tag: "1.19.4-alpine3.17-v1"
+- source: "golang@sha256:2381c1e5f8350a901597d633b2e517775eeac7a6682be39225a93b22cfd0f8bb"
+  tag: "1.19.5-alpine3.17"
 - source: "grafana/loki:2.2.1"
 - source: "grafana/grafana-image-renderer:3.2.1"
   amd64Only: true


### PR DESCRIPTION
[image](https://hub.docker.com/layers/library/golang/alpine/images/sha256-27a9653759f44afd08c94418307a26d2db9cf78af12933200bc2ca63c4844316?context=explore#!)
[release notes](https://go.dev/doc/devel/release#go1.19)