### PR TITLE
Update buildkit base image version

### DIFF
--- a/development/image-builder/images/buildkit/Dockerfile
+++ b/development/image-builder/images/buildkit/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache curl && \
   | tar xz docker-credential-gcr \
   && chmod +x docker-credential-gcr && mv docker-credential-gcr /usr/bin/
 
-FROM moby/buildkit:v0.10.4-rootless
+FROM moby/buildkit:v0.11.1-rootless
 
 COPY --from=creds /usr/bin/docker-credential-gcr /usr/bin/
 RUN docker-credential-gcr configure-docker --registries=eu.gcr.io,europe-docker.pkg.dev


### PR DESCRIPTION
**Description**
Update Buildkit image version to latest available:
https://hub.docker.com/r/moby/buildkit/tags?page=1&name=rootless
Changes proposed in this pull request:

- Update buildkit base image version
