### PR TITLE
Fix ProwJob authentication

### DIFF
--- a/development/tools/cmd/pjtester/main.go
+++ b/development/tools/cmd/pjtester/main.go
@@ -28,5 +28,5 @@ func main() {
 	if err := ghOptions.Validate(false); err != nil {
 		logrus.WithError(err).Fatalf("github options validation failed")
 	}
-	pjtester.SchedulePJ(ghOptions)
+	pjtester.SchedulePJ(&ghOptions)
 }

--- a/development/tools/pkg/pjtester/pjtester_test.go
+++ b/development/tools/pkg/pjtester/pjtester_test.go
@@ -212,7 +212,7 @@ var _ = Describe("Pjtester", func() {
 
 			ghOptions = prowflagutil.GitHubOptions{}
 			// TODO: test this function in separate context, opts must be defined at the beginning.
-			opts, err = newCommonOptions(ghOptions)
+			opts, err = newCommonOptions(&ghOptions)
 			Expect(err).To(Succeed())
 
 			testConfig, err = readTestCfg(testCfgFile)


### PR DESCRIPTION
At some point of work pjtester was losing information about authentication, so it was always using anonymous GitHub client.

* Remove usage of bugged GithubClientConfig in favor to use native GitHubClient function from prow.k8s.io

Closes #6728 
