### PR TITLE
Make the pipeline use k8s 1.24 version

### DIFF
--- a/prow/jobs/kyma/kyma-integration-gardener-eventing.yaml
+++ b/prow/jobs/kyma/kyma-integration-gardener-eventing.yaml
@@ -17,6 +17,7 @@ presubmits: # runs on PRs
         preset-bot-github-token: "true"
         preset-build-pr: "true"
         preset-cluster-version: "true"
+        preset-cluster-version-old: "true"
         preset-debug-commando-oom: "true"
         preset-gardener-gcp-kyma-integration: "true"
         preset-kyma-cli-stable: "true"

--- a/templates/data/kyma-integration-gardener-data.yaml
+++ b/templates/data/kyma-integration-gardener-data.yaml
@@ -98,6 +98,7 @@ templates:
                   run_if_changed: "^((tests/fast-integration\\S+|resources/eventing\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
                   labels:
                     preset-bot-github-token: "true"
+                    preset-cluster-version-old: "true"
                   env:
                     EXECUTION_PROFILE: "production"
                     MACHINE_TYPE: "n1-standard-8"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- `kyma-gardener-gcp-eventing-upgrade` tries to install 2.10 which has: poddisruptionbudget definition with `"policy/v1beta1"` in cluster essentials, this is not supported anymore in 1.25.
- Use older k8s version to make it compatible
- Example failing test: https://status.build.kyma-project.io/log?container=test&id=1616448124417478656&job=pre-main-kyma-gardener-gcp-eventing-upgrade
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
