### PR TITLE
Add warden in-cluster integration test

### DIFF
--- a/prow/jobs/kyma-project/warden/integration-test.yaml
+++ b/prow/jobs/kyma-project/warden/integration-test.yaml
@@ -1,0 +1,38 @@
+presubmits:
+  kyma-project/warden:
+    - name: pull-warden-integration-test
+      optional: true
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+      cluster: untrusted-workload
+      decorate: true
+      spec:
+        containers:
+          - image: eu.gcr.io/kyma-project/test-infra/kyma-integration:v20230119-993f0759
+            command:
+              - /bin/bash
+            args:
+              - -c
+              - |
+                service docker start
+                curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+                k3d cluster create
+                kubectl cluster-info
+                make install run-integration-tests
+                failed=$?
+                k3d cluster delete
+                exit $failed
+            requests:
+              memory: 1Gi
+            limits:
+              memory: 1Gi
+            securityContext:
+              privileged: true
+        tolerations:
+          - key: dedicated
+            operator: Equal
+            value: high-cpu
+            effect: NoSchedule
+        nodeSelector:
+          dedicated: "high-cpu"


### PR DESCRIPTION
Since warden requires only simple k8s cluster (no need to use Kyma), I used the ability to run K8s inside ProwJob with k3d. It worked flawlessly. Time - around 2 minutes of execution with entire cluster provision. Size - 8 lines of shell script. We reserve 1Gi of memory for the job, although less should be possible.

ProwJob does the following:
* starts Docker daemon
* provisions k3s cluster with k3d
* installs warden using `make install`
* runs test using `make run-integration-tests`
* destroys k3s cluster
* returns exit value of `make` and fails if command finished with an error

Delta - we have to use privileged mode. This is something that we cannot work around, we have to work with it.