### PR TITLE
Reauthenticate client on passwd change

### DIFF
--- a/development/gcp/cloud-run/create-github-issue/create-github-issue.go
+++ b/development/gcp/cloud-run/create-github-issue/create-github-issue.go
@@ -176,6 +176,7 @@ func createGithubIssue(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				logger.LogCritical("failed reauthenticate github client, error %s", err)
 			}
+			// Retry GitHub API call with eventually new credentials. This may fail again because of no new credentials provided.
 			sapGhClient.WrapperClientMu.RLock()
 			issue, result, err = sapGhClient.Issues.Create(ctx, githubOrg, githubRepo, &issueRequest)
 			sapGhClient.WrapperClientMu.RUnlock()

--- a/development/gcp/cloud-run/create-github-issue/create-github-issue.go
+++ b/development/gcp/cloud-run/create-github-issue/create-github-issue.go
@@ -27,11 +27,10 @@ var (
 	componentName        string
 	applicationName      string
 	projectID            string
-	githubToken          []byte
 	toolsGithubTokenPath string
 	githubOrg            string // "neighbors-team"
 	githubRepo           string // "leaks-test"
-	listenPort                 string
+	listenPort           string
 	sapGhClient          *kgithubv1.SapToolsClient
 )
 
@@ -61,7 +60,7 @@ func main() {
 
 	ctx := context.Background()
 
-	githubToken, err = os.ReadFile(toolsGithubTokenPath)
+	githubToken, err := os.ReadFile(toolsGithubTokenPath)
 	if err != nil {
 		mainLogger.LogCritical("failed read github token from file, error: %s", err)
 	}
@@ -157,21 +156,43 @@ func createGithubIssue(w http.ResponseWriter, r *http.Request) {
 		Milestone: nil,
 		Assignees: nil,
 	}
-	// Search issues
-	issue, response, err := sapGhClient.Issues.Create(ctx, githubOrg, githubRepo, &issueRequest)
+
+	var (
+		issue  *github.Issue
+		result *github.Response
+	)
+	sapGhClient.WrapperClientMu.RLock()
+	issue, result, err = sapGhClient.Issues.Create(ctx, githubOrg, githubRepo, &issueRequest)
+	sapGhClient.WrapperClientMu.RUnlock()
+	if result != nil {
+		switch {
+		case result.StatusCode == 401:
+			logger.LogWarning("Github authentication failed, got %d response status code, trying to reauthenticate", result.StatusCode)
+			githubToken, err := os.ReadFile(toolsGithubTokenPath)
+			if err != nil {
+				logger.LogCritical("failed read github token from file, error: %s", err)
+			}
+			_, err = sapGhClient.Reauthenticate(ctx, logger, githubToken)
+			if err != nil {
+				logger.LogCritical("failed reauthenticate github client, error %s", err)
+			}
+			sapGhClient.WrapperClientMu.RLock()
+			issue, result, err = sapGhClient.Issues.Create(ctx, githubOrg, githubRepo, &issueRequest)
+			sapGhClient.WrapperClientMu.RUnlock()
+			if result != nil && (result.StatusCode < 200 || result.StatusCode >= 300) {
+				crhttp.WriteHTTPErrorResponse(w, http.StatusInternalServerError, logger, "failed create github issues, received non 2xx response code, error: %s", err)
+				return
+			}
+		case result.StatusCode < 200 || result.StatusCode >= 300:
+			crhttp.WriteHTTPErrorResponse(w, http.StatusInternalServerError, logger, "failed create github issues, received non 2xx response code, error: %s", err)
+			return
+		}
+	}
 	if err != nil {
 		crhttp.WriteHTTPErrorResponse(w, http.StatusInternalServerError, logger, "failed create github issues, error: %s", err)
 		return
 	}
-	ok, err := kgithubv1.IsStatusOK(response)
-	if err != nil {
-		crhttp.WriteHTTPErrorResponse(w, http.StatusInternalServerError, logger, "failed create github issues, failed read status code, error %s", err)
-		return
-	}
-	if !ok {
-		crhttp.WriteHTTPErrorResponse(w, http.StatusInternalServerError, logger, "failed create github issues, received non 2xx response code: status code %d", response.StatusCode)
-		return
-	}
+
 	logger.LogInfo("created github issue: %s", issue.GetHTMLURL())
 	msg.GithubIssueNumber = issue.Number
 	msg.GithubIssueURL = issue.HTMLURL

--- a/development/gcp/cloud-run/search-github-issue/search-github-issues.go
+++ b/development/gcp/cloud-run/search-github-issue/search-github-issues.go
@@ -173,6 +173,7 @@ func searchGithubIssues(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				logger.LogCritical("failed reauthenticate github client, error %s", err)
 			}
+			// Retry GitHub API call with eventually new credentials. This may fail again because of no new credentials provided.
 			sapGhClient.WrapperClientMu.RLock()
 			searchResult, result, err = sapGhClient.Search.Issues(ctx, query, opts)
 			sapGhClient.WrapperClientMu.RUnlock()

--- a/development/gcp/pkg/cloudfunctions/logging.go
+++ b/development/gcp/pkg/cloudfunctions/logging.go
@@ -6,7 +6,7 @@ import (
 	"math/rand"
 )
 
-// Entry defines a log entry.
+// LogEntry defines a log entry.
 type LogEntry struct {
 	Message  string `json:"message"`
 	Severity string `json:"severity,omitempty"`
@@ -67,6 +67,13 @@ func (e LogEntry) LogCritical(format string, args ...interface{}) {
 func (e LogEntry) LogError(format string, args ...interface{}) {
 	message := fmt.Sprintf(format, args...)
 	e.Severity = "ERROR"
+	e.Message = message
+	fmt.Println(e)
+}
+
+func (e LogEntry) LogWarning(format string, args ...interface{}) {
+	message := fmt.Sprintf(format, args...)
+	e.Severity = "WARNING"
 	e.Message = message
 	fmt.Println(e)
 }

--- a/development/github/pkg/client/client.go
+++ b/development/github/pkg/client/client.go
@@ -9,8 +9,10 @@ import (
 	"fmt"
 	"hash"
 	"net/http"
+	"sync"
 
 	"github.com/google/go-github/v42/github"
+	"github.com/kyma-project/test-infra/development/gcp/pkg/cloudfunctions"
 	"github.com/kyma-project/test-infra/development/types"
 	"golang.org/x/oauth2"
 	"gopkg.in/yaml.v2"
@@ -38,8 +40,13 @@ type SapToolsClient struct {
 // Client wraps google github Client and provides additional methods.
 type Client struct {
 	*github.Client
-	hmacKey []byte
-	mac     hash.Hash
+	hmacKey []byte // A random generated key for hmac hashing.
+	// Token hmac hash used to authenticate client on GitHub.
+	// Before reauthenticating client, check if new token is different from stored token hmac hash.
+	tokenHmac hash.Hash
+	// Used to prevent race condition when reauthenticating client.
+	// RLock and RUnlock must be used to secure all client methods calls.
+	WrapperClientMu sync.RWMutex
 }
 
 // String provide string representation for tokenPathFlag.
@@ -95,12 +102,15 @@ func newOauthHTTPClient(ctx context.Context, accessToken string) *http.Client {
 func NewClient(ctx context.Context, accessToken string) (*Client, error) {
 	tc := newOauthHTTPClient(ctx, accessToken)
 	ghc := github.NewClient(tc)
-	c := &Client{Client: ghc}
+	c := &Client{
+		Client:          ghc,
+		WrapperClientMu: sync.RWMutex{},
+	}
 	err := c.generateHmacKey()
 	if err != nil {
 		return nil, err
 	}
-	err = c.storePasswordHash(accessToken)
+	err = c.storeTokenHash([]byte(accessToken))
 	if err != nil {
 		return nil, err
 	}
@@ -115,12 +125,15 @@ func NewSapToolsClient(ctx context.Context, accessToken string) (*SapToolsClient
 	if err != nil {
 		return nil, err
 	}
-	c := &Client{Client: ghec}
+	c := &Client{
+		Client:          ghec,
+		WrapperClientMu: sync.RWMutex{},
+	}
 	err = c.generateHmacKey()
 	if err != nil {
 		return nil, err
 	}
-	err = c.storePasswordHash(accessToken)
+	err = c.storeTokenHash([]byte(accessToken))
 	if err != nil {
 		return nil, err
 	}
@@ -143,6 +156,8 @@ func IsStatusOK(resp *github.Response) (bool, error) {
 	return true, nil
 }
 
+// generateHmacKey generate cryptographically safe random key.
+// Key is stored in a Client struct and used to hash password with hmac.
 func (c *Client) generateHmacKey() error {
 	buf := make([]byte, 128)
 	_, err := rand.Read(buf)
@@ -153,36 +168,59 @@ func (c *Client) generateHmacKey() error {
 	return nil
 }
 
-func (c *Client) storePasswordHash(token string) error {
+// storeTokenHash hash token with hmac sha256 and store it in a client.
+// Using hmac as it's designed for passwords secure storage.
+func (c *Client) storeTokenHash(token []byte) error {
 	mac := hmac.New(sha256.New, c.hmacKey)
-	_, err := mac.Write([]byte(token))
+	_, err := mac.Write(token)
 	if err != nil {
 		return err
 	}
-	c.mac = mac
+	c.tokenHmac = mac
 	return nil
 }
 
-func (c *Client) CompareTokensHashes(token string) (hash.Hash, error) {
+// CompareTokensHashes generates hmac hash for provided token and compare it with hash stored in a client.
+// If provided token is the same as a token stored in a client return nil hash.Hash and error, if not new token hmac hash
+// and nil error is returned.
+// Compare tokens to check if client reauthentication with new token is required.
+// Creating a new client with wrong token doesn't return error.
+// A client will get error again on first GitHub API call, so check first if new password exist and reauthentication
+// is required.
+func (c *Client) compareTokensHashes(token []byte) (hash.Hash, error) {
 	mac := hmac.New(sha256.New, c.hmacKey)
-	_, err := mac.Write([]byte(token))
+	_, err := mac.Write(token)
 	if err != nil {
 		return nil, err
 	}
-	if eq := hmac.Equal(c.mac.Sum(nil), mac.Sum(nil)); eq {
+	if eq := hmac.Equal(c.tokenHmac.Sum(nil), mac.Sum(nil)); eq {
 		return nil, nil
 	}
 	return mac, nil
 }
 
-func (c *SapToolsClient) Reauthenticate(ctx context.Context, accessToken string) error {
-	tc := newOauthHTTPClient(ctx, accessToken)
+// Reauthenticate creates new GitHub Enterprise client with provided access token and replace existing ones.
+// It locks wrapper client mutex for read and write to prevent race conditions between client threads.
+// TODO: replace cloudfunctions logger with interface
+func (c *SapToolsClient) Reauthenticate(ctx context.Context, logger *cloudfunctions.LogEntry, accessToken []byte) (bool, error) {
+	c.WrapperClientMu.Lock()
+	defer c.WrapperClientMu.Unlock()
+	tokenHmac, err := c.compareTokensHashes(accessToken)
+	if err != nil {
+		logger.LogCritical("failed compare token hashes, error %s", err)
+	}
+	if tokenHmac == nil {
+		logger.LogWarning("No new token available for GitHub client, can't reauthenticate.")
+		return false, nil
+	}
+	tc := newOauthHTTPClient(ctx, string(accessToken))
 	ghec, err := github.NewEnterpriseClient(SapToolsGithubURL, SapToolsGithubURL, tc)
 	if err != nil {
-		return err
+		return false, err
 	}
 	c.Client.Client = ghec
-	return nil
+	c.tokenHmac = tokenHmac
+	return true, nil
 }
 
 // GetUsersMap will get users-map.yaml file from github.tools.sap/kyma/test-infra repository.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Search and create github issue services call GitHub API as authenticated user. A token is delivered from secrete manager directly to the cloud run instance and is automatically updated once new version is added in secret manager. However token is not loaded by clients running in cloud run instances, because clients are created at container boot. To use new token, clients will react on 401 bad credentials http error returned by github API. Clients will read token again and replace client instance with new one with new token. Replacement will happen only if new and old tokens are different. Token is stored as hmac+sha256 hash.

Support for 401 bad credentials http error let clients react correctly on planned token rotation as well unplanned rotation, like when token leaks. Correctly means, it's thread safe and allow all in progress threads lock at the time of client reauthentication and retry GitHub API call with new token. This removes failed request because of bad credentials when a new token is already present in secret manager.
