### PR TITLE
Bump golangci-lint image to 1.51.1

### DIFF
--- a/prow/images/golangci-lint/Dockerfile
+++ b/prow/images/golangci-lint/Dockerfile
@@ -1,4 +1,4 @@
-FROM golangci/golangci-lint:v1.51.0
+FROM golangci/golangci-lint:v1.51.1
 
 
 # Commit details


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Upgrade `golangci/golangci-lint` from `1.51.0` to `1.51.1`


**Reason**
https://status.build.kyma-project.io/job-history/gs/kyma-prow-logs/pr-logs/directory/pull-lifecycle-mgr-lint is failing with a false positive for the `musttag` linter which was fixed in `golangci-lint` latest image.