### PR TITLE
image-builder: pin notary signers to specific job types

### DIFF
--- a/development/image-builder/sign/sign.go
+++ b/development/image-builder/sign/sign.go
@@ -27,6 +27,10 @@ type SignerConfig struct {
 	Type string `yaml:"type" json:"type"`
 	// Config defines specific configuration for signing backend.
 	Config SignerFactory `yaml:"config" json:"config"`
+	// JobType contains list of ProwJob types that should be supported.
+	// If the list is empty, the signer is enabled for all job types.
+	// Usable only in CI mode (CI=true)
+	JobType []string `yaml:"job-type" json:"job-type"`
 }
 
 type SignerFactory interface {
@@ -39,8 +43,9 @@ type Signer interface {
 
 func (sc *SignerConfig) UnmarshalYAML(value *yaml.Node) error {
 	var t struct {
-		Name string `yaml:"name"`
-		Type string `yaml:"type"`
+		Name    string   `yaml:"name"`
+		Type    string   `yaml:"type"`
+		JobType []string `yaml:"job-type"`
 	}
 	if err := value.Decode(&t); err != nil {
 		return err
@@ -59,5 +64,6 @@ func (sc *SignerConfig) UnmarshalYAML(value *yaml.Node) error {
 	}
 	sc.Type = t.Type
 	sc.Name = t.Name
+	sc.JobType = t.JobType
 	return nil
 }


### PR DESCRIPTION
This PR adds ability to enable specific signer service only for specific ProwJob type. When the signer configuration contains a job-type field, it is considered as CI-based service. Its invocation is only restricted to CI mode for a specific repository, or globally.
* If signer contains a job-type field, and is running in Prow, image-builder will determine if this service should sign an image based on the value of job-type and env variable `JOB_TYPE`
* If signer contains job-type field, but it's not running on CI, image-builder ignores signing using this service
* If signer doesn't contain a job-type field it will be used and enabled by default

This approach allows to pin specific notary service to each of job-types, eg. prod service only for postsubmit jobs, and dev service for all types of job

/area tools
/kind feature