### PR TITLE
Alert when error is logged for secrets leak detector services.

### DIFF
--- a/configs/terraform/secrets-leaks-log-scanner/gcs-bucket-mover.tf
+++ b/configs/terraform/secrets-leaks-log-scanner/gcs-bucket-mover.tf
@@ -1,25 +1,25 @@
 resource "google_service_account" "gcs_bucket_mover" {
-  account_id   = "gcs-bucket-mover-cr"
+  account_id  = "gcs-bucket-mover-cr"
   description = "Identity of cloud run instance running gcs bucket mover service."
 }
 
 resource "google_storage_bucket_iam_member" "kyma_prow_logs_viewer" {
   bucket = data.google_storage_bucket.kyma_prow_logs.name
-  role = "roles/storage.objectViewer"
+  role   = "roles/storage.objectViewer"
   member = "serviceAccount:${google_service_account.gcs_bucket_mover.email}"
 }
 
 resource "google_storage_bucket_iam_member" "kyma_prow_logs_secured_object_admin" {
   bucket = google_storage_bucket.kyma_prow_logs_secured.name
-  role = "roles/storage.objectAdmin"
+  role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.gcs_bucket_mover.email}"
 }
 
 resource "google_storage_bucket" "kyma_prow_logs_secured" {
-  name          = "kyma-prow-logs-secured"
-  location      = "EU"
-  force_destroy = true
-  storage_class = "STANDARD"
+  name                        = "kyma-prow-logs-secured"
+  location                    = "EU"
+  force_destroy               = true
+  storage_class               = "STANDARD"
   uniform_bucket_level_access = true
   custom_placement_config {
     data_locations = ["EUROPE-WEST1", "EUROPE-WEST4"]
@@ -73,4 +73,25 @@ resource "google_cloud_run_service_iam_policy" "gcs_bucket_mover" {
   service  = google_cloud_run_service.gcs_bucket_mover.name
 
   policy_data = data.google_iam_policy.run_invoker.policy_data
+}
+resource "google_monitoring_alert_policy" "gcs_bucket_mover" {
+  combiner     = "OR"
+  display_name = "gcs-bucket-mover-error-logged"
+  conditions {
+    display_name = "error-log-message"
+    condition_matched_log {
+      filter = "resource.type=cloud_run_revision AND severity>=ERROR AND jsonPayload.component=gcs-bucket-mover AND labels.io.kyma.app=secrets-leaks-detector"
+    }
+  }
+  notification_channels = ["projects/${var.google_project_id}/notificationChannels/5909844679104799956"]
+  alert_strategy {
+    notification_rate_limit {
+      period = "6 hr"
+    }
+    auto_close = "4 days"
+  }
+  user_labels = {
+    component = "gcs-bucket-mover"
+    app       = "secrets-leak-detector"
+  }
 }

--- a/configs/terraform/secrets-leaks-log-scanner/github-issue-creator.tf
+++ b/configs/terraform/secrets-leaks-log-scanner/github-issue-creator.tf
@@ -1,19 +1,19 @@
 resource "google_service_account" "github_issue_creator" {
-  account_id   = "github-issue-creator-cr"
+  account_id  = "github-issue-creator-cr"
   description = "Identity of cloud run instance running github issue creator service."
 }
 
 resource "google_secret_manager_secret_iam_member" "gh_issue_creator_gh_tools_kyma_bot_token_accessor" {
-  project = data.google_secret_manager_secret.gh_tools_kyma_bot_token.project
+  project   = data.google_secret_manager_secret.gh_tools_kyma_bot_token.project
   secret_id = data.google_secret_manager_secret.gh_tools_kyma_bot_token.secret_id
-  role = "roles/secretmanager.secretAccessor"
-  member = "serviceAccount:${google_service_account.github_issue_creator.email}"
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.github_issue_creator.email}"
 }
 
 resource "google_cloud_run_service" "github_issue_creator" {
   depends_on = [google_secret_manager_secret_iam_member.gh_issue_creator_gh_tools_kyma_bot_token_accessor]
-  name     = "github-issue-creator"
-  location = "europe-west3"
+  name       = "github-issue-creator"
+  location   = "europe-west3"
 
   metadata {
     annotations = {
@@ -51,7 +51,7 @@ resource "google_cloud_run_service" "github_issue_creator" {
           value = "leaks-test"
         }
         env {
-          name = "TOOLS_GITHUB_TOKEN_PATH"
+          name  = "TOOLS_GITHUB_TOKEN_PATH"
           value = "/etc/gh-token/gh-tools-kyma-bot-token"
         }
         volume_mounts {
@@ -75,4 +75,25 @@ resource "google_cloud_run_service_iam_policy" "github_issue_creator" {
   service  = google_cloud_run_service.github_issue_creator.name
 
   policy_data = data.google_iam_policy.run_invoker.policy_data
+}
+resource "google_monitoring_alert_policy" "github_issue_creator" {
+  combiner     = "OR"
+  display_name = "github-issue-creator-error-logged"
+  conditions {
+    display_name = "error-log-message"
+    condition_matched_log {
+      filter = "resource.type=cloud_run_revision AND severity>=ERROR AND jsonPayload.component=github-issue-creator AND labels.io.kyma.app=secrets-leaks-detector"
+    }
+  }
+  notification_channels = ["projects/${var.google_project_id}/notificationChannels/5909844679104799956"]
+  alert_strategy {
+    notification_rate_limit {
+      period = "6 hr"
+    }
+    auto_close = "4 days"
+  }
+  user_labels = {
+    component = "github-issue-creator"
+    app       = "secrets-leak-detector"
+  }
 }

--- a/configs/terraform/secrets-leaks-log-scanner/github-issue-finder.tf
+++ b/configs/terraform/secrets-leaks-log-scanner/github-issue-finder.tf
@@ -1,19 +1,19 @@
 resource "google_service_account" "github_issue_finder" {
-  account_id   = "github-issue-finder-cr"
+  account_id  = "github-issue-finder-cr"
   description = "Identity of cloud run instance running github issue finder service."
 }
 
 resource "google_secret_manager_secret_iam_member" "gh_issue_finder_gh_tools_kyma_bot_token_accessor" {
-  project = data.google_secret_manager_secret.gh_tools_kyma_bot_token.project
+  project   = data.google_secret_manager_secret.gh_tools_kyma_bot_token.project
   secret_id = data.google_secret_manager_secret.gh_tools_kyma_bot_token.secret_id
-  role = "roles/secretmanager.secretAccessor"
-  member = "serviceAccount:${google_service_account.github_issue_finder.email}"
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.github_issue_finder.email}"
 }
 
 resource "google_cloud_run_service" "github_issue_finder" {
   depends_on = [google_secret_manager_secret_iam_member.gh_issue_finder_gh_tools_kyma_bot_token_accessor]
-  name     = "github-issue-finder"
-  location = "europe-west3"
+  name       = "github-issue-finder"
+  location   = "europe-west3"
 
   metadata {
     annotations = {
@@ -51,7 +51,7 @@ resource "google_cloud_run_service" "github_issue_finder" {
           value = "leaks-test"
         }
         env {
-          name = "TOOLS_GITHUB_TOKEN_PATH"
+          name  = "TOOLS_GITHUB_TOKEN_PATH"
           value = "/etc/gh-token/gh-tools-kyma-bot-token"
         }
         volume_mounts {
@@ -75,4 +75,25 @@ resource "google_cloud_run_service_iam_policy" "github_issue_finder" {
   service  = google_cloud_run_service.github_issue_finder.name
 
   policy_data = data.google_iam_policy.run_invoker.policy_data
+}
+resource "google_monitoring_alert_policy" "github_issue_finder" {
+  combiner     = "OR"
+  display_name = "github-issue-finder-error-logged"
+  conditions {
+    display_name = "error-log-message"
+    condition_matched_log {
+      filter = "resource.type=cloud_run_revision AND severity>=ERROR AND jsonPayload.component=github-issue-finder AND labels.io.kyma.app=secrets-leaks-detector"
+    }
+  }
+  notification_channels = ["projects/${var.google_project_id}/notificationChannels/5909844679104799956"]
+  alert_strategy {
+    notification_rate_limit {
+      period = "6 hr"
+    }
+    auto_close = "4 days"
+  }
+  user_labels = {
+    component = "github-issue-finder"
+    app       = "secrets-leak-detector"
+  }
 }

--- a/configs/terraform/secrets-leaks-log-scanner/main.tf
+++ b/configs/terraform/secrets-leaks-log-scanner/main.tf
@@ -37,7 +37,7 @@ data "google_storage_bucket" "kyma_prow_logs" {
 }
 
 data "google_secret_manager_secret" "gh_tools_kyma_bot_token" {
-  secret_id = "gh-tools-kyma-bot-token"
+  secret_id = "trusted_default_kyma-bot-github-sap-token"
 }
 
 data "google_secret_manager_secret" "common_slack_bot_token" {

--- a/configs/terraform/secrets-leaks-log-scanner/secrets-leak-log-scanner.tf
+++ b/configs/terraform/secrets-leaks-log-scanner/secrets-leak-log-scanner.tf
@@ -1,11 +1,11 @@
 resource "google_service_account" "secrets_leak_log_scanner" {
-  account_id   = "secrets-leak-log-scanner-cr"
+  account_id  = "secrets-leak-log-scanner-cr"
   description = "Identity of cloud run instance running log scanner service."
 }
 
 resource "google_storage_bucket_iam_member" "secrets_leak_detector" {
   bucket = data.google_storage_bucket.kyma_prow_logs.name
-  role = "roles/storage.objectViewer"
+  role   = "roles/storage.objectViewer"
   member = "serviceAccount:${google_service_account.secrets_leak_detector.email}"
 }
 
@@ -56,3 +56,48 @@ resource "google_cloud_run_service_iam_policy" "secrets_leak_log_scanner" {
 
   policy_data = data.google_iam_policy.run_invoker.policy_data
 }
+
+resource "google_monitoring_alert_policy" "secrets_leak_log_scanner" {
+  combiner     = "OR"
+  display_name = "secrets-leak-log-scanner-error-logged"
+  conditions {
+    display_name = "error-log-message"
+    condition_matched_log {
+      filter = "resource.type=cloud_run_revision AND severity>=ERROR AND jsonPayload.component=secrets-leak-log-scanner AND labels.io.kyma.app=secrets-leaks-detector"
+    }
+  }
+  notification_channels = ["projects/${var.google_project_id}/notificationChannels/5909844679104799956"]
+  alert_strategy {
+    notification_rate_limit {
+      period = "6 hr"
+    }
+    auto_close = "4 days"
+  }
+  user_labels = {
+    component = "secrets-leak-log-scanner"
+    app       = "secrets-leak-detector"
+  }
+}
+
+#resource "google_logging_metric" "secrets_leak_log_scanner" {
+#  name = "secrests_leak_log_scanner_errors"
+#  filter = "resource.type=cloud_run_revision AND severity>=ERROR AND jsonPayload.component=secrets-leak-log-scanner AND labels.io.kyma.app=secrets-leaks-detector"
+#  metric_descriptor {
+#    metric_kind = "DELTA"
+#    value_type  = "INT64"
+#    labels {
+#      key = "component"
+#      value_type = "STRING"
+#      description = ""
+#    }
+#    labels {
+#      key = "app"
+#      value_type = "STRING"
+#      description = ""
+#    }
+#  }
+#  label_extractors = {
+#    "component" = "EXTRACT(jsonPayload.component)"
+#    "app" = "EXTRACT(labels.io.kyma.app)"
+#  }
+#}

--- a/configs/terraform/secrets-leaks-log-scanner/secrets-leak-log-scanner.tf
+++ b/configs/terraform/secrets-leaks-log-scanner/secrets-leak-log-scanner.tf
@@ -78,26 +78,3 @@ resource "google_monitoring_alert_policy" "secrets_leak_log_scanner" {
     app       = "secrets-leak-detector"
   }
 }
-
-#resource "google_logging_metric" "secrets_leak_log_scanner" {
-#  name = "secrests_leak_log_scanner_errors"
-#  filter = "resource.type=cloud_run_revision AND severity>=ERROR AND jsonPayload.component=secrets-leak-log-scanner AND labels.io.kyma.app=secrets-leaks-detector"
-#  metric_descriptor {
-#    metric_kind = "DELTA"
-#    value_type  = "INT64"
-#    labels {
-#      key = "component"
-#      value_type = "STRING"
-#      description = ""
-#    }
-#    labels {
-#      key = "app"
-#      value_type = "STRING"
-#      description = ""
-#    }
-#  }
-#  label_extractors = {
-#    "component" = "EXTRACT(jsonPayload.component)"
-#    "app" = "EXTRACT(labels.io.kyma.app)"
-#  }
-#}

--- a/configs/terraform/secrets-leaks-log-scanner/slack-message-sender.tf
+++ b/configs/terraform/secrets-leaks-log-scanner/slack-message-sender.tf
@@ -1,19 +1,19 @@
 resource "google_service_account" "slack_message_sender" {
-  account_id   = "slack-message-sender-cr"
+  account_id  = "slack-message-sender-cr"
   description = "Identity of cloud run instance running slack message sender service."
 }
 
 resource "google_secret_manager_secret_iam_member" "slack_msg_sender_common_slack_bot_token_accessor" {
-  project = data.google_secret_manager_secret.common_slack_bot_token.project
+  project   = data.google_secret_manager_secret.common_slack_bot_token.project
   secret_id = data.google_secret_manager_secret.common_slack_bot_token.secret_id
-  role = "roles/secretmanager.secretAccessor"
-  member = "serviceAccount:${google_service_account.slack_message_sender.email}"
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.slack_message_sender.email}"
 }
 
 resource "google_cloud_run_service" "slack_message_sender" {
   depends_on = [google_secret_manager_secret_iam_member.slack_msg_sender_common_slack_bot_token_accessor]
-  name     = "slack-message-sender"
-  location = "europe-west3"
+  name       = "slack-message-sender"
+  location   = "europe-west3"
 
   metadata {
     annotations = {
@@ -46,7 +46,7 @@ resource "google_cloud_run_service" "slack_message_sender" {
           value = "https://slack.com/api"
         }
         env {
-          name = "SLACK_TOKEN_PATH"
+          name  = "SLACK_TOKEN_PATH"
           value = "/etc/slack-secret"
         }
         volume_mounts {
@@ -71,4 +71,25 @@ resource "google_cloud_run_service_iam_policy" "slack_message_sender" {
   service  = google_cloud_run_service.slack_message_sender.name
 
   policy_data = data.google_iam_policy.run_invoker.policy_data
+}
+resource "google_monitoring_alert_policy" "slack_message_sender" {
+  combiner     = "OR"
+  display_name = "slack-message-sender-error-logged"
+  conditions {
+    display_name = "error-log-message"
+    condition_matched_log {
+      filter = "resource.type=cloud_run_revision AND severity>=ERROR AND jsonPayload.component=slack-message-sender AND labels.io.kyma.app=secrets-leaks-detector"
+    }
+  }
+  notification_channels = ["projects/${var.google_project_id}/notificationChannels/5909844679104799956"]
+  alert_strategy {
+    notification_rate_limit {
+      period = "6 hr"
+    }
+    auto_close = "4 days"
+  }
+  user_labels = {
+    component = "slack-message-sender"
+    app       = "secrets-leak-detector"
+  }
 }

--- a/development/gcp/pkg/cloudfunctions/logging.go
+++ b/development/gcp/pkg/cloudfunctions/logging.go
@@ -12,7 +12,7 @@ type LogEntry struct {
 	Severity string `json:"severity,omitempty"`
 	// Trace will be the same for one function call, you can use it for filetering in logs
 	Trace  string            `json:"logging.googleapis.com/trace,omitempty"`
-	Labels map[string]string `json:"logging.googleapis.com/operation,omitempty"`
+	Labels map[string]string `json:"labels,omitempty"`
 	// Cloud Log Viewer allows filtering and display of this as `jsonPayload.component`.
 	Component string `json:"component,omitempty"`
 }


### PR DESCRIPTION
Use labels on structured log entries.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Add Terraform config creating gcp log based alerting policy for all log scanner services.
Policy will alert on slack channel on error log messages. Notification will be replied every 6 hours and auto closed after 4 days.

Log messages from golang services will use LogEntry.Labels field instead jsonPayload level field.
