### PR TITLE
Reverting changes as they were not used in final solution.

### DIFF
--- a/development/github/pkg/client/v2/client.go
+++ b/development/github/pkg/client/v2/client.go
@@ -1,22 +1,15 @@
 package client
 
 import (
-	"flag"
 	"fmt"
 
 	prowflagutil "k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/github"
 )
 
-const (
-	SapToolsHost            = "github.tools.sap"
-	SapToolsGraphQLEndpoint = "https://github.tools.sap"
-)
-
 // GithubClientConfig holds configuration for GithubClient.
 type GithubClientConfig struct {
 	prowflagutil.GitHubOptions
-	token  string
 	DryRun bool
 }
 
@@ -31,67 +24,29 @@ type githubClient struct {
 }
 
 // GithubClientOption is a client constructor configuration option passing configuration to the client constructor.
-type GithubClientOption func(*flag.FlagSet) error
+type GithubClientOption func(*GithubClientConfig) error
 
 // NewGithubClient is a constructor function for GithubClient.
 // A constructed client can be configured by providing GithubClientOptions.
 func (o *GithubClientConfig) NewGithubClient(options ...GithubClientOption) (GithubClient, error) {
-	var err error
-	// Add flag to default github client flag set.
-	// New flag enable client to authenticate with token string.
-	fs := flag.NewFlagSet("ghclient", flag.ExitOnError)
-	fs.StringVar(&o.token, "github-token", "", "Github Token")
-	o.AddFlags(fs)
 	// Run provided configuration option functions.
 	for _, opt := range options {
-		err = opt(fs)
+		err := opt(o)
 		if err != nil {
 			return nil, fmt.Errorf("failed applying functional option: %w", err)
 		}
 	}
-	err = fs.Parse([]string{})
+	client, err := o.GitHubOptions.GitHubClient(o.DryRun)
 	if err != nil {
 		return nil, err
-	}
-	var client github.Client
-	if o.token != "" {
-		client, err = o.GitHubClientWithAccessToken(o.token)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		client, err = o.GitHubOptions.GitHubClient(o.DryRun)
-		if err != nil {
-			return nil, err
-		}
 	}
 	return &githubClient{Client: client}, nil
 }
 
 // WithTokenPath is a client constructor configuration option passing path to a file with GitHub token.
 func WithTokenPath(tokenpath string) GithubClientOption {
-	return func(fs *flag.FlagSet) error {
-		return fs.Set("github-token-path", tokenpath)
-	}
-}
-
-// WithToken is a client constructor configuration option passing a GitHub token to authenticate.
-func WithToken(token string) GithubClientOption {
-	return func(fs *flag.FlagSet) error {
-		return fs.Set("github-token", token)
-	}
-}
-
-// WithEndpoint is a client constructor configuration option passing a GitHub endpoint.
-func WithEndpoint(endpoint string) GithubClientOption {
-	return func(fs *flag.FlagSet) error {
-		return fs.Set("github-endpoint", endpoint)
-	}
-}
-
-// WithHost is a client constructor configuration option passing a GitHub host.
-func WithHost(hostname string) GithubClientOption {
-	return func(fs *flag.FlagSet) error {
-		return fs.Set("github-host", hostname)
+	return func(o *GithubClientConfig) error {
+		o.TokenPath = tokenpath
+		return nil
 	}
 }


### PR DESCRIPTION
Moreover parsing flags with empty list of args broke pjtester.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Changes made in GitHub constructor function wre not used in final solution. Moreover parsing flags with empty list of args broke constructing client with flags provided as cli args.
