### PR TITLE
tekton dashboard: restrict access to default namespace

### DIFF
--- a/tekton/deployments/dashboard_release.yaml
+++ b/tekton/deployments/dashboard_release.yaml
@@ -278,7 +278,7 @@ spec:
             - --read-only=true
             - --log-level=info
             - --log-format=json
-            - --namespace=
+            - --namespace=default
             - --stream-logs=true
             - --external-logs=
           env:


### PR DESCRIPTION
/area prow