### PR TITLE
Use gopher group in CODEOWNERS instead of enumerating its members

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,18 +15,16 @@
 /prow/images/buildpack-node @kyma-project/prow @akucharska @wawrzyn321 @a-thaler @lilitgh @sawthis @valentinvieriu @qbalukom
 
 /prow/jobs @kyma-project/prow
-/prow/jobs/addons @ralikio @szwedm @tillknuesting @wozniakjan @piotrmiskiewicz @pk85 @kyma-project/prow
 /prow/jobs/busola @qbalukom @sawthis @valentinvieriu @wawrzyn321 @akucharska @kyma-project/prow
 /prow/jobs/cli @chrkl @jeremyharisch @lindnerby @tobiscr @clebs @lilitgh @rakesh-garimella @skhalash @kyma-project/prow
 /prow/jobs/console @akucharska @qbalukom @sawthis @valentinvieriu @wawrzyn321 @kyma-project/prow
-/prow/jobs/control-plane @tillknuesting @piotrmiskiewicz @wozniakjan @akgalwas @franpog859 @koala7659 @pk85 @ralikio @szwedm @kyma-project/prow
+/prow/jobs/control-plane @kyma-project/gopher @akgalwas @franpog859 @koala7659 @kyma-project/prow
 /prow/jobs/incubator/compass @gvachkov @petartodorovv @desislavaa @dimitarpetrov @krasish @nickymateev @dzahariev @kirilkabakchiev @stefancholakov @svetlinzarev-sap @dragobt @kaloyanspiridonov @kyma-project/prow
 /prow/jobs/incubator/compass-console @gvachkov @petartodorovv @desislavaa @dimitarpetrov @krasish @nickymateev @dzahariev @kirilkabakchiev @stefancholakov @svetlinzarev-sap @dragobt @kaloyanspiridonov @kyma-project/prow
 /prow/jobs/incubator/documentation-component @kyma-project/prow
 /prow/jobs/incubator/hydra-login-consent @tomasz-smelcerz-sap @dariusztutaj @piotrkpc @kyma-project/prow
 /prow/jobs/incubator/kyma-showcase @cortey @lyczeq @mrcherry97 @mvshao @kyma-project/prow
 /prow/jobs/incubator/milv @m00g3n @pprecel @dbadura @kyma-project/prow
-/prow/jobs/incubator/octopus @szwedm @tillknuesting @wozniakjan @piotrmiskiewicz @pk85 @ralikio @kyma-project/prow
 /prow/jobs/incubator/ord-service @gvachkov @kirilkabakchiev @nickymateev @dzahariev @svetlinzarev-sap @dragobt @kaloyanspiridonov @kyma-project/prow
 /prow/jobs/incubator/reconciler @varbanv @clebs @kwiatekus @jeremyharisch @tobiscr @kyma-project/prow
 /prow/jobs/incubator/varkes @lilitgh @a-thaler @kyma-project/prow
@@ -44,10 +42,10 @@
 /prow/jobs/kyma/components/istio-installer @tomasz-smelcerz-sap @werdes72 @pk85 @dariusztutaj @strekm @kyma-project/prow
 /prow/jobs/kyma/components/kyma-operator @tomasz-smelcerz-sap @werdes72 @pk85 @dariusztutaj @strekm @kyma-project/prow
 /prow/jobs/kyma/components/permission-controller @pk85 @dariusztutaj @strekm @tomasz-smelcerz-sap @werdes72 @kyma-project/prow
-/prow/jobs/kyma/components/telemetry-operator @pk85 @szwedm @tillknuesting @a-thaler @ralikio @wozniakjan @piotrmiskiewicz @kyma-project/prow
-/prow/jobs/kyma/components/directory-size-exporter @pk85 @szwedm @tillknuesting @a-thaler @ralikio @wozniakjan @piotrmiskiewicz @kyma-project/prow
+/prow/jobs/kyma/components/telemetry-operator @a-thaler @kyma-project/prow
+/prow/jobs/kyma/components/directory-size-exporter @a-thaler @kyma-project/prow
 /prow/jobs/kyma/components/xip-patch @strekm @tomasz-smelcerz-sap @werdes72 @pk85 @dariusztutaj @kyma-project/prow
-/prow/jobs/kyma/tests/end-to-end @wozniakjan @piotrmiskiewicz @pk85 @ralikio @szwedm @tillknuesting @kyma-project/prow
+/prow/jobs/kyma/tests/end-to-end @kyma-project/gopher @kyma-project/prow
 /prow/jobs/kyma/tests/function-controller @pk85 @dbadura @kwiatekus @m00g3n @pprecel @kyma-project/prow
 /prow/jobs/kyma/tests/integration @strekm @tomasz-smelcerz-sap @werdes72 @pk85 @dariusztutaj @kyma-project/prow
 /prow/jobs/kyma/tests/serverless-bench @pk85 @dbadura @kwiatekus @m00g3n @pprecel @kyma-project/prow


### PR DESCRIPTION
https://github.com/orgs/kyma-project/teams/gopher/members

similar to https://github.com/kyma-project/control-plane/pull/2492