### PR TITLE
remove `allow_cancellations` field from prow config.yaml

### DIFF
--- a/development/tools/pkg/pjtester/test_artifacts/test-prow-config.yaml
+++ b/development/tools/pkg/pjtester/test_artifacts/test-prow-config.yaml
@@ -12,7 +12,6 @@ plank:
       [Full PR test history](https://status.build.kyma-project.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
       [Your PR dashboard](https://status.build.kyma-project.io/pr?query=is:pr+state:open+author:{{with
       index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
-  allow_cancellations: true # AllowCancellations enables aborting presubmit jobs for commits that have been superseded by newer commits in Github pull requests.
   max_concurrency: 100 # Limit of concurrent ProwJobs. Need to be adjusted depending of the cluster size.
   pod_pending_timeout: 60m
   default_decoration_configs:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -12,7 +12,6 @@ plank:
       [Full PR test history](https://status.build.kyma-project.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
       [Your PR dashboard](https://status.build.kyma-project.io/pr?query=is:pr+state:open+author:{{with
       index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
-  allow_cancellations: true # AllowCancellations enables aborting presubmit jobs for commits that have been superseded by newer commits in Github pull requests.
   max_concurrency: 100 # Limit of concurrent ProwJobs. Need to be adjusted depending of the cluster size.
   pod_pending_timeout: 60m
   default_decoration_config_entries:

--- a/prow/staging/config.yaml
+++ b/prow/staging/config.yaml
@@ -44,7 +44,6 @@ plank:
       [Full PR test history](https://status-dev.prow.build.kyma-project.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
       [Your PR dashboard](https://status-dev.prow.build.kyma-project.io/pr?query=is:pr+state:open+author:{{with
       index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
-  allow_cancellations: true # AllowCancellations enables aborting presubmit jobs for commits that have been superseded by newer commits in Github pull requests.
   max_concurrency: 100 # Limit of concurrent ProwJobs. Need to be adjusted depending of the cluster size.
   pod_pending_timeout: 60m
   default_decoration_configs:

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -10,7 +10,6 @@ plank:
       [Full PR test history](https://status.build.kyma-project.io/pr-history?org={{"{{"}}.Spec.Refs.Org{{"}}"}}&repo={{"{{"}}.Spec.Refs.Repo{{"}}"}}&pr={{"{{"}}with index .Spec.Refs.Pulls 0{{"}}{{"}}.Number{{"}}{{"}}end{{"}}"}}).
       [Your PR dashboard](https://status.build.kyma-project.io/pr?query=is:pr+state:open+author:{{"{{"}}with
       index .Spec.Refs.Pulls 0{{"}}{{"}}.Author{{"}}{{"}}end{{"}}"}}).
-  allow_cancellations: true # AllowCancellations enables aborting presubmit jobs for commits that have been superseded by newer commits in Github pull requests.
   max_concurrency: 100 # Limit of concurrent ProwJobs. Need to be adjusted depending of the cluster size.
   pod_pending_timeout: 60m
   default_decoration_config_entries:


### PR DESCRIPTION
This field is no longer available
```
{"component":"unset","file":"checkconfig/main.go:91","func":"main.reportWarning","level":"warning","msg":"unknown fields or bad config in prow/config.yaml: error unmarshaling JSON: while decoding JSON: json: unknown field \"allow_cancellations\"","severity":"warning","time":"2023-02-22T14:15:34+01:00"}
```
