### PR TITLE
Migrate rotate secrets service account cleaner to cloud run

### DIFF
--- a/development/secrets-rotator/cloud-run/rotate-service-account/rotateserviceaccount.go
+++ b/development/secrets-rotator/cloud-run/rotate-service-account/rotateserviceaccount.go
@@ -45,7 +45,7 @@ func main() {
 	var err error
 
 	componentName = os.Getenv("COMPONENT_NAME")     // issue-creator
-	applicationName = os.Getenv("APPLICATION_NAME") // github-bot
+	applicationName = os.Getenv("APPLICATION_NAME") // secrets-rotator
 	listenPort = os.Getenv("LISTEN_PORT")
 
 	mainLogger := cloudfunctions.NewLogger()
@@ -103,7 +103,9 @@ func rotateServiceAccount(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Create logger to use google cloud functions structured logging
 	logger := cloudfunctions.NewLogger()
+	// Set component for log entries to identify all messages for this function.
 	logger.WithComponent(componentName)
 	logger.WithLabel("io.kyma.app", applicationName)
 	logger.WithLabel("io.kyma.component", componentName)

--- a/development/secrets-rotator/cloud-run/service-account-keys-cleaner/Dockerfile
+++ b/development/secrets-rotator/cloud-run/service-account-keys-cleaner/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.20.0-alpine3.17 as builder
+
+WORKDIR /go/src/github.com/kyma-project/test-infra
+COPY . .
+
+RUN  CGO_ENABLED=0 go build -o /serviceaccountkeyscleaner -ldflags="-s -w" ./development/secrets-rotator/cloud-run/service-account-keys-cleaner
+
+FROM alpine:3.17.2
+
+COPY --from=builder /serviceaccountkeyscleaner /serviceaccountkeyscleaner
+RUN apk add --no-cache ca-certificates && \
+	chmod +x /serviceaccountkeyscleaner
+ENTRYPOINT ["/serviceaccountkeyscleaner"]

--- a/development/secrets-rotator/cloud-run/service-account-keys-cleaner/serviceaccountcleaner.go
+++ b/development/secrets-rotator/cloud-run/service-account-keys-cleaner/serviceaccountcleaner.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/compute/metadata"
+	gpubsub "cloud.google.com/go/pubsub"
+	"github.com/kyma-project/test-infra/development/gcp/pkg/cloudfunctions"
+	crhttp "github.com/kyma-project/test-infra/development/gcp/pkg/http"
+	"github.com/kyma-project/test-infra/development/gcp/pkg/iam"
+	"github.com/kyma-project/test-infra/development/gcp/pkg/pubsub"
+	"github.com/kyma-project/test-infra/development/gcp/pkg/secretmanager"
+	gcpiam "google.golang.org/api/iam/v1"
+)
+
+var (
+	secretManagerService  *secretmanager.Service
+	serviceAccountService *gcpiam.Service
+	componentName         string
+	applicationName       string
+	projectID             string
+	listenPort            string
+)
+
+func main() {
+	var err error
+
+	componentName = os.Getenv("COMPONENT_NAME")     // issue-creator
+	applicationName = os.Getenv("APPLICATION_NAME") // secrets-rotator
+	listenPort = os.Getenv("LISTEN_PORT")
+
+	mainLogger := cloudfunctions.NewLogger()
+	mainLogger.WithComponent(componentName)
+	mainLogger.WithLabel("io.kyma.app", applicationName)
+	mainLogger.WithLabel("io.kyma.component", componentName)
+
+	ctx := context.Background()
+
+	projectID, err = metadata.ProjectID()
+	if err != nil {
+		mainLogger.LogCritical("failed to retrieve GCP Project ID, error: " + err.Error())
+	}
+
+	secretManagerService, err = secretmanager.NewService(ctx)
+	if err != nil {
+		mainLogger.LogCritical("failed creating Secret Manager client, error: " + err.Error())
+	}
+
+	serviceAccountService, err = gcpiam.NewService(ctx)
+	if err != nil {
+		mainLogger.LogCritical("failed creating IAM client, error: " + err.Error())
+	}
+
+	http.HandleFunc("/", serviceAccountKeysCleaner)
+	// Determine listenPort for HTTP service.
+	if listenPort == "" {
+		listenPort = "8080"
+		mainLogger.LogInfo("Defaulting to listenPort %s", listenPort)
+	}
+	// Start HTTP server.
+	mainLogger.LogInfo("Listening on listenPort %s", listenPort)
+	if err := http.ListenAndServe(":"+listenPort, nil); err != nil {
+		mainLogger.LogCritical("failed listen on listenPort %s, error: %s", listenPort, err)
+	}
+}
+
+// serviceAccountCleaner destroys old versions of service-account secrets and corresponding keys
+func serviceAccountKeysCleaner(w http.ResponseWriter, r *http.Request) {
+	var (
+		trace               string
+		traceHeader         string
+		secretRotateMessage pubsub.SecretRotateMessage
+		err                 error
+	)
+
+	// set trace value to use it in logEntry
+	traceHeader = r.Header.Get("X-Cloud-Trace-Context")
+
+	if projectID != "" {
+		traceParts := strings.Split(traceHeader, "/")
+		if len(traceParts) > 0 && len(traceParts[0]) > 0 {
+			trace = fmt.Sprintf("projects/%s/traces/%s", projectID, traceParts[0])
+		}
+	}
+
+	// Create logger to use Google structured logging
+	logger := cloudfunctions.NewLogger()
+	// Set component for log entries to identify all messages for this function.
+	logger.WithComponent(componentName)
+	logger.WithLabel("io.kyma.app", applicationName)
+	logger.WithLabel("io.kyma.component", componentName)
+	logger.WithTrace(trace)
+
+	// decode http messages body
+	var message gpubsub.Message
+	if err := json.NewDecoder(r.Body).Decode(&message); err != nil {
+		crhttp.WriteHTTPErrorResponse(w, http.StatusInternalServerError, logger, "failed decode message body")
+		return
+	}
+
+	logger.WithLabel("messageId", message.ID)
+
+	err = json.Unmarshal(message.Data, &secretRotateMessage)
+	if err != nil {
+		crhttp.WriteHTTPErrorResponse(w, http.StatusBadRequest, logger, "failed to unmarshal message data field, error: %s", err.Error())
+		return
+	}
+
+	// options are provided as GET query:
+	// time that latest version of secret needs to exist before older ones can be destroyed
+	cutoffTimeHours := 5
+	keys, ok := r.URL.Query()["age"]
+	if ok && len(keys[0]) > 0 {
+		cutoffTimeHours, err = strconv.Atoi(keys[0])
+		if err != nil {
+			crhttp.WriteHTTPErrorResponse(w, http.StatusBadRequest, logger, "failed to convert age in hours to int: %s", err)
+			return
+		}
+	}
+
+	dryRun := false
+	keys, ok = r.URL.Query()["dry_run"]
+	if ok && keys[0] == "true" {
+		dryRun = true
+	}
+
+	keys, ok = r.URL.Query()["project"]
+	if ok {
+		projectID = keys[0]
+	}
+
+	// get all secrets that have type=service-account
+	projectPath := "projects/" + projectID
+	secrets, err := secretManagerService.GetAllSecrets(projectPath, "labels.type=service-account")
+	if err != nil {
+		crhttp.WriteHTTPErrorResponse(w, http.StatusInternalServerError, logger, "failed to get all secrets from %s project", projectPath)
+		return
+	}
+
+	// for each secret in SA
+	for _, secret := range secrets {
+		// for each secret in SA:
+
+		// if not excluded
+		if secret.Labels["skip-cleanup"] == "true" {
+			logger.LogDebug("Secret %s excluded from cleanup, continuing", secret.Labels["type"])
+			continue
+		}
+
+		// list only enabled versions
+		versions, err := secretManagerService.GetAllSecretVersions(secret.Name, "state:enabled")
+		if err != nil {
+			crhttp.WriteHTTPErrorResponse(w, http.StatusInternalServerError, logger, "Could not get enabled versions of a %s secret: %s", secret.Name, err)
+			return
+		}
+
+		// stop if there are less than two enabled versions
+		if len(versions) < 2 {
+			logger.LogDebug("less than two enabled versions for %s secret are available, skipping", secret.Name)
+			continue
+		}
+
+		// if latest older than X seconds
+		// timestamp in 2021-07-21T07:31:24.739506Z format
+		// 2006-01-02T15:04:05
+		latestVersionTimestamp, err := time.Parse("2006-01-02T15:04:05.000000Z", versions[0].CreateTime)
+		if err != nil {
+			crhttp.WriteHTTPErrorResponse(w, http.StatusInternalServerError, logger, "Couldn't parse date: %s", versions[0].CreateTime)
+			return
+		}
+		cutoffTime := time.Now().Add(time.Duration(-cutoffTimeHours) * time.Hour)
+
+		if latestVersionTimestamp.After(cutoffTime) {
+			logger.LogInfo("Latest secret is newer than minimal time: %s vs %s", latestVersionTimestamp.String(), cutoffTime.String())
+			continue
+		}
+
+		for i, version := range versions {
+			if i == 0 {
+				// skip latest
+				continue
+			}
+			// for each enabled except latest
+			versionDataString, err := secretManagerService.GetSecretVersionData(version.Name)
+			if err != nil {
+				crhttp.WriteHTTPErrorResponse(w, http.StatusInternalServerError, logger, "Couldn't get payload of a %s secret: %s", version.Name, err)
+				return
+			}
+
+			var versionData iam.ServiceAccountJSON
+			err = json.Unmarshal([]byte(versionDataString), &versionData)
+			if err != nil {
+				crhttp.WriteHTTPErrorResponse(w, http.StatusInternalServerError, logger, "failed to unmarshal secret JSON field, error: %s", err)
+				return
+			}
+
+			// get client_email
+			serviceAccountKeyPath := "projects/" + versionData.ProjectID + "/serviceAccounts/" + versionData.ClientEmail + "/keys/" + versionData.PrivateKeyID
+			logger.LogInfo("Looking for service account %s", serviceAccountKeyPath)
+
+			if !dryRun {
+				// delete the key
+				keyVersionCall := serviceAccountService.Projects.ServiceAccounts.Keys.Delete(serviceAccountKeyPath)
+				_, err = keyVersionCall.Do()
+				if err != nil {
+					logger.LogError("Could not delete %v key: %s", serviceAccountKeyPath, err)
+				}
+
+				// destroy the version
+				_, err = secretManagerService.DestroySecretVersion(version.Name)
+				if err != nil {
+					logger.LogError("Could not destroy %v secret version: %s", version.Name, err)
+				}
+			} else {
+				logger.LogDebug("Dry run: deleting %s and destroying %s", serviceAccountKeyPath, version.Name)
+			}
+		}
+
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/development/secrets-rotator/cloud-run/service-account-keys-cleaner/serviceaccountcleaner_test.go
+++ b/development/secrets-rotator/cloud-run/service-account-keys-cleaner/serviceaccountcleaner_test.go
@@ -1,0 +1,425 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kyma-project/test-infra/development/gcp/pkg/iam"
+	"github.com/kyma-project/test-infra/development/gcp/pkg/secretmanager"
+	gcpiam "google.golang.org/api/iam/v1"
+	"google.golang.org/api/option"
+	gcpsecretmanager "google.golang.org/api/secretmanager/v1"
+)
+
+var (
+	testingProjectName = "testing"
+)
+
+type fakeSecretVersion struct {
+	Data  string
+	Date  string
+	State string
+}
+
+func createFakeServiceAccountJSONData(email, key, state string) (string, error) {
+	data := iam.ServiceAccountJSON{
+		ProjectID:    projectID,
+		ClientEmail:  email,
+		PrivateKeyID: key,
+	}
+	dataString, err := json.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(dataString), nil
+}
+
+type fakeSecret struct {
+	Labels   map[string]string
+	Versions map[string]*fakeSecretVersion
+}
+
+type fakeSecretServer struct {
+	secrets                  map[string]*fakeSecret
+	unknownEndpointCallCount int
+}
+
+// naiveParseLabelFilter fakes filter parsing on server-side.
+// Expects filter in labels.name=value format
+// returns name, value, error
+func naiveParseLabelFilter(filter string) (string, string, error) {
+	first, value, equalFilter := strings.Cut(filter, "=")
+	if !equalFilter {
+		return "", "", errors.New("unexpected filter:" + filter + ", expected = symbol")
+	}
+	labels, name, twoPartFilter := strings.Cut(first, ".")
+	if (labels != "labels") || !twoPartFilter {
+		return "", "", errors.New("unexpected filter:" + filter + ", expected = symbol")
+	}
+	return name, value, nil
+}
+
+// naiveParseStateFilter fakes filter parsing on server-side.
+// Expects filter in key:value format
+// returns key, value, error
+func naiveParseSimpleFilter(filter string) (string, string, error) {
+	key, value, colonFilter := strings.Cut(filter, ":")
+	if !colonFilter {
+		return "", "", errors.New("unexpected filter:" + filter + ", expected = symbol")
+	}
+	return key, value, nil
+}
+
+func createSecretName(project, secret string) string {
+	return "projects/" + project + "/secrets/" + secret
+}
+
+func createSecretVersionName(project, secret, version string) string {
+	return createSecretName(project, secret) + "/versions/" + version
+}
+
+func (s *fakeSecretServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var err error
+
+	versionsRegex := regexp.MustCompile("/v1/projects/(.*)/secrets/(.*)/versions$")
+	versionAccessRegex := regexp.MustCompile("/v1/projects/(.*)/secrets/(.*)/versions/(.*):access$")
+	versionDestroyRegex := regexp.MustCompile("/v1/projects/(.*)/secrets/(.*)/versions/(.*):destroy$")
+
+	switch path := r.URL.Path; {
+	case path == "/v1/projects/"+testingProjectName+"/secrets":
+		{
+			filterLabel := ""
+			filterLabelValue := ""
+			if r.URL.Query().Get("filter") != "" {
+				filterLabel, filterLabelValue, err = naiveParseLabelFilter(r.URL.Query().Get("filter"))
+				if err != nil {
+					http.Error(w, "unable to parse labels filter: "+err.Error(), http.StatusBadRequest)
+				}
+			}
+
+			resp := gcpsecretmanager.ListSecretsResponse{}
+			for name, s := range s.secrets {
+				if filterLabel != "" {
+					if val, ok := s.Labels[filterLabel]; ok && val != filterLabelValue {
+						continue
+					}
+				}
+				resp.Secrets = append(resp.Secrets, &gcpsecretmanager.Secret{Name: createSecretName(testingProjectName, name), Labels: s.Labels})
+			}
+			b, err := json.Marshal(resp)
+			if err != nil {
+				http.Error(w, "unable to marshal request: "+err.Error(), http.StatusBadRequest)
+				return
+			}
+			w.Write(b)
+		}
+	case versionsRegex.MatchString(path):
+		{
+			versionsResponse := gcpsecretmanager.ListSecretVersionsResponse{}
+			// unknown url: /v1/secret_one_version/versions ;Query: filter=state%3Aenabled
+			filterKey := ""
+			filterValue := ""
+			if r.URL.Query().Get("filter") != "" {
+				filterKey, filterValue, err = naiveParseSimpleFilter(r.URL.Query().Get("filter"))
+				if err != nil {
+					http.Error(w, "unable to parse version state filter: "+err.Error(), http.StatusBadRequest)
+				}
+				if filterKey != "state" {
+					http.Error(w, "Bad filter key, expected state, got "+filterKey, http.StatusBadRequest)
+				}
+			}
+			projectName := strings.Split(path, "/")[3]
+			secretName := strings.Split(path, "/")[5]
+			if secret, ok := s.secrets[secretName]; ok {
+				var versionKeys []string
+				for versionName := range secret.Versions {
+					versionKeys = append(versionKeys, versionName)
+				}
+				sort.Strings(versionKeys)
+
+				for _, versionName := range versionKeys {
+					currentVersion := secret.Versions[versionName]
+					if filterValue != "" {
+						if currentVersion.State != filterValue {
+							continue
+						}
+					}
+					// secret versions are returned in reverse, from latest to oldest
+					version := &gcpsecretmanager.SecretVersion{Name: createSecretVersionName(projectName, secretName, versionName), CreateTime: currentVersion.Date, State: currentVersion.State}
+					versionsResponse.Versions = append([]*gcpsecretmanager.SecretVersion{version}, versionsResponse.Versions...)
+				}
+			} else {
+				http.Error(w, "unable to find secret: "+secretName, http.StatusBadRequest)
+			}
+
+			b, err := json.Marshal(versionsResponse)
+			if err != nil {
+				http.Error(w, "unable to marshal request: "+err.Error(), http.StatusBadRequest)
+				return
+			}
+			w.Write(b)
+		}
+	case versionAccessRegex.MatchString(path):
+		{
+			projectName := strings.Split(path, "/")[3]
+			secretName := strings.Split(path, "/")[5]
+			versionNameRaw := strings.Split(path, "/")[7]
+			versionName := strings.Split(versionNameRaw, ":")[0]
+
+			secret, ok := s.secrets[secretName]
+			if !ok {
+				http.Error(w, "unable to find secret: "+secretName, http.StatusBadRequest)
+				return
+			}
+			version, ok2 := secret.Versions[versionName]
+			if !ok2 {
+				http.Error(w, "unable to find secret "+secretName+" version "+versionName, http.StatusBadRequest)
+				return
+			}
+			payload := gcpsecretmanager.SecretPayload{Data: version.Data}
+			versionResponse := gcpsecretmanager.AccessSecretVersionResponse{Name: createSecretVersionName(projectName, secretName, versionName), Payload: &payload}
+			b, err := json.Marshal(versionResponse)
+			if err != nil {
+				http.Error(w, "unable to marshal request: "+err.Error(), http.StatusBadRequest)
+				return
+			}
+			w.Write(b)
+		}
+	case versionDestroyRegex.MatchString(path):
+		{
+			// projectName := strings.Split(path, "/")[3]
+			secretName := strings.Split(path, "/")[5]
+			versionNameRaw := strings.Split(path, "/")[7]
+			versionName := strings.Split(versionNameRaw, ":")[0]
+
+			ver := s.secrets[secretName].Versions[versionName]
+			ver.State = "destroyed"
+
+			b, err := json.Marshal(gcpsecretmanager.SecretVersion{})
+			if err != nil {
+				http.Error(w, "unable to marshal request: "+err.Error(), http.StatusBadRequest)
+				return
+			}
+			w.Write(b)
+		}
+	default:
+		{
+			fmt.Printf("unknown url: %s ;Query: %s ;Body: %s; %s\n", r.URL.Path, r.URL.Query().Encode(), r.Body, r.Method)
+			http.Error(w, "unknown URL: "+r.URL.Path, 500)
+			s.unknownEndpointCallCount++
+		}
+	}
+}
+
+type fakeIAMServer struct {
+	keys                     map[string]map[string]bool
+	unknownEndpointCallCount int
+}
+
+func (s *fakeIAMServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+
+	keyPathRegex := regexp.MustCompile("/v1/projects/(.*)/serviceAccounts/(.*)/keys/(.*)$")
+	switch path := r.URL.Path; {
+	case keyPathRegex.MatchString(path):
+		{
+			if r.Method != "DELETE" {
+				return
+			}
+			// projectName := strings.Split(path, "/")[3]
+			serviceAccountName := strings.Split(path, "/")[5]
+			keyName := strings.Split(path, "/")[7]
+
+			if _, ok := s.keys[serviceAccountName]; !ok {
+				fmt.Printf("unable to find service account %s\n", serviceAccountName)
+				// don't return here, as the function can still delete secret version even if the key was deleted manually
+			}
+
+			delete(s.keys[serviceAccountName], keyName)
+
+			b, err := json.Marshal(gcpiam.Empty{})
+			if err != nil {
+				http.Error(w, "unable to marshal request: "+err.Error(), http.StatusBadRequest)
+				return
+			}
+			w.Write(b)
+		}
+	default:
+		{
+			fmt.Printf("unknown url: %s ;Query: %s ;Body: %s; %s\n", r.URL.Path, r.URL.Query().Encode(), r.Body, r.Method)
+			http.Error(w, "unknown URL: "+r.URL.Path, 500)
+			s.unknownEndpointCallCount++
+		}
+	}
+}
+
+func TestServiceAccountKeysCleaner(t *testing.T) {
+	var err error
+	ctx := context.Background()
+	projectID = testingProjectName
+	fakeSecretEmail := "email"
+
+	fakeSecretKey := "secretKeyID"
+	fakeSecretVersionData, err := createFakeServiceAccountJSONData(fakeSecretEmail, fakeSecretKey, "enabled")
+	if err != nil {
+		t.Errorf("could not generate fake secret version data: %s", err)
+	}
+
+	fakeSecretKey2 := "secretKeyID2"
+	fakeSecretVersionData2, err := createFakeServiceAccountJSONData(fakeSecretEmail, fakeSecretKey, "enabled")
+	if err != nil {
+		t.Errorf("could not generate fake secret version data: %s", err)
+	}
+
+	timeTenHoursAgo := time.Now().Add(time.Duration(-10) * time.Hour).UTC().Format("2006-01-02T15:04:05.000000Z")
+	timeSixHoursAgo := time.Now().Add(time.Duration(-6) * time.Hour).UTC().Format("2006-01-02T15:04:05.000000Z")
+	// timeThreeHoursAgo := time.Now().Add(time.Duration(-3) * time.Hour).UTC().Format("2006-01-02T15:04:05.000000Z")
+	timeOneHoursAgo := time.Now().Add(time.Duration(-1) * time.Hour).UTC().Format("2006-01-02T15:04:05.000000Z")
+
+	tests := []struct {
+		name             string
+		secrets          map[string]*fakeSecret
+		expectedSecrets  map[string]*fakeSecret
+		keys             map[string]map[string]bool
+		expectedKeys     map[string]map[string]bool
+		requestBody      string
+		expectedResponse string
+	}{
+		{
+			name:             "empty secrets list",
+			secrets:          make(map[string]*fakeSecret),
+			expectedSecrets:  make(map[string]*fakeSecret),
+			keys:             make(map[string]map[string]bool),
+			expectedKeys:     make(map[string]map[string]bool),
+			requestBody:      "",
+			expectedResponse: "",
+		},
+		{
+			name: "secret without labels",
+			secrets: map[string]*fakeSecret{"secret_no_label": {
+				Labels:   map[string]string{},
+				Versions: map[string]*fakeSecretVersion{"1": {Data: fakeSecretVersionData, Date: timeTenHoursAgo, State: "enabled"}},
+			}},
+			expectedSecrets: map[string]*fakeSecret{"secret_no_label": {
+				Labels:   map[string]string{},
+				Versions: map[string]*fakeSecretVersion{"1": {Data: fakeSecretVersionData, Date: timeTenHoursAgo, State: "enabled"}},
+			}},
+			keys:             make(map[string]map[string]bool),
+			expectedKeys:     make(map[string]map[string]bool),
+			requestBody:      "",
+			expectedResponse: "",
+		},
+		{
+			name: "secret with correct labels, one enabled version",
+			secrets: map[string]*fakeSecret{"secret_one_version": {
+				Labels:   map[string]string{"type": "service-account"},
+				Versions: map[string]*fakeSecretVersion{"1": {Data: fakeSecretVersionData, Date: timeTenHoursAgo, State: "enabled"}},
+			}},
+			expectedSecrets: map[string]*fakeSecret{"secret_one_version": {
+				Labels:   map[string]string{"type": "service-account"},
+				Versions: map[string]*fakeSecretVersion{"1": {Data: fakeSecretVersionData, Date: timeTenHoursAgo, State: "enabled"}},
+			}},
+			keys:             make(map[string]map[string]bool),
+			expectedKeys:     make(map[string]map[string]bool),
+			requestBody:      "",
+			expectedResponse: "",
+		},
+		{
+			name: "secret with correct labels, two enabled version, latest is not outdated",
+			secrets: map[string]*fakeSecret{"secret_new": {
+				Labels: map[string]string{"type": "service-account"},
+				Versions: map[string]*fakeSecretVersion{
+					"1": {Data: fakeSecretVersionData, Date: timeTenHoursAgo, State: "enabled"},
+					"2": {Data: fakeSecretVersionData, Date: timeOneHoursAgo, State: "enabled"},
+				},
+			}},
+			expectedSecrets: map[string]*fakeSecret{"secret_new": {
+				Labels: map[string]string{"type": "service-account"},
+				Versions: map[string]*fakeSecretVersion{
+					"1": {Data: fakeSecretVersionData, Date: timeTenHoursAgo, State: "enabled"},
+					"2": {Data: fakeSecretVersionData, Date: timeOneHoursAgo, State: "enabled"},
+				},
+			}},
+			keys:             map[string]map[string]bool{fakeSecretEmail: {fakeSecretKey: true, fakeSecretKey2: true}},
+			expectedKeys:     map[string]map[string]bool{fakeSecretEmail: {fakeSecretKey: true, fakeSecretKey2: true}},
+			requestBody:      "",
+			expectedResponse: "",
+		},
+		{
+			name: "secret with correct labels, two enabled version, latest is outdated",
+			secrets: map[string]*fakeSecret{"secret_outdated": {
+				Labels: map[string]string{"type": "service-account"},
+				Versions: map[string]*fakeSecretVersion{
+					"1": {Data: fakeSecretVersionData, Date: timeTenHoursAgo, State: "enabled"},
+					"2": {Data: fakeSecretVersionData2, Date: timeSixHoursAgo, State: "enabled"},
+				},
+			}},
+			expectedSecrets: map[string]*fakeSecret{"secret_outdated": {
+				Labels: map[string]string{"type": "service-account"},
+				Versions: map[string]*fakeSecretVersion{
+					"1": {Data: fakeSecretVersionData, Date: timeTenHoursAgo, State: "destroyed"},
+					"2": {Data: fakeSecretVersionData2, Date: timeSixHoursAgo, State: "enabled"},
+				},
+			}},
+			keys:             map[string]map[string]bool{fakeSecretEmail: {fakeSecretKey: true, fakeSecretKey2: true}},
+			expectedKeys:     map[string]map[string]bool{fakeSecretEmail: {fakeSecretKey2: true}},
+			requestBody:      "",
+			expectedResponse: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			secretServerStruct := fakeSecretServer{secrets: test.secrets}
+
+			secretServer := httptest.NewServer(&secretServerStruct)
+			secretManagerService, err = secretmanager.NewService(ctx, option.WithoutAuthentication(), option.WithEndpoint(secretServer.URL))
+			if err != nil {
+				t.Errorf("Couldn't set up fake secretmanager: %s", err)
+			}
+
+			iamServerStruct := fakeIAMServer{keys: test.keys}
+			iamServer := httptest.NewServer(&iamServerStruct)
+			serviceAccountService, err = gcpiam.NewService(ctx, option.WithoutAuthentication(), option.WithEndpoint(iamServer.URL))
+			if err != nil {
+				t.Errorf("Couldn't set up fake serviceaccountmanager: %s", err)
+			}
+
+			req := httptest.NewRequest("GET", "/", strings.NewReader(test.requestBody))
+			req.Header.Add("Content-Type", "application/json")
+
+			rr := httptest.NewRecorder()
+			serviceAccountKeysCleaner(rr, req)
+
+			if got := rr.Body.String(); got != test.expectedResponse {
+				t.Errorf("ServiceAccountCleaner(%q) = %q, want %q", test.requestBody, got, test.expectedResponse)
+			}
+
+			if !reflect.DeepEqual(test.keys, test.expectedKeys) {
+				t.Errorf("List of expected keys differs, %v, want %v", test.keys, test.expectedKeys)
+			}
+
+			if !reflect.DeepEqual(test.secrets, test.expectedSecrets) {
+				t.Errorf("List of expected secrets differs, %v, want %v", test.secrets, test.expectedSecrets)
+			}
+
+			if secretServerStruct.unknownEndpointCallCount > 0 {
+				t.Errorf("At least one secret manager endpoint was not faked properly")
+			}
+
+			if iamServerStruct.unknownEndpointCallCount > 0 {
+				t.Errorf("At least one IAM endpoint was not faked properly")
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Refactored cloud function code to run as cloud-run service.
- Added Dockerfile for building service image.
- Files were copied to the dedicated secret-rotator application directory.
