### PR TITLE
Add dummy secret for control-plane-gke-integration pipeline required for provisioner

### DIFF
--- a/prow/scripts/cluster-integration/control-plane-gke-integration.sh
+++ b/prow/scripts/cluster-integration/control-plane-gke-integration.sh
@@ -259,6 +259,15 @@ data:
   auditlog-config-path: "/path"
   auditlog-security-path: "/path"
   auditlog-tenant: "tnt"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kcp-provisioner-database-encryption
+  namespace: kcp-system
+type: Opaque
+data:
+  secretKey: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIK #gitleaks:allow
 EOF
 }
 


### PR DESCRIPTION
In [PR-2500](https://github.com/kyma-project/control-plane/pull/2500/files) there is a requirement added into Provisioner deployment that it will not start without existence of a secret `kcp-provisioner-database-encryption`. 

This PR adds the secret to resources created in this pipeline.