### PR TITLE
Add ARM64 architecture to schema migrator build job

### DIFF
--- a/prow/jobs/incubator/compass/components/schema-migrator/schema-migrator-generic.yaml
+++ b/prow/jobs/incubator/compass/components/schema-migrator/schema-migrator-generic.yaml
@@ -36,6 +36,7 @@ presubmits: # runs on PRs
               - "--context=components/schema-migrator"
               - "--dockerfile=Dockerfile"
               - "--platform=linux/amd64"
+              - "--platform=linux/arm64"
             env:
               - name: BUILDKITD_FLAGS
                 value: "--oci-worker-no-process-sandbox"
@@ -104,6 +105,7 @@ postsubmits: # runs on main
               - "--context=components/schema-migrator"
               - "--dockerfile=Dockerfile"
               - "--platform=linux/amd64"
+              - "--platform=linux/arm64"
             env:
               - name: BUILDKITD_FLAGS
                 value: "--oci-worker-no-process-sandbox"

--- a/templates/data/generic_component_compass_data.yaml
+++ b/templates/data/generic_component_compass_data.yaml
@@ -591,6 +591,7 @@ templates:
                     - "--context=components/schema-migrator"
                     - "--dockerfile=Dockerfile"
                     - "--platform=linux/amd64"
+                    - "--platform=linux/arm64"
                   decoration_config:
                     timeout: 20m
                     grace_period: 1m
@@ -615,6 +616,7 @@ templates:
                     - "--context=components/schema-migrator"
                     - "--dockerfile=Dockerfile"
                     - "--platform=linux/amd64"
+                    - "--platform=linux/arm64"
                   decoration_config:
                     timeout: 20m
                     grace_period: 1m

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,13 @@
+pjConfigs:
+  prConfigs:
+    kyma-project:
+      test-infra:
+        prNumber: 7057
+  prowJobs:
+    kyma-incubator:
+      compass:
+        - pjName: "pull-schema-migrator-build"
+prConfigs:
+  kyma-incubator:
+    compass:
+      prNumber: 2913

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,8 +1,4 @@
 pjConfigs:
-  prConfigs:
-    kyma-project:
-      test-infra:
-        prNumber: 7057
   prowJobs:
     kyma-incubator:
       compass:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- add linux/arm64 to the list of architectures in schema migrator build job

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
