### PR TITLE
Upgrade k8s cluster version for kyma-upgrade-gardener-kyma2-minor-versions

### DIFF
--- a/prow/jobs/kyma/kyma-integration-gardener.yaml
+++ b/prow/jobs/kyma/kyma-integration-gardener.yaml
@@ -594,7 +594,7 @@ periodics: # runs on schedule
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-az-kyma-prow-credentials: "true"
         preset-bot-github-token: "true"
-        preset-cluster-version-previous: "true"
+        preset-cluster-version: "true"
         preset-debug-commando-oom: "true"
         preset-dind-enabled: "true"
         preset-docker-push-repository-gke-integration: "true"


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Upgrade k8s cluster version for `kyma-upgrade-gardener-kyma2-minor-versions` from `1.21` to `1.25`

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/16841