### PR TITLE
replace local signify-secret config to global kaniko_buildpack

### DIFF
--- a/prow/jobs/template-operator/template-operator.yaml
+++ b/prow/jobs/template-operator/template-operator.yaml
@@ -92,7 +92,7 @@ presubmits: # runs on PRs
       max_concurrency: 10
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230224-15885e7ef"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230227-a5399439c"
             command:
               - "/image-builder"
             args:
@@ -136,7 +136,7 @@ postsubmits: # runs on main
       max_concurrency: 10
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230224-15885e7ef"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230227-a5399439c"
             command:
               - "/image-builder"
             args:

--- a/prow/jobs/template-operator/template-operator.yaml
+++ b/prow/jobs/template-operator/template-operator.yaml
@@ -90,11 +90,9 @@ presubmits: # runs on PRs
       decorate: true
       cluster: untrusted-workload
       max_concurrency: 10
-      branches:
-        - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20221031-cc716911e"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230224-15885e7ef"
             command:
               - "/image-builder"
             args:
@@ -136,11 +134,9 @@ postsubmits: # runs on main
       decorate: true
       cluster: trusted-workload
       max_concurrency: 10
-      branches:
-        - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20221031-cc716911e"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230224-15885e7ef"
             command:
               - "/image-builder"
             args:

--- a/templates/data/template-operator-data.yaml
+++ b/templates/data/template-operator-data.yaml
@@ -6,32 +6,6 @@ templates:
           jobConfig_default:
             imagePullPolicy: "Always"
             privileged: "false"
-          default:
-            skip_report: "false"
-            max_concurrency: "10"
-            decorate: "true"
-            branches:
-              - "^main$"
-            pubsub_project: "sap-kyma-prow"
-            pubsub_topic: "prowjobs"
-            image: eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20221031-cc716911e
-            command: /image-builder
-            request_memory: "1.5Gi"
-            request_cpu: "1"
-            labels:
-              preset-sa-kyma-push-images: "true"
-            volumes:
-              - name: config
-                configMapName: kaniko-build-config
-              - name: signify-secret
-                secretName: signify-dev-secret
-            volumeMounts:
-              - name: config
-                mountPath: /config
-                readOnly: true
-              - name: signify-secret
-                mountPath: /secret
-                readOnly: true
         jobConfigs:
           - repoName: kyma-project/template-operator
             jobs:
@@ -74,9 +48,8 @@ templates:
                     - "--config=/config/kaniko-build-config.yaml"
                     - "--dockerfile=Dockerfile"
                 inheritedConfigs:
-                  local:
-                    - default
                   global:
+                    - kaniko_buildpack
                     - jobConfig_presubmit
               - jobConfig:
                   name: main-template-op-build
@@ -89,7 +62,6 @@ templates:
                     - "--dockerfile=Dockerfile"
                     - "--tag=latest"
                 inheritedConfigs:
-                  local:
-                    - default
                   global:
+                    - kaniko_buildpack
                     - jobConfig_postsubmit


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

To fix the pipeline failing in [template-operator](https://github.com/kyma-project/template-operator/pull/27) because of signning errors
```
sign images using services signify-dev,signify-prod
sign encountered error: signer init: open /secret-prod/secret.yaml: no such file or directory
```

https://storage.googleapis.com/kyma-prow-logs/pr-logs/pull/kyma-project_template-operator/27/pull-build-template-operator/1630456536729915392/build-log.txt