### PR TITLE
refactor: replace `github.com/ghodss/yaml` with `sigs.k8s.io/yaml`

### DIFF
--- a/development/tools/jobs/tester/tester.go
+++ b/development/tools/jobs/tester/tester.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kyma-project/test-infra/development/tools/jobs/releases"
 	"github.com/kyma-project/test-infra/development/tools/jobs/tester/preset"
 	"github.com/pkg/errors"
@@ -15,6 +14,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/development/tools/jobs/testinfra/branchprotector_test.go
+++ b/development/tools/jobs/testinfra/branchprotector_test.go
@@ -6,11 +6,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kyma-project/test-infra/development/tools/jobs/releases"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/test-infra/prow/config"
+	"sigs.k8s.io/yaml"
 )
 
 func TestBranchProtection(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/containerd/typeurl v1.0.2
 	github.com/forestgiant/sliceutil v0.0.0-20160425183142-94783f95db6c
 	github.com/fsouza/go-dockerclient v1.9.5
-	github.com/ghodss/yaml v1.0.0
 	github.com/go-playground/validator/v10 v10.11.2
 	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/google/go-containerregistry v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -462,7 +462,6 @@ github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui72
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gitleaks/go-gitdiff v0.8.0 h1:7aExTZm+K/M/EQKOyYcub8rIAdWK6ONxPGuRzxmWW+0=
 github.com/gitleaks/go-gitdiff v0.8.0/go.mod h1:pKz0X4YzCKZs30BL+weqBIG7mx0jl4tF1uXV9ZyNvrA=


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The package `github.com/ghodss/yaml` is no longer actively maintained. See discussion in https://github.com/ghodss/yaml/issues/75 and https://github.com/ghodss/yaml/issues/80. [`sigs.k8s.io/yaml`](https://github.com/kubernetes-sigs/yaml) is a permanent fork of `github.com/ghodss/yaml`.

The notable change is that `github.com/ghodss/yaml` uses `gopkg.in/yaml.v2 v2.2.2`, but `sigs.k8s.io/yaml` uses `gopkg.in/yaml.v2 v2.4.0`. Changes can be seen here [v2.2.2...v2.4.0](https://github.com/go-yaml/yaml/compare/v2.2.2...v2.4.0), mostly bug fixes.

Changes proposed in this pull request:

- Remove `github.com/ghodss/yaml` dependency

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
