### PR TITLE
Fix post-keb-trial-cleanup-job-build trigger

### DIFF
--- a/prow/jobs/control-plane/components/kyma-environment-broker/kyma-environment-broker-build.yaml
+++ b/prow/jobs/control-plane/components/kyma-environment-broker/kyma-environment-broker-build.yaml
@@ -450,9 +450,11 @@ postsubmits: # runs on main
       decorate: true
       cluster: trusted-workload
       max_concurrency: 10
+      branches:
+        - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230227-a5399439c - ^main$"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230227-a5399439c"
             command:
               - "/image-builder"
             args:

--- a/templates/data/control-plane-build.yaml
+++ b/templates/data/control-plane-build.yaml
@@ -281,6 +281,7 @@ templates:
                     preset-signify-prod-secret: "true"
                   run_if_changed: "^components/kyma-environment-broker"
                   image: eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230227-a5399439c
+                  branches:
                     - ^main$
                   args:
                     - --name=control-plane/kyma-environment-trial-cleanup-job


### PR DESCRIPTION
at the moment, there are PRs that for some reason require passing run of `post-keb-trial-cleanup-job-build`:
* https://github.com/kyma-project/control-plane/pull/2551
* https://github.com/kyma-project/control-plane/pull/2550
* https://github.com/kyma-project/control-plane/pull/2549