### PR TITLE
Fixed usage of wrong type to load http request body to.

### DIFF
--- a/development/gcp/cloud-run/gardener-sa-rotate/gardener-sa-rotate_test.go
+++ b/development/gcp/cloud-run/gardener-sa-rotate/gardener-sa-rotate_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	gpubsub "cloud.google.com/go/pubsub"
 	"github.com/kyma-project/test-infra/development/gcp/pkg/iam"
 	"github.com/kyma-project/test-infra/development/gcp/pkg/pubsub"
 	"github.com/kyma-project/test-infra/development/gcp/pkg/secretmanager"
@@ -435,7 +436,7 @@ func TestRotateGardenerServiceAccount(t *testing.T) {
 
 			kuberentesSecrets:         map[string]fakeKubernetesSecret{"sa-secret": {namespace: gardenerSecretNamespace, data: map[string][]byte{"serviceaccount.json": []byte(fakeSAData)}}},
 			expectedKuberentesSecrets: map[string]fakeKubernetesSecret{"sa-secret": {namespace: gardenerSecretNamespace, data: map[string][]byte{"serviceaccount.json": []byte(fakeSAData2)}}},
-			requestBody:               pubsub.Message{Message: pubsub.MessagePayload{Attributes: map[string]string{"eventType": "SECRET_ROTATE"}}},
+			requestBody:               pubsub.Message{Message: gpubsub.Message{Attributes: map[string]string{"eventType": "SECRET_ROTATE"}}},
 			requestMessageData:        pubsub.SecretRotateMessage{Name: createSecretName(testingProjectName, "sa-secret"), Labels: saSecretLabels},
 		},
 		{
@@ -454,7 +455,7 @@ func TestRotateGardenerServiceAccount(t *testing.T) {
 
 			kuberentesSecrets:         map[string]fakeKubernetesSecret{"sa-secret": {namespace: gardenerSecretNamespace, data: map[string][]byte{"serviceaccount.json": []byte(fakeSAData)}}},
 			expectedKuberentesSecrets: map[string]fakeKubernetesSecret{"sa-secret": {namespace: gardenerSecretNamespace, data: map[string][]byte{"serviceaccount.json": []byte(fakeSAData2)}}},
-			requestBody:               pubsub.Message{Message: pubsub.MessagePayload{Attributes: map[string]string{"eventType": "SECRET_ROTATE"}}},
+			requestBody:               pubsub.Message{Message: gpubsub.Message{Attributes: map[string]string{"eventType": "SECRET_ROTATE"}}},
 			requestMessageData:        pubsub.SecretRotateMessage{Name: createSecretName(testingProjectName, "sa-secret"), Labels: saSecretLabels},
 		},
 	}

--- a/development/gcp/cloud-run/gardener-sa-rotate/gardener-sa-rotate_test.go
+++ b/development/gcp/cloud-run/gardener-sa-rotate/gardener-sa-rotate_test.go
@@ -504,7 +504,7 @@ func TestRotateGardenerServiceAccount(t *testing.T) {
 			RotateGardenerServiceAccount(rr, req)
 
 			if got := rr.Body.String(); got != test.expectedResponse {
-				t.Errorf("ServiceAccountCleaner(%q) = %q, want %q", test.requestBody, got, test.expectedResponse)
+				t.Errorf("ServiceAccountCleaner(%v) = %q, want %q", test.requestBody, got, test.expectedResponse)
 			}
 
 			if !reflect.DeepEqual(test.keys, test.expectedKeys) {

--- a/development/gcp/pkg/pubsub/types.go
+++ b/development/gcp/pkg/pubsub/types.go
@@ -26,7 +26,8 @@ type Client struct {
 
 // Message is the message sent to pubsub system.
 type Message struct {
-	Message      MessagePayload `json:"message"`
+	// Message      MessagePayload `json:"message"`
+	Message      pubsub.Message `json:"message"`
 	Subscription string         `json:"subscription"`
 }
 

--- a/development/gcp/pkg/pubsub/types.go
+++ b/development/gcp/pkg/pubsub/types.go
@@ -26,7 +26,6 @@ type Client struct {
 
 // Message is the message sent to pubsub system.
 type Message struct {
-	// Message      MessagePayload `json:"message"`
 	Message      pubsub.Message `json:"message"`
 	Subscription string         `json:"subscription"`
 }

--- a/development/secrets-rotator/cloud-run/rotate-service-account/rotateserviceaccount.go
+++ b/development/secrets-rotator/cloud-run/rotate-service-account/rotateserviceaccount.go
@@ -128,7 +128,7 @@ func rotateServiceAccount(w http.ResponseWriter, r *http.Request) {
 	message := pubsubMessage.Message
 	logger.WithLabel("messageId", message.ID)
 
-	// Check if message is secret rotate message, this should never become true,
+	// Check if message is not a secret rotate message, this should never become true,
 	// because this service is subscribed to subscription with attribute filter.
 	// Pubsub subscription prevent receiving messages with unsupported event type.
 	if message.Attributes["eventType"] != "SECRET_ROTATE" {

--- a/development/secrets-rotator/cloud-run/rotate-service-account/rotateserviceaccount.go
+++ b/development/secrets-rotator/cloud-run/rotate-service-account/rotateserviceaccount.go
@@ -6,11 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httputil"
 	"os"
 	"strings"
 
 	"cloud.google.com/go/compute/metadata"
-	// gpubsub "cloud.google.com/go/pubsub"
 	"github.com/kyma-project/test-infra/development/gcp/pkg/cloudfunctions"
 	crhttp "github.com/kyma-project/test-infra/development/gcp/pkg/http"
 	"github.com/kyma-project/test-infra/development/gcp/pkg/pubsub"
@@ -111,19 +111,28 @@ func rotateServiceAccount(w http.ResponseWriter, r *http.Request) {
 	logger.WithLabel("io.kyma.component", componentName)
 	logger.WithTrace(trace)
 
+	// Dump http request. This will be printed in case of error.
+	request, err := httputil.DumpRequest(r, true)
+	if err != nil {
+		logger.LogError("failed to dump request, error: %s", err.Error())
+	}
+
 	// decode http messages body
 	var pubsubMessage pubsub.Message
 	if err := json.NewDecoder(r.Body).Decode(&pubsubMessage); err != nil {
+		logger.LogDebug("Received HTTP request: %s", string(request))
 		crhttp.WriteHTTPErrorResponse(w, http.StatusInternalServerError, logger, "failed decode message body")
 		return
 	}
 
 	message := pubsubMessage.Message
-	logger.LogDebug("Received message: %+v", message)
-
 	logger.WithLabel("messageId", message.ID)
 
+	// Check if message is secret rotate message, this should never become true,
+	// because this service is subscribed to subscription with attribute filter.
+	// Pubsub subscription prevent receiving messages with unsupported event type.
 	if message.Attributes["eventType"] != "SECRET_ROTATE" {
+		logger.LogDebug("Received HTTP request: %s", string(request))
 		logger.LogDebug("Unsupported event type: %s, quitting", message.Attributes["eventType"])
 		w.WriteHeader(http.StatusOK)
 		return
@@ -131,11 +140,13 @@ func rotateServiceAccount(w http.ResponseWriter, r *http.Request) {
 
 	err = json.Unmarshal(message.Data, &secretRotateMessage)
 	if err != nil {
+		logger.LogDebug("Received HTTP request: %s", string(request))
 		crhttp.WriteHTTPErrorResponse(w, http.StatusBadRequest, logger, "failed to unmarshal message data field, error: %s", err.Error())
 		return
 	}
 
 	if secretRotateMessage.Labels["type"] != "service-account" {
+		logger.LogDebug("Received HTTP request: %s", string(request))
 		logger.LogDebug("Unsupported secret type: %s, quitting", secretRotateMessage.Labels["type"])
 		w.WriteHeader(http.StatusOK)
 		return

--- a/development/secrets-rotator/cloud-run/rotate-service-account/rotateserviceaccount.go
+++ b/development/secrets-rotator/cloud-run/rotate-service-account/rotateserviceaccount.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/compute/metadata"
-	gpubsub "cloud.google.com/go/pubsub"
+	// gpubsub "cloud.google.com/go/pubsub"
 	"github.com/kyma-project/test-infra/development/gcp/pkg/cloudfunctions"
 	crhttp "github.com/kyma-project/test-infra/development/gcp/pkg/http"
 	"github.com/kyma-project/test-infra/development/gcp/pkg/pubsub"
@@ -112,11 +112,14 @@ func rotateServiceAccount(w http.ResponseWriter, r *http.Request) {
 	logger.WithTrace(trace)
 
 	// decode http messages body
-	var message gpubsub.Message
-	if err := json.NewDecoder(r.Body).Decode(&message); err != nil {
+	var pubsubMessage pubsub.Message
+	if err := json.NewDecoder(r.Body).Decode(&pubsubMessage); err != nil {
 		crhttp.WriteHTTPErrorResponse(w, http.StatusInternalServerError, logger, "failed decode message body")
 		return
 	}
+
+	message := pubsubMessage.Message
+	logger.LogDebug("Received message: %+v", message)
 
 	logger.WithLabel("messageId", message.ID)
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Using a github.com/kyma-project/test-infra/development/gcp/pkg/pubsub.Mesage type for unmarshaling http request body.
- Using a google pubsub Message type as a replacement for kyma-project MessagePayload type. We were duplicating an existing type in upstream package.
- Dumping http request and printing in case of error when reading http request body.
