### PR TITLE
Fix pull-btp-manager-build to always run

### DIFF
--- a/prow/jobs/btp-manager/btp-manager-build.yaml
+++ b/prow/jobs/btp-manager/btp-manager-build.yaml
@@ -11,7 +11,7 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pull-btp-manager-build"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
-      run_if_changed: '^api/*/.*$|^config/*/.*$|^controllers/*/.*$|^hack/*.*$|^internal/*/.*$|^module-chart/*/.*$|^pkg/*/.*$|^Dockerfile$|^(go.mod|go.sum)$|^(.*.go|Makefile|.*.sh)|^PROJECT$'
+      always_run: true
       skip_report: false
       decorate: true
       cluster: untrusted-workload

--- a/templates/data/btp-manager-build.yaml
+++ b/templates/data/btp-manager-build.yaml
@@ -5,9 +5,9 @@ templates:
         jobConfigs:
           - repoName: "github.com/kyma-project/btp-manager"
             jobs:
-              - jobConfig:
+              - jobConfig: # builds a docker image of the btp-manager tagged with the PR name
                   name: pull-btp-manager-build
-                  run_if_changed: "^api/*/.*$|^config/*/.*$|^controllers/*/.*$|^hack/*.*$|^internal/*/.*$|^module-chart/*/.*$|^pkg/*/.*$|^Dockerfile$|^(go.mod|go.sum)$|^(.*.go|Makefile|.*.sh)|^PROJECT$"
+                  always_run: true
                   args:
                     - "--name=btp-manager"
                     - "--context=."


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

`pull-btp-manager-build` should always run to create a new PR image for e2e tests.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
