### PR TITLE
Fix serverless-manager build args

### DIFF
--- a/prow/jobs/modules/internal/serverless-manager.yaml
+++ b/prow/jobs/modules/internal/serverless-manager.yaml
@@ -94,7 +94,6 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
       always_run: true
-      optional: true
       skip_report: false
       decorate: true
       cluster: untrusted-workload
@@ -159,7 +158,7 @@ presubmits: # runs on PRs
         preset-kyma-guard-bot-github-token: "true"
         preset-sa-vm-kyma-integration: "true"
       always_run: true
-      optional: true
+      optional: false
       skip_report: false
       decorate: true
       path_alias: github.com/kyma-project/serverless-manager
@@ -256,7 +255,6 @@ postsubmits: # runs on main
         preset-sa-kyma-push-images: "true"
         preset-signify-prod-secret: "true"
       always_run: true
-      optional: true
       skip_report: false
       decorate: true
       cluster: trusted-workload
@@ -271,7 +269,7 @@ postsubmits: # runs on main
               - "sh"
             args:
               - "-c"
-              - "git config --global --add safe.directory $(pwd)/module-chart && ./hack/generate_module-chart.sh && /image-builder --name=serverless-manager --config=/config/kaniko-build-config.yaml --context=. --dockerfile=Dockerfile"
+              - "git config --global --add safe.directory $(pwd)/module-chart && ./hack/generate_module-chart.sh && /image-builder --name=serverless-manager --config=/config/kaniko-build-config.yaml --context=. --dockerfile=Dockerfile --tag={{ .Env \"PULL_BASE_SHA\" }}"
             env:
               - name: BUILDKITD_FLAGS
                 value: "--oci-worker-no-process-sandbox"

--- a/templates/data/generic_module_data.yaml
+++ b/templates/data/generic_module_data.yaml
@@ -376,8 +376,6 @@ templates:
               - jobConfig:
                   name: pre-serverless-manager-operator-build
                   always_run: true
-                  # TODO: remove after test phase (or fixing pjtester)
-                  optional: "true"
                   command: sh
                   args:
                     - -c
@@ -402,8 +400,6 @@ templates:
               - jobConfig:
                   name: post-serverless-manager-operator-build
                   always_run: true
-                  # TODO: remove after test phase (or fixing pjtester)
-                  optional: "true"
                   labels:
                     preset-signify-prod-secret: "true"
                   command: sh
@@ -419,6 +415,7 @@ templates:
                       --config=/config/kaniko-build-config.yaml
                       --context=.
                       --dockerfile=Dockerfile
+                      --tag={{`{{ .Env \"PULL_BASE_SHA\" }}`}}
                 inheritedConfigs:
                   global:
                     - jobConfig_postsubmit
@@ -430,7 +427,7 @@ templates:
               - jobConfig:
                   name: pre-main-serverless-manager-verify
                   always_run: "true"
-                  optional: "true"
+                  optional: "false"
                   env:
                     # TODO: Below line is a workaround -> Check issue https://github.com/kyma-project/test-infra/issues/6513
                     JOB_VM_COMMAND: >-


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix serverless-manager build args (add missing --tag arg)
- unify values for the `optional` fields (between the keda-manager and the serverless-manager)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/serverless-manager/issues/22