### PR TITLE
Remove --templates flag from Keda Upgrade Pipe

### DIFF
--- a/prow/jobs/modules/external/keda-manager.yaml
+++ b/prow/jobs/modules/external/keda-manager.yaml
@@ -309,7 +309,7 @@ presubmits: # runs on PRs
               - name: JOB_REPO_NAME
                 value: "keda-manager"
               - name: JOB_VM_COMMAND
-                value: "export PATH=$PATH:$HOME/${JOB_REPO_NAME}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin && make kyma && ./bin/kyma-unstable provision k3d && mkdir tmp && curl -s https://raw.githubusercontent.com/kyma-project/kyma/main/modules/alpha/moduletemplate-keda.yaml > tmp/moduletemplate-keda.yaml && curl -s https://raw.githubusercontent.com/kyma-project/kyma/main/modules/alpha/kustomization.yaml > tmp/kustomization.yaml && ./bin/kyma-unstable alpha deploy --ci --force-conflicts --templates tmp/ && make ci-k3d-upgrade-test"
+                value: "export PATH=$PATH:$HOME/${JOB_REPO_NAME}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin && make kyma && ./bin/kyma-unstable provision k3d && mkdir tmp && curl -s https://raw.githubusercontent.com/kyma-project/kyma/main/modules/alpha/moduletemplate-keda.yaml > tmp/moduletemplate-keda.yaml && ./bin/kyma-unstable alpha deploy --ci --force-conflicts && kubectl apply -f tmp/moduletemplate-keda.yaml && make ci-k3d-upgrade-test"
             resources:
               requests:
                 memory: 200Mi

--- a/templates/data/generic_module_data.yaml
+++ b/templates/data/generic_module_data.yaml
@@ -268,8 +268,8 @@ templates:
                     && ./bin/kyma-unstable provision k3d
                     && mkdir tmp
                     && curl -s https://raw.githubusercontent.com/kyma-project/kyma/main/modules/alpha/moduletemplate-keda.yaml > tmp/moduletemplate-keda.yaml
-                    && curl -s https://raw.githubusercontent.com/kyma-project/kyma/main/modules/alpha/kustomization.yaml > tmp/kustomization.yaml
-                    && ./bin/kyma-unstable alpha deploy --ci --force-conflicts --templates tmp/
+                    && ./bin/kyma-unstable alpha deploy --ci --force-conflicts
+                    && kubectl apply -f tmp/moduletemplate-keda.yaml
                     && make ci-k3d-upgrade-test"
                 inheritedConfigs:
                   global:

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,9 @@
+pjConfigs:
+  prowJobs:
+    kyma-project:
+      keda-manager:
+        - pjName: "pre-main-keda-manager-upgrade-main-to-channel"
+prConfigs:
+  kyma-project:
+    keda-manager:
+      prNumber: 108


### PR DESCRIPTION
**Description**
Replacing the `--templates` flag with `kubectl apply` because 
`-- templates 
WARNING: This is a temporary flag for development and will be removed soon.`
