### PR TITLE
Switch busola and tpi/kaniko-executer jobs to buildkit

### DIFF
--- a/prow/jobs/busola/busola-backend/busola-backend.yaml
+++ b/prow/jobs/busola/busola-backend/busola-backend.yaml
@@ -5,6 +5,8 @@ presubmits: # runs on PRs
   kyma-project/busola:
     - name: pull-busola-backend-build
       annotations:
+        container.apparmor.security.beta.kubernetes.io/test: "unconfined"
+        container.seccomp.security.alpha.kubernetes.io/test: "unconfined"
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
@@ -21,7 +23,7 @@ presubmits: # runs on PRs
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230313-8dfce5f0b"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230313-8dfce5f0b-buildkit"
             command:
               - "/image-builder"
             args:
@@ -30,11 +32,16 @@ presubmits: # runs on PRs
               - "--dockerfile=Dockerfile"
               - "--config=/config/kaniko-build-config.yaml"
               - "--export-tags"
+            env:
+              - name: BUILDKITD_FLAGS
+                value: "--oci-worker-no-process-sandbox"
             resources:
               requests:
                 memory: 1.5Gi
                 cpu: 1
             volumeMounts:
+              - name: share
+                mountPath: /home/user/.local/share/buildkit
               - name: config
                 mountPath: /config
                 readOnly: true
@@ -49,6 +56,7 @@ presubmits: # runs on PRs
         nodeSelector:
             dedicated: "high-cpu"
         volumes:
+          - name: share
           - name: config
             configMap:
               name: kaniko-build-config
@@ -60,6 +68,8 @@ postsubmits: # runs on main
   kyma-project/busola:
     - name: post-busola-backend-build
       annotations:
+        container.apparmor.security.beta.kubernetes.io/test: "unconfined"
+        container.seccomp.security.alpha.kubernetes.io/test: "unconfined"
         pipeline.trigger: "pr-merge"
         testgrid-create-test-group: "false"
       labels:
@@ -78,7 +88,7 @@ postsubmits: # runs on main
         - ^main$
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230313-8dfce5f0b"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230313-8dfce5f0b-buildkit"
             command:
               - "/image-builder"
             args:
@@ -88,11 +98,16 @@ postsubmits: # runs on main
               - "--config=/config/kaniko-build-config.yaml"
               - "--export-tags"
               - "--tag=latest"
+            env:
+              - name: BUILDKITD_FLAGS
+                value: "--oci-worker-no-process-sandbox"
             resources:
               requests:
                 memory: 1.5Gi
                 cpu: 1
             volumeMounts:
+              - name: share
+                mountPath: /home/user/.local/share/buildkit
               - name: config
                 mountPath: /config
                 readOnly: true
@@ -107,6 +122,7 @@ postsubmits: # runs on main
         nodeSelector:
             dedicated: "high-cpu"
         volumes:
+          - name: share
           - name: config
             configMap:
               name: kaniko-build-config

--- a/prow/jobs/third-party-images/third-party-images.yaml
+++ b/prow/jobs/third-party-images/third-party-images.yaml
@@ -424,6 +424,8 @@ presubmits: # runs on PRs
               secretName: signify-dev-secret
     - name: pre-main-tpi-kaniko-executer
       annotations:
+        container.apparmor.security.beta.kubernetes.io/test: "unconfined"
+        container.seccomp.security.alpha.kubernetes.io/test: "unconfined"
         pipeline.trigger: "pr-submit"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
@@ -437,7 +439,7 @@ presubmits: # runs on PRs
       max_concurrency: 10
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230313-8dfce5f0b"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230313-8dfce5f0b-buildkit"
             command:
               - "/image-builder"
             args:
@@ -446,18 +448,31 @@ presubmits: # runs on PRs
               - "--context=kaniko-executer"
               - "--dockerfile=Dockerfile"
               - "--env-file=envs"
+            env:
+              - name: BUILDKITD_FLAGS
+                value: "--oci-worker-no-process-sandbox"
             resources:
               requests:
                 memory: 1.5Gi
                 cpu: 1
             volumeMounts:
+              - name: share
+                mountPath: /home/user/.local/share/buildkit
               - name: config
                 mountPath: /config
                 readOnly: true
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
+        tolerations:
+          - key: dedicated
+            operator: Equal
+            value: high-cpu
+            effect: NoSchedule
+        nodeSelector:
+            dedicated: "high-cpu"
         volumes:
+          - name: share
           - name: config
             configMap:
               name: kaniko-build-config
@@ -991,6 +1006,8 @@ postsubmits: # runs on main
               secretName: signify-dev-secret
     - name: post-main-tpi-kaniko-executer
       annotations:
+        container.apparmor.security.beta.kubernetes.io/test: "unconfined"
+        container.seccomp.security.alpha.kubernetes.io/test: "unconfined"
         pipeline.trigger: "pr-merge"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
@@ -1005,7 +1022,7 @@ postsubmits: # runs on main
       max_concurrency: 10
       spec:
         containers:
-          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230313-8dfce5f0b"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230313-8dfce5f0b-buildkit"
             command:
               - "/image-builder"
             args:
@@ -1015,18 +1032,31 @@ postsubmits: # runs on main
               - "--dockerfile=Dockerfile"
               - "--env-file=envs"
               - "--tag={{ .Env \"KANIKO_VERSION\" }}-{{ .ShortSHA }}"
+            env:
+              - name: BUILDKITD_FLAGS
+                value: "--oci-worker-no-process-sandbox"
             resources:
               requests:
                 memory: 1.5Gi
                 cpu: 1
             volumeMounts:
+              - name: share
+                mountPath: /home/user/.local/share/buildkit
               - name: config
                 mountPath: /config
                 readOnly: true
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
+        tolerations:
+          - key: dedicated
+            operator: Equal
+            value: high-cpu
+            effect: NoSchedule
+        nodeSelector:
+            dedicated: "high-cpu"
         volumes:
+          - name: share
           - name: config
             configMap:
               name: kaniko-build-config

--- a/templates/data/generic_component_busola_data.yaml
+++ b/templates/data/generic_component_busola_data.yaml
@@ -56,7 +56,7 @@ templates:
                 inheritedConfigs:
                   global:
                     - "jobConfig_default"
-                    - kaniko_buildpack
+                    - image-builder-buildkit
                     - jobConfig_presubmit
               - jobConfig:
                   name: post-busola-backend-build
@@ -74,7 +74,7 @@ templates:
                 inheritedConfigs:
                   global:
                     - "jobConfig_default"
-                    - kaniko_buildpack
+                    - image-builder-buildkit
                     - "jobConfig_postsubmit"
                     - "disable_testgrid"
 

--- a/templates/data/third-party-images-data.yaml
+++ b/templates/data/third-party-images-data.yaml
@@ -314,7 +314,7 @@ templates:
                 inheritedConfigs:
                   global:
                     - "jobConfig_presubmit"
-                    - "kaniko_buildpack"
+                    - image-builder-buildkit
               - jobConfig:
                   name: "post-main-tpi-kaniko-executer"
                   labels:
@@ -330,7 +330,7 @@ templates:
                 inheritedConfigs:
                   global:
                     - "jobConfig_postsubmit"
-                    - "kaniko_buildpack"
+                    - image-builder-buildkit
 
               - jobConfig:
                   name: "pre-main-tpi-kube-state-metrics"


### PR DESCRIPTION
/area ci
/kind bug

* Kaniko-based image-builder contains problem, where `--dockerfile` does not reflect  the path relative to `--context`. Requires code update and there's no time for that. Buildkit-based builder doesn't have that problem
* kanico-based image-builder for some reason cannot build working image for kaniko itself, because Dockerfile tries to replace `/kaniko/executor` file which is locked by runtime. Buildkit-based builder doesn't have that problem