### PR TITLE
Add golangci-lint task

### DIFF
--- a/task/golangci-lint/0.1/golangci-lint.yaml
+++ b/task/golangci-lint/0.1/golangci-lint.yaml
@@ -1,0 +1,39 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: golangci-lint
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.36.0"
+    tekton.dev/categories: Code Quality
+    tekton.dev/tags: linter
+    tekton.dev/displayName: "golangci-lint"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    The golanci-lint Task runs a golang linter.
+    A workspace named repo stores the source code to lint.
+  workspaces:
+    - name: repo
+      description: "The workspace where sources to lint are stored."
+      mountPath: /home/prow/go
+  params:
+    - name: REPO_OWNER
+      description: "GitHub org that triggered the job. Variable set by prow. Prow will not set this variable if the prowjob type is periodic. In that case an empty string default value will be used."
+      type: string
+      default: ""
+    - name: REPO_NAME
+      description: "GitHub repo that triggered the job. Variable set by prow. Prow will not set this variable if the prowjob type is periodic. In that case an empty string default value will be used."
+      type: string
+      default: ""
+  steps:
+    - name: build-image
+      image: eu.gcr.io/kyma-project/test-infra/golangci-lint:v20230221-85b2d35f
+      workingDir: /home/prow/go/src/github.com/$(params.REPO_OWNER)/$(params.REPO_NAME)
+      command:
+        - /golangci-lint.sh
+      resources:
+        limits:
+          memory: 1Gi
+          cpu: 1


### PR DESCRIPTION
This commit adds a new task for golangci-lint. The task runs a golang linter and is designed to be used in Tekton pipelines. The task is versioned at 0.1 and includes a description, workspaces, and parameters. The task uses the golangci-lint:v20230221-85b2d35f image and has resource limits of 1Gi memory and 1 CPU.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Added golangci-lint Tekton Task. Task is based on image we use on kubernetes agent.

**Related issue(s)**
See #6798
