### PR TITLE
Revert to Old Cli

### DIFF
--- a/prow/scripts/cluster-integration/control-plane-gke-integration.sh
+++ b/prow/scripts/cluster-integration/control-plane-gke-integration.sh
@@ -8,6 +8,7 @@ ENABLE_TEST_LOG_COLLECTOR=false
 export TEST_INFRA_SOURCES_DIR="${KYMA_PROJECT_DIR}/test-infra"
 export KCP_SOURCES_DIR="/home/prow/go/src/github.com/kyma-project/control-plane"
 export TEST_INFRA_CLUSTER_INTEGRATION_SCRIPTS="${TEST_INFRA_SOURCES_DIR}/prow/scripts/cluster-integration/helpers"
+export KYMA_MAJOR_VERSION="1"
 
 # shellcheck source=prow/scripts/lib/utils.sh
 source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/utils.sh"

--- a/prow/scripts/kyma-testing.sh
+++ b/prow/scripts/kyma-testing.sh
@@ -86,7 +86,7 @@ function main() {
   echo "- Testing Kyma..."
   echo "----------------------------"
 
-  kyma::install_cli
+  kyma::install_old_cli
 
   cts::check_crd_exist
 

--- a/prow/scripts/lib/kyma.sh
+++ b/prow/scripts/lib/kyma.sh
@@ -242,6 +242,34 @@ kyma::install_unstable_cli() {
     eval "${settings}"
 }
 
+
+kyma::install_old_cli() {
+    local settings
+    local kyma_version
+    settings="$(set +o); set -$-"
+    mkdir -p "/tmp/bin"
+    export PATH="/tmp/bin:${PATH}"
+    os=$(host::os)
+
+    pushd "/tmp/bin" || exit
+
+    log::info "--> Install kyma CLI ${os} locally to /tmp/bin"
+
+    if [[ "${KYMA_MAJOR_VERSION-}" == "1" ]]; then
+        curl -sSLo kyma.tar.gz "https://github.com/kyma-project/cli/releases/download/1.24.8/kyma_${os}_x86_64.tar.gz"
+        tar xvzf kyma.tar.gz
+    else
+        curl -sSLo kyma "https://storage.googleapis.com/kyma-cli-stable/kyma-${os}?alt=media"
+    fi
+
+    chmod +x kyma
+    kyma_version=$(kyma version --client)
+    log::info "--> Kyma CLI version: ${kyma_version}"
+    log::info "OK"
+    popd || exit
+    eval "${settings}"
+}
+
 kyma::install_cli() { #latest CLI release
     local settings
     settings="$(set +o); set -$-"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

In #7256 we have upgraded the Kyma Cli version. In the latests version there is no `kyma test` command that the `pre-main-control-plane-gke-integration` relies on. The PR reverts the change from #7256 to make the tests functional again.

Changes proposed in this pull request:

- Revert to old CLI in `pre-main-control-plane-gke-integration`


<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
