### PR TITLE
Revert K8s 1.26 for Gardener clusters

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -408,7 +408,7 @@ presets:
       - name: GKE_CLUSTER_VERSION
         value: "1.26"
       - name: GARDENER_CLUSTER_VERSION
-        value: "1.26.1"
+        value: "1.25"
   # test clusters log collector
   - labels:
       preset-log-collector-slack-token: "true"

--- a/prow/scripts/resources/busola/cluster-busola.yaml
+++ b/prow/scripts/resources/busola/cluster-busola.yaml
@@ -8,7 +8,7 @@ spec:
   kubernetes:
     kubeAPIServer:
       enableBasicAuthentication: false
-    version: 1.26.1
+    version: 1.25.6
   provider:
     controlPlaneConfig:
       apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1

--- a/prow/scripts/resources/busola/cluster-kyma.yaml
+++ b/prow/scripts/resources/busola/cluster-kyma.yaml
@@ -28,7 +28,7 @@ spec:
           - RS256
         usernameClaim: sub
         usernamePrefix: '-'
-    version: 1.26.1
+    version: 1.25.6
   networking:
     nodes: 10.250.0.0/16
     pods: 100.96.0.0/11

--- a/prow/scripts/resources/reconciler/shoot-template.yaml
+++ b/prow/scripts/resources/reconciler/shoot-template.yaml
@@ -8,7 +8,7 @@ spec:
   kubernetes:
     kubeAPIServer:
       enableBasicAuthentication: false
-    version: 1.26.1
+    version: 1.25.6
   provider:
     controlPlaneConfig:
       apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1

--- a/prow/scripts/resources/skr-test/shoot-template.yaml
+++ b/prow/scripts/resources/skr-test/shoot-template.yaml
@@ -12,7 +12,7 @@ spec:
     allowPrivilegedContainers: true
     kubeAPIServer:
       enableBasicAuthentication: false
-    version: 1.26.1
+    version: 1.25.6
   provider:
     controlPlaneConfig:
       apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1

--- a/templates/templates/prow-config.yaml
+++ b/templates/templates/prow-config.yaml
@@ -406,7 +406,7 @@ presets:
       - name: GKE_CLUSTER_VERSION
         value: "1.26"
       - name: GARDENER_CLUSTER_VERSION
-        value: "1.26.1"
+        value: "1.25"
   # test clusters log collector
   - labels:
       preset-log-collector-slack-token: "true"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Revert K8s 1.26.1 to 1.25.6 for Gardener clusters

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/test-infra/issues/7190