### PR TITLE
Update tekton default config.

### DIFF
--- a/tekton/deployments/config_defaults.yaml
+++ b/tekton/deployments/config_defaults.yaml
@@ -5,7 +5,14 @@ metadata:
   namespace: tekton-pipelines
 data:
   default-service-account: "tekton"
-  default-timeout-minutes: "60"
+  default-timeout-minutes: "120"
   default-managed-by-label-value: "kyma-tekton"
   default-task-run-workspace-binding: |
-    emptyDir: {}
+    volumeClaimTemplate:
+      spec:
+        storageClassName: "premium-rwo"
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Using volumeClaimTemplate as default workspace implementation provided by taskrun. Expecting this will be used the most.
- Aligned default tekton task timeout with timeout of prowjob running on kubernetes agent.

**Related issue(s)**
See #6798
