### PR TITLE
Add missing label for post-keb-deprovision-retrigger-job-build

### DIFF
--- a/prow/jobs/control-plane/components/kyma-environment-broker/kyma-environment-broker-build.yaml
+++ b/prow/jobs/control-plane/components/kyma-environment-broker/kyma-environment-broker-build.yaml
@@ -489,6 +489,7 @@ postsubmits: # runs on main
         prow.k8s.io/pubsub.runID: "post-keb-deprovision-retrigger-job-build"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
+        preset-signify-prod-secret: "true"
       run_if_changed: '^components/kyma-environment-broker'
       skip_report: false
       decorate: true

--- a/templates/data/control-plane-build.yaml
+++ b/templates/data/control-plane-build.yaml
@@ -309,6 +309,8 @@ templates:
                     - jobConfig_presubmit
               - jobConfig:
                   name: post-keb-deprovision-retrigger-job-build
+                  labels:
+                    preset-signify-prod-secret: "true"
                   run_if_changed: "^components/kyma-environment-broker"
                   image: eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230313-8dfce5f0b
                   branches:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

post-keb-deprovision-retrigger-job-build is missing a label, and the image is not signed. This PR fixes it.

Changes proposed in this pull request:

- Add `preset-signify-prod-secret` label

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
