### PR TITLE
Remove docker from image-syncer jobs

### DIFF
--- a/prow/jobs/test-infra/image-syncer.yaml
+++ b/prow/jobs/test-infra/image-syncer.yaml
@@ -67,7 +67,7 @@ presubmits: # runs on PRs
               - "bash"
             args:
               - "-c"
-              - "source prow/scripts/lib/docker.sh && docker::start && make -C development/image-syncer dry-run"
+              - "make -C development/image-syncer dry-run"
             resources:
               requests:
                 memory: 3Gi
@@ -108,7 +108,7 @@ postsubmits: # runs on main
               - "bash"
             args:
               - "-c"
-              - "source prow/scripts/lib/docker.sh && docker::start && make -C development/image-syncer run"
+              - "make -C development/image-syncer run"
             resources:
               requests:
                 memory: 3Gi

--- a/templates/data/image-syncer-data.yaml
+++ b/templates/data/image-syncer-data.yaml
@@ -29,7 +29,7 @@ templates:
                   command: "bash"
                   args:
                     - "-c"
-                    - 'source prow/scripts/lib/docker.sh && docker::start && make -C development/image-syncer dry-run'
+                    - 'make -C development/image-syncer dry-run'
                 inheritedConfigs:
                   global:
                     - "jobConfig_default"
@@ -45,7 +45,7 @@ templates:
                   command: "bash"
                   args:
                     - "-c"
-                    - 'source prow/scripts/lib/docker.sh && docker::start && make -C development/image-syncer run'
+                    - 'make -C development/image-syncer run'
                 inheritedConfigs:
                   global:
                     - "jobConfig_default"


### PR DESCRIPTION
Not used anymore, so not needed.
