### PR TITLE
Delete ias-adapter-migration job before installing Compass in compass-gke-benchmark job

### DIFF
--- a/prow/scripts/cluster-integration/compass-gke-benchmark.sh
+++ b/prow/scripts/cluster-integration/compass-gke-benchmark.sh
@@ -290,9 +290,10 @@ done
 
 kubectl delete cts $SUITE_NAME
 
-# Because of sequential compass installation, the second one fails due to compass-migration job patching failure. K8s job's fields are immutable.
-log::info "Deleting the old compass-migration job"
+# Because of sequential compass installation, the second one fails due to compass-migration and ias-adapter-migration jobs patching failure. K8s job's fields are immutable.
+log::info "Deleting the old compass-migration and ias-adapter-migration jobs"
 kubectl delete jobs -n compass-system compass-migration
+kubectl delete jobs -n compass-system ias-adapter-migration
 
 log::info "Install New Compass version"
 installCompassNew


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
We (CMP) introduced a new component called ias-adapter which comes with it's own k8s migration job. But because of sequential Compass installations, the compass-gke-benchmark job now fails because it tries to patch the new k8s job (which is immutable)

Changes proposed in this pull request:
- delete ias-adapter-migration job before installing Compass

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
