### PR TITLE
Add small ProwJob ownership validation test

### DIFF
--- a/prow/jobs/test-infra/go-validation.yaml
+++ b/prow/jobs/test-infra/go-validation.yaml
@@ -24,6 +24,7 @@ presubmits: # runs on PRs
               - "go"
             args:
               - "test"
+              - "-v"
               - "-cover"
               - "./..."
             resources:

--- a/templates/data/test-infra/golang-tests.yaml
+++ b/templates/data/test-infra/golang-tests.yaml
@@ -18,6 +18,7 @@ templates:
                   command: "go"
                   args:
                     - "test"
+                    - "-v"
                     - "-cover"
                     - "./..."
                 inheritedConfigs:

--- a/test/prowjobs/owner_annotations_test.go
+++ b/test/prowjobs/owner_annotations_test.go
@@ -1,0 +1,59 @@
+package prowjobs
+
+import (
+	"fmt"
+	"k8s.io/test-infra/prow/config"
+	"testing"
+)
+
+const (
+	OwnerAnnotationName       = "owner"
+	DescriptionAnnotationName = "description"
+)
+
+// Test_OwnerAnnotations is a band-aid solution to missing ownership annotations in ProwJob definition.
+// It looks up for all jobs in the registry, checks required annotations and fails if any of the annotations is missing.
+// Currently, it supports only single repository.
+// TODO (@Ressetkk): Change me to support InRepoConfig
+func Test_OwnerAnnotations(t *testing.T) {
+	prowConfig := "../../prow/config.yaml"
+	jobConfig := "../../prow/jobs"
+	c, err := config.Load(prowConfig, jobConfig, []string{}, "")
+	if err != nil {
+		t.Fatalf("error loading config files")
+	}
+	allRepos := c.AllRepos.List()
+	pre := c.AllStaticPresubmits(allRepos)
+	post := c.AllStaticPostsubmits(allRepos)
+	period := c.AllPeriodics()
+	var errs []error
+	for _, j := range pre {
+		errs = append(errs, checkRequiredAnnotations(j.Name, j.Annotations)...)
+	}
+	for _, j := range post {
+		errs = append(errs, checkRequiredAnnotations(j.Name, j.Annotations)...)
+	}
+	for _, j := range period {
+		errs = append(errs, checkRequiredAnnotations(j.Name, j.Annotations)...)
+	}
+
+	if len(errs) > 0 {
+		//for now not fail the job, only return information
+		//t.Fail()
+		for _, e := range errs {
+			t.Logf("%s\n", e)
+		}
+	}
+	t.Skipf("exceptionally skip")
+}
+
+func checkRequiredAnnotations(name string, a map[string]string) []error {
+	var errs []error
+	if _, ok := a[OwnerAnnotationName]; !ok {
+		errs = append(errs, fmt.Errorf("%s: does not contain required label '%s'", name, OwnerAnnotationName))
+	}
+	if _, ok := a[DescriptionAnnotationName]; !ok {
+		errs = append(errs, fmt.Errorf("%s: does not contain required label '%s'", name, DescriptionAnnotationName))
+	}
+	return errs
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->
/kind feature

As there is a small overhead with ProwJobs this PR provides small metadata check-up where it loads all ProwJobs,
Checks if they contain 2 annotations:
* `owner` - Person/Team responsible for the Job
* `description` - Small information about the purpose of the Job

For now I assumed the current configuration:
* Test works with unit-test-go ProwJob, so no need to add additional ProwJob
* Assumes all ProwJobs are in single repo - TO BE ALIGNED IN THE FUTURE WITH INREPOCONFIG
* Test is optional for now but reports if there are problems in the test. `pull-unit-test-go` should be checked during review
* Directory naming follows go default project layout https://github.com/golang-standards/project-layout/tree/master/test 

Additionally enabled verbose output for tests, so we get information in logs

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#5585