### PR TITLE
Enable add `area/` labels to require-matching-labels

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -156,3 +156,13 @@ require_matching_label:
     missing_label: needs-kind
     prs: true
     regexp: ^kind/
+  - org: kyma-project
+    branch: main
+    grace_period: 5s
+    issues: true
+    missing_comment: |
+      There are no `area/` labels present. Please add one by using the following command:
+      - `/area <area>`
+    missing_label: needs-area
+    prs: true
+    regexp: ^kind/


### PR DESCRIPTION
/kind feature
/area ci

It's an issue/PR quality gate, so author always remembers to add `area/` label.
Fixed formatting in kind comment.
