### PR TITLE
Update prefix in autobump config to new registry

### DIFF
--- a/prow/autobump-config/control-plane-autobump-reconciler-config.yaml
+++ b/prow/autobump-config/control-plane-autobump-reconciler-config.yaml
@@ -12,6 +12,6 @@ includedConfigPaths:
 targetVersion: "latest" #TODO THIS NEEDS TO BE REVERTED
 prefixes:
   - name: "Reconciler"
-    prefix: "eu.gcr.io/kyma-project/incubator/reconciler/"
+    prefix: "europe-docker.pkg.dev/kyma-project/prod/incubator/reconciler/"
     repo: "https://github.com/kyma-incubator/reconciler"
     summarise: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Update registry reference prefix for reconciler autobump config from `eu.gcr.io/kyma-project` to `europe-docker.pkg.dev/kyma-project/prod`

**Related issue(s)**
* https://github.com/kyma-project/lifecycle-manager/issues/523
