### PR TITLE
Enable automated-approver external plugin.

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -59,6 +59,11 @@ external_plugins:
     - name: cla-assistant
       events:
         - issue_comment
+  kyma-project/test-infra:
+    - name: automated-approver
+      events:
+        - pull_request
+        - pull_request_review
   kyma-incubator:
     - name: cla-assistant
       events:


### PR DESCRIPTION
Updated plugins.yaml. Automateda-approver plugin was disabled by changes in plugins.yaml file and automatic apply file to the cluster.
