### PR TITLE
Block PR merge when PR has `needs-kind` and `needs-area` labels

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -348,6 +348,8 @@ tide:
         - lgtm
       missingLabels:
         - needs-rebase
+        - needs-kind
+        - needs-area
         - do-not-merge/hold
         - do-not-merge/work-in-progress
         - do-not-merge/invalid-owners-file


### PR DESCRIPTION
/area ci
/kind feature

This quality gate is to ensure that Tide blocks PR merge unless it contains `area/` and `kind/` labels. For now it will work only for test-infra, because we have automation that manages this label.
