### PR TITLE
Bumps external image of golang from 1.20.3-alpine3.17 to 1.20.4-alpine3.17

### DIFF
--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -12,8 +12,8 @@ images:
 - source: "gcr.io/google-containers/pause:3.2"
 - source: "goreleaser/goreleaser:v1.11.5"
 # Golang image is pinned because it is force updated in the upstream
-- source: "golang@sha256:08e9c086194875334d606765bd60aa064abd3c215abfbcf5737619110d48d114"
-  tag: "1.20.3-alpine3.17"
+- source: "golang@sha256:4ee203ff3933e7a6f18d3574fd6661a73b58c60f028d2927274400f4774aaa41"
+  tag: "1.20.4-alpine3.17"
 - source: "grafana/loki:2.2.1"
 - source: "grafana/grafana-image-renderer:3.2.1"
   amd64Only: true


### PR DESCRIPTION
**Reason**
- we will be bumping to that image in our components to solve some security issues