### PR TITLE
changes the golang SHA to multi-platform one

### DIFF
--- a/development/image-syncer/README.md
+++ b/development/image-syncer/README.md
@@ -9,7 +9,7 @@ It copies images **only when they are not present** in the target repo. That gua
 
 Syncing process steps:
 1. Pull image from source.
-2. Check if image name contains SHA256 digest.
+2. Check if image name contains multi-platform SHA256 digest. To get this digest you can run `docker run mplatform/manifest-tool inspect {your-image}:{image-version}` and copy the first Digest this command returns. 
 3. If image name contains digest, re-tag target image with the tag instead of SHA256 digest.
 4. Check if image exists in target.
 5. If image does not exist, re-tag image and push to target registry.  

--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -12,9 +12,8 @@ images:
 - source: "gcr.io/google-containers/pause:3.2"
 - source: "goreleaser/goreleaser:v1.11.5"
 # Golang image is pinned because it is force updated in the upstream
-- source: "golang@sha256:4ee203ff3933e7a6f18d3574fd6661a73b58c60f028d2927274400f4774aaa41"
+- source: "golang@sha256:913de96707b0460bcfdfe422796bb6e559fc300f6c53286777805a9a3010a5ea"
   tag: "1.20.4-alpine3.17"
-  amd64Only: true  
 - source: "grafana/loki:2.2.1"
 - source: "grafana/grafana-image-renderer:3.2.1"
   amd64Only: true


### PR DESCRIPTION
**Description**
#7631 adds golang-1.20.4 with support only to AMD64 architecture

Changes proposed in this pull request:

- changes the golang-1.20.4 SHA to multi-platform
- ...
- ...

**Related issue(s)**
https://github.com/kyma-project/test-infra/pull/7631