### PR TITLE
Istio integration tests job

### DIFF
--- a/prow/jobs/istio/istio-integration.yaml
+++ b/prow/jobs/istio/istio-integration.yaml
@@ -1,0 +1,86 @@
+presubmits:
+  kyma-project/istio:
+    - name: pull-istio-integration
+      annotations:
+        owner: goat
+        description: Runs integration suite for istio operator
+      labels:
+        prow.k8s.io/pubsub.project: "sap-kyma-prow"
+        prow.k8s.io/pubsub.runID: "pull-istio-integration"
+        prow.k8s.io/pubsub.topic: "prowjobs"
+        preset-kind-volume-mounts: "true"
+        preset-dind-enabled: "true"
+      cluster: untrusted-workload
+      decorate: true
+      always_run: true
+      spec:
+        hostAliases:
+          - ip: "127.0.0.1"
+            hostnames:
+              - "k3d-registry.localhost"
+        containers:
+          - image: eu.gcr.io/kyma-project/test-infra/kyma-integration:v20230119-993f0759
+            command: ["/bin/bash"]
+            securityContext:
+              privileged: true
+            args:
+              - -c
+              - |
+                service docker start
+                echo "Waiting for Docker to be up..." && sleep 30
+                set -e
+                curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+                k3d registry create registry.localhost --port 5000
+                k3d cluster create k3d --registry-use k3d-registry.localhost:5000
+                IMG="k3d-registry.localhost:5000/istio-operator:latest" make docker-build docker-push istio-integration-test
+                k3d cluster delete k3d
+            resources:
+              requests:
+                cpu: 1
+                memory: 1Gi
+              limits:
+                cpu: 1.5
+                memory: 2Gi
+postsubmits:
+  kyma-project/istio:
+    - name: post-istio-integration
+      annotations:
+        owner: goat
+        description: Runs integration suite for istio operator
+      labels:
+        prow.k8s.io/pubsub.project: "sap-kyma-prow"
+        prow.k8s.io/pubsub.runID: "post-istio-integration"
+        prow.k8s.io/pubsub.topic: "prowjobs"
+        preset-kind-volume-mounts: "true"
+        preset-dind-enabled: "true"
+      cluster: untrusted-workload
+      decorate: true
+      always_run: true
+      spec:
+        hostAliases:
+          - ip: "127.0.0.1"
+            hostnames:
+              - "k3d-registry.localhost"
+        containers:
+          - image: eu.gcr.io/kyma-project/test-infra/kyma-integration:v20230119-993f0759
+            command: ["/bin/bash"]
+            securityContext:
+              privileged: true
+            args:
+              - -c
+              - |
+                service docker start
+                echo "Waiting for Docker to be up..." && sleep 30
+                set -e
+                curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+                k3d registry create registry.localhost --port 5000
+                k3d cluster create k3d --registry-use k3d-registry.localhost:5000
+                IMG="k3d-registry.localhost:5000/istio-operator:latest" make docker-build docker-push istio-integration-test
+                k3d cluster delete k3d
+            resources:
+              requests:
+                cpu: 1
+                memory: 1Gi
+              limits:
+                cpu: 1.5
+                memory: 2Gi


### PR DESCRIPTION
/area ci
/kind feature

Added integration test for istio. Test runs on k3d locally with registry, and runs makefile targets `docker-build docker-push istio-integration-tests`. It's self-contained job and uses current source (eg. current PR code) to execute tests.

https://status.build.kyma-project.io/view/gs/kyma-prow-logs/pr-logs/pull/kyma-project_istio/133/pull-istio-integration/1655927861103562752#1:build-log.txt%3A1002

https://github.com/kyma-project/istio/issues/58