### PR TITLE
Fix review assignments.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,50 +4,53 @@
 # The last matching pattern has the most precedence.
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
-# These are the default owners for the whole content of the `kyma` repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
+# These are the default owners for the whole content of the `kyma` repository.
+# The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
 
-* @kyma-project/prow @neighbors-dev-bot
-/development @kyma-project/prow @neighbors-dev-bot
-/docs @kyma-project/prow @mmitoraj @grego952 @NHingerl @IwonaLanger @nataliasitko @neighbors-dev-bot
-/prow @kyma-project/prow @neighbors-dev-bot
-/prow/cluster @kyma-project/prow @neighbors-dev-bot
-/prow/images @kyma-project/prow @neighbors-dev-bot
-/prow/images/buildpack-node @kyma-project/prow @akucharska  @a-thaler @lilitgh @valentinvieriu @neighbors-dev-bot
+# IMPORTANT: If a path is not owned by kyma-project/prow group it must have @neighbors-dev-bot added to let automation work.
 
-/prow/jobs @kyma-project/prow @neighbors-dev-bot
-/prow/jobs/busola @valentinvieriu  @akucharska @kyma-project/prow @neighbors-dev-bot
-/prow/jobs/cli @chrkl @jeremyharisch @lindnerby @tobiscr  @lilitgh @rakesh-garimella @skhalash @kyma-project/prow @neighbors-dev-bot
-/prow/jobs/control-plane @kyma-project/gopher @kyma-project/Framefrog @kyma-project/prow @neighbors-dev-bot
-/prow/jobs/incubator/compass @gvachkov @petartodorovv @desislavaa @dimitarpetrov @krasish @nickymateev @dzahariev @kirilkabakchiev @stefancholakov @svetlinzarev-sap @dragobt @kaloyanspiridonov @kyma-project/prow @neighbors-dev-bot
-/prow/jobs/incubator/compass-console @gvachkov @petartodorovv @desislavaa @dimitarpetrov @krasish @nickymateev @dzahariev @kirilkabakchiev @stefancholakov @svetlinzarev-sap @dragobt @kaloyanspiridonov @kyma-project/prow @neighbors-dev-bot
-/prow/jobs/incubator/milv @m00g3n @pprecel @dbadura @kyma-project/prow @neighbors-dev-bot
-/prow/jobs/incubator/ord-service @gvachkov @kirilkabakchiev @nickymateev @dzahariev @svetlinzarev-sap @dragobt @kaloyanspiridonov @kyma-project/prow @neighbors-dev-bot
-/prow/jobs/incubator/reconciler @varbanv @jeremyharisch @tobiscr @kyma-project/prow @neighbors-dev-bot
+* @kyma-project/prow
+/development @kyma-project/prow
+/docs @kyma-project/prow @mmitoraj @grego952 @NHingerl @IwonaLanger @nataliasitko
+/prow @kyma-project/prow
+/prow/cluster @kyma-project/prow
+/prow/images @kyma-project/prow
+/prow/images/buildpack-node @kyma-project/prow @akucharska @a-thaler @lilitgh @valentinvieriu
+
+/prow/jobs @kyma-project/prow
+/prow/jobs/busola @valentinvieriu  @akucharska @kyma-project/prow
+/prow/jobs/cli @chrkl @jeremyharisch @lindnerby @tobiscr  @lilitgh @rakesh-garimella @skhalash @kyma-project/prow
+/prow/jobs/control-plane @kyma-project/gopher @kyma-project/Framefrog @kyma-project/prow
+/prow/jobs/incubator/compass @gvachkov @petartodorovv @desislavaa @dimitarpetrov @krasish @nickymateev @dzahariev @kirilkabakchiev @stefancholakov @svetlinzarev-sap @dragobt @kaloyanspiridonov @kyma-project/prow
+/prow/jobs/incubator/compass-console @gvachkov @petartodorovv @desislavaa @dimitarpetrov @krasish @nickymateev @dzahariev @kirilkabakchiev @stefancholakov @svetlinzarev-sap @dragobt @kaloyanspiridonov @kyma-project/prow
+/prow/jobs/incubator/milv @m00g3n @pprecel @dbadura @kyma-project/prow
+/prow/jobs/incubator/ord-service @gvachkov @kirilkabakchiev @nickymateev @dzahariev @svetlinzarev-sap @dragobt @kaloyanspiridonov @kyma-project/prow
+/prow/jobs/incubator/reconciler @varbanv @jeremyharisch @tobiscr @kyma-project/prow
 /prow/jobs/kyma/kyma-integration-gardener.yaml @kyma-project/jellyfish @neighbors-dev-bot
-/prow/jobs/kyma/components/central-application-connectivity-validator @kyma-project/Framefrog @kyma-project/prow @neighbors-dev-bot
-/prow/jobs/kyma/components/central-application-gateway @kyma-project/prow @kyma-project/Framefrog @neighbors-dev-bot
-/prow/jobs/kyma/components/compass-runtime-agent @kyma-project/prow @kyma-project/Framefrog @neighbors-dev-bot
+/prow/jobs/kyma/components/central-application-connectivity-validator @kyma-project/Framefrog @kyma-project/prow
+/prow/jobs/kyma/components/central-application-gateway @kyma-project/prow @kyma-project/Framefrog
+/prow/jobs/kyma/components/compass-runtime-agent @kyma-project/prow @kyma-project/Framefrog
 /prow/jobs/kyma/components/event-publisher-proxy @kyma-project/eventing @neighbors-dev-bot
 /prow/jobs/kyma/components/eventing-controller @kyma-project/eventing @neighbors-dev-bot
-/prow/jobs/kyma/components/function-controller @pk85 @dbadura @kwiatekus @m00g3n @pprecel @kyma-project/prow @neighbors-dev-bot
-/prow/jobs/kyma/components/function-runtimes @dbadura @kwiatekus @m00g3n @pprecel @pk85 @kyma-project/prow @neighbors-dev-bot
-/prow/jobs/kyma/kyma-integration-gardener-eventing.yaml @kyma-project/prow @kyma-project/eventing @neighbors-dev-bot
-/prow/jobs/eventing-tools/ @kyma-project/prow @kyma-project/eventing @neighbors-dev-bot
-/prow/jobs/eventing-webhook/ @kyma-project/prow @kyma-project/eventing @neighbors-dev-bot
-/prow/jobs/telemetry-manager @kyma-project/observability @kyma-project/prow @neighbors-dev-bot
-/prow/jobs/directory-size-exporter @kyma-project/observability @kyma-project/prow @neighbors-dev-bot
-/prow/jobs/kyma/tests/fast-integration @kyma-project/prow @neighbors-dev-bot
-/prow/jobs/kyma/tests/serverless-bench @pk85 @dbadura @kwiatekus @m00g3n @pprecel @kyma-project/prow @neighbors-dev-bot
-/prow/jobs/kyma-project/telemetry-manager @kyma-project/observability @kyma-project/prow @neighbors-dev-bot
+/prow/jobs/kyma/components/function-controller @pk85 @dbadura @kwiatekus @m00g3n @pprecel @kyma-project/prow
+/prow/jobs/kyma/components/function-runtimes @dbadura @kwiatekus @m00g3n @pprecel @pk85 @kyma-project/prow
+/prow/jobs/kyma/kyma-integration-gardener-eventing.yaml @kyma-project/prow @kyma-project/eventing
+/prow/jobs/eventing-tools/ @kyma-project/prow @kyma-project/eventing
+/prow/jobs/eventing-webhook/ @kyma-project/prow @kyma-project/eventing
+/prow/jobs/telemetry-manager @kyma-project/observability @kyma-project/prow
+/prow/jobs/directory-size-exporter @kyma-project/observability @kyma-project/prow
+/prow/jobs/kyma/tests/fast-integration @kyma-project/prow
+/prow/jobs/kyma/tests/serverless-bench @pk85 @dbadura @kwiatekus @m00g3n @pprecel @kyma-project/prow
+/prow/jobs/kyma-project/telemetry-manager @kyma-project/observability @kyma-project/prow
 /prow/jobs/istio/ @kyma-project/goat @neighbors-dev-bot
 /prow/jobs/api-gateway/ @kyma-project/goat @neighbors-dev-bot
-/prow/scripts @kyma-project/prow @neighbors-dev-bot
+/prow/scripts @kyma-project/prow
 
-/templates @kyma-project/prow @neighbors-dev-bot
-/templates/templates @kyma-project/prow @neighbors-dev-bot
-templates/data/eventing-tools-data.yaml @kyma-project/prow @kyma-project/eventing @neighbors-dev-bot
-templates/data/eventing-webhook-certificates-build.yaml @kyma-project/prow @kyma-project/eventing @neighbors-dev-bot
-templates/data/eventing-webhook-certificates-release.yaml @kyma-project/prow @kyma-project/eventing @neighbors-dev-bot
+/templates @kyma-project/prow
+/templates/templates @kyma-project/prow
+templates/data/eventing-tools-data.yaml @kyma-project/prow @kyma-project/eventing
+templates/data/eventing-webhook-certificates-build.yaml @kyma-project/prow @kyma-project/eventing
+templates/data/eventing-webhook-certificates-release.yaml @kyma-project/prow @kyma-project/eventing
 
 # All .md files
 *.md @mmitoraj @NHingerl @grego952 @IwonaLanger @nataliasitko
@@ -57,4 +60,4 @@ templates/data/eventing-webhook-certificates-release.yaml @kyma-project/prow @ky
 
 # File index.md must be owned by prow group in case it will get changes in a pull request which is not allowed to be approved by approval bot.
 # In such case a human approver from prow group must approve the pull request.
-/docs/index.md @kyma-project/prow @neighbors-dev-bot
+/docs/index.md @kyma-project/prow


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Removed neighbors-dev-bot from lines where kyma-project/prow group is present. If bot account was added explicitly it was requested for review because our GitHub settings require review from codeowners. Because bot account is a member of prow group, automated review assignment requested only one additional prow group member for review to reach two reviewers from prow group.

With this change a bot will be explicitly added to the reviewers list only if pull request contains changes in path where kyma-project/prow is not an owner and neighbors-dev-bot is an owner. If the pull request will contain changes for paths where one has kyma-project/prow as owner and second one has a neighbors-dev-bot as owner, only one human member of kyma-project/prow will be requested for review.
