### PR TITLE
add file permission workaround to clone-refs.yaml

### DIFF
--- a/task/clone-refs/0.1/clone-refs.yaml
+++ b/task/clone-refs/0.1/clone-refs.yaml
@@ -50,3 +50,10 @@ spec:
           value: $(params.LOG)
         - name: SRC_ROOT
           value: $(params.SRC_ROOT)
+    - name: fix-permissions
+      image: alpine:edge
+      workingDir: $(workspaces.repo.path)
+      script:
+        chmod -R 777 .
+        chown 1000:1000 -R .
+        ls -la .


### PR DESCRIPTION
Added workaround that changes file permissions to 777 and sets owner/group to 1000:1000 so files are accessible by non-root users

/area ci
/kind bug