### PR TITLE
Updated Expression to better match release version and added a secondary job to build the new image

### DIFF
--- a/prow/jobs/modules/external/keda-manager.yaml
+++ b/prow/jobs/modules/external/keda-manager.yaml
@@ -234,7 +234,7 @@ postsubmits: # runs on main
       cluster: trusted-workload
       max_concurrency: 10
       branches:
-        - ^\d+\.\d+\.\d+(?:-.*)?$
+        - ^\w+\d+\.\d+\.\d+(?:-.*)?$
       spec:
         containers:
           - image: "eu.gcr.io/kyma-project/test-infra/buildpack-golang:v20230323-a1ac96db"

--- a/prow/jobs/modules/external/keda-manager.yaml
+++ b/prow/jobs/modules/external/keda-manager.yaml
@@ -218,6 +218,56 @@ presubmits: # runs on PRs
   
 postsubmits: # runs on main
   kyma-project/keda-manager:
+    - name: post-keda-manager-build
+      annotations:
+        description: "Job to build keda module for a release."
+        owner: "otters"
+        pipeline.trigger: "pr-merge"
+      labels:
+        prow.k8s.io/pubsub.project: "sap-kyma-prow"
+        prow.k8s.io/pubsub.runID: "post-keda-manager-build"
+        prow.k8s.io/pubsub.topic: "prowjobs"
+        preset-sa-kyma-push-images: "true"
+        preset-signify-prod-secret: "true"
+      always_run: true
+      skip_report: false
+      decorate: true
+      cluster: trusted-workload
+      max_concurrency: 10
+      branches:
+        - ^\w+\d+\.\d+\.\d+(?:-.*)?$
+      spec:
+        containers:
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230313-8dfce5f0b"
+            command:
+              - "/image-builder"
+            args:
+              - "--name=keda-manager"
+              - "--config=/config/kaniko-build-config.yaml"
+              - "--context=."
+              - "--dockerfile=Dockerfile"
+              - "--tag={{ .Env \"PULL_BASE_SHA\" }}"
+            resources:
+              requests:
+                memory: 1.5Gi
+                cpu: 1
+              limits:
+                memory: 3Gi
+                cpu: 2
+            volumeMounts:
+              - name: config
+                mountPath: /config
+                readOnly: true
+              - name: signify-secret
+                mountPath: /secret
+                readOnly: true
+        volumes:
+          - name: config
+            configMap:
+              name: kaniko-build-config
+          - name: signify-secret
+            secret:
+              secretName: signify-dev-secret
     - name: post-keda-manager-module-build
       annotations:
         description: "Job to build keda module for a release."
@@ -244,7 +294,7 @@ postsubmits: # runs on main
               - "ci"
             env:
               - name: IMG
-                value: "europe-docker.pkg.dev/kyma-project/dev/keda-manager:PR-${PULL_NUMBER}"
+                value: "europe-docker.pkg.dev/kyma-project/prod/keda-manager:${PULL_BASE_SHA}"
               - name: KUSTOMIZE_VERSION
                 value: "v4.5.6"
               - name: MODULE_REGISTRY

--- a/templates/data/generic_module_data.yaml
+++ b/templates/data/generic_module_data.yaml
@@ -109,6 +109,29 @@ templates:
                     - vm_job_k3d
                     - vm_job_labels
               - jobConfig:
+                  name: post-keda-manager-build
+                  annotations:
+                    owner: otters
+                    description: Job to build keda module for a release.
+                  always_run: true
+                  labels:
+                    preset-signify-prod-secret: "true"
+                  args:
+                    - "--name=keda-manager"
+                    - "--config=/config/kaniko-build-config.yaml"
+                    - "--context=."
+                    - "--dockerfile=Dockerfile"
+                    - '--tag={{`{{ .Env \"PULL_BASE_SHA\" }}`}}'
+                  branches:
+                    - ^\w+\d+\.\d+\.\d+(?:-.*)?$ #Watches for new Tag
+                inheritedConfigs:
+                  global:
+                    - jobConfig_postsubmit
+                  local:
+                    - job_default
+                    - job_build
+                    - limits
+              - jobConfig:
                   name: post-keda-manager-module-build
                   annotations:
                     owner: otters
@@ -119,7 +142,7 @@ templates:
                   env:
                     KUSTOMIZE_VERSION: "v4.5.6"
                     MODULE_REGISTRY: "europe-docker.pkg.dev/kyma-project/prod/unsigned"
-                    IMG: "europe-docker.pkg.dev/kyma-project/dev/keda-manager:PR-${PULL_NUMBER}"
+                    IMG: "europe-docker.pkg.dev/kyma-project/prod/keda-manager:${PULL_BASE_SHA}"
                   command: "./scripts/release.sh"
                   args:
                     - "ci"

--- a/templates/data/generic_module_data.yaml
+++ b/templates/data/generic_module_data.yaml
@@ -124,7 +124,7 @@ templates:
                   args:
                     - "ci"
                   branches:
-                    - ^\d+\.\d+\.\d+(?:-.*)?$ #Watches for new Tag
+                    - ^\w+\d+\.\d+\.\d+(?:-.*)?$ #Watches for new Tag
                 inheritedConfigs:
                   global:
                     - image_buildpack-golang # takes latest golang image


### PR DESCRIPTION
**Description**
Updates to match with Keda Manager release naming convention
&
Adds secondary job that builds new image to be used in release process
**Related issue(s)**
https://github.com/kyma-project/keda-manager/issues/129