### PR TITLE
Fix trigger for nats-manager unit test job

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -37,6 +37,7 @@
 /prow/jobs/kyma/kyma-integration-gardener-eventing.yaml @kyma-project/prow @kyma-project/eventing
 /prow/jobs/eventing-tools/ @kyma-project/prow @kyma-project/eventing
 /prow/jobs/eventing-webhook/ @kyma-project/prow @kyma-project/eventing
+/prow/jobs/nats-manager/ @kyma-project/prow @kyma-project/eventing
 /prow/jobs/telemetry-manager @kyma-project/observability @kyma-project/prow
 /prow/jobs/directory-size-exporter @kyma-project/observability @kyma-project/prow
 /prow/jobs/kyma/tests/fast-integration @kyma-project/prow
@@ -51,6 +52,7 @@
 templates/data/eventing-tools-data.yaml @kyma-project/prow @kyma-project/eventing
 templates/data/eventing-webhook-certificates-build.yaml @kyma-project/prow @kyma-project/eventing
 templates/data/eventing-webhook-certificates-release.yaml @kyma-project/prow @kyma-project/eventing
+templates/data/nats-manager-data.yaml @kyma-project/prow @kyma-project/eventing
 
 # All .md files
 *.md @mmitoraj @NHingerl @grego952 @IwonaLanger @nataliasitko

--- a/prow/jobs/nats-manager/nats-manager-generic.yaml
+++ b/prow/jobs/nats-manager/nats-manager-generic.yaml
@@ -51,7 +51,7 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
         prow.k8s.io/pubsub.runID: "pull-nats-manager-unit-test"
         prow.k8s.io/pubsub.topic: "prowjobs"
-      run_if_changed: '^\.go$|^go.(sum|mod)'
+      run_if_changed: '^\S+\.go$|^go\.(sum|mod)$'
       skip_report: false
       decorate: true
       cluster: untrusted-workload

--- a/templates/data/nats-manager-data.yaml
+++ b/templates/data/nats-manager-data.yaml
@@ -40,7 +40,7 @@ templates:
                   args:
                     - "-c"
                     - "make test-only"
-                  run_if_changed: "^\\.go$|^go.(sum|mod)"
+                  run_if_changed: "^\\S+\\.go$|^go\\.(sum|mod)$"
                 inheritedConfigs:
                   global:
                     - testing


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
`pull-nats-manager-unit-test` was not getting triggered on nats-manager PRs. The regex pattern needed to be slightly changed to fix the trigger.

The job will now get triggered if the following files are changed:
- {any folder structure}/file.go
- go.mod
- go.sum

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
