### PR TITLE
Add automatic provisioning of k3d in e2e-k3d image

### DIFF
--- a/images/e2e-dind-k3d/init.sh
+++ b/images/e2e-dind-k3d/init.sh
@@ -4,9 +4,21 @@ set -e
 
 LOG_DIR=${ARTIFACTS:-"/var/log"}
 
-if [[ -n "${DOCKER_IN_DOCKER_ENABLED}" ]]; then
+if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
   echo "[* * *] Starting Docker in Docker"
   dockerd --data-root=/docker-graph > "${LOG_DIR}/dockerd.log" 2>&1 &
 fi
 
+if [[ "$K3D_ENABLED" == "true" ]]; then
+  ARGS=()
+  echo -n "[ * * * ] Provisioning k3d cluster"
+  if [[ "$PROVISION_REGISTRY" == "true" ]]; then
+    echo " with registry k3d-registry.localhost:5000"
+    k3d registry create registry.localhost --port 5000
+    ARGS+=( "--registry-use=k3d-registry.localhost:5000" )
+  else
+    echo
+  fi
+  k3d cluster create k3d "${ARGS[@]}"
+fi
 exec "$@"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1409,3 +1409,13 @@ presets:
       - name: sa-kyma-dns-serviceuser
         mountPath: /sa-kyma-dns-serviceuser
         readOnly: true
+  - labels:
+      preset-k3d-enabled: "true"
+    env:
+      - name: K3D_ENABLED
+        value: "true"
+  - labels:
+      preset-provision-registry: "true"
+    env:
+      - name: PROVISION_REGISTRY
+        value: "true"


### PR DESCRIPTION
/kind feature
/area ci

This PR adds additional logic of provisioning k3d cluster with registry inside of e2e-dind-k3d image.
This is roughly based on implementation in https://github.com/kyma-project/test-infra/pull/7741/files

This will give the ability to provide entire k8s environment without additional effort.