### PR TITLE
Fix command used by image-detector

### DIFF
--- a/prow/jobs/test-infra/prow-periodics.yaml
+++ b/prow/jobs/test-infra/prow-periodics.yaml
@@ -53,7 +53,7 @@ postsubmits: # runs on main
         containers:
           - image: "europe-docker.pkg.dev/kyma-project/prod/test-infra/image-detector:v20230605-f0fdfaf8"
             command:
-              - "/image-detector"
+              - "/imagedetector"
             args:
               - "--prow-config prow/config.yaml"
               - "--prow-jobs-dir prow/jobs"

--- a/templates/data/prow-periodics-data.yaml
+++ b/templates/data/prow-periodics-data.yaml
@@ -121,7 +121,7 @@ templates:
                   skip_report: "false"
                   max_concurrency: "10"
                   type_postsubmit: "true"
-                  command: /image-detector
+                  command: /imagedetector
                   args:
                     - --prow-config prow/config.yaml
                     - --prow-jobs-dir prow/jobs


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Invalid command name cause image-detector job to fail constantly. This is simple fix for it.

Changes proposed in this pull request:

- Remove "-" from command used by image detector prow job

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
