### PR TITLE
Add initial e2e-dind-nodejs image

### DIFF
--- a/images/e2e-dind-nodejs/Dockerfile
+++ b/images/e2e-dind-nodejs/Dockerfile
@@ -1,0 +1,66 @@
+FROM node:16.20.0-bookworm-slim as base
+
+
+ENV TERM=xterm
+ENV DEBIAN_FRONTEND=noninteractive
+
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+#TODO Pin chrome and Docker to specific version if needed
+#TODO adjust required packages with --no-install-recommends
+# hadolint ignore=DL3015
+RUN set -eux; \
+    apt-get update && apt-get install -y \
+    curl \
+    iptables \
+    build-essential \
+    libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb && \
+    curl -sL https://get.docker.com | sh - && \
+    update-alternatives --set iptables /usr/sbin/iptables-legacy && \
+    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy && \
+    curl -sL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+    sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list' && \
+    apt-get update && apt-get install -y google-chrome-stable && \
+    rm -rf /var/cache/apt/* && apt-get clean
+
+ARG DUMB_INIT_VERSION=1.2.5
+RUN curl -Lo /usr/local/bin/dumb-init "https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_$(uname -m)" && \
+    chmod +x /usr/local/bin/dumb-init
+
+RUN set -eux; \
+    addgroup -S dockremap 	&& \
+    adduser -SDHs /sbin/nologin dockremap; \
+    echo 'dockremap:165536:65536' >> /etc/subuid && \
+    echo 'dockremap:165536:65536' >> /etc/subgid
+
+RUN mkdir -p /workspace; \
+    chmod 1777 /workspace
+
+WORKDIR /workspace
+
+FROM golang:1.20.4 AS go-deps
+ENV CGO_ENABLED=0
+ARG K3D_VERSION=v5.4.9
+
+RUN apt-get install --no-install-recommends -y curl
+
+RUN curl -Lso install.sh https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh && \
+    chmod +x ./install.sh &&\
+    TAG=${K3D_VERSION} ./install.sh &&\
+    rm install.sh
+
+# Only k3d is needed atm. If it's proven unstable, switch to kind
+#ARG KIND_VERSION=v0.18.0
+#RUN go install sigs.k8s.io/kind@${KIND_VERSION}
+
+ARG CLUSTER_VERSION=v1.26.3
+RUN curl -Lo /usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/${CLUSTER_VERSION}/bin/linux/$(go env GOARCH)/kubectl" && \
+    chmod +x /usr/local/bin/kubectl
+
+FROM base
+
+COPY init.sh /
+COPY --from=go-deps /usr/local/bin/k3d /usr/local/bin/
+COPY --from=go-deps /usr/local/bin/kubectl /usr/local/bin/
+
+ENTRYPOINT [ "/init.sh" ]

--- a/images/e2e-dind-nodejs/init.sh
+++ b/images/e2e-dind-nodejs/init.sh
@@ -1,0 +1,25 @@
+#!/usr/local/bin/dumb-init /bin/bash
+
+set -e
+
+LOG_DIR=${ARTIFACTS:-"/var/log"}
+
+if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
+  echo "[ * * * ] Starting Docker in Docker"
+  dockerd --data-root=/docker-graph > "${LOG_DIR}/dockerd.log" 2>&1 &
+  sleep 5 # sleep to wait for Docker daemon - idk if we can use some kind of condition
+fi
+
+if [[ "$K3D_ENABLED" == "true" ]]; then
+  ARGS=()
+  echo -n "[ * * * ] Provisioning k3d cluster"
+  if [[ "$PROVISION_REGISTRY" == "true" ]]; then
+    echo " with registry k3d-registry.localhost:5000"
+    k3d registry create registry.localhost --port 5000
+    ARGS+=( "--registry-use=k3d-registry.localhost:5000" )
+  else
+    echo
+  fi
+  k3d cluster create k3d "${ARGS[@]}"
+fi
+exec "$@"


### PR DESCRIPTION
/area ci
/kind feature

add additional debian-based image that contains nodejs16, docker, k3d and chrome browser. It's meant to be used with Cypress-based UI tests

TODO stays for future reference

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#7862 