### PR TITLE
Add extra-refs to image-detector periodic prow job

### DIFF
--- a/prow/jobs/test-infra/prow-periodics.yaml
+++ b/prow/jobs/test-infra/prow-periodics.yaml
@@ -231,6 +231,11 @@ periodics: # runs on schedule
       skip_report: false
       decorate: true
       cluster: trusted-workload
+      extra_refs:
+        - org: kyma-project
+          repo: test-infra
+          path_alias: github.com/kyma-project/test-infra
+          base_ref: main
       reporter_config:
         slack:
           channel: kyma-prow-alerts

--- a/prow/jobs/test-infra/prow-periodics.yaml
+++ b/prow/jobs/test-infra/prow-periodics.yaml
@@ -60,7 +60,7 @@ postsubmits: # runs on main
           channel: kyma-prow-alerts
       spec:
         containers:
-          - image: "europe-docker.pkg.dev/kyma-project/prod/test-infra/image-detector:v20230605-f0fdfaf8"
+          - image: "europe-docker.pkg.dev/kyma-project/prod/test-infra/image-detector:v20230622-de57a1f7"
             securityContext:
               privileged: false
               seccompProfile:
@@ -217,6 +217,41 @@ periodics: # runs on schedule
             args:
               - "--config=prow/autobump-config/prow-cluster-autobump-config.yaml"
               - "--labels-override=kind/chore,area/prow"
+    - name: test-infra-image-detector-autobump
+      annotations:
+        description: "daily detect prow images for scan"
+        owner: "neighbors"
+        testgrid-create-test-group: "false"
+      labels:
+        prow.k8s.io/pubsub.project: "sap-kyma-prow"
+        prow.k8s.io/pubsub.runID: "test-infra-image-detector-autobump"
+        prow.k8s.io/pubsub.topic: "prowjobs"
+        preset-autobump-bot-github-token: "true"
+      cron: "0 8 * * *"
+      skip_report: false
+      decorate: true
+      cluster: trusted-workload
+      reporter_config:
+        slack:
+          channel: kyma-prow-alerts
+      spec:
+        containers:
+          - image: "europe-docker.pkg.dev/kyma-project/prod/test-infra/image-detector:v20230622-de57a1f7"
+            securityContext:
+              privileged: false
+              seccompProfile:
+                type: RuntimeDefault
+              allowPrivilegeEscalation: false
+            command:
+              - "/imagedetector"
+            args:
+              - "--prow-config=prow/config.yaml"
+              - "--prow-jobs-dir=prow/jobs"
+              - "--terraform-dir=configs/terraform"
+              - "--sec-scanner-config=sec-scanner-config.yaml"
+              - "--kubernetes-dir=prow/cluster/components"
+              - "--autobump-config=prow/image-detector/test-infra-sec-config-autobump-config.yaml"
+              - "--inrepo-config=prow/image-detector/inrepo-config.yaml"
     - name: ci-prow-autobump-jobs
       annotations:
         description: "Autobump image versions in prow jobs"

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -195,7 +195,7 @@ globalSets:
   image_markdown_index:
     image: "eu.gcr.io/kyma-project/test-infra/markdown-index:v20230404-24c76bf3"
   image_image_detector:
-    image: "europe-docker.pkg.dev/kyma-project/prod/test-infra/image-detector:v20230605-f0fdfaf8"
+    image: "europe-docker.pkg.dev/kyma-project/prod/test-infra/image-detector:v20230622-de57a1f7"
   # JobConfig sets
   jobConfig_default:
     skip_report: "false"

--- a/templates/data/prow-periodics-data.yaml
+++ b/templates/data/prow-periodics-data.yaml
@@ -121,6 +121,7 @@ templates:
                     - pubsub_labels
                     - disable_testgrid
                     - image_image_detector
+                    - extra_refs_test-infra
                     - "unprivileged"
               - jobConfig:
                   name: post-test-infra-markdown-index-autobump

--- a/templates/data/prow-periodics-data.yaml
+++ b/templates/data/prow-periodics-data.yaml
@@ -98,6 +98,31 @@ templates:
                     - extra_refs_test-infra
                     - "unprivileged"
               - jobConfig:
+                  name: test-infra-image-detector-autobump
+                  annotations:
+                    owner: neighbors
+                    description: daily detect prow images for scan
+                  cron: "0 8 * * *"
+                  slack_channel: kyma-prow-alerts
+                  command: /imagedetector
+                  args:
+                    - --prow-config=prow/config.yaml
+                    - --prow-jobs-dir=prow/jobs
+                    - --terraform-dir=configs/terraform
+                    - --sec-scanner-config=sec-scanner-config.yaml
+                    - --kubernetes-dir=prow/cluster/components
+                    - --autobump-config=prow/image-detector/test-infra-sec-config-autobump-config.yaml
+                    - --inrepo-config=prow/image-detector/inrepo-config.yaml
+                inheritedConfigs:
+                  local:
+                    - periodic_config
+                    - github_token_mounts
+                  global:
+                    - pubsub_labels
+                    - disable_testgrid
+                    - image_image_detector
+                    - "unprivileged"
+              - jobConfig:
                   name: post-test-infra-markdown-index-autobump
                   annotations:
                     owner: neighbors


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add extra-refs, so periodic image detection for scanners can access configs from tes-infra repo

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
