### PR TITLE
Not fail on not found inrepo config

### DIFF
--- a/development/image-detector/main.go
+++ b/development/image-detector/main.go
@@ -139,7 +139,8 @@ var rootCmd = &cobra.Command{
 			for _, repo := range cfg {
 				imgs, err := extractimageurls.FromInRepoConfig(repo, ghToken)
 				if err != nil {
-					log.Fatalf("failed to exract image urls from repository %s: %v", &repo, err)
+					log.Printf("warn: failed to exract image urls from repository %s: %v", &repo, err)
+					continue
 				}
 
 				images = append(images, imgs...)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Current behavior require list of repositories containing only repos with valid inrepo config, proposed changes change behavior to warn and not fail if inrepo config is not found.

Changes proposed in this pull request:

- Warn instead of fail on not found prow in-repo config

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
