### PR TITLE
New k8s next integration test job

### DIFF
--- a/prow/jobs/kyma/kyma-preview.yaml
+++ b/prow/jobs/kyma/kyma-preview.yaml
@@ -1,0 +1,47 @@
+periodics:
+  - name: ci-kyma-k8s-integration-next-k3d
+    annotations:
+      owner: huskies
+      description: Runs fast-integration test on next k8s version
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    interval: 12h
+    skip_report: true
+    cluster: untrusted-workload
+    extra_refs:
+      - org: kyma-project
+        repo: kyma
+        base_ref: main
+    spec:
+      containers:
+        # TODO change image to production once build toolchain is done
+        - image: eu.gcr.io/sap-kyma-neighbors-dev/e2e-nodejs-chrome:test
+          securityContext:
+            privileged: true
+            seccompProfile:
+              type: Unconfined
+            allowPrivilegeEscalation: true
+          env:
+            - name: K8S_VERSION
+              value: "1.27.3"
+          command: ["/init.sh"]
+          args:
+            - bash
+            - -c
+            - |
+              set -e
+              curl -sSLo /usr/local/bin/kyma "https://storage.googleapis.com/kyma-cli-stable/kyma-linux?alt=media"
+              chmod +x /usr/local/bin/kyma
+              kyma provision k3d --ci -k "$K8S_VERSION"
+              kubectl get nodes
+              kyma deploy --ci --source=local --workspace "$(pwd)"
+              make -C tests/fast-integration ci
+          resources:
+            requests:
+              cpu: 1
+              memory: 2Gi
+            limits:
+              cpu: 2
+              memory: 4Gi


### PR DESCRIPTION
/area ci
/kind feature

Rewritten k8s next integration job as periodic that runs every 12h. Locally on k3d. Without flaky tests.
It uses experimental image which will have to be changed into prod one once build toolchain is finished. But let's not block it, as it's quite important.