### PR TITLE
Prevent images using latest tag.

### DIFF
--- a/opa/gatekeeper/constraint-templates/k8sAllowedImages.yaml
+++ b/opa/gatekeeper/constraint-templates/k8sAllowedImages.yaml
@@ -1,4 +1,5 @@
 # k8sallowedimages constraint template validates that a pod is not using an image that is not allowed.
+# It prevents the use of images with the :latest tag.
 # The k8sallowedimages accepts one parameter:
 # - images: a list of allowed image URLs. Each image URL must be a prefix of the image URL used in the Pod spec.
 apiVersion: templates.gatekeeper.sh/v1beta1
@@ -22,19 +23,33 @@ spec:
     - target: admission.k8s.gatekeeper.sh
       rego: |
         package k8sallowedimages
-       
-        # Check violations for conatainers.
+        # Check containers are not using latest tag.
         violation[{"msg": msg}] {
-          # Check object is using an image that is not allowed.
           container := input.review.object.spec.containers[_]
-          not strings.any_prefix_match(input.parameters.images, container.image)
-          msg := sprintf("container <%v> in namespace <%v> has an invalid image repo <%v>, allowed repos are %v", [container.name, container.image, input.review.object.metadata.namespace, input.parameters.images])
+          # Check if object is using an image with latest tag.
+          strings.endswith(container.image, ":latest")
+          msg := sprintf("container <%v> in namespace <%v> has image <%v> with latest tag, using latest tag is not allowed", [container.name, input.review.object.metadata.namespace, container.image])
         }
 
-        # Check violations for init containers.
+        # Check init containers are not using latest tag.
         violation[{"msg": msg}] {
-          # Check object is using an image that is not allowed.
           container := input.review.object.spec.initContainers[_]
+          # Check if object is using an image with latest tag.
+          strings.endswith(container.image, ":latest")
+          msg := sprintf("container <%v> in namespace <%v> has image <%v> with latest tag, using latest tag is not allowed", [container.name, input.review.object.metadata.namespace, container.image])
+        }
+        # Check containers are using allowed images.
+        violation[{"msg": msg}] {
+          container := input.review.object.spec.containers[_]
+          # Check object is using an image that is not allowed.
           not strings.any_prefix_match(input.parameters.images, container.image)
-          msg := sprintf("container <%v> in namespace <%v> has an invalid image repo <%v>, allowed repos are %v", [container.name, container.image, input.review.object.metadata.namespace, input.parameters.images])
+          msg := sprintf("container <%v> in namespace <%v> has an invalid image repo <%v>, allowed repos are %v", [container.name, input.review.object.metadata.namespace, container.image, input.parameters.images])
+        }
+
+        # Check init containers are using allowed images.
+        violation[{"msg": msg}] {
+          container := input.review.object.spec.initContainers[_]
+          # Check object is using an image that is not allowed.
+          not strings.any_prefix_match(input.parameters.images, container.image)
+          msg := sprintf("container <%v> in namespace <%v> has an invalid image repo <%v>, allowed repos are %v", [container.name, input.review.object.metadata.namespace, container.image, input.parameters.images])
         }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7946f3b</samp>

This pull request improves the security and reliability of the `k8sAllowedImages` constraint template by requiring specific image tags. It changes the rego logic and messages in `opa/gatekeeper/constraint-templates/k8sAllowedImages.yaml` to enforce this policy.

Changes proposed in this pull request:

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7946f3b</samp>

*  Add comment to explain constraint template for allowed images ([link](https://github.com/kyma-project/test-infra/pull/7953/files?diff=unified&w=0#diff-219a468056913f41307647bb5c44f3bdfa39f6073b39330478f3eee59dbcb074R2))
*  Add rules to check for images with :latest tag in containers and init containers ([link](https://github.com/kyma-project/test-infra/pull/7953/files?diff=unified&w=0#diff-219a468056913f41307647bb5c44f3bdfa39f6073b39330478f3eee59dbcb074L25-R54))
*  Reorder rules to give priority to :latest tag check over allowed images check ([link](https://github.com/kyma-project/test-infra/pull/7953/files?diff=unified&w=0#diff-219a468056913f41307647bb5c44f3bdfa39f6073b39330478f3eee59dbcb074L25-R54))
*  Update violation messages to include image name and :latest tag ([link](https://github.com/kyma-project/test-infra/pull/7953/files?diff=unified&w=0#diff-219a468056913f41307647bb5c44f3bdfa39f6073b39330478f3eee59dbcb074L25-R54))
