### PR TITLE
Provide private image registry for cap-operator

### DIFF
--- a/configs/terraform/environments/prod/artifact-registry-locals.tf
+++ b/configs/terraform/environments/prod/artifact-registry-locals.tf
@@ -1,0 +1,9 @@
+locals {
+  artifact_registry_tags = {
+    owner  = var.owner
+    module = var.module
+    type   = var.type
+  }
+
+  location = var.artifact_registry_multi_region == true ? var.artifact_registry_primary_area : var.gcp_region
+}

--- a/configs/terraform/environments/prod/artifact-registry-variables.tf
+++ b/configs/terraform/environments/prod/artifact-registry-variables.tf
@@ -1,6 +1,12 @@
 ###################################
 # Artifact Registry related values
 ###################################
+variable "owner" {
+  type        = string
+  description = "owner inside SAP"
+  default     = "neighbors"
+}
+
 variable "module" {
   type        = string
   description = "Module name"

--- a/configs/terraform/environments/prod/artifact-registry-variables.tf
+++ b/configs/terraform/environments/prod/artifact-registry-variables.tf
@@ -1,0 +1,49 @@
+###################################
+# Artifact Registry related values
+###################################
+variable "module" {
+  type        = string
+  description = "Module name"
+}
+
+variable "type" {
+  type        = string
+  description = "Environment for the resources"
+}
+
+variable "artifact_registry_multi_region" {
+  type        = bool
+  description = "Is Location type Multi-region"
+  default     = true
+}
+
+variable "artifact_registry_primary_area" {
+  type        = string
+  description = "Location type Multi-region"
+  default     = "europe"
+}
+
+
+variable "artifact_registry_prefix" {
+  type        = string
+  description = "Naming prefix for all Artifact registry"
+  default     = "modules"
+}
+
+variable "artifact_registry_count" {
+  type        = number
+  description = "Number of Artifact registries to create"
+  default     = 2
+}
+
+variable "artifact_registry_names" {
+  type        = list(string)
+  description = "Artifact Registry names"
+  default     = ["ocim", "internal"]
+}
+
+variable "immutable_artifact_registry" {
+  type        = bool
+  description = "Is Artifact registry immutable"
+  default     = false
+}

--- a/configs/terraform/environments/prod/artifact-registry.tf
+++ b/configs/terraform/environments/prod/artifact-registry.tf
@@ -16,20 +16,11 @@ resource "google_artifact_registry_repository" "artifact_registry" {
   }
 }
 
-resource "google_artifact_registry_repository_iam_member" "member_service_account_1" {
+resource "google_artifact_registry_repository_iam_member" "member_service_account" {
   count      = var.artifact_registry_count
-  project    = var.gcp_project
+  project    = var.gcp_project_id
   location   = local.location
   repository = google_artifact_registry_repository.artifact_registry[count.index].name
   role       = "roles/artifactregistry.writer"
-  member     = "serviceAccount:sa-dev-kyma-project@sap-kyma-prow.iam.gserviceaccount.com"
-}
-
-resource "google_artifact_registry_repository_iam_member" "member_service_account_2" {
-  count      = var.artifact_registry_count
-  project    = var.gcp_project
-  location   = local.location
-  repository = google_artifact_registry_repository.artifact_registry[count.index].name
-  role       = "roles/artifactregistry.writer"
-  member     = "serviceAccount:sa-gcr-push-kyma-project@sap-kyma-prow.iam.gserviceaccount.com"
+  member     = "serviceAccount:sa-kyma-project@sap-kyma-prow.iam.gserviceaccount.com"
 }

--- a/configs/terraform/environments/prod/artifact-registry.tf
+++ b/configs/terraform/environments/prod/artifact-registry.tf
@@ -1,0 +1,35 @@
+
+
+resource "google_artifact_registry_repository" "artifact_registry" {
+  count         = var.artifact_registry_count
+  location      = local.location
+  repository_id = "${lower(var.artifact_registry_prefix)}-${lower(var.artifact_registry_names[count.index])}"
+  description   = "${lower(var.artifact_registry_prefix)}-${lower(var.artifact_registry_names[count.index])} repository"
+  format        = "DOCKER"
+
+  labels = merge(local.artifact_registry_tags, {
+    name = "${lower(var.artifact_registry_prefix)}-${lower(var.artifact_registry_names[count.index])}"
+  })
+
+  docker_config {
+    immutable_tags = var.immutable_artifact_registry
+  }
+}
+
+resource "google_artifact_registry_repository_iam_member" "member_service_account_1" {
+  count      = var.artifact_registry_count
+  project    = var.gcp_project
+  location   = local.location
+  repository = google_artifact_registry_repository.artifact_registry[count.index].name
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:sa-dev-kyma-project@sap-kyma-prow.iam.gserviceaccount.com"
+}
+
+resource "google_artifact_registry_repository_iam_member" "member_service_account_2" {
+  count      = var.artifact_registry_count
+  project    = var.gcp_project
+  location   = local.location
+  repository = google_artifact_registry_repository.artifact_registry[count.index].name
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:sa-gcr-push-kyma-project@sap-kyma-prow.iam.gserviceaccount.com"
+}

--- a/configs/terraform/environments/prod/output.tf
+++ b/configs/terraform/environments/prod/output.tf
@@ -31,3 +31,8 @@ output "trusted_workload_terraform_executor_k8s_service_account" {
 output "untrusted_workload_terraform_executor_k8s_service_account" {
   value = kubernetes_service_account.untrusted_workload_terraform_executor
 }
+
+output "artifact_registry_list" {
+  description = "Artifact Registry name"
+  value       = google_artifact_registry_repository.artifact_registry[*].name
+}

--- a/configs/terraform/environments/prod/terraform.tfvars
+++ b/configs/terraform/environments/prod/terraform.tfvars
@@ -1,0 +1,6 @@
+module                         = "cap-operator"
+artifact_registry_prefix       = "modules"
+type                           = "development"
+credential_file                = null
+immutable_artifact_registry    = false
+artifact_registry_multi_region = true

--- a/docs/how-to/how-to-create-standard-terraform-config.md
+++ b/docs/how-to/how-to-create-standard-terraform-config.md
@@ -22,7 +22,7 @@ The Terraform config should be stored in the `terraform` directory in the locati
 
 Example structure of the Terraform config is the following:
 
-```bash
+
 ├── environments
 │   ├── dev
 │   │   ├── backend.tf


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Set up private image registry (registres) that can be used to publish modules that should be accessible by internal SAP teams.
- Terraform based solution which creates registry: modules (OCIM, INTERNAL)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.tools.sap/kyma/backlog/issues/4079
