### PR TITLE
Prevent accidential deleteion of sa used by terraform

### DIFF
--- a/configs/terraform/environments/prod/terraform-executor.tf
+++ b/configs/terraform/environments/prod/terraform-executor.tf
@@ -24,6 +24,9 @@ resource "google_project_iam_member" "terraform_executor_prow_project_owner" {
   project = var.terraform_executor_gcp_service_account.project_id
   role    = "roles/owner"
   member  = "serviceAccount:${google_service_account.terraform_executor.email}"
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "google_service_account_iam_binding" "terraform_workload_identity" {
@@ -37,6 +40,9 @@ resource "google_project_iam_member" "terraform_executor_workloads_project_owner
   project = var.workloads_project_id
   role    = "roles/owner"
   member  = "serviceAccount:${google_service_account.terraform_executor.email}"
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "kubernetes_service_account" "trusted_workload_terraform_executor" {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Currently when removing service account from config we can encounter race condition when old service account is deleted but new is not created yet (see: https://github.com/kyma-project/test-infra/pull/8019). Adding explicit "prevent_destroy" lifecycle to service accounts will cause plan fail in that case

Changes proposed in this pull request:

- Prevent destroy of terraform service accounts

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
