### PR TITLE
pre-main-kyma-integration-k3d-runtime-agent not watching installation directory

### DIFF
--- a/prow/jobs/kyma/components/compass-runtime-agent/compass-runtime-agent-tests.yaml
+++ b/prow/jobs/kyma/components/compass-runtime-agent/compass-runtime-agent-tests.yaml
@@ -15,13 +15,12 @@ presubmits: # runs on PRs
         preset-kyma-integration-compass-dev: "true"
         preset-dind-enabled: "true"
         preset-kind-volume-mounts: "true"
-      run_if_changed: '^((resources/compass-runtime-agent\S+|installation\S+|tests/components/application-connector\S+|resources/istio\S+|resources/istio-resources\S+)(\.[^.][^.][^.]+$|\.[^.][^dD]$|\.[^mM][^.]$|\.[^.]$|/[^.]+$))'
+      run_if_changed: '^((resources/compass-runtime-agent\S+|tests/components/application-connector\S+|resources/istio\S+|resources/istio-resources\S+)(\.[^.][^.][^.]+$|\.[^.][^dD]$|\.[^mM][^.]$|\.[^.]$|/[^.]+$))'
       skip_report: false
       decorate: true
       path_alias: github.com/kyma-project/kyma
       cluster: untrusted-workload
       max_concurrency: 10
-      optional: true
       branches:
         - ^master$
         - ^main$

--- a/prow/jobs/kyma/components/compass-runtime-agent/compass-runtime-agent-tests.yaml
+++ b/prow/jobs/kyma/components/compass-runtime-agent/compass-runtime-agent-tests.yaml
@@ -21,6 +21,7 @@ presubmits: # runs on PRs
       path_alias: github.com/kyma-project/kyma
       cluster: untrusted-workload
       max_concurrency: 10
+      optional: true
       branches:
         - ^master$
         - ^main$


### PR DESCRIPTION
**Description**

https://status.build.kyma-project.io/job-history/gs/kyma-prow-logs/pr-logs/directory/pre-main-kyma-integration-k3d-runtime-agent is failing constantly right now.

Changes proposed in this pull request:

- pre-main-kyma-integration-k3d-runtime-agent not watching installation directory
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
