### PR TITLE
Adjust cleanup and add TERM to trap

### DIFF
--- a/images/e2e-dind-k3d/init.sh
+++ b/images/e2e-dind-k3d/init.sh
@@ -6,13 +6,15 @@ LOG_DIR=${ARTIFACTS:-"/var/log"}
 DOCKERD_PROCESS=""
 function cleanup() {
   set +e
-  echo "[ * * * ] Cleaning up..."
-  k3d cluster delete --all
-  k3d registry delete --all
-  kill -SIGTSTP "$DOCKERD_PROCESS"
+  if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
+    echo "[ * * * ] Cleaning up Docker resources..."
+    docker stop "$(docker ps -aq)"
+    docker system prune --all -f --volumes
+    kill -SIGTSTP "$DOCKERD_PROCESS"
+  fi
   set -e
 }
-trap cleanup INT ERR EXIT
+trap cleanup INT ERR EXIT TERM
 
 if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
   echo "[ * * * ] Starting Docker in Docker"

--- a/images/e2e-dind-nodejs/init.sh
+++ b/images/e2e-dind-nodejs/init.sh
@@ -6,13 +6,15 @@ LOG_DIR=${ARTIFACTS:-"/var/log"}
 DOCKERD_PROCESS=""
 function cleanup() {
   set +e
-  echo "[ * * * ] Cleaning up..."
-  k3d cluster delete --all
-  k3d registry delete --all
-  kill -SIGTSTP "$DOCKERD_PROCESS"
+  if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
+    echo "[ * * * ] Cleaning up Docker resources..."
+    docker stop "$(docker ps -aq)"
+    docker system prune --all -f --volumes
+    kill -SIGTSTP "$DOCKERD_PROCESS"
+  fi
   set -e
 }
-trap cleanup INT ERR EXIT
+trap cleanup INT ERR EXIT TERM
 
 if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
   echo "[ * * * ] Starting Docker in Docker"


### PR DESCRIPTION
/area ci
/kind bug

For some reason trap does not get executed. Probably TERM also needs to be handled, so I've added it.
Additionally cleanup cleans up only Docker configuration, because k3d runs on this Docker, everything cluster-related will be removed as well.