### PR TITLE
change exec to bash -c

### DIFF
--- a/images/e2e-dind-k3d/init.sh
+++ b/images/e2e-dind-k3d/init.sh
@@ -40,4 +40,4 @@ if [[ "$K3D_ENABLED" == "true" ]]; then
   fi
   k3d cluster create k3d "${ARGS[@]}"
 fi
-exec "$@"
+bash -c "$@"

--- a/images/e2e-dind-nodejs/init.sh
+++ b/images/e2e-dind-nodejs/init.sh
@@ -40,4 +40,4 @@ if [[ "$K3D_ENABLED" == "true" ]]; then
   fi
   k3d cluster create k3d "${ARGS[@]}"
 fi
-exec "$@"
+bash -c "$@"


### PR DESCRIPTION
/kind bug
/area ci

`exec` replaces current process - that means this script replaces /init.sh so there are no process that handles child processes termination. And that's why trap is not working.

/cc @halamix2 
