### PR TITLE
Remove high-cpu references

### DIFF
--- a/prow/jobs/api-gateway/api-gateway-integration-tests.yaml
+++ b/prow/jobs/api-gateway/api-gateway-integration-tests.yaml
@@ -54,13 +54,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/api-gateway:
@@ -117,13 +110,6 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-api-gateway-custom-domain-integration-gcp
       annotations:
         description: "runs api-gateway integration tests with custom domain handling on Gardener GCP cluster"
@@ -172,13 +158,6 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-api-gateway-custom-domain-integration-aws
       annotations:
         description: "runs api-gateway integration tests with custom domain handling on Gardener AWS cluster"
@@ -227,11 +206,4 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/btp-manager/btp-manager-build.yaml
+++ b/prow/jobs/btp-manager/btp-manager-build.yaml
@@ -94,13 +94,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/btp-manager:
@@ -197,11 +190,4 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/busola/busola-backend/backend-deployment-check.yaml
+++ b/prow/jobs/busola/busola-backend/backend-deployment-check.yaml
@@ -45,11 +45,4 @@ presubmits: # runs on PRs
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/busola/busola-backend/busola-backend.yaml
+++ b/prow/jobs/busola/busola-backend/busola-backend.yaml
@@ -53,13 +53,6 @@ presubmits: # runs on PRs
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config
@@ -124,13 +117,6 @@ postsubmits: # runs on main
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config

--- a/prow/jobs/busola/busola-web/busola-web.yaml
+++ b/prow/jobs/busola/busola-web/busola-web.yaml
@@ -48,13 +48,6 @@ presubmits: # runs on PRs
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: config
             configMap:
@@ -113,13 +106,6 @@ postsubmits: # runs on main
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: config
             configMap:

--- a/prow/jobs/busola/busola-web/web-deployment-check.yaml
+++ b/prow/jobs/busola/busola-web/web-deployment-check.yaml
@@ -45,11 +45,4 @@ presubmits: # runs on PRs
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/busola/busola.yaml
+++ b/prow/jobs/busola/busola.yaml
@@ -48,13 +48,6 @@ presubmits: # runs on PRs
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: config
             configMap:
@@ -113,13 +106,6 @@ postsubmits: # runs on main
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: config
             configMap:

--- a/prow/jobs/busola/lighthouse.yaml
+++ b/prow/jobs/busola/lighthouse.yaml
@@ -50,13 +50,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/busola:
@@ -108,11 +101,4 @@ postsubmits: # runs on main
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/cli/cli.yaml
+++ b/prow/jobs/cli/cli.yaml
@@ -36,13 +36,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pull-cli-lint
       annotations:
         description: "Go lint"
@@ -141,13 +134,6 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: rel-kyma-cli
       annotations:
         description: "Go lint + Go test pre-rel + Build CLI pre-rel"
@@ -184,13 +170,6 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: unstable-cli
       annotations:
         description: "Bump reconciler version used by CLI and publish the unstable CLI binaries"
@@ -246,11 +225,4 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/control-plane/components/kubeconfig-service/kubeconfig-service-generic.yaml
+++ b/prow/jobs/control-plane/components/kubeconfig-service/kubeconfig-service-generic.yaml
@@ -46,13 +46,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-rel216-control-plane-components-kubeconfig-service
       annotations:
         description: "Builds and validates kubeconfig-service before merge"
@@ -95,13 +88,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-rel215-control-plane-components-kubeconfig-service
       annotations:
         description: "Builds and validates kubeconfig-service before merge"
@@ -144,13 +130,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-rel214-control-plane-components-kubeconfig-service
       annotations:
         description: "Builds and validates kubeconfig-service before merge"
@@ -193,11 +172,4 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/control-plane/components/kyma-environment-broker/kyma-environment-broker-generic.yaml
+++ b/prow/jobs/control-plane/components/kyma-environment-broker/kyma-environment-broker-generic.yaml
@@ -43,10 +43,3 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-          dedicated: "high-cpu"

--- a/prow/jobs/control-plane/components/kyma-metrics-collector/kyma-metrics-collector-generic.yaml
+++ b/prow/jobs/control-plane/components/kyma-metrics-collector/kyma-metrics-collector-generic.yaml
@@ -46,13 +46,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-rel216-control-plane-components-kyma-metrics-collector
       annotations:
         description: "build the kmc image"
@@ -95,13 +88,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-rel215-control-plane-components-kyma-metrics-collector
       annotations:
         description: "build the kmc image"
@@ -144,13 +130,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-rel214-control-plane-components-kyma-metrics-collector
       annotations:
         description: "build the kmc image"
@@ -193,11 +172,4 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/control-plane/components/provisioner/provisioner-generic.yaml
+++ b/prow/jobs/control-plane/components/provisioner/provisioner-generic.yaml
@@ -43,10 +43,3 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"

--- a/prow/jobs/control-plane/components/schema-migrator/schema-migrator-kcp-generic.yaml
+++ b/prow/jobs/control-plane/components/schema-migrator/schema-migrator-kcp-generic.yaml
@@ -43,10 +43,3 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"

--- a/prow/jobs/control-plane/control-plane-reconciler-integration.yaml
+++ b/prow/jobs/control-plane/control-plane-reconciler-integration.yaml
@@ -61,13 +61,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-control-plane-reconciler-e2e-latest-release
       annotations:
         description: "control-plane reconciler e2e test"
@@ -129,11 +122,4 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/control-plane/control-plane-reconciler-upgrade-kyma2-latest-to-main-gardener.yaml
+++ b/prow/jobs/control-plane/control-plane-reconciler-upgrade-kyma2-latest-to-main-gardener.yaml
@@ -62,11 +62,4 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/control-plane/control-plane-validation.yaml
+++ b/prow/jobs/control-plane/control-plane-validation.yaml
@@ -50,11 +50,4 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/control-plane/kcp-cli.yaml
+++ b/prow/jobs/control-plane/kcp-cli.yaml
@@ -45,13 +45,6 @@ presubmits: # runs on PRs
             volumeMounts:
               - name: sa-kyma-artifacts
                 mountPath: /etc/credentials/sa-kyma-artifacts
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: sa-kyma-artifacts
             secret:
@@ -102,13 +95,6 @@ postsubmits: # runs on main
             volumeMounts:
               - name: sa-kyma-artifacts
                 mountPath: /etc/credentials/sa-kyma-artifacts
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: sa-kyma-artifacts
             secret:

--- a/prow/jobs/control-plane/tests/e2e/provisioning/provisioning-test-generic.yaml
+++ b/prow/jobs/control-plane/tests/e2e/provisioning/provisioning-test-generic.yaml
@@ -43,10 +43,3 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-          dedicated: "high-cpu"

--- a/prow/jobs/control-plane/tests/provisioner-tests/provisioner-tests-generic.yaml
+++ b/prow/jobs/control-plane/tests/provisioner-tests/provisioner-tests-generic.yaml
@@ -43,10 +43,3 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"

--- a/prow/jobs/governance.yaml
+++ b/prow/jobs/governance.yaml
@@ -44,13 +44,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 10Mi
                 cpu: 100m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/community:
     - name: pre-main-community-governance
@@ -95,13 +88,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 10Mi
                 cpu: 100m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/examples:
     - name: pre-main-examples-governance
@@ -146,13 +132,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 10Mi
                 cpu: 100m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/kyma:
     - name: kyma-metadata-schema-governance
@@ -199,13 +178,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 10Mi
                 cpu: 100m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-kyma-governance
       annotations:
         description: "dead links governance job"
@@ -248,13 +220,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 10Mi
                 cpu: 100m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pull-kyma-crd-governance
       annotations:
         description: "dead links governance job"
@@ -330,13 +295,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 10Mi
                 cpu: 100m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/website:
     - name: pre-main-website-governance
@@ -381,13 +339,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 10Mi
                 cpu: 100m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/documentation-component:
   
@@ -434,13 +385,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 10Mi
                 cpu: 100m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/directory-size-exporter:
     - name: pre-main-directory-size-exporter-governance
@@ -485,13 +429,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 10Mi
                 cpu: 100m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 periodics: # runs on schedule
     - name: busola-governance-nightly
@@ -539,13 +476,6 @@ periodics: # runs on schedule
               requests:
                 memory: 10Mi
                 cpu: 100m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
     - name: community-governance-nightly
       annotations:
@@ -592,13 +522,6 @@ periodics: # runs on schedule
               requests:
                 memory: 10Mi
                 cpu: 100m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   
     - name: kyma-governance-nightly
@@ -646,13 +569,6 @@ periodics: # runs on schedule
               requests:
                 memory: 10Mi
                 cpu: 100m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
     - name: test-infra-governance-nightly
       annotations:
@@ -699,13 +615,6 @@ periodics: # runs on schedule
               requests:
                 memory: 10Mi
                 cpu: 100m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
     - name: website-governance-nightly
       annotations:
@@ -752,13 +661,6 @@ periodics: # runs on schedule
               requests:
                 memory: 10Mi
                 cpu: 100m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
     - name: documentation-component-governance-nightly
       annotations:
@@ -807,13 +709,6 @@ periodics: # runs on schedule
               requests:
                 memory: 10Mi
                 cpu: 100m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   
   

--- a/prow/jobs/incubator/compass/compass-gke-benchmark.yaml
+++ b/prow/jobs/incubator/compass/compass-gke-benchmark.yaml
@@ -66,11 +66,4 @@ presubmits: # runs on PRs
               requests:
                 memory: 200Mi
                 cpu: 80m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/incubator/compass/compass-integration-no-dump.yaml
+++ b/prow/jobs/incubator/compass/compass-integration-no-dump.yaml
@@ -50,11 +50,4 @@ presubmits: # runs on PRs
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/incubator/compass/compass-integration-with-dump.yaml
+++ b/prow/jobs/incubator/compass/compass-integration-with-dump.yaml
@@ -52,11 +52,4 @@ presubmits: # runs on PRs
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/incubator/compass/compass-smoke-test.yaml
+++ b/prow/jobs/incubator/compass/compass-smoke-test.yaml
@@ -52,11 +52,4 @@ presubmits: # runs on PRs
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/incubator/compass/components/connectivity-adapter/connectivity-adapter-generic.yaml
+++ b/prow/jobs/incubator/compass/components/connectivity-adapter/connectivity-adapter-generic.yaml
@@ -58,13 +58,6 @@ presubmits: # runs on PRs
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config
@@ -164,13 +157,6 @@ postsubmits: # runs on main
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config

--- a/prow/jobs/incubator/compass/components/connector/connector-generic.yaml
+++ b/prow/jobs/incubator/compass/components/connector/connector-generic.yaml
@@ -58,13 +58,6 @@ presubmits: # runs on PRs
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config
@@ -164,13 +157,6 @@ postsubmits: # runs on main
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config

--- a/prow/jobs/incubator/compass/components/director/director-generic.yaml
+++ b/prow/jobs/incubator/compass/components/director/director-generic.yaml
@@ -58,13 +58,6 @@ presubmits: # runs on PRs
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config
@@ -196,13 +189,6 @@ postsubmits: # runs on main
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config

--- a/prow/jobs/incubator/compass/components/external-services-mock/external-services-mock-generic.yaml
+++ b/prow/jobs/incubator/compass/components/external-services-mock/external-services-mock-generic.yaml
@@ -58,13 +58,6 @@ presubmits: # runs on PRs
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config
@@ -164,13 +157,6 @@ postsubmits: # runs on main
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config

--- a/prow/jobs/incubator/compass/components/gateway/gateway-generic.yaml
+++ b/prow/jobs/incubator/compass/components/gateway/gateway-generic.yaml
@@ -58,13 +58,6 @@ presubmits: # runs on PRs
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config
@@ -164,13 +157,6 @@ postsubmits: # runs on main
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config

--- a/prow/jobs/incubator/compass/components/hydrator/hydrator-generic.yaml
+++ b/prow/jobs/incubator/compass/components/hydrator/hydrator-generic.yaml
@@ -58,13 +58,6 @@ presubmits: # runs on PRs
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config
@@ -164,13 +157,6 @@ postsubmits: # runs on main
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config

--- a/prow/jobs/incubator/compass/components/ias-adapter/ias-adapter-generic.yaml
+++ b/prow/jobs/incubator/compass/components/ias-adapter/ias-adapter-generic.yaml
@@ -58,13 +58,6 @@ presubmits: # runs on PRs
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config
@@ -164,13 +157,6 @@ postsubmits: # runs on main
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config

--- a/prow/jobs/incubator/compass/components/kyma-adapter/kyma-adapter-generic.yaml
+++ b/prow/jobs/incubator/compass/components/kyma-adapter/kyma-adapter-generic.yaml
@@ -58,13 +58,6 @@ presubmits: # runs on PRs
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config
@@ -196,13 +189,6 @@ postsubmits: # runs on main
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config

--- a/prow/jobs/incubator/compass/components/operations-controller/operations-controller-generic.yaml
+++ b/prow/jobs/incubator/compass/components/operations-controller/operations-controller-generic.yaml
@@ -58,13 +58,6 @@ presubmits: # runs on PRs
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config
@@ -164,13 +157,6 @@ postsubmits: # runs on main
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config

--- a/prow/jobs/incubator/compass/components/pairing-adapter/pairing-adapter-generic.yaml
+++ b/prow/jobs/incubator/compass/components/pairing-adapter/pairing-adapter-generic.yaml
@@ -58,13 +58,6 @@ presubmits: # runs on PRs
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config
@@ -164,13 +157,6 @@ postsubmits: # runs on main
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config

--- a/prow/jobs/incubator/compass/components/schema-migrator/compass-director-gqlgen-validate.yaml
+++ b/prow/jobs/incubator/compass/components/schema-migrator/compass-director-gqlgen-validate.yaml
@@ -55,11 +55,4 @@ presubmits: # runs on PRs
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/incubator/compass/components/schema-migrator/compass-schema-migrator-validate.yaml
+++ b/prow/jobs/incubator/compass/components/schema-migrator/compass-schema-migrator-validate.yaml
@@ -55,11 +55,4 @@ presubmits: # runs on PRs
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/incubator/compass/components/schema-migrator/schema-migrator-generic.yaml
+++ b/prow/jobs/incubator/compass/components/schema-migrator/schema-migrator-generic.yaml
@@ -57,13 +57,6 @@ presubmits: # runs on PRs
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config
@@ -130,13 +123,6 @@ postsubmits: # runs on main
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config

--- a/prow/jobs/incubator/compass/components/system-broker/system-broker-generic.yaml
+++ b/prow/jobs/incubator/compass/components/system-broker/system-broker-generic.yaml
@@ -58,13 +58,6 @@ presubmits: # runs on PRs
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config
@@ -164,13 +157,6 @@ postsubmits: # runs on main
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config

--- a/prow/jobs/incubator/compass/post-main-compass-vm-clean-no-dump.yaml
+++ b/prow/jobs/incubator/compass/post-main-compass-vm-clean-no-dump.yaml
@@ -53,11 +53,4 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/incubator/compass/post-main-compass-vm-clean-with-dump.yaml
+++ b/prow/jobs/incubator/compass/post-main-compass-vm-clean-with-dump.yaml
@@ -53,11 +53,4 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/incubator/compass/tests/compass-e2e-tests/compass-e2e-tests.yaml
+++ b/prow/jobs/incubator/compass/tests/compass-e2e-tests/compass-e2e-tests.yaml
@@ -58,13 +58,6 @@ presubmits: # runs on PRs
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config
@@ -132,13 +125,6 @@ postsubmits: # runs on main
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config

--- a/prow/jobs/incubator/hydroform/hydroform.yaml
+++ b/prow/jobs/incubator/hydroform/hydroform.yaml
@@ -36,13 +36,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/hydroform:
@@ -79,11 +72,4 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/incubator/milv/milv.yaml
+++ b/prow/jobs/incubator/milv/milv.yaml
@@ -47,13 +47,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-incubator/milv:
@@ -101,11 +94,4 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/incubator/ord-service/components/ord-service/ord-service-generic.yaml
+++ b/prow/jobs/incubator/ord-service/components/ord-service/ord-service-generic.yaml
@@ -57,13 +57,6 @@ presubmits: # runs on PRs
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config
@@ -162,13 +155,6 @@ postsubmits: # runs on main
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config

--- a/prow/jobs/incubator/reconciler/reconciler.yaml
+++ b/prow/jobs/incubator/reconciler/reconciler.yaml
@@ -108,13 +108,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-reconciler-publish-pr-cli
       annotations:
         description: "pre publish reconciler"
@@ -159,13 +152,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-reconciler-cli-integration-kyma-latest-k3d
       annotations:
         description: "int test reconciler"
@@ -217,13 +203,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-reconciler-cli-integration-kyma-main-k3d
       annotations:
         description: "int test reconciler"
@@ -275,13 +254,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-reconciler-cli-kyma-prev-to-last-release-upgrade-k3d
       annotations:
         description: "upgrade test reconciler"
@@ -335,13 +307,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-latest-istio-reconciler-integration-k3d
       annotations:
         description: "runs istio reconciler integration tests on k3d"
@@ -394,13 +359,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-istio-reconciler-integration-k3d
       annotations:
         description: "runs istio reconciler integration tests on k3d"
@@ -455,13 +413,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-ory-reconciler-eval-integration-k3d
       annotations:
         description: "runs ory reconciler integration tests with evaluation profile on k3d"
@@ -516,13 +467,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-ory-reconciler-prod-integration-gcp
       annotations:
         description: "runs ory reconciler integration tests with production profile on Gardener GCP cluster"
@@ -584,13 +528,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-dev-reconciler-integration-k3d
       annotations:
         description: "int test reconciler"
@@ -636,13 +573,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-dev-kyma-incubator-reconciler
       annotations:
         description: "build reconciler"
@@ -687,13 +617,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-kyma-incubator-mothership-reconciler
       annotations:
         description: "build mothership reconciler"
@@ -836,13 +759,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-reconciler-validate-go-mod
       annotations:
         description: "validate gomod reconciler"
@@ -883,13 +799,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-incubator/reconciler:
@@ -945,13 +854,6 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-main-istio-reconciler-integration-k3d
       annotations:
         description: "runs istio reconciler integration tests on k3d"
@@ -1006,13 +908,6 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-main-kyma-incubator-mothership-reconciler
       annotations:
         description: "build reconciler"
@@ -1161,13 +1056,6 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 periodics: # runs on schedule
     - name: reconciler-control-plane-image-bump
@@ -1221,13 +1109,6 @@ periodics: # runs on schedule
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: nightly-main-reconciler
       annotations:
         description: "Creates and installs reconciler from main every night."
@@ -1291,13 +1172,6 @@ periodics: # runs on schedule
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: nightly-main-reconciler-e2e
       annotations:
         description: "Executes e2e test periodically on nightly cluster for reconciler."
@@ -1364,11 +1238,4 @@ periodics: # runs on schedule
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/istio/istio-manager.yaml
+++ b/prow/jobs/istio/istio-manager.yaml
@@ -48,13 +48,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pull-istio-operator-build
       annotations:
         description: "build istio operator image"
@@ -166,13 +159,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/istio:
@@ -222,13 +208,6 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: rel-istio-build
       annotations:
         description: "builds istio operator image on release"
@@ -331,13 +310,6 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-istio-operator-build
       annotations:
         description: "build istio operator image"
@@ -461,11 +433,4 @@ periodics: # runs on schedule
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/kyma-dashboard/kyma-dashboard-dev.yaml
+++ b/prow/jobs/kyma-dashboard/kyma-dashboard-dev.yaml
@@ -47,13 +47,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/kyma-dashboard:
@@ -102,11 +95,4 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/kyma-dashboard/kyma-dashboard-prod.yaml
+++ b/prow/jobs/kyma-dashboard/kyma-dashboard-prod.yaml
@@ -47,13 +47,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/kyma-dashboard:
@@ -102,11 +95,4 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/kyma-dashboard/kyma-dashboard-stage.yaml
+++ b/prow/jobs/kyma-dashboard/kyma-dashboard-stage.yaml
@@ -47,13 +47,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/kyma-dashboard:
@@ -102,11 +95,4 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/kyma-project/telemetry-manager/telemetry-manager-e2e-test.yaml
+++ b/prow/jobs/kyma-project/telemetry-manager/telemetry-manager-e2e-test.yaml
@@ -30,10 +30,3 @@ presubmits:
               seccompProfile:
                 type: Unconfined
               allowPrivilegeEscalation: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-          dedicated: "high-cpu"

--- a/prow/jobs/kyma-project/telemetry-manager/telemetry-manager-verify-module.yaml
+++ b/prow/jobs/kyma-project/telemetry-manager/telemetry-manager-verify-module.yaml
@@ -30,10 +30,3 @@ presubmits:
               seccompProfile:
                 type: Unconfined
               allowPrivilegeEscalation: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-          dedicated: "high-cpu"

--- a/prow/jobs/kyma-project/warden/integration-test.yaml
+++ b/prow/jobs/kyma-project/warden/integration-test.yaml
@@ -40,10 +40,3 @@ presubmits:
               seccompProfile:
                 type: Unconfined
               allowPrivilegeEscalation: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-          dedicated: "high-cpu"

--- a/prow/jobs/kyma-project/warden/warden.yaml
+++ b/prow/jobs/kyma-project/warden/warden.yaml
@@ -133,13 +133,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pull-warden-unit-test
       annotations:
         description: "Warden unit test job"

--- a/prow/jobs/kyma/common/common.yaml
+++ b/prow/jobs/kyma/common/common.yaml
@@ -38,13 +38,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/kyma:
@@ -84,11 +77,4 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/kyma/keb-endpoints-test.yaml
+++ b/prow/jobs/kyma/keb-endpoints-test.yaml
@@ -46,11 +46,4 @@ periodics: # runs on schedule
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/kyma/kyma-artifacts.yaml
+++ b/prow/jobs/kyma/kyma-artifacts.yaml
@@ -46,13 +46,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 1Gi
                 cpu: 0.2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-rel216-kyma-artifacts
       annotations:
         description: "Build Kyma release artifacts"
@@ -95,13 +88,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 1Gi
                 cpu: 0.2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-rel215-kyma-artifacts
       annotations:
         description: "Build Kyma release artifacts"
@@ -144,13 +130,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 1Gi
                 cpu: 0.2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-rel214-kyma-artifacts
       annotations:
         description: "Build Kyma release artifacts"
@@ -193,13 +172,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 1Gi
                 cpu: 0.2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-rel217-kyma-artifacts
       annotations:
         description: "Build Kyma release artifacts"
@@ -242,13 +214,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 1Gi
                 cpu: 0.2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/kyma:
@@ -296,13 +261,6 @@ postsubmits: # runs on main
               requests:
                 memory: 1Gi
                 cpu: 0.2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-rel216-kyma-artifacts
       annotations:
         description: "Build Kyma release artifacts"
@@ -346,13 +304,6 @@ postsubmits: # runs on main
               requests:
                 memory: 1Gi
                 cpu: 0.2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-rel215-kyma-artifacts
       annotations:
         description: "Build Kyma release artifacts"
@@ -396,13 +347,6 @@ postsubmits: # runs on main
               requests:
                 memory: 1Gi
                 cpu: 0.2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-rel214-kyma-artifacts
       annotations:
         description: "Build Kyma release artifacts"
@@ -446,13 +390,6 @@ postsubmits: # runs on main
               requests:
                 memory: 1Gi
                 cpu: 0.2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-rel217-kyma-artifacts
       annotations:
         description: "Build Kyma release artifacts"
@@ -496,11 +433,4 @@ postsubmits: # runs on main
               requests:
                 memory: 1Gi
                 cpu: 0.2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/kyma/kyma-gardener-cleanup.yaml
+++ b/prow/jobs/kyma/kyma-gardener-cleanup.yaml
@@ -45,11 +45,4 @@ periodics: # runs on schedule
               requests:
                 memory: 1Gi
                 cpu: 400m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/kyma/kyma-integration-gardener-eventing.yaml
+++ b/prow/jobs/kyma/kyma-integration-gardener-eventing.yaml
@@ -76,13 +76,6 @@ presubmits: # runs on PRs
               - name: kyma-tunas-prow-event-mesh
                 mountPath: /etc/credentials/kyma-tunas-prow-event-mesh
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: kyma-tunas-prow-event-mesh
             secret:
@@ -151,13 +144,6 @@ presubmits: # runs on PRs
               - name: kyma-tunas-prow-event-mesh
                 mountPath: /etc/credentials/kyma-tunas-prow-event-mesh
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: kyma-tunas-prow-event-mesh
             secret:

--- a/prow/jobs/kyma/kyma-integration-gardener.yaml
+++ b/prow/jobs/kyma/kyma-integration-gardener.yaml
@@ -80,13 +80,6 @@ periodics: # runs on schedule
               requests:
                 memory: 1Gi
                 cpu: 400m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: kyma-integration-production-gardener-azure
       annotations:
         description: "Production profile for Kyma Azure Gardener integration job."
@@ -165,13 +158,6 @@ periodics: # runs on schedule
               requests:
                 memory: 1Gi
                 cpu: 400m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: kyma-weekly-gardener-gcp-busola-kyma
       annotations:
         description: "set up nkyma cluster"
@@ -234,13 +220,6 @@ periodics: # runs on schedule
               requests:
                 memory: 1Gi
                 cpu: 400m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: kyma-upgrade-gardener-kyma2-to-main-reconciler-main
       annotations:
         description: "Azure Kyma 2.0 to main branch."
@@ -312,13 +291,6 @@ periodics: # runs on schedule
               requests:
                 memory: 1Gi
                 cpu: 400m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: kyma-upgrade-gardener-kyma2-minor-versions
       annotations:
         description: "Azure Kyma 2 previous minor versions."
@@ -389,11 +361,4 @@ periodics: # runs on schedule
               requests:
                 memory: 1Gi
                 cpu: 400m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/kyma/kyma-integration.yaml
+++ b/prow/jobs/kyma/kyma-integration.yaml
@@ -54,13 +54,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-kyma-integration-k3d-app-gateway
       annotations:
         description: "It tests the acceptance criteria of the (Central) Application Gateway component"
@@ -114,13 +107,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-kyma-integration-k3d-app-conn-validator
       annotations:
         description: "It tests the acceptance criteria of the (Central) Application Connectivity Validator component"
@@ -174,13 +160,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-kyma-integration-k3d-central-app-connectivity-compass
       annotations:
         description: "It tests Compass integration. It won't be needed after the implementation of this issue - https://github.com/kyma-project/kyma/issues/15037"
@@ -234,13 +213,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-serverless-integration-k3s
       annotations:
         description: "serverless integration k3s job"
@@ -290,13 +262,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-serverless-git-auth-integration-k3s
       annotations:
         description: "Serverless git-function authentication nightly integration tests"
@@ -348,13 +313,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-kyma-integration-k3d-telemetry
       annotations:
         description: "runs telemetry integration tests on k3d"
@@ -402,13 +360,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-kyma-eval-istio-integration-k3d
       annotations:
         description: "runs istio integration tests with evaluation profile on k3d"
@@ -456,13 +407,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-kyma-prod-istio-integration-k3d
       annotations:
         description: "runs istio integration tests with production profile on k3d"
@@ -510,13 +454,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-kyma-istio-reconcilation-k3d
       annotations:
         description: "runs istio reconcilation tests with production profile on k3d"
@@ -568,13 +505,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/kyma:
@@ -633,13 +563,6 @@ postsubmits: # runs on main
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-main-kyma-integration-k3d-app-gateway
       annotations:
         description: "Kyma integration job on k3d for testing application gateway."
@@ -693,13 +616,6 @@ postsubmits: # runs on main
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-main-kyma-integration-k3d-app-conn-validator
       annotations:
         description: "Kyma integration job on k3d for testing application connectivity validator."
@@ -753,13 +669,6 @@ postsubmits: # runs on main
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 periodics: # runs on schedule
     - name: utilities-kyma-integration-cleaner
@@ -795,13 +704,6 @@ periodics: # runs on schedule
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: orphaned-assetstore-gcp-bucket-cleaner
       annotations:
         description: "Periodic cleanup of orphaned Google cloud assetstore buckets"
@@ -841,13 +743,6 @@ periodics: # runs on schedule
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: orphaned-disks-cleaner
       annotations:
         description: "Periodic cleanup of orphaned Google cloud disks"
@@ -888,13 +783,6 @@ periodics: # runs on schedule
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: orphaned-ips-cleaner
       annotations:
         description: "Periodic cleanup of orphaned Google cloud IPs"
@@ -935,13 +823,6 @@ periodics: # runs on schedule
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: orphaned-clusters-cleaner
       annotations:
         description: "Periodic cleanup of orphaned Google cloud clusters"
@@ -982,13 +863,6 @@ periodics: # runs on schedule
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: orphaned-vms-cleaner
       annotations:
         description: "Periodic cleanup of orphaned Google cloud VMs"
@@ -1029,13 +903,6 @@ periodics: # runs on schedule
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: orphaned-loadbalancer-cleaner
       annotations:
         description: "Periodic cleanup of orphaned Google cloud load balancers"
@@ -1076,13 +943,6 @@ periodics: # runs on schedule
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: orphaned-dns-cleaner
       annotations:
         description: "Periodic cleanup of orphaned Google cloud DNS records"
@@ -1124,13 +984,6 @@ periodics: # runs on schedule
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: gcr-cleaner-prow-workloads
       annotations:
         description: "Cleans up GCR images older than 7 days in eu.gcr.io/sap-kyma-prow-workloads"
@@ -1170,13 +1023,6 @@ periodics: # runs on schedule
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: github-issues
       annotations:
         description: "Exports data from github to the big query (Grafana metrics)"
@@ -1215,13 +1061,6 @@ periodics: # runs on schedule
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: serverless-function-metrics-generator
       annotations:
         description: "Serverless function metrics generator"
@@ -1273,13 +1112,6 @@ periodics: # runs on schedule
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: kyma-upgrade-k3d-kyma2-to-main
       annotations:
         description: "K3d Kyma 2.0 to main branch."
@@ -1339,13 +1171,6 @@ periodics: # runs on schedule
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: kyma-integration-k3d
       annotations:
         description: "Kyma integration periodic job on k3d"
@@ -1398,13 +1223,6 @@ periodics: # runs on schedule
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: kyma-integration-k3d-telemetry
       annotations:
         description: "runs telemetry integration tests on k3d"
@@ -1456,13 +1274,6 @@ periodics: # runs on schedule
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: kyma-gke-nightly
       annotations:
         description: "Kyma GKE nightly build (depraceted, needed for sec scans)"
@@ -1545,13 +1356,6 @@ periodics: # runs on schedule
               - name: sa-stability-fluentd-storage-writer
                 mountPath: /etc/credentials/sa-stability-fluentd-storage-writer
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: sa-stability-fluentd-storage-writer
             secret:

--- a/prow/jobs/kyma/kyma-release-pr-image-guard.yaml
+++ b/prow/jobs/kyma/kyma-release-pr-image-guard.yaml
@@ -41,11 +41,4 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/kyma/kyma-validation.yaml
+++ b/prow/jobs/kyma/kyma-validation.yaml
@@ -43,13 +43,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 1.5Gi
                 cpu: 0.8
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-kyma-validate-image-existence
       annotations:
         description: "his tool validates if all images defined in charts exist"
@@ -90,13 +83,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 1.5Gi
                 cpu: 0.8
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-kyma-validate-dockerfiles
       annotations:
         description: "Validate Dockerfiles, run hadolint."
@@ -131,11 +117,4 @@ presubmits: # runs on PRs
               requests:
                 memory: 1.5Gi
                 cpu: 0.8
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/kyma/releases/kyma-release-214.yaml
+++ b/prow/jobs/kyma/releases/kyma-release-214.yaml
@@ -46,13 +46,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/kyma:
@@ -104,13 +97,6 @@ postsubmits: # runs on main
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-rel214-kyma-release-candidate
       annotations:
         owner: neighbors
@@ -183,13 +169,6 @@ postsubmits: # runs on main
               - name: kyma-tunas-release-testing-event-mesh
                 mountPath: /etc/credentials/kyma-tunas-release-testing-event-mesh
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: kyma-tunas-release-testing-event-mesh
             secret:
@@ -282,13 +261,6 @@ periodics: # runs on schedule
               - name: sa-stability-fluentd-storage-writer
                 mountPath: /etc/credentials/sa-stability-fluentd-storage-writer
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: sa-stability-fluentd-storage-writer
             secret:

--- a/prow/jobs/kyma/releases/kyma-release-215.yaml
+++ b/prow/jobs/kyma/releases/kyma-release-215.yaml
@@ -46,13 +46,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/kyma:
@@ -104,13 +97,6 @@ postsubmits: # runs on main
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-rel215-kyma-release-candidate
       annotations:
         owner: neighbors
@@ -183,13 +169,6 @@ postsubmits: # runs on main
               - name: kyma-tunas-release-testing-event-mesh
                 mountPath: /etc/credentials/kyma-tunas-release-testing-event-mesh
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: kyma-tunas-release-testing-event-mesh
             secret:
@@ -282,13 +261,6 @@ periodics: # runs on schedule
               - name: sa-stability-fluentd-storage-writer
                 mountPath: /etc/credentials/sa-stability-fluentd-storage-writer
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: sa-stability-fluentd-storage-writer
             secret:

--- a/prow/jobs/kyma/releases/kyma-release-216.yaml
+++ b/prow/jobs/kyma/releases/kyma-release-216.yaml
@@ -46,13 +46,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/kyma:
@@ -104,13 +97,6 @@ postsubmits: # runs on main
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-rel216-kyma-release-candidate
       annotations:
         description: "Release candidate job for Kyma 2.16."
@@ -183,13 +169,6 @@ postsubmits: # runs on main
               - name: kyma-tunas-release-testing-event-mesh
                 mountPath: /etc/credentials/kyma-tunas-release-testing-event-mesh
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: kyma-tunas-release-testing-event-mesh
             secret:
@@ -282,13 +261,6 @@ periodics: # runs on schedule
               - name: sa-stability-fluentd-storage-writer
                 mountPath: /etc/credentials/sa-stability-fluentd-storage-writer
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: sa-stability-fluentd-storage-writer
             secret:

--- a/prow/jobs/kyma/releases/kyma-release-217.yaml
+++ b/prow/jobs/kyma/releases/kyma-release-217.yaml
@@ -46,13 +46,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/kyma:
@@ -104,13 +97,6 @@ postsubmits: # runs on main
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-rel217-kyma-release-candidate
       annotations:
         description: "Release candidate job for Kyma 2.17."
@@ -183,13 +169,6 @@ postsubmits: # runs on main
               - name: kyma-tunas-release-testing-event-mesh
                 mountPath: /etc/credentials/kyma-tunas-release-testing-event-mesh
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: kyma-tunas-release-testing-event-mesh
             secret:
@@ -282,13 +261,6 @@ periodics: # runs on schedule
               - name: sa-stability-fluentd-storage-writer
                 mountPath: /etc/credentials/sa-stability-fluentd-storage-writer
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: sa-stability-fluentd-storage-writer
             secret:

--- a/prow/jobs/kyma/skr-aws-upgrade-integration-dev.yaml
+++ b/prow/jobs/kyma/skr-aws-upgrade-integration-dev.yaml
@@ -63,11 +63,4 @@ periodics: # runs on schedule
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/kyma/skr-integration.yaml
+++ b/prow/jobs/kyma/skr-integration.yaml
@@ -57,13 +57,6 @@ periodics: # runs on schedule
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: skr-azure-lite-integration-dev
       annotations:
         description: "skr integration test azure"
@@ -120,13 +113,6 @@ periodics: # runs on schedule
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: skr-aws-integration-dev
       annotations:
         description: "skr integration test aws"
@@ -183,13 +169,6 @@ periodics: # runs on schedule
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: skr-trial-integration-dev
       annotations:
         description: "skr integration test trial"
@@ -246,13 +225,6 @@ periodics: # runs on schedule
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: skr-free-aws-integration-dev
       annotations:
         description: "skr integration test free"
@@ -311,13 +283,6 @@ periodics: # runs on schedule
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: skr-preview-dev
       annotations:
         description: "skr integration test preview"
@@ -373,13 +338,6 @@ periodics: # runs on schedule
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: skr-aws-own-cluster-dev
       annotations:
         description: "skr integration test own cluster"
@@ -440,11 +398,4 @@ periodics: # runs on schedule
               requests:
                 memory: 100Mi
                 cpu: 50m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/kyma/tests/fast-integration/fast-integration-image-generic.yaml
+++ b/prow/jobs/kyma/tests/fast-integration/fast-integration-image-generic.yaml
@@ -46,13 +46,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-rel216-kyma-tests-fast-integration-image
       annotations:
         description: "build fast-integration image"
@@ -95,13 +88,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-rel215-kyma-tests-fast-integration-image
       annotations:
         description: "build fast-integration image"
@@ -144,13 +130,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-rel214-kyma-tests-fast-integration-image
       annotations:
         description: "build fast-integration image"
@@ -193,13 +172,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/kyma:
@@ -247,13 +219,6 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-rel216-kyma-tests-fast-integration-image
       annotations:
         description: "build fast-integration image"
@@ -297,13 +262,6 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-rel215-kyma-tests-fast-integration-image
       annotations:
         description: "build fast-integration image"
@@ -347,13 +305,6 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-rel214-kyma-tests-fast-integration-image
       annotations:
         description: "build fast-integration image"
@@ -397,11 +348,4 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/lifecycle-manager/lifecycle-manager.yaml
+++ b/prow/jobs/lifecycle-manager/lifecycle-manager.yaml
@@ -36,13 +36,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pull-lifecycle-mgr-tests
       annotations:
         description: "run lm tests"
@@ -79,13 +72,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pull-lifecycle-mgr-build
       annotations:
         description: "run lm build"

--- a/prow/jobs/modules/external/keda-manager.yaml
+++ b/prow/jobs/modules/external/keda-manager.yaml
@@ -37,13 +37,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pull-keda-module-build
       annotations:
         description: "keda module build job"
@@ -88,13 +81,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-keda-manager-operator-tests
       annotations:
         description: "keda operator tests"
@@ -131,13 +117,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-keda-manager-operator-build
       annotations:
         description: "keda operator build job"
@@ -242,13 +221,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 200Mi
                 cpu: 80m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/keda-manager:
@@ -350,13 +322,6 @@ postsubmits: # runs on main
               limits:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-keda-module-build
       annotations:
         description: "keda module build job"
@@ -399,13 +364,6 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-keda-manager-operator-build
       annotations:
         description: "keda module build job"
@@ -512,13 +470,6 @@ postsubmits: # runs on main
               requests:
                 memory: 200Mi
                 cpu: 80m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-main-keda-manager-upgrade-latest-to-main
       annotations:
         description: "upgrade keda manager test"
@@ -572,13 +523,6 @@ postsubmits: # runs on main
               requests:
                 memory: 200Mi
                 cpu: 80m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 periodics: # runs on schedule
     - name: keda-operator-nightly-periodic
@@ -656,13 +600,6 @@ periodics: # runs on schedule
               - name: sa-stability-fluentd-storage-writer
                 mountPath: /etc/credentials/sa-stability-fluentd-storage-writer
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: sa-stability-fluentd-storage-writer
             secret:

--- a/prow/jobs/modules/internal/serverless-manager.yaml
+++ b/prow/jobs/modules/internal/serverless-manager.yaml
@@ -47,13 +47,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-serverless-manager-operator-tests
       annotations:
         description: "serverless manager tests"
@@ -90,13 +83,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-serverless-manager-operator-build
       annotations:
         description: "serverless manager operator build"
@@ -146,13 +132,6 @@ presubmits: # runs on PRs
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: module-chart
           - name: share
@@ -217,13 +196,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 200Mi
                 cpu: 80m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/serverless-manager:
@@ -269,13 +241,6 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: post-serverless-manager-operator-build
       annotations:
         description: "build serverless manager"
@@ -326,13 +291,6 @@ postsubmits: # runs on main
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: module-chart
           - name: share
@@ -397,13 +355,6 @@ postsubmits: # runs on main
               requests:
                 memory: 200Mi
                 cpu: 80m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 periodics: # runs on schedule
     - name: serverless-operator-nightly-periodic
@@ -481,13 +432,6 @@ periodics: # runs on schedule
               - name: sa-stability-fluentd-storage-writer
                 mountPath: /etc/credentials/sa-stability-fluentd-storage-writer
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: sa-stability-fluentd-storage-writer
             secret:

--- a/prow/jobs/runtime-watcher/runtime-watcher.yaml
+++ b/prow/jobs/runtime-watcher/runtime-watcher.yaml
@@ -36,13 +36,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pull-tests-skr
       annotations:
         description: "test runtime watcher"
@@ -79,13 +72,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pull-lint-listener
       annotations:
         description: "lint runtime watcher listener"
@@ -119,13 +105,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pull-tests-listener
       annotations:
         description: "test runtime watcher listener"
@@ -162,13 +141,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pull-build-skr
       annotations:
         description: "build runtime watcher skr"

--- a/prow/jobs/telemetry-manager/telemetry-manager-generic.yaml
+++ b/prow/jobs/telemetry-manager/telemetry-manager-generic.yaml
@@ -150,11 +150,4 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/template-operator/template-operator.yaml
+++ b/prow/jobs/template-operator/template-operator.yaml
@@ -36,13 +36,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pull-template-op-tests
       annotations:
         description: "template operator test"
@@ -79,13 +72,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pull-build-template-operator
       annotations:
         description: "template operator build"

--- a/prow/jobs/test-infra/build-test-vm-image.yaml
+++ b/prow/jobs/test-infra/build-test-vm-image.yaml
@@ -38,13 +38,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pull-test-k3d-on-vm-image
       annotations:
         description: "Test k3d installation on Google Cloud VM template image for test-vm-image"
@@ -80,13 +73,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/test-infra:
@@ -126,11 +112,4 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/test-infra/gardener-kubeconfig-rotation.yaml
+++ b/prow/jobs/test-infra/gardener-kubeconfig-rotation.yaml
@@ -44,13 +44,6 @@ periodics: # runs on schedule
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: secrets-rotate-gardener-prow
       annotations:
         description: "Rotate kubeconfig for Gardener prow project"
@@ -93,13 +86,6 @@ periodics: # runs on schedule
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: secrets-rotate-gardener-kyma-dev
       annotations:
         description: "Rotate kubeconfig for Gardener kyma-dev project"
@@ -142,11 +128,4 @@ periodics: # runs on schedule
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/test-infra/go-validation.yaml
+++ b/prow/jobs/test-infra/go-validation.yaml
@@ -71,11 +71,4 @@ presubmits: # runs on PRs
               requests:
                 memory: 1Gi
                 cpu: 500m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/test-infra/hide-terraform-comments.yaml
+++ b/prow/jobs/test-infra/hide-terraform-comments.yaml
@@ -45,11 +45,4 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/test-infra/image-syncer.yaml
+++ b/prow/jobs/test-infra/image-syncer.yaml
@@ -38,13 +38,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-test-infra-image-syncer-dry-run
       annotations:
         description: "Dry-run of sync images from external sources to Kyma owned registry"
@@ -82,13 +75,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/test-infra:
@@ -128,11 +114,4 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/test-infra/kyma-bot.yaml
+++ b/prow/jobs/test-infra/kyma-bot.yaml
@@ -44,11 +44,4 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/test-infra/pjconfigtests.yaml
+++ b/prow/jobs/test-infra/pjconfigtests.yaml
@@ -36,13 +36,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/kyma:
     - name: pull-kyma-pjconfigtest
@@ -83,13 +76,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/busola:
     - name: pull-busola-pjconfigtest
@@ -130,13 +116,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/control-plane:
     - name: pull-control-plane-pjconfigtest
@@ -177,13 +156,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/cli:
     - name: pull-cli-pjconfigtest
@@ -224,13 +196,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/website:
     - name: pull-website-pjconfigtest
@@ -271,13 +236,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/lifecycle-manager:
     - name: pull-lifecycle-manager-pjconfigtest
@@ -318,13 +276,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/third-party-images:
     - name: pull-third-party-images-pjconfigtest
@@ -365,13 +316,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/community:
     - name: pull-community-pjconfigtest
@@ -412,13 +356,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/hydroform:
     - name: pull-hydroform-pjconfigtest
@@ -459,13 +396,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/istio-operator:
     - name: pull-istio-operator-pjconfigtest
@@ -506,13 +436,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/addons:
     - name: pull-addons-pjconfigtest
@@ -553,13 +476,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/private-fn-for-e2e-serverless-tests:
     - name: pull-private-fn-for-e2e-serverless-tests-pjconfigtest
@@ -600,13 +516,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/charts:
     - name: pull-charts-pjconfigtest
@@ -647,13 +556,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/examples:
     - name: pull-examples-pjconfigtest
@@ -694,13 +596,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/api-gateway:
     - name: pull-api-gateway-pjconfigtest
@@ -741,13 +636,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/istio:
     - name: pull-istio-pjconfigtest
@@ -788,13 +676,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/runtime-watcher:
     - name: pull-runtime-watcher-pjconfigtest
@@ -835,13 +716,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/keda-manager:
     - name: pull-keda-manager-pjconfigtest
@@ -882,13 +756,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/kyma-dashboard:
     - name: pull-kyma-dashboard-pjconfigtest
@@ -929,13 +796,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/application-connector-manager:
     - name: pull-application-connector-manager-pjconfigtest
@@ -976,13 +836,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/rafter:
     - name: pull-rafter-pjconfigtest
@@ -1023,13 +876,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/btp-manager:
     - name: pull-btp-manager-pjconfigtest
@@ -1070,13 +916,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/kyma-environment-broker:
     - name: pull-kyma-environment-broker-pjconfigtest
@@ -1117,13 +956,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/telemetry-manager:
     - name: pull-telemetry-manager-pjconfigtest
@@ -1164,13 +996,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/director-size-exporter:
     - name: pull-director-size-exporter-pjconfigtest
@@ -1211,13 +1036,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/compass-manager:
     - name: pull-compass-manager-pjconfigtest
@@ -1258,13 +1076,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/compass:
     - name: pull-compass-pjconfigtest
@@ -1305,13 +1116,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/ord-service:
     - name: pull-ord-service-pjconfigtest
@@ -1352,13 +1156,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/reconciler:
     - name: pull-reconciler-pjconfigtest
@@ -1399,13 +1196,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/bullseye-showcase:
     - name: pull-bullseye-showcase-pjconfigtest
@@ -1446,13 +1236,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/documentation-component:
     - name: pull-documentation-component-pjconfigtest
@@ -1493,13 +1276,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/compass-console:
     - name: pull-compass-console-pjconfigtest
@@ -1540,13 +1316,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/sap-btp-service-operator:
     - name: pull-sap-btp-service-operator-pjconfigtest
@@ -1587,13 +1356,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/milv:
     - name: pull-milv-pjconfigtest
@@ -1634,13 +1396,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/varkes:
     - name: pull-varkes-pjconfigtest
@@ -1681,13 +1436,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/slack-bot:
     - name: pull-slack-bot-pjconfigtest
@@ -1728,13 +1476,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/migrate:
     - name: pull-migrate-pjconfigtest
@@ -1775,13 +1516,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/github-dashboard:
     - name: pull-github-dashboard-pjconfigtest
@@ -1822,13 +1556,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/website-vuepress:
     - name: pull-website-vuepress-pjconfigtest
@@ -1869,13 +1596,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/kitbag:
     - name: pull-kitbag-pjconfigtest
@@ -1916,13 +1636,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/kyma-showcase:
     - name: pull-kyma-showcase-pjconfigtest
@@ -1963,13 +1676,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/hydra-login-consent:
     - name: pull-hydra-login-consent-pjconfigtest
@@ -2010,13 +1716,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/kymart:
     - name: pull-kymart-pjconfigtest
@@ -2057,13 +1756,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/examples:
     - name: pull-examples-pjconfigtest
@@ -2104,13 +1796,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/vstudio-extension:
     - name: pull-vstudio-extension-pjconfigtest
@@ -2151,13 +1836,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/wordpress-connector:
     - name: pull-wordpress-connector-pjconfigtest
@@ -2198,13 +1876,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/connector-tools:
     - name: pull-connector-tools-pjconfigtest
@@ -2245,13 +1916,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/artwork:
     - name: pull-artwork-pjconfigtest
@@ -2292,13 +1956,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/opensap:
     - name: pull-opensap-pjconfigtest
@@ -2339,13 +1996,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/testdrape:
     - name: pull-testdrape-pjconfigtest
@@ -2386,13 +2036,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/sc-removal:
     - name: pull-sc-removal-pjconfigtest
@@ -2433,13 +2076,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/service-catalog-tester:
     - name: pull-service-catalog-tester-pjconfigtest
@@ -2480,13 +2116,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/service-catalog:
     - name: pull-service-catalog-pjconfigtest
@@ -2527,11 +2156,4 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/test-infra/pjtester.yaml
+++ b/prow/jobs/test-infra/pjtester.yaml
@@ -45,13 +45,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -92,13 +85,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/kyma:
     - name: pull-kyma-pjtester
@@ -148,13 +134,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -195,13 +174,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/busola:
     - name: pull-busola-pjtester
@@ -251,13 +223,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -298,13 +263,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/control-plane:
     - name: pull-control-plane-pjtester
@@ -354,13 +312,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -401,13 +352,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/cli:
     - name: pull-cli-pjtester
@@ -457,13 +401,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -504,13 +441,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/website:
     - name: pull-website-pjtester
@@ -560,13 +490,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -607,13 +530,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/lifecycle-manager:
     - name: pull-lifecycle-manager-pjtester
@@ -663,13 +579,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -710,13 +619,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/third-party-images:
     - name: pull-third-party-images-pjtester
@@ -766,13 +668,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -813,13 +708,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/community:
     - name: pull-community-pjtester
@@ -869,13 +757,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -916,13 +797,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/hydroform:
     - name: pull-hydroform-pjtester
@@ -972,13 +846,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -1019,13 +886,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/istio-operator:
     - name: pull-istio-operator-pjtester
@@ -1075,13 +935,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -1122,13 +975,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/addons:
     - name: pull-addons-pjtester
@@ -1178,13 +1024,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -1225,13 +1064,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/private-fn-for-e2e-serverless-tests:
     - name: pull-private-fn-for-e2e-serverless-tests-pjtester
@@ -1281,13 +1113,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -1328,13 +1153,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/charts:
     - name: pull-charts-pjtester
@@ -1384,13 +1202,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -1431,13 +1242,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/examples:
     - name: pull-examples-pjtester
@@ -1487,13 +1291,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -1534,13 +1331,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/api-gateway:
     - name: pull-api-gateway-pjtester
@@ -1590,13 +1380,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -1637,13 +1420,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/istio:
     - name: pull-istio-pjtester
@@ -1693,13 +1469,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -1740,13 +1509,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/runtime-watcher:
     - name: pull-runtime-watcher-pjtester
@@ -1796,13 +1558,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -1843,13 +1598,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/keda-manager:
     - name: pull-keda-manager-pjtester
@@ -1899,13 +1647,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -1946,13 +1687,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/kyma-dashboard:
     - name: pull-kyma-dashboard-pjtester
@@ -2002,13 +1736,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -2049,13 +1776,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/application-connector-manager:
     - name: pull-application-connector-manager-pjtester
@@ -2105,13 +1825,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -2152,13 +1865,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/rafter:
     - name: pull-rafter-pjtester
@@ -2208,13 +1914,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -2255,13 +1954,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/btp-manager:
     - name: pull-btp-manager-pjtester
@@ -2311,13 +2003,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -2358,13 +2043,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/kyma-environment-broker:
     - name: pull-kyma-environment-broker-pjtester
@@ -2414,13 +2092,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -2461,13 +2132,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/telemetry-manager:
     - name: pull-telemetry-manager-pjtester
@@ -2517,13 +2181,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -2564,13 +2221,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/director-size-exporter:
     - name: pull-director-size-exporter-pjtester
@@ -2620,13 +2270,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -2667,13 +2310,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-project/compass-manager:
     - name: pull-compass-manager-pjtester
@@ -2723,13 +2359,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -2770,13 +2399,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/compass:
     - name: pull-compass-pjtester
@@ -2826,13 +2448,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -2873,13 +2488,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/ord-service:
     - name: pull-ord-service-pjtester
@@ -2929,13 +2537,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -2976,13 +2577,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/reconciler:
     - name: pull-reconciler-pjtester
@@ -3032,13 +2626,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -3079,13 +2666,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/bullseye-showcase:
     - name: pull-bullseye-showcase-pjtester
@@ -3135,13 +2715,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -3182,13 +2755,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/documentation-component:
     - name: pull-documentation-component-pjtester
@@ -3238,13 +2804,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -3285,13 +2844,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/compass-console:
     - name: pull-compass-console-pjtester
@@ -3341,13 +2893,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -3388,13 +2933,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/sap-btp-service-operator:
     - name: pull-sap-btp-service-operator-pjtester
@@ -3444,13 +2982,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -3491,13 +3022,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/milv:
     - name: pull-milv-pjtester
@@ -3547,13 +3071,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -3594,13 +3111,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/varkes:
     - name: pull-varkes-pjtester
@@ -3650,13 +3160,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -3697,13 +3200,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/slack-bot:
     - name: pull-slack-bot-pjtester
@@ -3753,13 +3249,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -3800,13 +3289,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/migrate:
     - name: pull-migrate-pjtester
@@ -3856,13 +3338,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -3903,13 +3378,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/github-dashboard:
     - name: pull-github-dashboard-pjtester
@@ -3959,13 +3427,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -4006,13 +3467,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/website-vuepress:
     - name: pull-website-vuepress-pjtester
@@ -4062,13 +3516,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -4109,13 +3556,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/kitbag:
     - name: pull-kitbag-pjtester
@@ -4165,13 +3605,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -4212,13 +3645,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/kyma-showcase:
     - name: pull-kyma-showcase-pjtester
@@ -4268,13 +3694,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -4315,13 +3734,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/hydra-login-consent:
     - name: pull-hydra-login-consent-pjtester
@@ -4371,13 +3783,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -4418,13 +3823,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/kymart:
     - name: pull-kymart-pjtester
@@ -4474,13 +3872,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -4521,13 +3912,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/examples:
     - name: pull-examples-pjtester
@@ -4577,13 +3961,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -4624,13 +4001,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/vstudio-extension:
     - name: pull-vstudio-extension-pjtester
@@ -4680,13 +4050,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -4727,13 +4090,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/wordpress-connector:
     - name: pull-wordpress-connector-pjtester
@@ -4783,13 +4139,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -4830,13 +4179,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/connector-tools:
     - name: pull-connector-tools-pjtester
@@ -4886,13 +4228,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -4933,13 +4268,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/artwork:
     - name: pull-artwork-pjtester
@@ -4989,13 +4317,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -5036,13 +4357,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/opensap:
     - name: pull-opensap-pjtester
@@ -5092,13 +4406,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -5139,13 +4446,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/testdrape:
     - name: pull-testdrape-pjtester
@@ -5195,13 +4495,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -5242,13 +4535,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/sc-removal:
     - name: pull-sc-removal-pjtester
@@ -5298,13 +4584,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -5345,13 +4624,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/service-catalog-tester:
     - name: pull-service-catalog-tester-pjtester
@@ -5401,13 +4673,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -5448,13 +4713,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
   kyma-incubator/service-catalog:
     - name: pull-service-catalog-pjtester
@@ -5504,13 +4762,6 @@ presubmits: # runs on PRs
               - name: pjtester-kubeconfig
                 mountPath: /etc/kubeconfig/pjtester
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: oauth
             secret:
@@ -5551,11 +4802,4 @@ presubmits: # runs on PRs
               requests:
                 memory: 100M
                 cpu: 200m
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/test-infra/secret-leaks-log-scanner.yaml
+++ b/prow/jobs/test-infra/secret-leaks-log-scanner.yaml
@@ -291,13 +291,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/test-infra:
@@ -594,11 +587,4 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/test-infra/secrets-rotator.yaml
+++ b/prow/jobs/test-infra/secrets-rotator.yaml
@@ -140,13 +140,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/test-infra:
@@ -289,11 +282,4 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/test-infra/terraform-prod-module.yaml
+++ b/prow/jobs/test-infra/terraform-prod-module.yaml
@@ -40,13 +40,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   
 postsubmits: # runs on main
   kyma-project/test-infra:
@@ -87,11 +80,4 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
   

--- a/prow/jobs/test-infra/validation.yaml
+++ b/prow/jobs/test-infra/validation.yaml
@@ -67,13 +67,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-test-infra-validate-image-url-helper
       annotations:
         description: "Validate image url helper tool"
@@ -110,13 +103,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-test-infra-validate-prowjobparser
       annotations:
         description: "Validate prowjobparser tool"
@@ -153,13 +139,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-main-test-infra-validate-generated-files
       annotations:
         description: "Validate rendertemplate generated files"
@@ -193,13 +172,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
     - name: pre-test-infra-validate-dockerfiles
       annotations:
         description: "Validate Dockerfiles, run hadolint."

--- a/prow/jobs/third-party-images/third-party-images.yaml
+++ b/prow/jobs/third-party-images/third-party-images.yaml
@@ -539,13 +539,6 @@ presubmits: # runs on PRs
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config
@@ -1233,13 +1226,6 @@ postsubmits: # runs on main
               - name: signify-secret
                 mountPath: /secret
                 readOnly: true
-        tolerations:
-          - key: dedicated
-            operator: Equal
-            value: high-cpu
-            effect: NoSchedule
-        nodeSelector:
-            dedicated: "high-cpu"
         volumes:
           - name: share
           - name: config

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -105,13 +105,6 @@ globalSets:
     decorate: "true"
     pubsub_project: "sap-kyma-prow"
     pubsub_topic: "prowjobs"
-    nodeSelector:
-      dedicated: high-cpu
-    tolerations:
-      - key: dedicated
-        value: high-cpu
-        operator: Equal
-        effect: NoSchedule
     image: eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230313-8dfce5f0b-buildkit
     command: "/image-builder"
     request_memory: "1.5Gi"
@@ -213,13 +206,6 @@ globalSets:
     request_cpu: "2"
     cluster_presubmit: "untrusted-workload"
     cluster_postsubmit: "trusted-workload"
-    nodeSelector:
-      dedicated: high-cpu
-    tolerations:
-      - key: dedicated
-        value: high-cpu
-        operator: Equal
-        effect: NoSchedule
     <<: *pubsub_config
   jobConfig_kyma20_docu:
     skip_report: "false"
@@ -236,13 +222,6 @@ globalSets:
     request_cpu: "0.8"
     cluster_presubmit: "untrusted-workload"
     cluster_postsubmit: "trusted-workload"
-    nodeSelector:
-      dedicated: high-cpu
-    tolerations:
-      - key: dedicated
-        value: high-cpu
-        operator: Equal
-        effect: NoSchedule
     <<: *pubsub_config
   jobConfig_presubmit:
     annotations:


### PR DESCRIPTION
/kind deprecation
/area ci

Housekeeping, standard-pool has pretty high node count and uses new machines so autoscaler should keep up. Prepare to remove old and pricey node pools from clusters
