### PR TITLE
Do not use rootless user in Prow images

### DIFF
--- a/images/buildpack-go/Dockerfile
+++ b/images/buildpack-go/Dockerfile
@@ -43,7 +43,7 @@ COPY --from=deps /go/bin/kubebuilder /usr/local/bin/kubebuilder
 COPY --from=deps /go/bin/kustomize /usr/local/bin/kustomize
 COPY --from=deps /usr/bin/docker-credential-gcr /usr/bin/docker-credential-gcr
 COPY --from=tools /go/bin/jobguard /usr/local/bin/jobguard
-USER prow:prow
+#USER prow:prow
 
 RUN docker-credential-gcr configure-docker --registries=eu.gcr.io,europe-docker.pkg.dev
 

--- a/images/e2e-garden/Dockerfile
+++ b/images/e2e-garden/Dockerfile
@@ -36,6 +36,6 @@ FROM base
 
 COPY --from=tools /go/bin/jobguard /usr/local/bin/jobguard
 
-USER prow:prow
+#USER prow:prow
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]

--- a/images/e2e-gcloud/Dockerfile
+++ b/images/e2e-gcloud/Dockerfile
@@ -55,6 +55,6 @@ FROM base
 COPY --from=tools /go/bin/jobguard /usr/local/bin/jobguard
 
 
-USER prow:prow
+#USER prow:prow
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]


### PR DESCRIPTION
/kind bug
/area ci

Currently when Prow uses git to copy references, it uses Linux's default mask 0022 and runs git process as root. That means devs cannot interact with the workspace once in ProwJob, because workspace is owned by root user.

This needs to be fixed in Prow's upstream code. I opted to not use rootless user for now.
