### PR TITLE
Disable signify-dev signer

### DIFF
--- a/configs/kaniko-build-config.yaml
+++ b/configs/kaniko-build-config.yaml
@@ -12,7 +12,7 @@ cache:
 sign-config:
   enabled-signers:
     '*':
-      - signify-dev
+#      - signify-dev
       - signify-prod
   signers:
     - name: signify-dev


### PR DESCRIPTION
/kind failing-test
/area ci

Dev seems to be unreliable. Since this signing was enabled mostly because of the validation process, it should be used in the E2E test of image-builder to verify if signing is actually working in production-like environment. And production artifacts should not be signed using dev landscape at all.

