### PR TITLE
Add one size node pool for small workloads

### DIFF
--- a/configs/terraform/environments/prod/prow.tf
+++ b/configs/terraform/environments/prod/prow.tf
@@ -42,3 +42,22 @@ resource "google_container_node_pool" "preemptible_standard_pool" {
     }
   }
 }
+
+resource "google_container_node_pool" "general_trusted" {
+  cluster = google_container_cluster.trusted_workload.id
+  name = "general-pool"
+  node_count = 1
+  node_config {
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+    preemptible = true
+    machine_type = "e2-medium"
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+    labels = {
+      workload = "general-purpose"
+    }
+  }
+}


### PR DESCRIPTION
With this configuration standard-pool should descale when not in working hours. If the load increases, then cluster should autoscale standard nodes. The price is super low ($9 per month) and if it is going to allow scaling down of a cluster outside working hours, then it's a gain.

/area ci
/kind feature
