### PR TITLE
Switch to ko-based build for go applications

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,3 @@
+defaultPlatforms:
+  - linux/arm64
+  - linux/amd64

--- a/.koapps.yaml
+++ b/.koapps.yaml
@@ -1,0 +1,7 @@
+apps:
+  - ko://github.com/kyma-project/test-infra/development/tools/cmd/pjtester
+  - ko://github.com/kyma-project/test-infra/development/image-syncer
+  - ko://github.com/kyma-project/test-infra/development/image-detector
+  - ko://github.com/kyma-project/test-infra/development/image-url-helper
+  - ko://github.com/kyma-project/test-infra/development/markdown-index
+  - ko://github.com/kyma-project/test-infra/development/tools/cmd/usersmapchecker

--- a/prow/jobs/test-infra/ko-build.yaml
+++ b/prow/jobs/test-infra/ko-build.yaml
@@ -1,0 +1,64 @@
+presubmits:
+  kyma-project/test-infra:
+    - name: pull-test-infra-ko-build
+      decorate: true
+      cluster: untrusted-workload
+      annotations:
+        owner: neighbors
+        description: Builds go-based toolkit in one go
+      labels:
+        prow.k8s.io/pubsub.project: "sap-kyma-prow"
+        prow.k8s.io/pubsub.runID: "pull-test-infra-ko-build"
+        prow.k8s.io/pubsub.topic: "prowjobs"
+      spec:
+        containers:
+          - image: europe-docker.pkg.dev/kyma-project/prod/testimages/buildpack-go:v20230717-e09b0fee
+            env:
+              - name: KO_DOCKER_REPO
+                value: europe-docker.pkg.dev/kyma-project/prod/test-infra
+            command: [ "ko" ]
+            args:
+              - resolve
+              - -f
+              - .koapps.yaml
+              - --push=false
+              - --base-import-paths
+              - -j4
+            securityContext:
+              privileged: false
+              seccompProfile:
+                type: RuntimeDefault
+              allowPrivilegeEscalation: false
+postsubmits:
+  kyma-project/test-infra:
+    - name: post-test-infra-ko-build
+      decorate: true
+      cluster: trusted-workload
+      annotations:
+        owner: neighbors
+        description: Builds go-based toolkit in one go
+      labels:
+        preset-kyma-push-images: "true"
+        prow.k8s.io/pubsub.project: "sap-kyma-prow"
+        prow.k8s.io/pubsub.runID: "post-test-infra-ko-build"
+        prow.k8s.io/pubsub.topic: "prowjobs"
+      spec:
+        containers:
+          - image: europe-docker.pkg.dev/kyma-project/prod/testimages/buildpack-go:v20230717-e09b0fee
+            env:
+              - name: KO_DOCKER_REPO
+                value: europe-docker.pkg.dev/kyma-project/prod/test-infra/ko
+            command: [ "bash", "-c" ]
+            args:
+              - |-
+                TAG="$(date +v%Y%m%d)-${PULL_BASE_SHA::8}"
+                ko resolve -f .koapps.yaml \
+                  --base-import-paths \
+                  --tags=latest \
+                  --tags="$TAG" \
+                  -j4
+            securityContext:
+              privileged: false
+              seccompProfile:
+                type: RuntimeDefault
+              allowPrivilegeEscalation: false


### PR DESCRIPTION
/kind feature
/area ci

This PR tackles down problem of managing multiple Dockerfiles where we usually only need to build small image with a single binary. This leverages the usage of ko as main build tool. To build an image/application it's needed to just add its import path to the .koapps.yaml

Then it will be automatically picked up by ko and built in next ProwJob run.

