### PR TITLE
Revert unprivileged mode from buildkit jobs

### DIFF
--- a/prow/jobs/modules/internal/serverless-manager.yaml
+++ b/prow/jobs/modules/internal/serverless-manager.yaml
@@ -105,10 +105,10 @@ presubmits: # runs on PRs
         containers:
           - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230313-8dfce5f0b-buildkit"
             securityContext:
-              privileged: false
+              privileged: true
               seccompProfile:
-                type: RuntimeDefault
-              allowPrivilegeEscalation: false
+                type: Unconfined
+              allowPrivilegeEscalation: true
             command:
               - "sh"
             args:
@@ -256,10 +256,10 @@ postsubmits: # runs on main
         containers:
           - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230313-8dfce5f0b-buildkit"
             securityContext:
-              privileged: false
+              privileged: true
               seccompProfile:
-                type: RuntimeDefault
-              allowPrivilegeEscalation: false
+                type: Unconfined
+              allowPrivilegeEscalation: true
             command:
               - "sh"
             args:

--- a/templates/data/generic_module_data.yaml
+++ b/templates/data/generic_module_data.yaml
@@ -471,7 +471,6 @@ templates:
                   global:
                     - jobConfig_presubmit
                     - image-builder-buildkit
-                    - unprivileged
                   local:
                     - main_branches
                     - job_build_volumes
@@ -501,7 +500,6 @@ templates:
                   global:
                     - jobConfig_postsubmit
                     - image-builder-buildkit
-                    - unprivileged
                   local:
                     - main_branches
                     - job_build_volumes


### PR DESCRIPTION
/kind failing-test
/area ci

The buildkit solution needs more refinement. There are problems with running buildkit safely.
