### PR TITLE
Add new alpine-git image

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -5,3 +5,4 @@ ignored:
   - DL3013 # pip pin version. Disabled bcause hard dependencies management
   - DL3018 # apk pin version. Disabled bcause hard dependencies management
   - DL3033 # yum pin version. Disabled bcause hard dependencies management
+  - DL3007 # We use tagging of local images in build chain as latest.

--- a/images/alpine/Dockerfile
+++ b/images/alpine/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:3.18.2
+
+RUN apk upgrade --no-cache && apk add --no-cache ca-certificates

--- a/images/alpine/git/Dockerfile
+++ b/images/alpine/git/Dockerfile
@@ -1,0 +1,3 @@
+FROM europe-docker.pkg.dev/kyma-project/prod/testimages/alpine:latest
+
+RUN apk add --no-cache git

--- a/images/build-images.sh
+++ b/images/build-images.sh
@@ -4,39 +4,28 @@ set -e
 
 # WORKAROUND
 #TODO (@Ressetkk): Use bundled image with docker-credential-gcr and docker
-if ! command -v docker-credential-gcr; then
-  curl -fsSLo docker-credential-gcr.tar.gz "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.10/docker-credential-gcr_linux_amd64-2.1.10.tar.gz" && \
-  tar xzf docker-credential-gcr.tar.gz \
-  && chmod +x docker-credential-gcr && mv docker-credential-gcr /usr/bin/
+if [[ $CI == "true" ]]; then
+  if ! command -v docker-credential-gcr; then
+    curl -fsSLo docker-credential-gcr.tar.gz "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.10/docker-credential-gcr_linux_amd64-2.1.10.tar.gz" && \
+    tar xzf docker-credential-gcr.tar.gz \
+    && chmod +x docker-credential-gcr && mv docker-credential-gcr /usr/bin/
+  fi
+
+  docker-credential-gcr configure-docker --registries=europe-docker.pkg.dev
 fi
-
-docker-credential-gcr configure-docker --registries=europe-docker.pkg.dev
-
 REGISTRY="europe-docker.pkg.dev/kyma-project/prod/testimages"
 TAG="$(date +v%Y%m%d)-${PULL_BASE_SHA::8}"
 
-# Add new image here
-images=(
-e2e-dind-nodejs
-e2e-dind-k3d
-e2e-gcloud
-buildpack-go
-e2e-garden
-governance-toolkit
-)
-
-docker buildx create --driver docker-container --use --name builder
-
 toPush=()
-for v in "${images[@]}"; do
-  echo "building $v..."
+for v in $(find . -type d -exec test -e '{}'/Dockerfile \; -print | cut -c3-) ; do
+  name=$(echo "$v" | sed "s/\//-/g")
+  echo "building $name..."
   docker buildx build \
-    --builder "builder" \
     --load \
-    -t "$REGISTRY/$v:latest" \
-    -t "$REGISTRY/$v:$TAG" \
+    -t "$REGISTRY/$name:latest" \
+    -t "$REGISTRY/$name:$TAG" \
     "./$v"
-  toPush+=("$REGISTRY/$v")
+  toPush+=("$REGISTRY/$name")
 done
 
 if [[ "$1" == "push" ]]; then


### PR DESCRIPTION
Pjtester is using git as a binary due to k8s/test-infra implementation (lol). It's needed to include it with pjtester binary because otherwise job fails.

Additionally followed tree structure in builder. Looks like it's working as expected though the script wil need a bit more tweaking. Tree structure building seems to be working just fine :D

/kind feature
/area ci
