### PR TITLE
Add gcr-cleaner to clean up ACR

### DIFF
--- a/prow/jobs/test-infra/gcr-cleaner.yaml
+++ b/prow/jobs/test-infra/gcr-cleaner.yaml
@@ -1,0 +1,105 @@
+periodics:
+  - name: ci-gcr-cleaner-untagged
+    annotations:
+      owner: neighbors
+      description: "periodic that cleans up untagged images from all repos"
+    labels:
+      prow.k8s.io/pubsub.project: "sap-kyma-prow"
+      prow.k8s.io/pubsub.runID: "ci-gcr-cleaner-untagged"
+      prow.k8s.io/pubsub.topic: "prowjobs"
+    decorate: true
+    cluster: trusted-workload
+    reporter_config:
+      slack:
+        channel: kyma-prow-alerts
+    cron: "25 * * * 1-5"
+    spec:
+      serviceAccountName: gcr-cleaner
+      containers:
+        - image: europe-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli:latest
+          imagePullPolicy: Always
+          command: [ "/bin/gcr-cleaner-cli" ]
+          args:
+            - -repo=europe-docker.pkg.dev/kyma-project
+            - -recursive
+          securityContext:
+            privileged: false
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+  - name: ci-gcr-cleaner-cache
+    annotations:
+      owner: neighbors
+      description: "periodic that cleans up ACR cache always at 3:25 on Monday"
+    labels:
+      prow.k8s.io/pubsub.project: "sap-kyma-prow"
+      prow.k8s.io/pubsub.runID: "ci-gcr-cleaner-cache"
+      prow.k8s.io/pubsub.topic: "prowjobs"
+    decorate: true
+    cluster: trusted-workload
+    reporter_config:
+      slack:
+        channel: kyma-prow-alerts
+    cron: "33 3 * * 1"
+    spec:
+      serviceAccountName: gcr-cleaner
+      containers:
+        - image: europe-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli:latest
+          imagePullPolicy: Always
+          command: [ "/bin/gcr-cleaner-cli" ]
+          args:
+            - -repo=europe-docker.pkg.dev/kyma-project/cache/cache
+            - -tag-filter-any=.*
+          securityContext:
+            privileged: false
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+  - name: ci-gcr-cleaner-pr
+    annotations:
+      owner: neighbors
+      description: "periodic that cleans up PR images from dev that are older than 30 days"
+    labels:
+      prow.k8s.io/pubsub.project: "sap-kyma-prow"
+      prow.k8s.io/pubsub.runID: "ci-gcr-cleaner-pr"
+      prow.k8s.io/pubsub.topic: "prowjobs"
+    decorate: true
+    cluster: trusted-workload
+    reporter_config:
+      slack:
+        channel: kyma-prow-alerts
+    cron: "40 * * * 1-5"
+    spec:
+      serviceAccountName: gcr-cleaner
+      containers:
+        - image: europe-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli:latest
+          imagePullPolicy: Always
+          command: [ "/bin/gcr-cleaner-cli" ]
+          args:
+            - -repo=europe-docker.pkg.dev/kyma-project/dev
+            - -recursive
+            - -tag-filter-any=PR-.*
+            - -grace=720h
+          securityContext:
+            privileged: false
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 1Gi

--- a/prow/workload-cluster/trusted-workload/trusted_workloadidentity_serviceaccount.yaml
+++ b/prow/workload-cluster/trusted-workload/trusted_workloadidentity_serviceaccount.yaml
@@ -1,65 +1,73 @@
 # Service Accounts linked to Google Workload Identity
 ---
-- apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    annotations:
-      iam.gke.io/gcp-service-account: sa-gcs-plank@sap-kyma-prow.iam.gserviceaccount.com
-    name: prowjob-default-sa
-    namespace: default
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: sa-gcs-plank@sap-kyma-prow.iam.gserviceaccount.com
+  name: prowjob-default-sa
+  namespace: default
 ---
-- apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    annotations:
-      iam.gke.io/gcp-service-account: sa-gcr-push-kyma-project@sap-kyma-prow.iam.gserviceaccount.com
-    name: sa-gcr-push
-    namespace: default
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: sa-gcr-push-kyma-project@sap-kyma-prow.iam.gserviceaccount.com
+  name: sa-gcr-push
+  namespace: default
 ---
-- apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    annotations:
-      iam.gke.io/gcp-service-account: sa-prow-job-resource-cleaners@sap-kyma-prow.iam.gserviceaccount.com
-    name: sa-prow-job-resource-cleaners
-    namespace: default
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: sa-prow-job-resource-cleaners@sap-kyma-prow.iam.gserviceaccount.com
+  name: sa-prow-job-resource-cleaners
+  namespace: default
 ---
-- apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    annotations:
-      iam.gke.io/gcp-service-account: sa-prowjob-gcp-logging-client@sap-kyma-prow.iam.gserviceaccount.com
-    name: sa-prowjob-gcp-logging-client
-    namespace: default
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: sa-prowjob-gcp-logging-client@sap-kyma-prow.iam.gserviceaccount.com
+  name: sa-prowjob-gcp-logging-client
+  namespace: default
 ---
-- apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    annotations:
-      iam.gke.io/gcp-service-account: terraform-executor@sap-kyma-prow.iam.gserviceaccount.com
-    name: terraform-executor
-    namespace: default
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: terraform-executor@sap-kyma-prow.iam.gserviceaccount.com
+  name: terraform-executor
+  namespace: default
 ---
-- apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    annotations:
-      iam.gke.io/gcp-service-account: gencred-refresher@sap-kyma-prow.iam.gserviceaccount.com
-    name: gencred-refresher
-    namespace: default
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: gencred-refresher@sap-kyma-prow.iam.gserviceaccount.com
+  name: gencred-refresher
+  namespace: default
 ---
-- apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    annotations:
-      iam.gke.io/gcp-service-account: sa-prow-deploy@sap-kyma-prow.iam.gserviceaccount.com
-    name: sa-prow-deploy
-    namespace: default
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: sa-prow-deploy@sap-kyma-prow.iam.gserviceaccount.com
+  name: sa-prow-deploy
+  namespace: default
 ---
-- apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    annotations:
-      iam.gke.io/gcp-service-account: sa-secret-update@sap-kyma-prow.iam.gserviceaccount.com
-    name: sa-secret-update
-    namespace: default
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: sa-secret-update@sap-kyma-prow.iam.gserviceaccount.com
+  name: sa-secret-update
+  namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: gcr-cleaner@sap-kyma-prow.iam.gserviceaccount.com
+  name: gcr-cleaner
+  namespace: default


### PR DESCRIPTION
/kind feature
/area ci

Simple "cleanup" policies for ACR.
* Removes all untagged images every hour in working days
* Cleans up cache registry at 3:33 every week
* Removes PR images from dev that are older than 30 days