### PR TITLE
Add K8s default limit ranges for pods

### DIFF
--- a/prow/workload-cluster/test-pods_LimitRange.yaml
+++ b/prow/workload-cluster/test-pods_LimitRange.yaml
@@ -1,0 +1,15 @@
+# TODO (Ressetkk): this needs to be moved to test-pods namespace once we move ProwJobs to its own namespace
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: test-pods-limits
+  namespace: default
+spec:
+  limits:
+    - default:
+        cpu: 2500m
+        memory: 4Gi
+      defaultRequest:
+        cpu: 1500m
+        memory: 2Gi
+      type: Container


### PR DESCRIPTION
To not starve other processes if their resource usage exceeds requests, or there are no requests at all.

/kind feature
/area ci
