### PR TITLE
Set up limits and requests for pod-utils

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -25,6 +25,35 @@ plank:
           initupload: gcr.io/k8s-prow/initupload:v20230728-f11c40f6c3
           entrypoint: gcr.io/k8s-prow/entrypoint:v20230728-f11c40f6c3
           sidecar: gcr.io/k8s-prow/sidecar:v20230728-f11c40f6c3
+        resources:
+          clonerefs:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 100m
+              memory: 100Mi
+          initupload:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 100m
+              memory: 100Mi
+          place_entrypoint:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+            limits:
+              cpu: 10m
+              memory: 50Mi
+          sidecar:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+            limits:
+              cpu: 10m
+              memory: 50Mi
         gcs_configuration:
           bucket: kyma-prow-logs
           path_strategy: "explicit"


### PR DESCRIPTION
So they are not taking up the default limits set in LimitRange

/kind chore
/area ci
