### PR TITLE
Fix OPA Gatekeeper warnings

### DIFF
--- a/prow/cluster/resources/gatekeeper-constraints/workloads/allowedImagesProwProwjobsNamespace.yaml
+++ b/prow/cluster/resources/gatekeeper-constraints/workloads/allowedImagesProwProwjobsNamespace.yaml
@@ -32,3 +32,4 @@ spec:
       - "eu.gcr.io/sap-kyma-neighbors-dev"
       - "europe-docker.pkg.dev/kyma-project"
       - "europe-west3-docker.pkg.dev/sap-kyma-neighbors-dev"
+      - "europe-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli"

--- a/prow/cluster/resources/gatekeeper-constraints/workloads/kymaBotGithubSapTokenTrustedUsage.yaml
+++ b/prow/cluster/resources/gatekeeper-constraints/workloads/kymaBotGithubSapTokenTrustedUsage.yaml
@@ -17,7 +17,7 @@ spec:
         command:
           - /tools/entrypoint
         args: []
-        entrypoint_options: '^{.*"args":\["usersmapchecker"\],"container_name":"test",.*}$'
+        entrypoint_options: '^{.*"args":\["/ko-app/usersmapchecker"\],"container_name":"test",.*}$'
       # Prowjob name: github-issues
       - image: "europe-docker.pkg.dev/kyma-project/prod/test-infra/prow-tools:*"
         command:

--- a/prow/cluster/resources/gatekeeper-constraints/workloads/kymaBotGithubSecretTrustedUsage.yaml
+++ b/prow/cluster/resources/gatekeeper-constraints/workloads/kymaBotGithubSecretTrustedUsage.yaml
@@ -123,7 +123,7 @@ spec:
         command:
           - /tools/entrypoint
         args: []
-        entrypoint_options: '^.*"args":\["usersmapchecker"\],"container_name":"test",.*$'
+        entrypoint_options: '^{.*"args":\["/ko-app/usersmapchecker"\],"container_name":"test",.*}$'
       # pull-secret-leaks-log-scanner-tf-plan
       - image: "europe-docker.pkg.dev/kyma-project/prod/test-infra/terraform:*"
         command:

--- a/prow/jobs/test-infra/gcr-cleaner.yaml
+++ b/prow/jobs/test-infra/gcr-cleaner.yaml
@@ -96,6 +96,7 @@ periodics:
             privileged: false
             seccompProfile:
               type: RuntimeDefault
+            allowPrivilegeEscalation: false
           resources:
             requests:
               cpu: 500m


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add gcr-cleaner to allowed images
- Disable privilige escalation for gcr cleaner
- Fix regexp for pre-main-check-users-map prowjob

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->


/kind bug
/area security
/test all