### PR TITLE
Remove docker::init from azure.sh

### DIFF
--- a/prow/scripts/lib/gardener/azure.sh
+++ b/prow/scripts/lib/gardener/azure.sh
@@ -18,8 +18,6 @@ source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/log.sh"
 source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/kyma.sh"
 # shellcheck source=prow/scripts/lib/utils.sh
 source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/utils.sh"
-# shellcheck source=prow/scripts/lib/docker.sh
-source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/docker.sh"
 # shellcheck source=prow/scripts/lib/gardener/gardener.sh
 source "${TEST_INFRA_SOURCES_DIR}/prow/scripts/lib/gardener/gardener.sh"
 
@@ -79,8 +77,6 @@ gardener::init() {
 
     export INSTALLATION_OVERRIDE_STACKDRIVER="installer-config-logging-stackdiver.yaml"
 
-    # we need to start the docker daemon
-    docker::start
 }
 
 gardener::set_machine_type() {


### PR DESCRIPTION
Looks like a leftover as it's not present in other gardener lib scripts.

/kind bug
/area ci
