### PR TITLE
consolidate nginx images

### DIFF
--- a/prow/autobump-config/dockerhub-autobump.yaml
+++ b/prow/autobump-config/dockerhub-autobump.yaml
@@ -1,0 +1,22 @@
+gitHubLogin: "kyma-bot"
+gitHubToken: "/etc/github/token"
+gitName: "Kyma Bot"
+gitEmail: "kyma.bot@sap.com"
+skipPullRequest: false
+gitHubOrg: "kyma-project"
+gitHubRepo: "test-infra"
+remoteName: "test-infra-1"
+upstreamURLBase: "https://raw.githubusercontent.com/kyma-project/test-infra/main"
+headBranchName: "dockerio-autobump"
+includedConfigPaths:
+  - "prow"
+  - "development"
+targetVersion: "latest"
+prefixes:
+  - name: "nginx"
+    prefix: "docker.io/library/nginx"
+    refConfigFile: "templates/config.yaml"
+    stagingRefConfigFile: "templates/config.yaml"
+    repo: "https://github.com/kyma-project/test-infra"
+    summarise: true
+    consistentImages: true

--- a/prow/cluster/components/monitoring/grafana_deployment.yaml
+++ b/prow/cluster/components/monitoring/grafana_deployment.yaml
@@ -21,7 +21,7 @@ spec:
         app: grafana
     spec:
       containers:
-      - image: docker.io/nginx:1.23.2-alpine
+      - image: docker.io/library/nginx:1.23.2-alpine
         name: nginx
         readinessProbe:
           httpGet:

--- a/prow/cluster/components/pushgateway_deployment.yaml
+++ b/prow/cluster/components/pushgateway_deployment.yaml
@@ -87,7 +87,7 @@ spec:
         ports:
           - name: http
             containerPort: 8081
-        image: nginx:1
+        image: docker.io/library/nginx:1.23.2-alpine
         volumeMounts:
         - name: config-volume
           mountPath: /etc/nginx/

--- a/prow/cluster/components/web_server_deployment.yaml
+++ b/prow/cluster/components/web_server_deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.20-alpine
+        image: docker.io/library/nginx:1.23.2-alpine
         ports:
         - containerPort: 80
         volumeMounts:

--- a/prow/jobs/test-infra/prow-periodics.yaml
+++ b/prow/jobs/test-infra/prow-periodics.yaml
@@ -285,4 +285,38 @@ periodics: # runs on schedule
             args:
               - "--config=prow/autobump-config/test-infra-autobump-config.yaml"
               - "--labels-override=skip-review,area/ci,kind/chore"
+    - name: ci-dockerhub-autobump
+      annotations:
+        description: "Autobump images from docker.io"
+        owner: "neighbors"
+        testgrid-create-test-group: "false"
+      labels:
+        prow.k8s.io/pubsub.project: "sap-kyma-prow"
+        prow.k8s.io/pubsub.runID: "ci-dockerhub-autobump"
+        prow.k8s.io/pubsub.topic: "prowjobs"
+        preset-autobump-bot-github-token: "true"
+      cron: "55 * * * 1-5"
+      skip_report: false
+      decorate: true
+      cluster: trusted-workload
+      extra_refs:
+        - org: kyma-project
+          repo: test-infra
+          base_ref: main
+      reporter_config:
+        slack:
+          channel: kyma-prow-alerts
+      spec:
+        containers:
+          - image: "gcr.io/k8s-prow/generic-autobumper:v20230802-d51826a399"
+            securityContext:
+              privileged: false
+              seccompProfile:
+                type: RuntimeDefault
+              allowPrivilegeEscalation: false
+            command:
+              - "generic-autobumper"
+            args:
+              - "--config=prow/autobump-config/dockerhub-autobump.yaml"
+              - "--labels-override=skip-review,area/ci,kind/chore"
   

--- a/prow/staging/cluster/monitoring/grafana_deployment.yaml
+++ b/prow/staging/cluster/monitoring/grafana_deployment.yaml
@@ -21,7 +21,7 @@ spec:
         app: grafana
     spec:
       containers:
-      - image: docker.io/nginx:1.17.0-alpine
+      - image: docker.io/library/nginx:1.23.2-alpine
         name: nginx
         readinessProbe:
           httpGet:

--- a/prow/staging/cluster/pushgateway_deployment.yaml
+++ b/prow/staging/cluster/pushgateway_deployment.yaml
@@ -87,7 +87,7 @@ spec:
         ports:
           - name: http
             containerPort: 8081
-        image: nginx:1
+        image: docker.io/library/nginx:1.23.2-alpine
         volumeMounts:
         - name: config-volume
           mountPath: /etc/nginx/

--- a/templates/data/prow-periodics-data.yaml
+++ b/templates/data/prow-periodics-data.yaml
@@ -221,3 +221,24 @@ templates:
                     - "disable_testgrid"
                     - extra_refs_test-infra
                     - "unprivileged"
+              - jobConfig:
+                  name: ci-dockerhub-autobump
+                  annotations:
+                    owner: neighbors
+                    description: "Autobump images from docker.io"
+                  cron: "55 * * * 1-5"
+                  slack_channel: kyma-prow-alerts
+                  image: gcr.io/k8s-prow/generic-autobumper:v20230802-d51826a399
+                  command: generic-autobumper
+                  args:
+                    - --config=prow/autobump-config/dockerhub-autobump.yaml
+                    - --labels-override=skip-review,area/ci,kind/chore
+                inheritedConfigs:
+                  local:
+                    - periodic_config
+                    - github_token_mounts
+                  global:
+                    - "pubsub_labels"
+                    - "disable_testgrid"
+                    - extra_refs_test-infra
+                    - "unprivileged"


### PR DESCRIPTION
And experimentally enable autobumping for docker.io nginx. This change consolidates all nginx images used by our workloads. We need to have less images of the same application, so the triaging process will be easier

/area ci
/kind cleanup