### PR TITLE
Update dependencies in buildpack-go

### DIFF
--- a/images/buildpack-go/Dockerfile
+++ b/images/buildpack-go/Dockerfile
@@ -11,7 +11,8 @@ RUN set -eux; \
     gettext \
     yq \
     binutils \
-    dumb-init
+    dumb-init \
+    libgit2-dev
 
 RUN adduser -D prow
 


### PR DESCRIPTION
/kind bug
/area ci

There's missing dependency to libgit2.

#8513 
