### PR TITLE
Add pkgconf

### DIFF
--- a/images/buildpack-go/Dockerfile
+++ b/images/buildpack-go/Dockerfile
@@ -12,6 +12,7 @@ RUN set -eux; \
     yq \
     binutils \
     dumb-init \
+    pkgconf \
     libgit2-dev
 
 RUN adduser -D prow


### PR DESCRIPTION
It's missing and CGO requires it

/kind failing-test
/area ci

