### PR TITLE
Fix pre-main-provisioner-e2e-tests

### DIFF
--- a/prow/jobs/control-plane/components/provisioner/provisioner-integration-test.yaml
+++ b/prow/jobs/control-plane/components/provisioner/provisioner-integration-test.yaml
@@ -23,7 +23,8 @@ presubmits: # runs on PRs
       spec:
         containers:
           - image: europe-docker.pkg.dev/kyma-project/prod/testimages/e2e-dind-k3d:v20230804-a5b27764
-            command:
+            command: ["/init.sh"]
+            args:
               - components/provisioner/e2e_test/test.sh
             resources:
               requests:


### PR DESCRIPTION
Missing /init.sh invoke

/kind bug
/area ci