### PR TITLE
Fix EAM Integration Tests Prow Job

### DIFF
--- a/prow/jobs/eventing-auth-manager/eam-integration-test.yaml
+++ b/prow/jobs/eventing-auth-manager/eam-integration-test.yaml
@@ -30,7 +30,7 @@ presubmits: # runs on PRs
                 type: Unconfined
               allowPrivilegeEscalation: true
             args:
-              - -c
+              - bash -c
               - |
                 export KUBECONFIG=$(k3d kubeconfig write kcp)
                 TEST_EVENTING_AUTH_TARGET_KUBECONFIG_PATH=${KUBECONFIG} USE_EXISTING_CLUSTER=true make test


### PR DESCRIPTION
**Description**
Use bash to run integration tests script

Changes proposed in this pull request:

- Use bash to run integration tests script