### PR TITLE
bug: Fix missing dumb-init

### DIFF
--- a/images/e2e-dind-k3d/init.sh
+++ b/images/e2e-dind-k3d/init.sh
@@ -1,4 +1,4 @@
-#!/usr/local/bin/dumb-init /bin/bash
+#!/usr/bin/dumb-init /bin/bash
 
 set -e
 


### PR DESCRIPTION
Dumb-init changed the place to /usr/bin/dumb-init. The change wasn't reflected in /init.sh

/kind bug
/area ci
