### PR TITLE
Fix region for cloud scheduler

### DIFF
--- a/configs/terraform/environments/prod/secrets-rotator.tf
+++ b/configs/terraform/environments/prod/secrets-rotator.tf
@@ -38,9 +38,9 @@ output "service_account_keys_rotator" {
 
 resource "google_project_iam_member" "service_account_keys_rotator_workloads_project" {
   provider = google.workloads
-  project = var.workloads_project_id
-  role    = "roles/iam.serviceAccountKeyAdmin"
-  member  = "serviceAccount:${module.service_account_keys_rotator.service_account_keys_rotator_service_account.email}"
+  project  = var.workloads_project_id
+  role     = "roles/iam.serviceAccountKeyAdmin"
+  member   = "serviceAccount:${module.service_account_keys_rotator.service_account_keys_rotator_service_account.email}"
 }
 
 module "service_account_keys_cleaner" {
@@ -50,6 +50,7 @@ module "service_account_keys_cleaner" {
   service_name     = var.service_account_keys_cleaner_service_name
 
   region                                     = var.gcp_region
+  scheduler_region                           = var.gcp_scheduler_region
   service_account_keys_cleaner_account_id    = var.service_account_keys_cleaner_account_id
   service_account_keys_cleaner_image         = var.service_account_keys_cleaner_image
   cloud_run_service_listen_port              = var.secrets_rotator_cloud_run_listen_port
@@ -65,7 +66,7 @@ output "service_account_keys_cleaner" {
 
 resource "google_project_iam_member" "service_account_keys_cleaner_workloads_project" {
   provider = google.workloads
-  project = var.workloads_project_id
-  role    = "roles/iam.serviceAccountKeyAdmin"
-  member  = "serviceAccount:${module.service_account_keys_cleaner.service_account_keys_cleaner_service_account.email}"
+  project  = var.workloads_project_id
+  role     = "roles/iam.serviceAccountKeyAdmin"
+  member   = "serviceAccount:${module.service_account_keys_cleaner.service_account_keys_cleaner_service_account.email}"
 }

--- a/configs/terraform/environments/prod/variables.tf
+++ b/configs/terraform/environments/prod/variables.tf
@@ -4,6 +4,12 @@ variable "gcp_region" {
   description = "Default Google Cloud region to create resources."
 }
 
+variable "gcp_scheduler_region" {
+  type        = string
+  default     = "europe-west3"
+  description = "Additional Google Cloud Region to create resources."
+}
+
 variable "gcp_project_id" {
   type        = string
   default     = "sap-kyma-prow"

--- a/configs/terraform/modules/service-account-keys-cleaner/main.tf
+++ b/configs/terraform/modules/service-account-keys-cleaner/main.tf
@@ -65,7 +65,7 @@ resource "google_cloud_run_service" "service_account_keys_cleaner" {
 
 resource "google_cloud_scheduler_job" "service_account_keys_cleaner" {
   name             = var.scheduler_name
-  region           = var.region
+  region           = var.scheduler_region
   description      = "Call service account keys cleaner service, to remove old versions of secrets"
   schedule         = var.scheduler_cron_schedule
   time_zone        = "Etc/UTC"

--- a/configs/terraform/modules/service-account-keys-cleaner/variables.tf
+++ b/configs/terraform/modules/service-account-keys-cleaner/variables.tf
@@ -3,6 +3,11 @@ variable "region" {
   description = "Google Cloud region to deploy the service account keys cleaner to."
 }
 
+variable "scheduler_region" {
+  type        = string
+  description = "Google Cloud region to deploy the service account keys cleaner scheduler to."
+}
+
 variable "service_name" {
   type        = string
   description = "Name of the service account keys cleaner service instance."


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

During apply of new merged root module for secrets-rotator error occurred due to europe-west4 region is not available as cloud scheduler region. This PR resolves it by add a separate variable to define scheduler region, by default set to europe-west3

Changes proposed in this pull request:

- Set different cloud scheduler region

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #8216 and #8706 