### PR TITLE
Fix bad shebang in e2e-dind-nodejs init script

### DIFF
--- a/images/e2e-dind-nodejs/init.sh
+++ b/images/e2e-dind-nodejs/init.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/dumb-init /bin/bash
+#!/usr/local/bin/dumb-init /bin/bash
 
 set -e
 


### PR DESCRIPTION
It was omitted during syncing 2 scripts

/kind bug
/area ci
