### PR TITLE
Update kyma branchprotection rules

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -250,10 +250,12 @@ branch-protection:
         - "^dependabot/"
       repos:
         kyma:
+          protect: false
           branches:
-            kyma-2.0-docu:
-              required_pull_request_reviews:
-                require_code_owner_reviews: false
+            main:
+              protect: true
+            release-.*:
+              protect: true
         website:
           branches:
             main:
@@ -264,6 +266,11 @@ branch-protection:
               required_status_checks:
                 contexts:
                   - "netlify/kyma-project-old/deploy-preview"
+        community:
+          protect: false
+          branches:
+            main:
+              protect: true
         private-fn-for-e2e-serverless-tests:
           protect: false
         organization-and-operations:


### PR DESCRIPTION
Right now kyma repo has horrendous number of branches that are being protected. This slows down branchprotection to hours. This change will disable protecting all branches except release ones and main

/kind chore
/area ci
