### PR TITLE
Artifact Registry in a specified project with dedicated provider

### DIFF
--- a/configs/terraform/environments/dev/artifact-registry/main.tf
+++ b/configs/terraform/environments/dev/artifact-registry/main.tf
@@ -6,13 +6,13 @@ module "artifact_registry" {
     google = google.artifact_registry_smart_tractor
   }
 
-  for_each                                 = var.artifact_registry_collection
-  artifact_registry_name                   = each.value.name
-  artifact_registry_type                   = each.value.type
-  artifact_registry_immutable_tags         = each.value.immutable
-  artifact_registry_multi_region           = each.value.multi_region
-  artifact_registry_owner                  = each.value.owner
-  artifact_registry_writer_serviceaccounts = each.value.writer_serviceaccounts
-  artifact_registry_reader_serviceaccounts = each.value.reader_serviceaccounts
-  artifact_registry_public                 = each.value.public
+  for_each               = var.artifact_registry_collection
+  registry_name          = each.value.name
+  type                   = each.value.type
+  immutable_tags         = each.value.immutable
+  multi_region           = each.value.multi_region
+  owner                  = each.value.owner
+  writer_serviceaccounts = each.value.writer_serviceaccounts
+  reader_serviceaccounts = each.value.reader_serviceaccounts
+  public                 = each.value.public
 }

--- a/configs/terraform/environments/dev/artifact-registry/main.tf
+++ b/configs/terraform/environments/dev/artifact-registry/main.tf
@@ -3,7 +3,7 @@ module "artifact_registry" {
   source = "../../../modules/artifact-registry"
 
   providers = {
-    google = google.artifact_registry_gcp
+    google = google.artifact_registry_smart_tractor
   }
 
   for_each                                 = var.artifact_registry_collection

--- a/configs/terraform/environments/dev/artifact-registry/main.tf
+++ b/configs/terraform/environments/dev/artifact-registry/main.tf
@@ -1,13 +1,18 @@
+
 module "artifact_registry" {
   source = "../../../modules/artifact-registry"
+
+  providers = {
+    google = google.artifact_registry_gcp
+  }
 
   for_each                                 = var.artifact_registry_collection
   artifact_registry_name                   = each.value.name
   artifact_registry_type                   = each.value.type
-  immutable_artifact_registry              = each.value.immutable
+  artifact_registry_immutable_tags         = each.value.immutable
   artifact_registry_multi_region           = each.value.multi_region
   artifact_registry_owner                  = each.value.owner
-  artifact_registry_writer_serviceaccount  = each.value.writer_serviceaccount
+  artifact_registry_writer_serviceaccounts = each.value.writer_serviceaccounts
   artifact_registry_reader_serviceaccounts = each.value.reader_serviceaccounts
   artifact_registry_public                 = each.value.public
 }

--- a/configs/terraform/environments/dev/artifact-registry/provider.tf
+++ b/configs/terraform/environments/dev/artifact-registry/provider.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 provider "google" {
-  alias   = "artifact_registry_gcp"
+  alias   = "artifact_registry_smart_tractor"
   project = var.artifact_registry_gcp_project_id
   region  = var.artifact_registry_gcp_region
 }

--- a/configs/terraform/environments/dev/artifact-registry/provider.tf
+++ b/configs/terraform/environments/dev/artifact-registry/provider.tf
@@ -8,6 +8,8 @@ terraform {
 }
 
 provider "google" {
-  project = var.gcp_project_id
-  region  = var.gcp_region
+  alias   = "artifact_registry_gcp"
+  project = var.artifact_registry_gcp_project_id
+  region  = var.artifact_registry_gcp_region
 }
+

--- a/configs/terraform/environments/dev/artifact-registry/terraform.tfvars
+++ b/configs/terraform/environments/dev/artifact-registry/terraform.tfvars
@@ -1,10 +1,11 @@
-gcp_region = "europe-west4"
+artifact_registry_gcp_project_id = "finall-cloud-main"
+artifact_registry_gcp_region     = "europe-west4"
 artifact_registry_collection = {
   modules-internal = {
     name                   = "modules-internal"
     owner                  = "neighbors"
     type                   = "development"
     reader_serviceaccounts = ["klm-controller-manager@sap-ti-dx-kyma-mps-dev.iam.gserviceaccount.com", "klm-controller-manager@sap-ti-dx-kyma-mps-stage.iam.gserviceaccount.com", "klm-controller-manager@sap-ti-dx-kyma-mps-prod.iam.gserviceaccount.com"]
-    writer_serviceaccount  = "kyma-submission-pipeline@kyma-project.iam.gserviceaccount.com"
+    writer_serviceaccounts = ["kyma-submission-pipeline@kyma-project.iam.gserviceaccount.com"]
   },
 }

--- a/configs/terraform/environments/dev/artifact-registry/terraform.tfvars
+++ b/configs/terraform/environments/dev/artifact-registry/terraform.tfvars
@@ -1,4 +1,4 @@
-artifact_registry_gcp_project_id = "finall-cloud-main"
+artifact_registry_gcp_project_id = "smart-tractor-389208"
 artifact_registry_gcp_region     = "europe-west4"
 artifact_registry_collection = {
   modules-internal = {

--- a/configs/terraform/environments/dev/artifact-registry/variables.tf
+++ b/configs/terraform/environments/dev/artifact-registry/variables.tf
@@ -2,12 +2,12 @@
 ###################################
 # Artifact Registry related values
 ###################################
-variable "gcp_region" {
+variable "artifact_registry_gcp_region" {
   type        = string
   description = "Default Google Cloud region to create resources."
 }
 
-variable "gcp_project_id" {
+variable "artifact_registry_gcp_project_id" {
   type        = string
   description = "Google Cloud project to create resources."
 }
@@ -18,7 +18,7 @@ variable "artifact_registry_collection" {
     name                   = string
     owner                  = string
     type                   = string
-    writer_serviceaccount  = optional(string, "")
+    writer_serviceaccounts = optional(list(string), [])
     reader_serviceaccounts = list(string)
     primary_area           = optional(string, "europe")
     multi_region           = optional(bool, true)

--- a/configs/terraform/environments/prod/artifact-registry-variables.tf
+++ b/configs/terraform/environments/prod/artifact-registry-variables.tf
@@ -2,18 +2,7 @@
 ###################################
 # Artifact Registry related values
 ###################################
-variable "artifact_registry_gcp_region_kyma_project" {
-  type        = string
-  description = "Default Google Cloud region to create resources."
-  default     = "europe-west4"
-}
-
-variable "artifact_registry_gcp_project_id_kyma_project" {
-  type        = string
-  description = "Google Cloud project to create resources."
-  default     = "kyma-project"
-}
-variable "artifact_registry_collection_kyma_project" {
+variable "kyma_project_artifact_registry_collection" {
   description = "Artifact Registry related data set"
   type = map(object({
     name                   = string

--- a/configs/terraform/environments/prod/artifact-registry-variables.tf
+++ b/configs/terraform/environments/prod/artifact-registry-variables.tf
@@ -2,16 +2,18 @@
 ###################################
 # Artifact Registry related values
 ###################################
-variable "artifact_registry_gcp_region" {
+variable "artifact_registry_gcp_region_kyma_project" {
   type        = string
   description = "Default Google Cloud region to create resources."
+  default     = "europe-west4"
 }
 
-variable "artifact_registry_gcp_project_id" {
+variable "artifact_registry_gcp_project_id_kyma_project" {
   type        = string
   description = "Google Cloud project to create resources."
+  default     = "kyma-project"
 }
-variable "artifact_registry_collection" {
+variable "artifact_registry_collection_kyma_project" {
   description = "Artifact Registry related data set"
   type = map(object({
     name                   = string

--- a/configs/terraform/environments/prod/artifact-registry-variables.tf
+++ b/configs/terraform/environments/prod/artifact-registry-variables.tf
@@ -2,13 +2,22 @@
 ###################################
 # Artifact Registry related values
 ###################################
+variable "artifact_registry_gcp_region" {
+  type        = string
+  description = "Default Google Cloud region to create resources."
+}
+
+variable "artifact_registry_gcp_project_id" {
+  type        = string
+  description = "Google Cloud project to create resources."
+}
 variable "artifact_registry_collection" {
   description = "Artifact Registry related data set"
   type = map(object({
     name                   = string
     owner                  = string
     type                   = string
-    writer_serviceaccount  = optional(string, "")
+    writer_serviceaccounts = optional(list(string), [])
     reader_serviceaccounts = list(string)
     primary_area           = optional(string, "europe")
     multi_region           = optional(bool, true)

--- a/configs/terraform/environments/prod/artifact-registry.tf
+++ b/configs/terraform/environments/prod/artifact-registry.tf
@@ -1,18 +1,12 @@
-provider "google" {
-  alias   = "artifact_registry_kyma_project"
-  project = var.artifact_registry_gcp_project_id_kyma_project
-  region  = var.artifact_registry_gcp_region_kyma_project
-}
-
 module "artifact_registry" {
   source = "../../modules/artifact-registry"
 
   providers = {
-    google = google.artifact_registry_kyma_project
+    google = google.kyma_project_provider
   }
 
 
-  for_each               = var.artifact_registry_collection_kyma_project
+  for_each               = var.kyma_project_artifact_registry_collection
   registry_name          = each.value.name
   type                   = each.value.type
   immutable_tags         = each.value.immutable

--- a/configs/terraform/environments/prod/artifact-registry.tf
+++ b/configs/terraform/environments/prod/artifact-registry.tf
@@ -1,7 +1,7 @@
 provider "google" {
   alias   = "artifact_registry_kyma_project"
-  project = var.artifact_registry_gcp_project_id
-  region  = var.artifact_registry_gcp_region
+  project = var.artifact_registry_gcp_project_id_kyma_project
+  region  = var.artifact_registry_gcp_region_kyma_project
 }
 
 module "artifact_registry" {
@@ -12,7 +12,7 @@ module "artifact_registry" {
   }
 
 
-  for_each                                 = var.artifact_registry_collection
+  for_each                                 = var.artifact_registry_collection_kyma_project
   artifact_registry_name                   = each.value.name
   artifact_registry_type                   = each.value.type
   artifact_registry_immutable_tags         = each.value.immutable

--- a/configs/terraform/environments/prod/artifact-registry.tf
+++ b/configs/terraform/environments/prod/artifact-registry.tf
@@ -2,7 +2,7 @@ module "artifact_registry" {
   source = "../../modules/artifact-registry"
 
   providers = {
-    google = google.kyma_project_provider
+    google = google.kyma_project
   }
 
 

--- a/configs/terraform/environments/prod/artifact-registry.tf
+++ b/configs/terraform/environments/prod/artifact-registry.tf
@@ -12,13 +12,13 @@ module "artifact_registry" {
   }
 
 
-  for_each                                 = var.artifact_registry_collection_kyma_project
-  artifact_registry_name                   = each.value.name
-  artifact_registry_type                   = each.value.type
-  artifact_registry_immutable_tags         = each.value.immutable
-  artifact_registry_multi_region           = each.value.multi_region
-  artifact_registry_owner                  = each.value.owner
-  artifact_registry_writer_serviceaccounts = each.value.writer_serviceaccounts
-  artifact_registry_reader_serviceaccounts = each.value.reader_serviceaccounts
-  artifact_registry_public                 = each.value.public
+  for_each               = var.artifact_registry_collection_kyma_project
+  registry_name          = each.value.name
+  type                   = each.value.type
+  immutable_tags         = each.value.immutable
+  multi_region           = each.value.multi_region
+  owner                  = each.value.owner
+  writer_serviceaccounts = each.value.writer_serviceaccounts
+  reader_serviceaccounts = each.value.reader_serviceaccounts
+  public                 = each.value.public
 }

--- a/configs/terraform/environments/prod/artifact-registry.tf
+++ b/configs/terraform/environments/prod/artifact-registry.tf
@@ -1,5 +1,5 @@
 provider "google" {
-  alias   = "artifact_registry_gcp"
+  alias   = "artifact_registry_kyma_project"
   project = var.artifact_registry_gcp_project_id
   region  = var.artifact_registry_gcp_region
 }
@@ -8,7 +8,7 @@ module "artifact_registry" {
   source = "../../modules/artifact-registry"
 
   providers = {
-    google = google.artifact_registry_gcp
+    google = google.artifact_registry_kyma_project
   }
 
 

--- a/configs/terraform/environments/prod/artifact-registry.tf
+++ b/configs/terraform/environments/prod/artifact-registry.tf
@@ -1,12 +1,24 @@
+provider "google" {
+  alias   = "artifact_registry_gcp"
+  project = var.artifact_registry_gcp_project_id
+  region  = var.artifact_registry_gcp_region
+}
+
 module "artifact_registry" {
-  source                                   = "../../modules/artifact-registry"
+  source = "../../modules/artifact-registry"
+
+  providers = {
+    google = google.artifact_registry_gcp
+  }
+
+
   for_each                                 = var.artifact_registry_collection
   artifact_registry_name                   = each.value.name
   artifact_registry_type                   = each.value.type
-  immutable_artifact_registry              = each.value.immutable
+  artifact_registry_immutable_tags         = each.value.immutable
   artifact_registry_multi_region           = each.value.multi_region
   artifact_registry_owner                  = each.value.owner
-  artifact_registry_writer_serviceaccount  = each.value.writer_serviceaccount
+  artifact_registry_writer_serviceaccounts = each.value.writer_serviceaccounts
   artifact_registry_reader_serviceaccounts = each.value.reader_serviceaccounts
   artifact_registry_public                 = each.value.public
 }

--- a/configs/terraform/environments/prod/provider.tf
+++ b/configs/terraform/environments/prod/provider.tf
@@ -114,7 +114,7 @@ provider "kubectl" {
 }
 
 provider "google" {
-  alias   = "kyma_project_provider"
+  alias   = "kyma_project"
   project = var.kyma_project_gcp_project_id
   region  = var.kyma_project_gcp_region
 }

--- a/configs/terraform/environments/prod/provider.tf
+++ b/configs/terraform/environments/prod/provider.tf
@@ -28,9 +28,9 @@ provider "google" {
 }
 
 provider "google" {
-  alias = "workloads"
+  alias   = "workloads"
   project = var.workloads_project_id
-  region = var.gcp_region
+  region  = var.gcp_region
 }
 
 provider "google-beta" {
@@ -111,4 +111,10 @@ provider "kubectl" {
     data.google_container_cluster.untrusted_workload_k8s_cluster.master_auth[0].cluster_ca_certificate,
   )
   load_config_file = false
+}
+
+provider "google" {
+  alias   = "kyma_project_provider"
+  project = var.kyma_project_gcp_project_id
+  region  = var.kyma_project_gcp_region
 }

--- a/configs/terraform/environments/prod/terraform.tfvars
+++ b/configs/terraform/environments/prod/terraform.tfvars
@@ -1,4 +1,4 @@
-artifact_registry_collection_kyma_project = {
+kyma_project_artifact_registry_collection = {
   modules-internal = {
     name                   = "modules-internal"
     owner                  = "neighbors"

--- a/configs/terraform/environments/prod/terraform.tfvars
+++ b/configs/terraform/environments/prod/terraform.tfvars
@@ -1,6 +1,4 @@
-artifact_registry_gcp_project_id = "kyma-project"
-artifact_registry_gcp_region     = "europe-west4"
-artifact_registry_collection = {
+artifact_registry_collection_kyma_project = {
   modules-internal = {
     name                   = "modules-internal"
     owner                  = "neighbors"

--- a/configs/terraform/environments/prod/terraform.tfvars
+++ b/configs/terraform/environments/prod/terraform.tfvars
@@ -1,11 +1,12 @@
-gcp_region = "europe-west4"
+artifact_registry_gcp_project_id = "kyma-project"
+artifact_registry_gcp_region     = "europe-west4"
 artifact_registry_collection = {
   modules-internal = {
     name                   = "modules-internal"
     owner                  = "neighbors"
     type                   = "production"
     reader_serviceaccounts = ["klm-controller-manager@sap-ti-dx-kyma-mps-dev.iam.gserviceaccount.com", "klm-controller-manager@sap-ti-dx-kyma-mps-stage.iam.gserviceaccount.com", "klm-controller-manager@sap-ti-dx-kyma-mps-prod.iam.gserviceaccount.com"]
-    writer_serviceaccount  = "kyma-submission-pipeline@kyma-project.iam.gserviceaccount.com"
+    writer_serviceaccounts = ["kyma-submission-pipeline@kyma-project.iam.gserviceaccount.com"]
   },
 }
 service_account_keys_rotator_service_name            = "service-account-keys-rotator"

--- a/configs/terraform/environments/prod/variables.tf
+++ b/configs/terraform/environments/prod/variables.tf
@@ -170,3 +170,15 @@ variable "service_account_keys_cleaner_scheduler_cron_schedule" {
   type        = string
   description = "Cron schedule for the service account keys cleaner scheduler."
 }
+
+variable "kyma_project_gcp_region" {
+  type        = string
+  description = "Default Google Cloud region to create resources in kyma-project"
+  default     = "europe-west4"
+}
+
+variable "kyma_project_gcp_project_id" {
+  type        = string
+  description = "Google Cloud project to create resources"
+  default     = "kyma-project"
+}

--- a/configs/terraform/modules/artifact-registry/README.md
+++ b/configs/terraform/modules/artifact-registry/README.md
@@ -1,4 +1,4 @@
-# gcp-artifact-registry-terraform
+# Artifact Registry creator tool (GCP, Terraform)
 
 This is the GCP image registry creator tool. Use the registry to publish modules that should be accessible to internal SAP teams.
 
@@ -11,13 +11,16 @@ Configure Artifact Registry related values in the `terraform.tfvars` file.
 You can configure multiple artifact registries as a list of objects in `artifact_registry_collection`.
 
 ```terraform
+artifact_registry_gcp_project_id = "kyma-project"
+artifact_registry_gcp_region     = "europe-west4"
+
 artifact_registry_collection = {
   modules-internal={
     name                   = "modules-internal"
     owner                  = "neighbors"
     type                   = "production"
     reader_serviceaccounts = ["klm-controller-manager@sap-ti-dx-kyma-mps-dev.iam.gserviceaccount.com", "klm-controller-manager@sap-ti-dx-kyma-mps-stage.iam.gserviceaccount.com", "klm-controller-manager@sap-ti-dx-kyma-mps-prod.iam.gserviceaccount.com"]
-    writer_serviceaccount  = "kyma-submission-pipeline@kyma-project.iam.gserviceaccount.com"
+    writer_serviceaccounts  = ["kyma-submission-pipeline@kyma-project.iam.gserviceaccount.com"]
   },
 }
 ```
@@ -43,7 +46,7 @@ Additionally, you can define optional parameters. Here are all the parameters yo
 | **owner**                  | Registry Owner Team                                                     | string       | x        |               |
 | **type**                   | Environment type (development, production)                              | string       | x        |               |
 | **reader_serviceaccounts** | List of Service Accounts that have `Reader` access to registry          | list(string) | x        |               |
-| **writer_serviceaccount**  | List of Service Accounts that have  `Writer`  access to registry        | string       |          | ""            |
+| **writer_serviceaccounts**  | List of Service Accounts that have  `Writer`  access to registry        | list(string)       |          | ""            |
 | **primary_area**           | Primary area (if multi-region registry)                                 | string       |          | europe        |
 | **multi_region**           | Multi-region or single-region registry                                  | bool         |          | true          |
 | **public**                 | Is it available for every internet user with `Reader` access? | bool    |          | false         |

--- a/configs/terraform/modules/artifact-registry/README.md
+++ b/configs/terraform/modules/artifact-registry/README.md
@@ -4,17 +4,19 @@ This is the GCP image registry creator tool. Use the registry to publish modules
 
 ## Usage
 
-Configure Artifact Registry related values in the `terraform.tfvars` file. 
+Configure Artifact Registry related values in the `terraform.tfvars` file.
+
 > **CAUTION:** Do not delete or update the existing registry-related data set unless you have the knowledge necessary to perform the operations.
 
+Default project settings:
+
+- Project: `kyma-project`
+- Region: `europe-west4`
 
 You can configure multiple artifact registries as a list of objects in `artifact_registry_collection`.
 
 ```terraform
-artifact_registry_gcp_project_id = "kyma-project"
-artifact_registry_gcp_region     = "europe-west4"
-
-artifact_registry_collection = {
+artifact_registry_collection_kyma_project = {
   modules-internal={
     name                   = "modules-internal"
     owner                  = "neighbors"
@@ -24,11 +26,13 @@ artifact_registry_collection = {
   },
 }
 ```
-If you want to create a new Artifact registry, copy an existing registry data and then modify the **required** parameters according to your needs. 
+
+If you want to create a new Artifact registry, copy an existing registry data and then modify the **required** parameters according to your needs.
+
 > **CAUTION:** Do not delete or update the existing registry-related data set unless you have the knowledge necessary to perform the operations.
 
 ```terraform
-artifact_registry_collection = {
+artifact_registry_collection_<project_id> = {
     ...
   <your registry's name>={
     name                   = "<your registry's name>"
@@ -39,18 +43,19 @@ artifact_registry_collection = {
   ...
 }
 ```
+
 Additionally, you can define optional parameters. Here are all the parameters you can use:
-| Parameter              | Description                                                             | Type         | Required | Default value |
+| Parameter | Description | Type | Required | Default value |
 |------------------------|-------------------------------------------------------------------------|--------------|----------|---------------|
-| **name**                   | Artifact Registry name                                                  | string       | x        |               |
-| **owner**                  | Registry Owner Team                                                     | string       | x        |               |
-| **type**                   | Environment type (development, production)                              | string       | x        |               |
-| **reader_serviceaccounts** | List of Service Accounts that have `Reader` access to registry          | list(string) | x        |               |
-| **writer_serviceaccounts**  | List of Service Accounts that have  `RepoAdmin`  access to registry        | list(string)       |          | ""            |
-| **primary_area**           | Primary area (if multi-region registry)                                 | string       |          | europe        |
-| **multi_region**           | Multi-region or single-region registry                                  | bool         |          | true          |
-| **public**                 | Is it available for every internet user with `Reader` access? | bool    |          | false         |
-| **immutable**              | Enable Immutable tags                                                         | bool         |          | false         |
+| **name** | Artifact Registry name | string | x | |
+| **owner** | Registry Owner Team | string | x | |
+| **type** | Environment type (development, production) | string | x | |
+| **reader_serviceaccounts** | List of Service Accounts that have `Reader` access to registry | list(string) | x | |
+| **writer_serviceaccounts** | List of Service Accounts that have `RepoAdmin` access to registry | list(string) | | "" |
+| **primary_area** | Primary area (if multi-region registry) | string | | europe |
+| **multi_region** | Multi-region or single-region registry | bool | | true |
+| **public** | Is it available for every internet user with `Reader` access? | bool | | false |
+| **immutable** | Enable Immutable tags | bool | | false |
 
 When you use the GCP private image registry, consider the following:
 

--- a/configs/terraform/modules/artifact-registry/README.md
+++ b/configs/terraform/modules/artifact-registry/README.md
@@ -46,7 +46,7 @@ Additionally, you can define optional parameters. Here are all the parameters yo
 | **owner**                  | Registry Owner Team                                                     | string       | x        |               |
 | **type**                   | Environment type (development, production)                              | string       | x        |               |
 | **reader_serviceaccounts** | List of Service Accounts that have `Reader` access to registry          | list(string) | x        |               |
-| **writer_serviceaccounts**  | List of Service Accounts that have  `Writer`  access to registry        | list(string)       |          | ""            |
+| **writer_serviceaccounts**  | List of Service Accounts that have  `RepoAdmin`  access to registry        | list(string)       |          | ""            |
 | **primary_area**           | Primary area (if multi-region registry)                                 | string       |          | europe        |
 | **multi_region**           | Multi-region or single-region registry                                  | bool         |          | true          |
 | **public**                 | Is it available for every internet user with `Reader` access? | bool    |          | false         |
@@ -55,7 +55,7 @@ Additionally, you can define optional parameters. Here are all the parameters yo
 When you use the GCP private image registry, consider the following:
 
 - The solution is prepared for the GCP Service Account related execution.
-- The `roles/artifactregistry.writer` role binding is part of the solution. To learn more, read [Artifact Registry Repository Access Control](https://cloud.google.com/artifact-registry/docs/access-control). If this variable is empty, the solution doesn't add any service account with the `writer` permission.
+- The `roles/artifactregistry.repoAdmin` role binding is part of the solution. To learn more, read [Artifact Registry Repository Access Control](https://cloud.google.com/artifact-registry/docs/access-control). If this variable is empty, the solution doesn't add any service account with the `writer` permission.
 - The `roles/artifactregistry.reader` role binding is required for lifecycle-manager service accounts. To learn more, read [Artifact Registry Repository Access Control](https://cloud.google.com/artifact-registry/docs/access-control).
 - You can make your repository public if you use the `public = true` in the `terraform.tfvars`.
 - Vulnerability scanning is enabled by default.

--- a/configs/terraform/modules/artifact-registry/main.tf
+++ b/configs/terraform/modules/artifact-registry/main.tf
@@ -12,17 +12,17 @@ resource "google_artifact_registry_repository" "artifact_registry" {
     type  = var.artifact_registry_type
   }
   docker_config {
-    immutable_tags = var.immutable_artifact_registry
+    immutable_tags = var.artifact_registry_immutable_tags
   }
 }
 
-resource "google_artifact_registry_repository_iam_member" "member_service_account" {
-  count      = var.artifact_registry_writer_serviceaccount == "" ? 0 : 1
+resource "google_artifact_registry_repository_iam_member" "writer_service_account" {
+  for_each   = toset(var.artifact_registry_writer_serviceaccounts)
   project    = data.google_client_config.this.project
   location   = var.artifact_registry_multi_region == true ? var.artifact_registry_primary_area : data.google_client_config.this.region
   repository = google_artifact_registry_repository.artifact_registry.name
   role       = "roles/artifactregistry.writer"
-  member     = "serviceAccount:${var.artifact_registry_writer_serviceaccount}"
+  member     = "serviceAccount:${each.value}"
 }
 
 resource "google_artifact_registry_repository_iam_member" "reader_service_accounts" {

--- a/configs/terraform/modules/artifact-registry/main.tf
+++ b/configs/terraform/modules/artifact-registry/main.tf
@@ -1,43 +1,43 @@
 data "google_client_config" "this" {}
 
 resource "google_artifact_registry_repository" "artifact_registry" {
-  location      = var.artifact_registry_multi_region == true ? var.artifact_registry_primary_area : data.google_client_config.this.region
-  repository_id = lower(var.artifact_registry_name)
-  description   = "${lower(var.artifact_registry_name)} repository"
+  location      = var.multi_region == true ? var.primary_area : data.google_client_config.this.region
+  repository_id = lower(var.registry_name)
+  description   = "${lower(var.registry_name)} registry"
   format        = "DOCKER"
 
   labels = {
-    name  = "${lower(var.artifact_registry_name)}"
-    owner = var.artifact_registry_owner
-    type  = var.artifact_registry_type
+    name  = "${lower(var.registry_name)}"
+    owner = var.owner
+    type  = var.type
   }
   docker_config {
-    immutable_tags = var.artifact_registry_immutable_tags
+    immutable_tags = var.immutable_tags
   }
 }
 
 resource "google_artifact_registry_repository_iam_member" "writer_service_account" {
-  for_each   = toset(var.artifact_registry_writer_serviceaccounts)
+  for_each   = toset(var.writer_serviceaccounts)
   project    = data.google_client_config.this.project
-  location   = var.artifact_registry_multi_region == true ? var.artifact_registry_primary_area : data.google_client_config.this.region
+  location   = var.multi_region == true ? var.primary_area : data.google_client_config.this.region
   repository = google_artifact_registry_repository.artifact_registry.name
   role       = "roles/artifactregistry.repoAdmin"
   member     = "serviceAccount:${each.value}"
 }
 
 resource "google_artifact_registry_repository_iam_member" "reader_service_accounts" {
-  for_each   = toset(var.artifact_registry_reader_serviceaccounts)
+  for_each   = toset(var.reader_serviceaccounts)
   project    = data.google_client_config.this.project
-  location   = var.artifact_registry_multi_region == true ? var.artifact_registry_primary_area : data.google_client_config.this.region
+  location   = var.multi_region == true ? var.primary_area : data.google_client_config.this.region
   repository = google_artifact_registry_repository.artifact_registry.name
   role       = "roles/artifactregistry.reader"
   member     = "serviceAccount:${each.value}"
 }
 
 resource "google_artifact_registry_repository_iam_member" "public_access" {
-  count      = var.artifact_registry_public == true ? 1 : 0
+  count      = var.public == true ? 1 : 0
   project    = data.google_client_config.this.project
-  location   = var.artifact_registry_multi_region == true ? var.artifact_registry_primary_area : data.google_client_config.this.region
+  location   = var.multi_region == true ? var.primary_area : data.google_client_config.this.region
   repository = google_artifact_registry_repository.artifact_registry.name
   role       = "roles/artifactregistry.reader"
   member     = "allUsers"

--- a/configs/terraform/modules/artifact-registry/main.tf
+++ b/configs/terraform/modules/artifact-registry/main.tf
@@ -21,7 +21,7 @@ resource "google_artifact_registry_repository_iam_member" "writer_service_accoun
   project    = data.google_client_config.this.project
   location   = var.artifact_registry_multi_region == true ? var.artifact_registry_primary_area : data.google_client_config.this.region
   repository = google_artifact_registry_repository.artifact_registry.name
-  role       = "roles/artifactregistry.writer"
+  role       = "roles/artifactregistry.repoAdmin"
   member     = "serviceAccount:${each.value}"
 }
 

--- a/configs/terraform/modules/artifact-registry/variables.tf
+++ b/configs/terraform/modules/artifact-registry/variables.tf
@@ -1,52 +1,52 @@
 ###################################
 # Artifact Registry related values
 ###################################
-variable "artifact_registry_name" {
+variable "registry_name" {
   type        = string
   description = "Artifact Registry name"
 }
 
-variable "artifact_registry_owner" {
+variable "owner" {
   type        = string
   description = "Owner inside SAP"
   default     = "neighbors"
 }
 
-variable "artifact_registry_writer_serviceaccounts" {
+variable "writer_serviceaccounts" {
   type        = list(string)
-  description = "Service Account"
+  description = "Service Accounts with reapoAdmin access"
 }
 
-variable "artifact_registry_reader_serviceaccounts" {
+variable "reader_serviceaccounts" {
   type        = list(string)
   description = "Service Accounts with read access (lifecycle-maneger)"
 }
 
-variable "artifact_registry_type" {
+variable "type" {
   type        = string
   description = "Environment for the resources"
   default     = "development"
 }
 
-variable "artifact_registry_multi_region" {
+variable "multi_region" {
   type        = bool
   description = "Is Location type Multi-region"
   default     = true
 }
 
-variable "artifact_registry_primary_area" {
+variable "primary_area" {
   type        = string
   description = "Location type Multi-region"
   default     = "europe"
 }
 
-variable "artifact_registry_immutable_tags" {
+variable "immutable_tags" {
   type        = bool
   description = "Is Artifact registry immutable"
   default     = false
 }
 
-variable "artifact_registry_public" {
+variable "public" {
   type        = bool
   description = "Is Artifact registry public"
   default     = false

--- a/configs/terraform/modules/artifact-registry/variables.tf
+++ b/configs/terraform/modules/artifact-registry/variables.tf
@@ -12,8 +12,8 @@ variable "artifact_registry_owner" {
   default     = "neighbors"
 }
 
-variable "artifact_registry_writer_serviceaccount" {
-  type        = string
+variable "artifact_registry_writer_serviceaccounts" {
+  type        = list(string)
   description = "Service Account"
 }
 
@@ -40,7 +40,7 @@ variable "artifact_registry_primary_area" {
   default     = "europe"
 }
 
-variable "immutable_artifact_registry" {
+variable "artifact_registry_immutable_tags" {
   type        = bool
   description = "Is Artifact registry immutable"
   default     = false

--- a/development/secrets-rotator/cloud-run/rotate-service-account/README.md
+++ b/development/secrets-rotator/cloud-run/rotate-service-account/README.md
@@ -13,7 +13,7 @@ RotateServiceAccount creates a new key for a GCP service account and updates the
 
 ## Cloud Run deployment
 
-RotateServiceAccount is deployed to Cloud Run applying Terraform config stored in [./terraform directory](../../../../configs/terraform). `terraform apply` is executed automatically on every PR changing Terraform .tf files belonging to the application. 
+RotateServiceAccount is deployed to Cloud Run applying Terraform config stored in [`./terraform` directory](../../../../configs/terraform). `terraform apply` is executed automatically on every PR changing Terraform `.tf` files belonging to the application. 
 
 ## RotateServiceAccount usage
 

--- a/development/secrets-rotator/cloud-run/rotate-service-account/README.md
+++ b/development/secrets-rotator/cloud-run/rotate-service-account/README.md
@@ -13,7 +13,7 @@ RotateServiceAccount creates a new key for a GCP service account and updates the
 
 ## Cloud Run deployment
 
-RotateServiceAccount is deployed to Cloud Run applying Terraform config stored in [./terraform directory](../../terraform). `terraform apply` is executed automatically on every PR changing Terraform .tf files belonging to the application. 
+RotateServiceAccount is deployed to Cloud Run applying Terraform config stored in [./terraform directory](../../../../configs/terraform). `terraform apply` is executed automatically on every PR changing Terraform .tf files belonging to the application. 
 
 ## RotateServiceAccount usage
 

--- a/development/secrets-rotator/cloud-run/service-account-keys-cleaner/README.md
+++ b/development/secrets-rotator/cloud-run/service-account-keys-cleaner/README.md
@@ -15,7 +15,7 @@ The Cloud Run service deletes old keys for a GCP service account and updates the
 
 ## Cloud Run service deployment
 
-ServiceAccountKeysCleaner is deployed to Cloud Run applying Terraform config stored in [./terraform directory](../../terraform). `terraform apply` runs automatically on every PR changing `Terraform .tf` files belonging to the application.
+ServiceAccountKeysCleaner is deployed to Cloud Run applying Terraform config stored in [./terraform directory](../../../../configs/terraform). `terraform apply` runs automatically on every PR changing `Terraform .tf` files belonging to the application.
 
 1. Create the `service-${PROJECT_NUMBER}@gcp-sa-secretmanager.iam.gserviceaccount.com` service account with the `roles/pubsub.publisher` role if it does not exist.
 2. Merge your changes to test-infra main branch to trigger Terraform execution.

--- a/development/secrets-rotator/cloud-run/service-account-keys-cleaner/README.md
+++ b/development/secrets-rotator/cloud-run/service-account-keys-cleaner/README.md
@@ -15,7 +15,7 @@ The Cloud Run service deletes old keys for a GCP service account and updates the
 
 ## Cloud Run service deployment
 
-ServiceAccountKeysCleaner is deployed to Cloud Run applying Terraform config stored in [./terraform directory](../../../../configs/terraform). `terraform apply` runs automatically on every PR changing `Terraform .tf` files belonging to the application.
+ServiceAccountKeysCleaner is deployed to Cloud Run applying Terraform config stored in [`./terraform` directory](../../../../configs/terraform). `terraform apply` runs automatically on every PR changing Terraform `.tf` files belonging to the application.
 
 1. Create the `service-${PROJECT_NUMBER}@gcp-sa-secretmanager.iam.gserviceaccount.com` service account with the `roles/pubsub.publisher` role if it does not exist.
 2. Merge your changes to test-infra main branch to trigger Terraform execution.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 [Changelog Generator](/changelog-generator/README.md) - This project is a Docker image that is used to generate a changelog in the `kyma` repository. It uses GitHub API to get pull requests with specified labels.
 
-[gcp-artifact-registry-terraform](/configs/terraform/modules/artifact-registry/README.md) - This is the GCP image registry creator tool. Use the registry to publish modules that should be accessible to internal SAP teams.
+[Artifact Registry creator tool (GCP, Terraform)](/configs/terraform/modules/artifact-registry/README.md) - This is the GCP image registry creator tool. Use the registry to publish modules that should be accessible to internal SAP teams.
 
 [Create Custom Image](/development/custom-image/README.md) - The purpose of this document is to define how to create a new Google Compute Engine [custom image](https://cloud.google.com/compute/docs/images) with required dependencies. You can use the new image to provision virtual machine (VM) instances with all dependencies already installed.
 


### PR DESCRIPTION
According to https://github.tools.sap/kyma/backlog/issues/4079 we applied a solution. (PR: https://github.com/kyma-project/test-infra/pull/8479)

Then we realised on 2023-08-10: Due to test-infra basic config, the modules-internal Artifact Registry has been created in wrong project.

Right project: **kyma-project**
Wrong (current) project: **sap-kyma-prow**


Changes proposed in this pull request:

- `immutable_artifact_registry` was renamed to `artifact_registry_immutable_tags`
- Some document related changes
- The entire solution uses a dedicated provider

```yaml
provider "google" {
  alias   = "kyma_project_provider"
  project = var.kyma_project_gcp_project_id
  region  = var.kyma_project_gcp_region
}
```

What does this improvement mean?
- You can create multiple artifact registry in a dedicated project.
- You cannot create multiple artifact registries in multiple project, with the current configuration. For that you have to define the project relates `provider`
- The project where you can create artifact registries, could be different than the project where the prow execute the terraform solution.

**Related issue(s)**

- https://github.tools.sap/kyma/backlog/issues/4079 
- https://github.com/kyma-project/test-infra/pull/8479