### PR TITLE
Add old tag for backward compatibility with generic-autobumper

### DIFF
--- a/prow/jobs/kyma-project/k8s-prow/k8s-prow-postsubmits.yaml
+++ b/prow/jobs/kyma-project/k8s-prow/k8s-prow-postsubmits.yaml
@@ -40,6 +40,7 @@ postsubmits:
                   --base-import-paths \
                   -t="$PULL_BASE_REF" \
                   -t="$PULL_BASE_SHA" \
+                  -t="$(date +v%Y%m%d)-${PULL_BASE_SHA::8}" \
                   -t=latest
             # docker-in-docker needs privileged mode
             securityContext:


### PR DESCRIPTION
Since new prow images are tagged that follow semantic-versioned `YEAR.MONTH.DAY` generic-autobumper cannot handle it. As a quick fix, add back the old tag.

/kind bug
/area prow
