### PR TITLE
make pre-main-reconciler-publish-pr-cli optional

### DIFF
--- a/prow/jobs/incubator/reconciler/reconciler.yaml
+++ b/prow/jobs/incubator/reconciler/reconciler.yaml
@@ -78,6 +78,7 @@ presubmits: # runs on PRs
         preset-kyma-cli-pr-unstable: "true"
         preset-sa-vm-kyma-integration: "true"
       run_if_changed: '^((cmd\S+|configs\S+|internal\S+|pkg\S+)(\.[^.][^.][^.]+$|\.[^.][^dD]$|\.[^mM][^.]$|\.[^.]$|/[^.]+$))'
+      optional: true
       skip_report: false
       decorate: true
       cluster: untrusted-workload

--- a/templates/data/incubator-buildpack-data.yaml
+++ b/templates/data/incubator-buildpack-data.yaml
@@ -139,7 +139,7 @@ templates:
                     owner: jellyfish
                     description: pre publish reconciler
                   image: "europe-docker.pkg.dev/kyma-project/prod/testimages/e2e-gcloud:v20230831-da9ad29f"
-                  optional: false
+                  optional: true
                   # following regexp won't start build if only Markdown files were changed
                   run_if_changed: "^((cmd\\S+|configs\\S+|internal\\S+|pkg\\S+)(\\.[^.][^.][^.]+$|\\.[^.][^dD]$|\\.[^mM][^.]$|\\.[^.]$|/[^.]+$))"
                   labels:


### PR DESCRIPTION
since this job test cli and reconciler dependencies based on PR, when breaking change introduced, it will potentially make this job fail, it make no sense config it as required job. 