### PR TITLE
renames build jobs from cluster inventory to infrastructure manager

### DIFF
--- a/prow/jobs/infrastructure-manager/infrastructure-manager.yaml
+++ b/prow/jobs/infrastructure-manager/infrastructure-manager.yaml
@@ -2,14 +2,14 @@
 
 
 presubmits: # runs on PRs
-  kyma-project/cluster-inventory:
-    - name: pull-cluster-inventory-build
+  kyma-project/infrastructure-manager:
+    - name: pull-infrastructure-manager-build
       annotations:
-        description: "run cluster-inventory build"
+        description: "run infrastructure-manager build"
         owner: "framefrog"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pull-cluster-inventory-build"
+        prow.k8s.io/pubsub.runID: "pull-infrastructure-manager-build"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
       always_run: true
@@ -28,7 +28,7 @@ presubmits: # runs on PRs
             command:
               - "/image-builder"
             args:
-              - "--name=cluster-inventory"
+              - "--name=infrastructure-manager"
               - "--config=/config/kaniko-build-config.yaml"
               - "--dockerfile=Dockerfile"
             resources:
@@ -51,14 +51,14 @@ presubmits: # runs on PRs
               secretName: signify-dev-secret
   
 postsubmits: # runs on main
-  kyma-project/cluster-inventory:
-    - name: main-cluster-inventory-build
+  kyma-project/infrastructure-manager:
+    - name: main-infrastructure-manager-build
       annotations:
-        description: "build cluster-inventory"
+        description: "build infrastructure-manager"
         owner: "framefrog"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "main-cluster-inventory-build"
+        prow.k8s.io/pubsub.runID: "main-infrastructure-manager-build"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
         preset-signify-prod-secret: "true"
@@ -80,7 +80,7 @@ postsubmits: # runs on main
             command:
               - "/image-builder"
             args:
-              - "--name=cluster-inventory"
+              - "--name=infrastructure-manager"
               - "--config=/config/kaniko-build-config.yaml"
               - "--dockerfile=Dockerfile"
               - "--tag=latest"

--- a/templates/data/infrastructure-manager-data.yaml
+++ b/templates/data/infrastructure-manager-data.yaml
@@ -1,21 +1,21 @@
 templates:
   - from: generic.tmpl
     render:
-      - to: ../../prow/jobs/cluster-inventory/cluster-inventory.yaml
+      - to: ../../prow/jobs/infrastructure-manager/infrastructure-manager.yaml
         localSets:
           jobConfig_default:
             imagePullPolicy: "Always"
         jobConfigs:
-          - repoName: kyma-project/cluster-inventory
+          - repoName: kyma-project/infrastructure-manager
             jobs:
               - jobConfig:
-                  name: pull-cluster-inventory-build
+                  name: pull-infrastructure-manager-build
                   annotations:
                     owner: framefrog
-                    description: run cluster-inventory build
+                    description: run infrastructure-manager build
                   always_run: true
                   args:
-                    - "--name=cluster-inventory"
+                    - "--name=infrastructure-manager"
                     - "--config=/config/kaniko-build-config.yaml"
                     - "--dockerfile=Dockerfile"
                 inheritedConfigs:
@@ -23,17 +23,17 @@ templates:
                     - kaniko_buildpack
                     - jobConfig_presubmit
               - jobConfig:
-                  name: main-cluster-inventory-build
+                  name: main-infrastructure-manager-build
                   annotations:
                     owner: framefrog
-                    description: build cluster-inventory
+                    description: build infrastructure-manager
                   labels:
                     preset-signify-prod-secret: "true"
                   branches:
                     - ^main$ # any pr against main triggers this
                   always_run: true
                   args:
-                    - "--name=cluster-inventory"
+                    - "--name=infrastructure-manager"
                     - "--config=/config/kaniko-build-config.yaml"
                     - "--dockerfile=Dockerfile"
                     - "--tag=latest"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- renames build jobs from cluster inventory to infrastructure manager
- ...
- ...

**Related issue(s)**
- https://github.com/kyma-project/infrastructure-manager/issues/9

/area control-plane
/kind cleanup
