### PR TITLE
add image golang:1.21.1-alpine3.18

### DIFF
--- a/development/image-syncer/external-images.yaml
+++ b/development/image-syncer/external-images.yaml
@@ -14,8 +14,8 @@ images:
 - source: "gcr.io/google-containers/pause:3.2"
 - source: "goreleaser/goreleaser:v1.11.5"
 # Golang image is pinned because it is force updated in the upstream
-- source: "golang@sha256:dd8888bb7f1b0b05e1e625aa29483f50f38a9b64073a4db00b04076cec52b71c"
-  tag: "1.21.0-alpine3.18"
+- source: "golang@sha256:96634e55b363cb93d39f78fb18aa64abc7f96d372c176660d7b8b6118939d97b""
+  tag: "1.21.1-alpine3.18"
   amd64Only: true
 - source: "grafana/grafana-image-renderer:3.2.1"
   amd64Only: true


### PR DESCRIPTION
add docker image for [golang:1.21.1-alpine3.18](https://hub.docker.com/layers/library/golang/1.21.1-alpine3.18/images/sha256-0c860c7ceba62231d0f99fb92e9d7c1577f26fea794a12c75756a8f64b146e45?context=explore)
[release notes](https://go.dev/doc/devel/release#go1.21.minor)