### PR TITLE
Adding postsubmit job to build application-connector-manager

### DIFF
--- a/prow/jobs/modules/internal/application-connector-manager.yaml
+++ b/prow/jobs/modules/internal/application-connector-manager.yaml
@@ -168,8 +168,7 @@ presubmits: # runs on PRs
             args:
               - "bash"
               - "-c"
-              - "make -C hack/ci k3d-integration-test
-"
+              - "make -C hack/ci k3d-integration-test"
             resources:
               requests:
                 memory: 4Gi
@@ -180,16 +179,16 @@ presubmits: # runs on PRs
   
 postsubmits: # runs on main
   kyma-project/application-connector-manager:
-    - name: post-application-connector-manager-module-build
+    - name: post-application-connector-manager-build
       annotations:
-        description: "Job to build application-connector module for a release."
+        description: "Job to build application-connector operator for a release."
         owner: "framefrog"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "post-application-connector-manager-module-build"
+        prow.k8s.io/pubsub.runID: "post-application-connector-manager-build"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
-      run_if_changed: '^.env$|^hack/ci/*/.*$|^pkg/*/.*$|^controllers/*/.*$|^charts/*/.*$|^api/*/.*$|^config.yaml$|^Dockerfile$|^(go.mod|go.sum)$|^*/(.*.go|Makefile|.*.sh)|^PROJECT$|^config/*/.*$'
+      always_run: true
       skip_report: false
       decorate: true
       cluster: trusted-workload
@@ -198,29 +197,37 @@ postsubmits: # runs on main
         - ^main$
       spec:
         containers:
-          - image: "europe-docker.pkg.dev/kyma-project/prod/testimages/buildpack-go:v20231003-4f0ff1b3"
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230313-8dfce5f0b"
             securityContext:
               privileged: false
               seccompProfile:
                 type: RuntimeDefault
               allowPrivilegeEscalation: false
             command:
-              - "make"
+              - "/image-builder"
             args:
-              - "-C"
-              - "hack/ci"
-              - "module-build"
-            env:
-              - name: IMG
-                value: "europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:${PULL_BASE_SHA}"
-              - name: KUSTOMIZE_VERSION
-                value: "v4.5.6"
-              - name: MODULE_REGISTRY
-                value: "europe-docker.pkg.dev/kyma-project/prod/unsigned"
+              - "--name=application-connector-manager"
+              - "--config=/config/kaniko-build-config.yaml"
+              - "--context=."
+              - "--dockerfile=Dockerfile"
             resources:
               requests:
-                memory: 3Gi
-                cpu: 2
+                memory: 1.5Gi
+                cpu: 1
+            volumeMounts:
+              - name: config
+                mountPath: /config
+                readOnly: true
+              - name: signify-secret
+                mountPath: /secret
+                readOnly: true
+        volumes:
+          - name: config
+            configMap:
+              name: kaniko-build-config
+          - name: signify-secret
+            secret:
+              secretName: signify-dev-secret
     - name: post-application-connector-module-build
       annotations:
         description: "application-connector module build job"

--- a/prow/jobs/modules/internal/application-connector-manager.yaml
+++ b/prow/jobs/modules/internal/application-connector-manager.yaml
@@ -46,41 +46,6 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
-    - name: pre-application-connector-manager-tests
-      annotations:
-        description: "application-connector operator tests"
-        owner: "framefrogs"
-      labels:
-        prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "pre-application-connector-manager-tests"
-        prow.k8s.io/pubsub.topic: "prowjobs"
-        preset-dind-enabled: "true"
-        preset-docker-push-repository-kyma: "true"
-        preset-sa-kyma-push-images: "true"
-      run_if_changed: '^(go.mod|go.sum)$|^*/(.*.go|Makefile|Dockerfile|.*.sh)'
-      skip_report: false
-      decorate: true
-      cluster: untrusted-workload
-      max_concurrency: 10
-      branches:
-        - ^main$
-      spec:
-        containers:
-          - image: "europe-docker.pkg.dev/kyma-project/prod/testimages/buildpack-go:v20231003-4f0ff1b3"
-            securityContext:
-              privileged: false
-              seccompProfile:
-                type: RuntimeDefault
-              allowPrivilegeEscalation: false
-            command:
-              - "bash"
-            args:
-              - "-c"
-              - "make test"
-            resources:
-              requests:
-                memory: 3Gi
-                cpu: 2
     - name: pre-application-connector-manager-build
       annotations:
         description: "application-connector operator build job"
@@ -168,7 +133,8 @@ presubmits: # runs on PRs
             args:
               - "bash"
               - "-c"
-              - "make -C hack/ci k3d-integration-test"
+              - "make -C hack/ci k3d-integration-test
+"
             resources:
               requests:
                 memory: 4Gi
@@ -181,19 +147,21 @@ postsubmits: # runs on main
   kyma-project/application-connector-manager:
     - name: post-application-connector-manager-build
       annotations:
-        description: "Job to build application-connector operator for a release."
+        description: "Job to build application-connector operator for a release"
         owner: "framefrog"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
         prow.k8s.io/pubsub.runID: "post-application-connector-manager-build"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
+        preset-signify-prod-secret: "true"
       always_run: true
       skip_report: false
       decorate: true
       cluster: trusted-workload
       max_concurrency: 10
       branches:
+        - ^master$
         - ^main$
       spec:
         containers:
@@ -210,6 +178,7 @@ postsubmits: # runs on main
               - "--config=/config/kaniko-build-config.yaml"
               - "--context=."
               - "--dockerfile=Dockerfile"
+              - "--tag={{ .Env \"PULL_BASE_REF\" }}"
             resources:
               requests:
                 memory: 1.5Gi
@@ -228,47 +197,6 @@ postsubmits: # runs on main
           - name: signify-secret
             secret:
               secretName: signify-dev-secret
-    - name: post-application-connector-module-build
-      annotations:
-        description: "application-connector module build job"
-        owner: "framefrog"
-      labels:
-        prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "post-application-connector-module-build"
-        prow.k8s.io/pubsub.topic: "prowjobs"
-        preset-sa-kyma-push-images: "true"
-      run_if_changed: '^application-connector.yaml$|^.env$|^hack/ci/*/.*$|^pkg/*/.*$|^controllers/*/.*$|^charts/*/.*$|^api/*/.*$|^config.yaml$|^Dockerfile$|^(go.mod|go.sum)$|^*/(.*.go|Makefile|.*.sh)|^PROJECT$|^config/*/.*$|^docs/*/.*$'
-      skip_report: false
-      decorate: true
-      cluster: trusted-workload
-      max_concurrency: 10
-      branches:
-        - ^main$
-      spec:
-        containers:
-          - image: "europe-docker.pkg.dev/kyma-project/prod/testimages/buildpack-go:v20231003-4f0ff1b3"
-            securityContext:
-              privileged: false
-              seccompProfile:
-                type: RuntimeDefault
-              allowPrivilegeEscalation: false
-            command:
-              - "make"
-            args:
-              - "-C"
-              - "hack/ci"
-              - "module-build"
-            env:
-              - name: IMG
-                value: "europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:${PULL_BASE_SHA}"
-              - name: KUSTOMIZE_VERSION
-                value: "v4.5.6"
-              - name: MODULE_REGISTRY
-                value: "europe-docker.pkg.dev/kyma-project/prod/unsigned"
-            resources:
-              requests:
-                memory: 3Gi
-                cpu: 2
     - name: post-main-application-connector-manager-verify
       annotations:
         description: "runs application-connector manager verity job on k3d VM"

--- a/templates/data/generic_module_data.yaml
+++ b/templates/data/generic_module_data.yaml
@@ -999,29 +999,10 @@ templates:
           - repoName: github.com/kyma-project/application-connector-manager
             jobs:
               - jobConfig:
-                  name: post-application-connector-manager-module-build
-                  annotations:
-                    owner: framefrog
-                    description: Job to build application-connector module for a release.
-                  labels:
-                    preset-sa-kyma-push-images: "true"
-                  env:
-                    KUSTOMIZE_VERSION: "v4.5.6"
-                    MODULE_REGISTRY: "europe-docker.pkg.dev/kyma-project/prod/unsigned"
-                    IMG: "europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:${PULL_BASE_SHA}"
-                  run_if_changed: "^.env$|^hack/ci/*/.*$|^pkg/*/.*$|^controllers/*/.*$|^charts/*/.*$|^api/*/.*$|^config.yaml$|^Dockerfile$|^(go.mod|go.sum)$|^*/(.*.go|Makefile|.*.sh)|^PROJECT$|^config/*/.*$"
-                  command: "make"
-                  args:
-                    - "-C"
-                    - "hack/ci"
-                    - "module-build"
-                  branches:
-                    - ^main$ # any pr against main triggers this
-                inheritedConfigs:
                   global:
                     - image_buildpack-golang # takes latest golang image
                     - jobConfig_default
-                    - jobConfig_postsubmit
+                    - jobConfig_presubmit
               - jobConfig:
                   name: pre-application-connector-module-build
                   annotations:
@@ -1048,49 +1029,6 @@ templates:
                     - jobConfig_default
                     - jobConfig_presubmit
               - jobConfig:
-                  name: post-application-connector-module-build
-                  annotations:
-                    owner: framefrog
-                    description: application-connector module build job
-                  labels:
-                    preset-sa-kyma-push-images: "true"
-                  env:
-                    KUSTOMIZE_VERSION: "v4.5.6"
-                    MODULE_REGISTRY: "europe-docker.pkg.dev/kyma-project/prod/unsigned"
-                    IMG: "europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:${PULL_BASE_SHA}"
-                  run_if_changed: "^application-connector.yaml$|^.env$|^hack/ci/*/.*$|^pkg/*/.*$|^controllers/*/.*$|^charts/*/.*$|^api/*/.*$|^config.yaml$|^Dockerfile$|^(go.mod|go.sum)$|^*/(.*.go|Makefile|.*.sh)|^PROJECT$|^config/*/.*$|^docs/*/.*$"
-                  command: "make"
-                  args:
-                    - "-C"
-                    - "hack/ci"
-                    - "module-build"
-                  branches:
-                    - ^main$ # any pr against main triggers this
-                inheritedConfigs:
-                  global:
-                    - image_buildpack-golang # takes latest golang image
-                    - jobConfig_default
-                    - jobConfig_postsubmit
-              - jobConfig:
-                  name: pre-application-connector-manager-tests
-                  annotations:
-                    owner: framefrogs
-                    description: application-connector operator tests
-                  run_if_changed: "^(go.mod|go.sum)$|^*/(.*.go|Makefile|Dockerfile|.*.sh)"
-                  command: "bash"
-                  args:
-                    - "-c"
-                    - "make test"
-                  branches:
-                    - ^main$ # any pr against main triggers this
-                inheritedConfigs:
-                  global:
-                    - image_buildpack-golang # takes latest golang image
-                    - jobConfig_default
-                    - jobConfig_presubmit
-                    - build_labels # default labels
-                    - unprivileged
-              - jobConfig:
                   annotations:
                     owner: framefrog
                     description: application-connector operator build job
@@ -1105,6 +1043,26 @@ templates:
                   global:
                     - jobConfig_default
                     - jobConfig_presubmit
+                  local:
+                    - job_build
+              - jobConfig:
+                  name: post-application-connector-manager-build
+                  annotations:
+                    owner: framefrog
+                    description: Job to build application-connector operator for a release
+                  always_run: true
+                  labels:
+                    preset-signify-prod-secret: "true"
+                  args:
+                    - "--name=application-connector-manager"
+                    - "--config=/config/kaniko-build-config.yaml"
+                    - "--context=."
+                    - "--dockerfile=Dockerfile"
+                    - '--tag={{`{{ .Env \"PULL_BASE_REF\" }}`}}'
+                inheritedConfigs:
+                  global:
+                    - jobConfig_default
+                    - jobConfig_postsubmit
                   local:
                     - job_build
               - jobConfig:
@@ -1123,7 +1081,7 @@ templates:
                   global:
                     - jobConfig_default
                     - privileged
-                    - jobConfig_presubmit # TODO: Prepare a Keda-Manager Image
+                    - jobConfig_presubmit # TODO: Prepare application-connector Image
                     - extra_refs_test-infra
                   local:
                     - dind_job_k3d
@@ -1143,7 +1101,7 @@ templates:
                   global:
                     - jobConfig_default
                     - privileged
-                    - jobConfig_postsubmit # TODO: Prepare a Keda-Manager Image
+                    - jobConfig_postsubmit # TODO: Prepare a application-connector Image
                     - extra_refs_test-infra
                   local:
                     - dind_job_k3d


### PR DESCRIPTION
Removed job application-connector operator tests already migrated to GH Actions

Fixed post submit job to build release image for application-connector-manager