### PR TITLE
Fix post-application-connector-module-build job to run as postsubmit

### DIFF
--- a/prow/jobs/modules/internal/application-connector-manager.yaml
+++ b/prow/jobs/modules/internal/application-connector-manager.yaml
@@ -3,47 +3,6 @@
 
 presubmits: # runs on PRs
   kyma-project/application-connector-manager:
-    - name: post-application-connector-module-build
-      annotations:
-        description: "application-connector module build job"
-        owner: "framefrog"
-      labels:
-        prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "post-application-connector-module-build"
-        prow.k8s.io/pubsub.topic: "prowjobs"
-        preset-sa-kyma-push-images: "true"
-      always_run: true
-      skip_report: false
-      decorate: true
-      cluster: untrusted-workload
-      max_concurrency: 10
-      branches:
-        - ^main$
-      spec:
-        containers:
-          - image: "europe-docker.pkg.dev/kyma-project/prod/testimages/buildpack-go:v20231004-3defcf03"
-            securityContext:
-              privileged: false
-              seccompProfile:
-                type: RuntimeDefault
-              allowPrivilegeEscalation: false
-            command:
-              - "make"
-            args:
-              - "-C"
-              - "hack/ci"
-              - "module-build"
-            env:
-              - name: IMG
-                value: "europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:${PULL_BASE_SHA}"
-              - name: KUSTOMIZE_VERSION
-                value: "v4.5.6"
-              - name: MODULE_REGISTRY
-                value: "europe-docker.pkg.dev/kyma-project/prod/unsigned"
-            resources:
-              requests:
-                memory: 3Gi
-                cpu: 2
     - name: pre-application-connector-module-build
       annotations:
         description: "application-connector module build job"
@@ -140,6 +99,47 @@ presubmits: # runs on PRs
   
 postsubmits: # runs on main
   kyma-project/application-connector-manager:
+    - name: post-application-connector-module-build
+      annotations:
+        description: "application-connector module build job"
+        owner: "framefrog"
+      labels:
+        prow.k8s.io/pubsub.project: "sap-kyma-prow"
+        prow.k8s.io/pubsub.runID: "post-application-connector-module-build"
+        prow.k8s.io/pubsub.topic: "prowjobs"
+        preset-sa-kyma-push-images: "true"
+      always_run: true
+      skip_report: false
+      decorate: true
+      cluster: trusted-workload
+      max_concurrency: 10
+      branches:
+        - ^main$
+      spec:
+        containers:
+          - image: "europe-docker.pkg.dev/kyma-project/prod/testimages/buildpack-go:v20231004-3defcf03"
+            securityContext:
+              privileged: false
+              seccompProfile:
+                type: RuntimeDefault
+              allowPrivilegeEscalation: false
+            command:
+              - "make"
+            args:
+              - "-C"
+              - "hack/ci"
+              - "module-build"
+            env:
+              - name: IMG
+                value: "europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:${PULL_BASE_SHA}"
+              - name: KUSTOMIZE_VERSION
+                value: "v4.5.6"
+              - name: MODULE_REGISTRY
+                value: "europe-docker.pkg.dev/kyma-project/prod/unsigned"
+            resources:
+              requests:
+                memory: 3Gi
+                cpu: 2
     - name: post-application-connector-manager-build
       annotations:
         description: "Job to build application-connector operator for a release"

--- a/templates/data/generic_module_data.yaml
+++ b/templates/data/generic_module_data.yaml
@@ -1020,7 +1020,7 @@ templates:
                   global:
                     - image_buildpack-golang # takes latest golang image
                     - jobConfig_default
-                    - jobConfig_presubmit
+                    - jobConfig_postsubmit
               - jobConfig:
                   name: pre-application-connector-module-build
                   annotations:


### PR DESCRIPTION
The job post-application-connector-module-build was not configured correctly to run as postsubmit. 

This PR contains a fix.