### PR TITLE
Restore pre-main-application-connector-manager-verify job 

### DIFF
--- a/prow/jobs/modules/internal/application-connector-manager.yaml
+++ b/prow/jobs/modules/internal/application-connector-manager.yaml
@@ -96,6 +96,52 @@ presubmits: # runs on PRs
           - name: signify-secret
             secret:
               secretName: signify-dev-secret
+    - name: pre-main-application-connector-manager-verify
+      annotations:
+        description: "runs application-connector manager verity job on k3d VM"
+        owner: "framefrog"
+      labels:
+        prow.k8s.io/pubsub.project: "sap-kyma-prow"
+        prow.k8s.io/pubsub.runID: "pre-main-application-connector-manager-verify"
+        prow.k8s.io/pubsub.topic: "prowjobs"
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-kyma-guard-bot-github-token: "true"
+      always_run: true
+      optional: false
+      skip_report: false
+      decorate: true
+      cluster: untrusted-workload
+      max_concurrency: 10
+      branches:
+        - ^master$
+        - ^main$
+      extra_refs:
+        - org: kyma-project
+          repo: test-infra
+          base_ref: main
+      spec:
+        containers:
+          - image: "europe-docker.pkg.dev/kyma-project/prod/testimages/e2e-dind-k3d:v20231004-3defcf03"
+            securityContext:
+              privileged: true
+              seccompProfile:
+                type: Unconfined
+              allowPrivilegeEscalation: true
+            command:
+              - "/init.sh"
+            args:
+              - "bash"
+              - "-c"
+              - "make -C hack/ci k3d-integration-test
+"
+            resources:
+              requests:
+                memory: 4Gi
+                cpu: 3
+              limits:
+                memory: 4Gi
+                cpu: 3
   
 postsubmits: # runs on main
   kyma-project/application-connector-manager:

--- a/prow/jobs/modules/internal/application-connector-manager.yaml
+++ b/prow/jobs/modules/internal/application-connector-manager.yaml
@@ -133,8 +133,7 @@ presubmits: # runs on PRs
             args:
               - "bash"
               - "-c"
-              - "make -C hack/ci k3d-integration-test
-"
+              - "make -C hack/ci k3d-integration-test"
             resources:
               requests:
                 memory: 4Gi

--- a/templates/data/generic_module_data.yaml
+++ b/templates/data/generic_module_data.yaml
@@ -1084,6 +1084,26 @@ templates:
                   local:
                     - job_build
               - jobConfig:
+                  name: pre-main-application-connector-manager-verify
+                  annotations:
+                    owner: framefrog
+                    description: runs application-connector manager verity job on k3d VM
+                  always_run: "true"
+                  optional: "false"
+                  args:
+                    - bash
+                    - -c
+                    - |
+                      make -C hack/ci k3d-integration-test
+                inheritedConfigs:
+                  global:
+                    - jobConfig_default
+                    - privileged
+                    - jobConfig_presubmit # TODO: Prepare application-connector Image
+                    - extra_refs_test-infra
+                  local:
+                    - dind_job_k3d
+              - jobConfig:
                   name: post-main-application-connector-manager-upgrade-latest-to-main
                   annotations:
                     owner: framefrog

--- a/templates/data/generic_module_data.yaml
+++ b/templates/data/generic_module_data.yaml
@@ -1093,8 +1093,7 @@ templates:
                   args:
                     - bash
                     - -c
-                    - |
-                      make -C hack/ci k3d-integration-test
+                    - make -C hack/ci k3d-integration-test
                 inheritedConfigs:
                   global:
                     - jobConfig_default


### PR DESCRIPTION
This job is required by GitHub. 
We cannot merge any code without it.

