### PR TITLE
remove -operator suffix from names used by serverless jobs

### DIFF
--- a/prow/jobs/kyma/tests/serverless/serverless-integration-k3d.yaml
+++ b/prow/jobs/kyma/tests/serverless/serverless-integration-k3d.yaml
@@ -35,7 +35,7 @@ presubmits: # runs on PRs
             args:
               - "bash"
               - "-c"
-              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/kyma-serverless-integration-k3d-operator.sh serverless-integration serverless-contract-tests"
+              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/kyma-serverless-integration-k3d.sh serverless-integration serverless-contract-tests"
             env:
               - name: SERVERLESS_SOURCES
                 value: "/home/prow/go/src/github.com/kyma-project/serverless-manager/"
@@ -75,7 +75,7 @@ presubmits: # runs on PRs
             args:
               - "bash"
               - "-c"
-              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/kyma-serverless-integration-k3d-operator.sh git-auth-integration"
+              - "/home/prow/go/src/github.com/kyma-project/test-infra/prow/scripts/cluster-integration/kyma-serverless-integration-k3d.sh git-auth-integration"
             env:
               - name: SERVERLESS_SOURCES
                 value: "/home/prow/go/src/github.com/kyma-project/serverless-manager/"

--- a/prow/scripts/cluster-integration/kyma-serverless-integration-k3d.sh
+++ b/prow/scripts/cluster-integration/kyma-serverless-integration-k3d.sh
@@ -11,7 +11,7 @@ source "${SCRIPT_DIR}/../lib/serverless-shared-k3s.sh"
 
 date
 
-make -C "$SERVERLESS_SOURCES"/hack/ci run-without-lifecycle-manager-operator
+make -C "$SERVERLESS_SOURCES"/hack/ci run-without-lifecycle-manager
 
 export INTEGRATION_SUITE=("$@")
 run_tests "${INTEGRATION_SUITE[@]}"


### PR DESCRIPTION
Changes proposed in this pull request:

- remove "-operator" suffix from names used by serverless jobs and scripts - this is part of moving serverless sources from kyma repo to serverless-manager repo

**Related issue(s)**
See also #8991 