### PR TITLE
Remove fast-integration from reconciler e2e pipelines

### DIFF
--- a/prow/scripts/reconciler/reconciler-e2e-gardener.sh
+++ b/prow/scripts/reconciler/reconciler-e2e-gardener.sh
@@ -23,8 +23,6 @@
 set -e
 pwd
 
-ENABLE_TEST_LOG_COLLECTOR=false
-
 # Exported variables
 # KYMA_SOURCE set to dummy value, required by gardener/gcp.sh
 export KYMA_SOURCE="main"
@@ -104,14 +102,6 @@ reconciler::trigger_kyma_reconcile
 
 # Wait until reconciliation is complete
 reconciler::wait_until_kyma_reconciled
-
-### Once Kyma is installed run the fast integration test
-echo "Executing test"
-if [[ $KYMA_TEST_SOURCE == "latest-release" ]]; then
-  kubectl apply -f https://github.com/kyma-project/serverless-manager/releases/latest/download/serverless-operator.yaml
-  kubectl apply -f https://github.com/kyma-project/serverless-manager/releases/latest/download/default_serverless_cr.yaml -n kyma-system
-fi
-make -C ../../kyma-project/kyma/tests/fast-integration ci
 
 #!!! Must be at the end of the script !!!
 ERROR_LOGGING_GUARD="false"

--- a/prow/scripts/reconciler/reconciler-e2e-nightly-gardener.sh
+++ b/prow/scripts/reconciler/reconciler-e2e-nightly-gardener.sh
@@ -45,6 +45,4 @@ reconciler::trigger_kyma_reconcile
 
 reconciler::wait_until_kyma_reconciled
 
-make -C ../../kyma-project/kyma/tests/fast-integration ci
-
 reconciler::break_kyma


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Since monitoring will be removed from fast-integration soon and serverless has already been removed, `make ci` target of fast-integration will become obsolete and doesn't test anything anymore: We remove fast-integration execution here from all reconciler e2e pipelines

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
