### PR TITLE
Fix semver tagging for k8s-prow

### DIFF
--- a/prow/jobs/kyma-project/k8s-prow/k8s-prow-periodics.yaml
+++ b/prow/jobs/kyma-project/k8s-prow/k8s-prow-periodics.yaml
@@ -102,7 +102,7 @@ periodics:
               git config --global user.name "Kyma Bot"
               git clone --depth=1 https://github.com/kyma-project/k8s-prow.git && cd k8s-prow
               git remote set-url --push origin https://kyma-bot:$GITHUB_TOKEN@github.com/kyma-project/k8s-prow.git
-              tag=$(date +%Y.%-m.%d)
+              tag=$(date +%Y.%-m.%-d)
               git tag "$tag"
               git push origin "$tag"
               echo "✅  Done"


### PR DESCRIPTION
This resulted in release job not running because version tag with a 0 on the beginning is not compatible with semver. Change day in tag to be singular digit for beginning of a month.

/kind bug
/area ci
