### PR TITLE
Allow passing WS keys via direct variables

### DIFF
--- a/images/unified-agent/start-wssagent.sh
+++ b/images/unified-agent/start-wssagent.sh
@@ -22,8 +22,13 @@ if [[ -z "$PROJECT" ]]; then
 fi
 
 # pass values to Whitesource binary through WS_* variables
-export WS_USERKEY=$(cat "${WHITESOURCE_USERKEY}")
-export WS_APIKEY=$(cat "${WHITESOURCE_APIKEY}")
+if [[ -z "$WS_USERKEY" ]]; then
+  export WS_USERKEY=$(cat "${WHITESOURCE_USERKEY}")
+fi
+
+if [[ -z "$WS_APIKEY" ]]; then
+  export WS_APIKEY=$(cat "${WHITESOURCE_APIKEY}")
+fi
 
 # don't stop scans on first failure, but fail the whole job after all scans have finished
 export scan_failed


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Currently, passing keys for white source unified agent is only possible via files.
This change introduces the possibility to set variables outside script so it can be set in ADO pipeline or during container run.

Changes proposed in this pull request:

- Allow setting whitesource keys outside start-wssagent.sh

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
