### PR TITLE
add golang image 1.21.3-alpine3.18

### DIFF
--- a/cmd/image-syncer/external-images.yaml
+++ b/cmd/image-syncer/external-images.yaml
@@ -14,8 +14,8 @@ images:
 - source: "gcr.io/google-containers/pause:3.2"
 - source: "goreleaser/goreleaser:v1.11.5"
 # Golang image is pinned because it is force updated in the upstream
-- source: "golang@sha256:ae2875fe53715dfd55166c68a1aa8c50cfe1347aec5e0b1a61974591af50b435"
-  tag: "1.21.2-alpine3.18"
+- source: "golang@sha256:926f7f7e1ab8509b4e91d5ec6d5916ebb45155b0c8920291ba9f361d65385806"
+  tag: "1.21.3-alpine3.18"
   amd64Only: true
 - source: "grafana/grafana-image-renderer:3.2.1"
   amd64Only: true


### PR DESCRIPTION
docker: https://hub.docker.com/layers/library/golang/1.21.3-alpine3.18/images/sha256-27c76dcf886c5024320f4fa8ceb57d907494a3bb3d477d0aa7ac8385acd871ea?context=explore

rel notes: https://go.dev/doc/devel/release#go1.21.minor