### PR TITLE
Update regex for release tag in post-telemetry-manager-release-module job

### DIFF
--- a/prow/jobs/telemetry-manager/telemetry-manager-generic.yaml
+++ b/prow/jobs/telemetry-manager/telemetry-manager-generic.yaml
@@ -124,7 +124,7 @@ postsubmits: # runs on main
       cluster: trusted-workload
       max_concurrency: 10
       branches:
-        - ^\d+\.\d+\.\d+(?:-.*)?$
+        - ^\d+\.\d+\.\d+$
       reporter_config:
         slack:
           channel: huskies-notifications

--- a/templates/data/telemetry-manager-data.yaml
+++ b/templates/data/telemetry-manager-data.yaml
@@ -78,7 +78,7 @@ templates:
                   args:
                     - "release"
                   branches:
-                    - "^\\d+\\.\\d+\\.\\d+(?:-.*)?$" # Regex for release tag
+                    - "^\\d+\\.\\d+\\.\\d+$" # Regex for release tag
                   image: "europe-docker.pkg.dev/kyma-project/prod/testimages/e2e-gcloud:v20231020-cd787c4d"
                 inheritedConfigs:
                   global:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- After the changes in this [PR](https://github.tools.sap/kyma/module-manifests/issues/63#issue-3700140), each module version should have a corresponding Github tag in the telemetry-manager repository https://github.com/kyma-project/telemetry-manager. For modules released in the experimental channel, the module version is x.x.x-dev. So, we need to push this additional tag when creating a Github release, but without triggering an additional release job. Therefore, the regex for the tag which triggers the release job is modified.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
