### PR TITLE
Adjust jobs to work with new serverless-manager's Dockerfile

### DIFF
--- a/prow/cluster/resources/gatekeeper-constraints/workloads/signifySecretTrustedUsage.yaml
+++ b/prow/cluster/resources/gatekeeper-constraints/workloads/signifySecretTrustedUsage.yaml
@@ -43,7 +43,7 @@ spec:
         command:
           - /tools/entrypoint
         args: []
-        entrypoint_options: '^{.*"args":\["sh","-c","mkdir -p module-chart \\u0026\\u0026 cp -r config\/serverless\/\* module-chart \\u0026\\u0026 \/image-builder --name=serverless-operator --config=\/config\/kaniko-build-config\.yaml --context=\. --dockerfile=Dockerfile"\],"container_name":"test",.*}$'
+        entrypoint_options: '^{.*"args":\["sh","-c","\/image-builder --name=serverless-operator --config=\/config\/kaniko-build-config\.yaml --context=\. --dockerfile=Dockerfile"\],"container_name":"test",.*}$'
       # sidecar
       - image: "europe-docker.pkg.dev/kyma-project/prod/k8s-prow/sidecar:*"
         command: []
@@ -60,7 +60,7 @@ spec:
         command:
           - /tools/entrypoint
         args: []
-        entrypoint_options: '^{.*"args":\["sh","-c","mkdir -p module-chart \\u0026\\u0026 cp -r config\/serverless\/\* module-chart \\u0026\\u0026 \/image-builder --name=serverless-operator --config=\/config\/kaniko-build-config\.yaml --context=.+ --dockerfile=.+ --tag=.+"\],"container_name":"test".*}$'
+        entrypoint_options: '^{.*"args":\["sh","-c","\/image-builder --name=serverless-operator --config=\/config\/kaniko-build-config\.yaml --context=.+ --dockerfile=.+ --tag=.+"\],"container_name":"test".*}$'
       # post-keb-build
       # post-keb-cleanup-job-build
       # post-keb-deprovision-retrigger-job-build

--- a/prow/cluster/resources/gatekeeper-constraints/workloads/signifySecretTrustedUsage.yaml
+++ b/prow/cluster/resources/gatekeeper-constraints/workloads/signifySecretTrustedUsage.yaml
@@ -43,7 +43,7 @@ spec:
         command:
           - /tools/entrypoint
         args: []
-        entrypoint_options: '^{.*"args":\["sh","-c","\/image-builder --name=serverless-operator --config=\/config\/kaniko-build-config\.yaml --context=\. --dockerfile=Dockerfile"\],"container_name":"test",.*}$'
+        entrypoint_options: '^{.*"args":\["sh","-c","\/image-builder --name=serverless-operator --config=\/config\/kaniko-build-config\.yaml --context=\. --dockerfile=.+"\],"container_name":"test",.*}$'
       # sidecar
       - image: "europe-docker.pkg.dev/kyma-project/prod/k8s-prow/sidecar:*"
         command: []

--- a/prow/jobs/kyma-project/serverless-manager/serverless-manager.yaml
+++ b/prow/jobs/kyma-project/serverless-manager/serverless-manager.yaml
@@ -599,7 +599,7 @@ presubmits: # runs on PRs
               - "sh"
             args:
               - "-c"
-              - "mkdir -p module-chart && cp -r config/serverless/* module-chart && /image-builder --name=serverless-operator --config=/config/kaniko-build-config.yaml --context=. --dockerfile=Dockerfile"
+              - "/image-builder --name=serverless-operator --config=/config/kaniko-build-config.yaml --context=. --dockerfile=components/operator/Dockerfile"
             env:
               - name: BUILDKITD_FLAGS
                 value: "--oci-worker-no-process-sandbox"
@@ -608,8 +608,6 @@ presubmits: # runs on PRs
                 memory: 1.5Gi
                 cpu: 1
             volumeMounts:
-              - name: module-chart
-                mountPath: /home/prow/go/src/github.com/kyma-project/serverless-manager/module-chart
               - name: share
                 mountPath: /home/user/.local/share/buildkit
               - name: config
@@ -619,7 +617,6 @@ presubmits: # runs on PRs
                 mountPath: /secret
                 readOnly: true
         volumes:
-          - name: module-chart
           - name: share
           - name: config
             configMap:
@@ -1147,7 +1144,7 @@ postsubmits: # runs on main
               - "sh"
             args:
               - "-c"
-              - "mkdir -p module-chart && cp -r config/serverless/* module-chart && /image-builder --name=serverless-operator --config=/config/kaniko-build-config.yaml --context=. --dockerfile=Dockerfile --tag=$PULL_BASE_REF"
+              - "/image-builder --name=serverless-operator --config=/config/kaniko-build-config.yaml --context=. --dockerfile=components/operator/Dockerfile --tag=$PULL_BASE_REF"
             env:
               - name: BUILDKITD_FLAGS
                 value: "--oci-worker-no-process-sandbox"
@@ -1156,8 +1153,6 @@ postsubmits: # runs on main
                 memory: 1.5Gi
                 cpu: 1
             volumeMounts:
-              - name: module-chart
-                mountPath: /home/prow/go/src/github.com/kyma-project/serverless-manager/module-chart
               - name: share
                 mountPath: /home/user/.local/share/buildkit
               - name: config
@@ -1167,7 +1162,6 @@ postsubmits: # runs on main
                 mountPath: /secret
                 readOnly: true
         volumes:
-          - name: module-chart
           - name: share
           - name: config
             configMap:
@@ -1287,7 +1281,7 @@ postsubmits: # runs on main
               - "sh"
             args:
               - "-c"
-              - "mkdir -p module-chart && cp -r config/serverless/* module-chart && /image-builder --name=serverless-operator --config=/config/kaniko-build-config.yaml --context=. --dockerfile=Dockerfile --tag=$PULL_BASE_SHA"
+              - "/image-builder --name=serverless-operator --config=/config/kaniko-build-config.yaml --context=. --dockerfile=components/operator/Dockerfile --tag=$PULL_BASE_SHA"
             env:
               - name: BUILDKITD_FLAGS
                 value: "--oci-worker-no-process-sandbox"
@@ -1296,8 +1290,6 @@ postsubmits: # runs on main
                 memory: 1.5Gi
                 cpu: 1
             volumeMounts:
-              - name: module-chart
-                mountPath: /home/prow/go/src/github.com/kyma-project/serverless-manager/module-chart
               - name: share
                 mountPath: /home/user/.local/share/buildkit
               - name: config
@@ -1307,7 +1299,6 @@ postsubmits: # runs on main
                 mountPath: /secret
                 readOnly: true
         volumes:
-          - name: module-chart
           - name: share
           - name: config
             configMap:

--- a/templates/data/generic_module_data.yaml
+++ b/templates/data/generic_module_data.yaml
@@ -312,31 +312,6 @@ templates:
             branches:
               - "^main$"
               - "^release-*"
-          job_build_volumes:
-            volumes:
-              # we create this volume because we don't have permissions for directory
-              - name: module-chart
-                emptyDir: true
-              # copied from globalSet image-builder-buildkit because volumes aren't merged
-              - name: share
-                emptyDir: true
-              - name: config
-                configMapName: kaniko-build-config
-              - name: signify-secret
-                secretName: signify-dev-secret
-            volumeMounts:
-              # we create this volume because we don't have permissions for directory
-              - mountPath: /home/prow/go/src/github.com/kyma-project/serverless-manager/module-chart
-                name: module-chart
-              # copied from globalSet image-builder-buildkit because volumes aren't merged
-              - mountPath: /home/user/.local/share/buildkit
-                name: share
-              - name: config
-                mountPath: /config
-                readOnly: true
-              - name: signify-secret
-                mountPath: /secret
-                readOnly: true
           dind_job_k3d:
             annotations:
             labels:
@@ -723,15 +698,11 @@ templates:
                   args:
                     - -c
                     - >-
-                      mkdir -p module-chart
-                      &&
-                      cp -r config/serverless/* module-chart
-                      &&
                       /image-builder
                       --name=serverless-operator
                       --config=/config/kaniko-build-config.yaml
                       --context=.
-                      --dockerfile=Dockerfile
+                      --dockerfile=components/operator/Dockerfile
                       --tag=$PULL_BASE_REF
                   branches:
                      - ^v?\d+\.\d+\.\d+(?:-.*)?$ #Watches for new Tag
@@ -741,7 +712,6 @@ templates:
                     - image-builder-buildkit
                   local:
                     - job_branches
-                    - job_build_volumes
               - jobConfig:
                   name: release-serverless-module-build
                   annotations:
@@ -843,22 +813,17 @@ templates:
                   args:
                     - -c
                     - >-
-                      mkdir -p module-chart
-                      &&
-                      cp -r config/serverless/* module-chart
-                      &&
                       /image-builder
                       --name=serverless-operator
                       --config=/config/kaniko-build-config.yaml
                       --context=.
-                      --dockerfile=Dockerfile
+                      --dockerfile=components/operator/Dockerfile
                 inheritedConfigs:
                   global:
                     - jobConfig_presubmit
                     - image-builder-buildkit
                   local:
                     - job_branches
-                    - job_build_volumes
               - jobConfig:
                   name: post-serverless-operator-build
                   annotations:
@@ -871,15 +836,11 @@ templates:
                   args:
                     - -c
                     - >-
-                      mkdir -p module-chart
-                      &&
-                      cp -r config/serverless/* module-chart
-                      &&
                       /image-builder
                       --name=serverless-operator
                       --config=/config/kaniko-build-config.yaml
                       --context=.
-                      --dockerfile=Dockerfile
+                      --dockerfile=components/operator/Dockerfile
                       --tag=$PULL_BASE_SHA
                 inheritedConfigs:
                   global:
@@ -887,7 +848,6 @@ templates:
                     - image-builder-buildkit
                   local:
                     - job_branches
-                    - job_build_volumes
               - jobConfig:
                   name: pre-serverless-operator-verify
                   annotations:


### PR DESCRIPTION

**Description**

Adjust jobs to work with new serverless-manager's Dockerfile. 

Changes proposed in this pull request:

- Remove operations connected to `module-chart` which is removed
- Adjust path to `Dockerfile` 
- Remove unused `job_build_volumes`

**Related issue(s)**
https://github.com/kyma-project/serverless-manager/issues/345
