### PR TITLE
Fix post-test-infra-markdown-index-autobump secret constrain

### DIFF
--- a/prow/cluster/resources/gatekeeper-constraints/workloads/kymaAutobumpBotGithubTokenTrustedUsage.yaml
+++ b/prow/cluster/resources/gatekeeper-constraints/workloads/kymaAutobumpBotGithubTokenTrustedUsage.yaml
@@ -17,7 +17,7 @@ spec:
         command:
           - /tools/entrypoint
         args: []
-        entrypoint_options: '^{.*"args":\["\/ko-app\/markdown-index","--config=prow\/markdown-index\/test-infra-markdown-index-autobump-config\.yaml","--labels-override=kind\/chore,area\/documentation"\],"container_name":"test",.*}$'
+        entrypoint_options: '^{.*"args":\["\/ko-app\/markdown-index","--config=configs\/autobump-config\/test-infra-markdown-index-autobump-config\.yaml","--labels-override=kind\/chore,area\/documentation"\],"container_name":"test",.*}$'
       # Prowjob name: test-infra-image-detector-autobump
       # Prowjob name: post-test-infra-image-detector-autobump
       - image: "europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/image-detector:*"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix post-test-infra-markdown-index-autobump "Container test is not allowed to use restricted secret" error

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/test-infra/pull/9179