### PR TITLE
Enable publishing watcher images with tags

### DIFF
--- a/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
+++ b/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
@@ -80,7 +80,7 @@ postsubmits:
               - "--config=/config/kaniko-build-config.yaml"
               - "--context=runtime-watcher"
               - "--dockerfile=Dockerfile"
-              - "--tag=$(PULL_BASE_REF)"
+              - "--tag={{.Env \"PULL_BASE_REF\" }}"
             volumeMounts:
               - name: config
                 mountPath: /config

--- a/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
+++ b/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
@@ -81,7 +81,7 @@ postsubmits:
               - "--config=/config/kaniko-build-config.yaml"
               - "--context=runtime-watcher"
               - "--dockerfile=Dockerfile"
-              - "--tag={{.Env \"PULL_BASE_REF\" }}"
+              - "--tag=$(PULL_BASE_REF)"
             volumeMounts:
               - name: config
                 mountPath: /config

--- a/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
+++ b/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
@@ -86,7 +86,13 @@ postsubmits:
               - name: config
                 mountPath: /config
                 readOnly: true
+#              - name: signify-secret
+#                mountPath: /secret
+#                readOnly: true
         volumes:
           - name: config
             configMap:
               name: kaniko-build-config
+#          - name: signify-secret
+#            secret:
+#              secretName: signify-dev-secret

--- a/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
+++ b/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
@@ -86,13 +86,13 @@ postsubmits:
               - name: config
                 mountPath: /config
                 readOnly: true
-              - name: signify-secret
-                mountPath: /secret
-                readOnly: true
+#              - name: signify-secret
+#                mountPath: /secret
+#                readOnly: true
         volumes:
           - name: config
             configMap:
               name: kaniko-build-config
-          - name: signify-secret
-            secret:
-              secretName: signify-dev-secret
+#          - name: signify-secret
+#            secret:
+#              secretName: signify-dev-secret

--- a/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
+++ b/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
@@ -49,13 +49,13 @@ presubmits:
               secretName: signify-dev-secret
 postsubmits:
   kyma-project/runtime-watcher:
-    - name: main-build-skr
+    - name: watcher-build-skr
       annotations:
-        description: "build runtime watcher skr"
+        description: "build runtime watcher for skr"
         owner: "jellyfish"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
-        prow.k8s.io/pubsub.runID: "main-build-skr"
+        prow.k8s.io/pubsub.runID: "watcher-build-skr"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
         preset-signify-prod-secret: "true"
@@ -81,7 +81,7 @@ postsubmits:
               - "--config=/config/kaniko-build-config.yaml"
               - "--context=runtime-watcher"
               - "--dockerfile=Dockerfile"
-              - "--tag=latest"
+              - "--tag={{.Env \"PULL_BASE_REF\" }}"
             volumeMounts:
               - name: config
                 mountPath: /config

--- a/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
+++ b/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
@@ -58,6 +58,7 @@ postsubmits:
         prow.k8s.io/pubsub.runID: "watcher-build-skr"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
+        preset-signify-prod-secret: "true"
       always_run: true
       skip_report: false
       decorate: true

--- a/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
+++ b/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
@@ -86,13 +86,7 @@ postsubmits:
               - name: config
                 mountPath: /config
                 readOnly: true
-#              - name: signify-secret
-#                mountPath: /secret
-#                readOnly: true
         volumes:
           - name: config
             configMap:
               name: kaniko-build-config
-#          - name: signify-secret
-#            secret:
-#              secretName: signify-dev-secret

--- a/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
+++ b/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
@@ -65,7 +65,7 @@ postsubmits:
       cluster: trusted-workload
       max_concurrency: 10
       branches:
-        - ^main$
+        - ^\d+\.\d+\.\d+(?:-.*)?$
       spec:
         containers:
           - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230313-8dfce5f0b"

--- a/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
+++ b/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
@@ -86,13 +86,13 @@ postsubmits:
               - name: config
                 mountPath: /config
                 readOnly: true
-#              - name: signify-secret
-#                mountPath: /secret
-#                readOnly: true
+              - name: signify-secret
+                mountPath: /secret
+                readOnly: true
         volumes:
           - name: config
             configMap:
               name: kaniko-build-config
-#          - name: signify-secret
-#            secret:
-#              secretName: signify-dev-secret
+          - name: signify-secret
+            secret:
+              secretName: signify-dev-secret

--- a/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
+++ b/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
@@ -58,7 +58,6 @@ postsubmits:
         prow.k8s.io/pubsub.runID: "watcher-build-skr"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
-        preset-signify-prod-secret: "true"
       always_run: true
       skip_report: false
       decorate: true

--- a/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
+++ b/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
@@ -80,7 +80,7 @@ postsubmits:
               - "--config=/config/kaniko-build-config.yaml"
               - "--context=runtime-watcher"
               - "--dockerfile=Dockerfile"
-              - "--tag={{.Env \"PULL_BASE_REF\" }}"
+              - "--tag=$(PULL_BASE_REF)"
             volumeMounts:
               - name: config
                 mountPath: /config

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,6 @@
+pjConfigs:
+  prowJobs:
+    kyma-project:
+      runtime-watcher:
+      - pjName: "watcher-build-skr"
+

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,6 +1,0 @@
-pjConfigs:
-  prowJobs:
-    kyma-project:
-      runtime-watcher:
-      - pjName: "watcher-build-skr"
-


### PR DESCRIPTION
**Description**
Change the job configuration so that it can build the image from the defined tag.

Changes proposed in this pull request:

- Change the tag used to build the image - it should use the tag defined in the repository
- Renamed the job to be more explicit

**Related issue(s)**
See: https://github.com/kyma-project/runtime-watcher/issues/134