### PR TITLE
bug: workaround - static nodeport for gcsweb healthchecks

### DIFF
--- a/prow/cluster/components/gcsweb.yaml
+++ b/prow/cluster/components/gcsweb.yaml
@@ -30,25 +30,44 @@ spec:
           ports:
             - containerPort: 8080
               protocol: TCP
+            - containerPort: 8081
+              name: healthz
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8080
+              port: 8081
             initialDelaySeconds: 3
             timeoutSeconds: 2
             failureThreshold: 2
           readinessProbe:
             httpGet:
-              path: /healthz
-              port: 8080
+              path: /healthz/ready
+              port: 8081
             initialDelaySeconds: 3
             timeoutSeconds: 2
             failureThreshold: 2
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: gcsweb-bc
+  namespace: default
+spec:
+  healthCheck:
+    checkIntervalSec: 5
+    timeoutSec: 3
+    healthyThreshold: 1
+    unhealthyThreshold: 10
+    type: HTTP
+    requestPath: /healthz/ready
+    port: 30425
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: gcsweb
+  annotations:
+    cloud.google.com/backend-config: '{"default": "gcsweb-bc"}'
   labels:
     app: gcsweb
 spec:
@@ -59,3 +78,7 @@ spec:
     - name: http
       port: 80
       targetPort: 8080
+    - name: healthz
+      port: 8081
+      targetPort: 8081
+      nodePort: 30425


### PR DESCRIPTION
/kind bug
/area ci

Currently GCP external LB doesn't support proper configuration of health checks for its load balancers, when health checks are served on different port. This port must be exposed, so external LB can access it. This change is a workaround, as it exposes healthcheck port and sets static nodePort on a cluster. Then custom BackendConfig uses this exposed port to manage healthchecks for a service.