### PR TITLE
Adjust serverless jobs to the new Makefile paths

### DIFF
--- a/prow/jobs/kyma-project/serverless/serverless.yaml
+++ b/prow/jobs/kyma-project/serverless/serverless.yaml
@@ -201,7 +201,7 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-serverless-runtimes-java17-jvm-alpha-build"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
-      run_if_changed: '^components/runtimes/java17'
+      run_if_changed: '^components/runtimes/java17/'
       skip_report: false
       decorate: true
       cluster: untrusted-workload
@@ -248,7 +248,7 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-serverless-runtimes-nodejs-v16-build"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
-      run_if_changed: '^components/runtimes/nodejs'
+      run_if_changed: '^components/runtimes/nodejs/'
       skip_report: false
       decorate: true
       cluster: untrusted-workload
@@ -295,7 +295,7 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-serverless-runtimes-nodejs-v18-build"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
-      run_if_changed: '^components/runtimes/nodejs'
+      run_if_changed: '^components/runtimes/nodejs/'
       skip_report: false
       decorate: true
       cluster: untrusted-workload
@@ -342,7 +342,7 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-serverless-runtimes-python39-build"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
-      run_if_changed: '^components/runtimes/python39'
+      run_if_changed: '^components/runtimes/python39/'
       skip_report: false
       decorate: true
       cluster: untrusted-workload
@@ -389,7 +389,7 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-gitserver-build"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
-      run_if_changed: '^tests/gitserver'
+      run_if_changed: '^tests/gitserver/'
       optional: true
       skip_report: false
       decorate: true
@@ -499,7 +499,7 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pre-serverless-module-build"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
-      run_if_changed: '^.env$|^hack/ci/*/.*$|^pkg/*/.*$|^controllers/*/.*$|^charts/*/.*$|^api/*/.*$|^config.yaml$|^Dockerfile$|^(go.mod|go.sum)$|^*/(.*.go|Makefile|.*.sh)|^PROJECT$|^config/*/.*$'
+      run_if_changed: '^config/operator/.*$|^sec-scanners-config.yaml$|^.version$|^module-config-template.yaml$'
       skip_report: false
       decorate: true
       cluster: untrusted-workload
@@ -519,7 +519,7 @@ presubmits: # runs on PRs
               - "make"
             args:
               - "-C"
-              - "hack/ci"
+              - "components/operator/hack/ci"
               - "module-build"
             env:
               - name: IMG
@@ -562,10 +562,11 @@ presubmits: # runs on PRs
                 type: RuntimeDefault
               allowPrivilegeEscalation: false
             command:
-              - "bash"
+              - "make"
             args:
-              - "-c"
-              - "make test"
+              - "-C"
+              - "components/operator"
+              - "test"
             resources:
               requests:
                 memory: 3Gi
@@ -661,7 +662,7 @@ presubmits: # runs on PRs
             args:
               - "bash"
               - "-c"
-              - "make -C hack/ci k3d-integration-test
+              - "make -C components/operator/hack/ci k3d-integration-test
 "
             resources:
               requests:
@@ -881,7 +882,7 @@ postsubmits: # runs on main
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
         preset-signify-prod-secret: "true"
-      run_if_changed: '^components/runtimes/java17'
+      run_if_changed: '^components/runtimes/java17/'
       skip_report: false
       decorate: true
       cluster: trusted-workload
@@ -930,7 +931,7 @@ postsubmits: # runs on main
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
         preset-signify-prod-secret: "true"
-      run_if_changed: '^components/runtimes/nodejs'
+      run_if_changed: '^components/runtimes/nodejs/'
       skip_report: false
       decorate: true
       cluster: trusted-workload
@@ -979,7 +980,7 @@ postsubmits: # runs on main
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
         preset-signify-prod-secret: "true"
-      run_if_changed: '^components/runtimes/nodejs'
+      run_if_changed: '^components/runtimes/nodejs/'
       skip_report: false
       decorate: true
       cluster: trusted-workload
@@ -1028,7 +1029,7 @@ postsubmits: # runs on main
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
         preset-signify-prod-secret: "true"
-      run_if_changed: '^components/runtimes/python39'
+      run_if_changed: '^components/runtimes/python39/'
       skip_report: false
       decorate: true
       cluster: trusted-workload
@@ -1218,7 +1219,7 @@ postsubmits: # runs on main
         prow.k8s.io/pubsub.runID: "post-serverless-module-build"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
-      run_if_changed: '^.env$|^hack/ci/*/.*$|^pkg/*/.*$|^controllers/*/.*$|^charts/*/.*$|^api/*/.*$|^config.yaml$|^Dockerfile$|^(go.mod|go.sum)$|^*/(.*.go|Makefile|.*.sh)|^PROJECT$|^config/*/.*$'
+      run_if_changed: '^config/operator/.*$|^sec-scanners-config.yaml$|^.version$|^module-config-template.yaml$'
       skip_report: false
       decorate: true
       cluster: trusted-workload
@@ -1238,7 +1239,7 @@ postsubmits: # runs on main
               - "make"
             args:
               - "-C"
-              - "hack/ci"
+              - "components/operator/hack/ci"
               - "module-build"
             env:
               - name: IMG
@@ -1343,7 +1344,7 @@ postsubmits: # runs on main
             args:
               - "bash"
               - "-c"
-              - "make -C hack/ci k3d-integration-test
+              - "make -C components/operator/hack/ci k3d-integration-test
 "
             resources:
               requests:
@@ -1389,7 +1390,7 @@ postsubmits: # runs on main
             args:
               - "bash"
               - "-c"
-              - "make -C hack/ci k3d-upgrade-test
+              - "make -C components/operator/hack/ci k3d-upgrade-test
 "
             resources:
               requests:
@@ -1437,7 +1438,7 @@ periodics: # runs on schedule
             args:
               - "bash"
               - "-c"
-              - "make -C hack/ci run-with-lifecycle-manager
+              - "make -C components/operator/hack/ci run-with-lifecycle-manager
 "
             resources:
               requests:

--- a/templates/data/generic_module_data.yaml
+++ b/templates/data/generic_module_data.yaml
@@ -466,7 +466,7 @@ templates:
                   annotations:
                     owner: otters
                     description: function java 17 build job
-                  run_if_changed: "^components/runtimes/java17"
+                  run_if_changed: "^components/runtimes/java17/"
                   args:
                     - "--name=function-runtime-java17-jvm-alpha"
                     - "--config=/config/kaniko-build-config.yaml"
@@ -483,7 +483,7 @@ templates:
                     description: function java 17 build job
                   labels:
                     preset-signify-prod-secret: "true"
-                  run_if_changed: "^components/runtimes/java17"
+                  run_if_changed: "^components/runtimes/java17/"
                   args:
                     - "--name=function-runtime-java17-jvm-alpha"
                     - "--config=/config/kaniko-build-config.yaml"
@@ -499,7 +499,7 @@ templates:
                   annotations:
                     owner: otters
                     description: function nodejs16 build job
-                  run_if_changed: "^components/runtimes/nodejs"
+                  run_if_changed: "^components/runtimes/nodejs/"
                   args:
                     - "--name=function-runtime-nodejs16"
                     - "--config=/config/kaniko-build-config.yaml"
@@ -516,7 +516,7 @@ templates:
                     description: function nodejs16 build job
                   labels:
                     preset-signify-prod-secret: "true"
-                  run_if_changed: "^components/runtimes/nodejs"
+                  run_if_changed: "^components/runtimes/nodejs/"
                   args:
                     - "--name=function-runtime-nodejs16"
                     - "--config=/config/kaniko-build-config.yaml"
@@ -532,7 +532,7 @@ templates:
                   annotations:
                     owner: otters
                     description: function nodejs18 build job
-                  run_if_changed: "^components/runtimes/nodejs"
+                  run_if_changed: "^components/runtimes/nodejs/"
                   args:
                     - "--name=function-runtime-nodejs18"
                     - "--config=/config/kaniko-build-config.yaml"
@@ -549,7 +549,7 @@ templates:
                     description: function nodejs18 build job
                   labels:
                     preset-signify-prod-secret: "true"
-                  run_if_changed: "^components/runtimes/nodejs"
+                  run_if_changed: "^components/runtimes/nodejs/"
                   args:
                     - "--name=function-runtime-nodejs18"
                     - "--config=/config/kaniko-build-config.yaml"
@@ -565,7 +565,7 @@ templates:
                   annotations:
                     owner: otters
                     description: function python3.9 build job
-                  run_if_changed: "^components/runtimes/python39"
+                  run_if_changed: "^components/runtimes/python39/"
                   args:
                     - "--name=function-runtime-python39"
                     - "--config=/config/kaniko-build-config.yaml"
@@ -582,7 +582,7 @@ templates:
                     description: function pytho3.9 build job
                   labels:
                     preset-signify-prod-secret: "true"
-                  run_if_changed: "^components/runtimes/python39"
+                  run_if_changed: "^components/runtimes/python39/"
                   args:
                     - "--name=function-runtime-python39"
                     - "--config=/config/kaniko-build-config.yaml"
@@ -603,7 +603,7 @@ templates:
                     - "--config=/config/kaniko-build-config.yaml"
                     - "--context=tests/gitserver"
                     - "--dockerfile=tests/gitserver/Dockerfile"
-                  run_if_changed: "^tests/gitserver"
+                  run_if_changed: "^tests/gitserver/"
                   optional: "true"
                 inheritedConfigs:
                   global:
@@ -672,7 +672,7 @@ templates:
                     - bash
                     - -c
                     - |
-                      make -C hack/ci run-with-lifecycle-manager
+                      make -C components/operator/hack/ci run-with-lifecycle-manager
                   extra_refs:
                     serverless:
                       - org: kyma-project
@@ -746,11 +746,11 @@ templates:
                     KUSTOMIZE_VERSION: "v4.5.6"
                     MODULE_REGISTRY: "europe-docker.pkg.dev/kyma-project/prod/unsigned"
                     IMG: "europe-docker.pkg.dev/kyma-project/prod/serverless-operator:${PULL_BASE_SHA}"
-                  run_if_changed: "^.env$|^hack/ci/*/.*$|^pkg/*/.*$|^controllers/*/.*$|^charts/*/.*$|^api/*/.*$|^config.yaml$|^Dockerfile$|^(go.mod|go.sum)$|^*/(.*.go|Makefile|.*.sh)|^PROJECT$|^config/*/.*$"
+                  run_if_changed: "^config/operator/.*$|^sec-scanners-config.yaml$|^.version$|^module-config-template.yaml$"
                   command: "make"
                   args:
                     - "-C"
-                    - "hack/ci"
+                    - "components/operator/hack/ci"
                     - "module-build"
                 inheritedConfigs:
                   global:
@@ -771,11 +771,11 @@ templates:
                     MODULE_REGISTRY: "europe-docker.pkg.dev/kyma-project/dev/unsigned"
                     IMG: "europe-docker.pkg.dev/kyma-project/dev/serverless-operator:PR-${PULL_NUMBER}"
                     MODULE_SHA: "PR-${PULL_NUMBER}"
-                  run_if_changed: "^.env$|^hack/ci/*/.*$|^pkg/*/.*$|^controllers/*/.*$|^charts/*/.*$|^api/*/.*$|^config.yaml$|^Dockerfile$|^(go.mod|go.sum)$|^*/(.*.go|Makefile|.*.sh)|^PROJECT$|^config/*/.*$"
+                  run_if_changed: "^config/operator/.*$|^sec-scanners-config.yaml$|^.version$|^module-config-template.yaml$"
                   command: "make"
                   args:
                     - "-C"
-                    - "hack/ci"
+                    - "components/operator/hack/ci"
                     - "module-build"
                 inheritedConfigs:
                   global:
@@ -790,10 +790,11 @@ templates:
                     owner: otters
                     description: serverless operator tests
                   run_if_changed: "^(go.mod|go.sum)$|^*/(.*.go|Makefile|Dockerfile|.*.sh)"
-                  command: "bash"
+                  command: "make"
                   args:
-                    - "-c"
-                    - "make test"
+                    - "-C"
+                    - "components/operator"
+                    - "test"
                 inheritedConfigs:
                   global:
                     - image_buildpack-golang # takes latest golang image
@@ -857,7 +858,7 @@ templates:
                     - bash
                     - -c
                     - |
-                      make -C hack/ci k3d-integration-test
+                      make -C components/operator/hack/ci k3d-integration-test
                   always_run: "true"
                   optional: "false"
                 inheritedConfigs:
@@ -878,7 +879,7 @@ templates:
                     - bash
                     - -c
                     - |
-                      make -C hack/ci k3d-integration-test
+                      make -C components/operator/hack/ci k3d-integration-test
                   always_run: "true"
                   optional: "true"
                 inheritedConfigs:
@@ -901,7 +902,7 @@ templates:
                     - bash
                     - -c
                     - |
-                      make -C hack/ci k3d-upgrade-test
+                      make -C components/operator/hack/ci k3d-upgrade-test
                 inheritedConfigs:
                   global:
                     - jobConfig_default


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Due to moving `hack/ci` to `components/operator` in `serverless` repo we need to adjust paths in serverless jobs.

Changes proposed in this pull request:

- Adjust path to `components/operator/hack/ci` in serverless jobs
- Adjust `run_if_changed` regex for serverless jobs
- Adjust path to `components/operator` `make test` target

**Related issue(s)**
https://github.com/kyma-project/serverless/issues/345