### PR TITLE
Add version arg to the runtime-watcher prowjob

### DIFF
--- a/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
+++ b/prow/jobs/kyma-project/runtime-watcher/runtime-watcher.yaml
@@ -82,6 +82,7 @@ postsubmits:
               - "--context=runtime-watcher"
               - "--dockerfile=Dockerfile"
               - "--tag=$(PULL_BASE_REF)"
+              - "--export-tags"
             volumeMounts:
               - name: config
                 mountPath: /config


### PR DESCRIPTION
**Description**

Add `--build-arg` to the runtime-watcher prowjob to support explicit binary version for the watcher.
See also: https://github.com/kyma-project/runtime-watcher/pull/147

The expected result:
I want to have the following docker ARG available: `BUILD_VERSION={{ .Date }}-{{ .ShortSHA }}`, e.g: `BUILD_VERSION=v20231107-140215fd`
This should be configured on the **postsubmit** job.


Changes proposed in this pull request:

- Add `--export-tags` to the runtime-watcher prowjob. This exposes the internal `default_tag` of `image_builder` as the docker ARG.

**Related issue(s)**
https://github.com/kyma-project/runtime-watcher/issues/134