### PR TITLE
switch k8s to 1.27.5

### DIFF
--- a/images/e2e-dind-k3d/Dockerfile
+++ b/images/e2e-dind-k3d/Dockerfile
@@ -54,7 +54,7 @@ RUN curl -Lo helm.tar.gz "https://get.helm.sh/helm-${HELM_VERSION}-linux-$(go en
     tar -xzOf helm.tar.gz "linux-$(go env GOARCH)/helm" > /usr/local/bin/helm && \
     chmod +x /usr/local/bin/helm
 
-ARG CLUSTER_VERSION=v1.27.7
+ARG CLUSTER_VERSION=v1.27.5
 RUN curl -Lo /usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/${CLUSTER_VERSION}/bin/linux/$(go env GOARCH)/kubectl" && \
     chmod +x /usr/local/bin/kubectl
 

--- a/images/e2e-dind-nodejs/Dockerfile
+++ b/images/e2e-dind-nodejs/Dockerfile
@@ -52,7 +52,7 @@ RUN curl -Lso install.sh https://raw.githubusercontent.com/k3d-io/k3d/main/insta
 #ARG KIND_VERSION=v0.18.0
 #RUN go install sigs.k8s.io/kind@${KIND_VERSION}
 
-ARG CLUSTER_VERSION=v1.27.7
+ARG CLUSTER_VERSION=v1.27.5
 RUN curl -Lo /usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/${CLUSTER_VERSION}/bin/linux/$(go env GOARCH)/kubectl" && \
     chmod +x /usr/local/bin/kubectl
 

--- a/images/e2e-garden/Dockerfile
+++ b/images/e2e-garden/Dockerfile
@@ -22,7 +22,7 @@ RUN set -eux; \
 
 RUN adduser -D prow
 
-ARG CLUSTER_VERSION=v1.27.7
+ARG CLUSTER_VERSION=v1.27.5
 RUN curl -Lo /usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/${CLUSTER_VERSION}/bin/linux/$(go env GOARCH)/kubectl" && \
     chmod +x /usr/local/bin/kubectl
 


### PR DESCRIPTION
/kind bug
/area ci

Bump k8s version to 1.27.5. 1.27.7 is not compatible with Gardener yet

Fixes #9299 