### PR TITLE
bump go image

### DIFF
--- a/cmd/image-syncer/external-images.yaml
+++ b/cmd/image-syncer/external-images.yaml
@@ -14,8 +14,8 @@ images:
 - source: "gcr.io/google-containers/pause:3.2"
 - source: "goreleaser/goreleaser:v1.11.5"
 # Golang image is pinned because it is force updated in the upstream
-- source: "golang@sha256:926f7f7e1ab8509b4e91d5ec6d5916ebb45155b0c8920291ba9f361d65385806"
-  tag: "1.21.3-alpine3.18"
+- source: "golang@sha256:110b07af87238fbdc5f1df52b00927cf58ce3de358eeeb1854f10a8b5e5e1411"
+  tag: "1.21.4-alpine3.18"
   amd64Only: true
 - source: "grafana/grafana-image-renderer:3.2.1"
   amd64Only: true


### PR DESCRIPTION
This PR bumps the golang image to v`1.21.4`.
https://go.dev/doc/devel/release#go1.21.0