### PR TITLE
Add golangci config

### DIFF
--- a/prow/jobs/kyma-project/keda-manager/keda-manager.yaml
+++ b/prow/jobs/kyma-project/keda-manager/keda-manager.yaml
@@ -11,7 +11,7 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
         prow.k8s.io/pubsub.runID: "pre-keda-manager-operator-lint"
         prow.k8s.io/pubsub.topic: "prowjobs"
-      run_if_changed: '^(go.mod|go.sum|main.go)$|^*/(.*.go|Makefile|.*.sh)'
+      run_if_changed: '^(go.mod|go.sum|main.go|.golangci.yaml)$|^*/(.*.go|Makefile|.*.sh)$'
       optional: true
       skip_report: false
       decorate: true
@@ -31,7 +31,7 @@ presubmits: # runs on PRs
               - "bash"
             args:
               - "-c"
-              - "golangci-lint run --timeout=15m && echo 'OK!'"
+              - "golangci-lint run -v && echo 'OK!'"
             resources:
               requests:
                 memory: 3Gi

--- a/prow/jobs/kyma-project/serverless/serverless.yaml
+++ b/prow/jobs/kyma-project/serverless/serverless.yaml
@@ -467,12 +467,14 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
         prow.k8s.io/pubsub.runID: "pre-serverless-controller-lint"
         prow.k8s.io/pubsub.topic: "prowjobs"
-      run_if_changed: '^components/serverless/(.*\.go$|.golangcilint.yaml)'
+      run_if_changed: '^components/serverless/(.*\.go|.golangci.yaml)$'
       optional: true
       skip_report: false
       decorate: true
       cluster: untrusted-workload
       max_concurrency: 10
+      branches:
+        - ^main$
       spec:
         containers:
           - image: "europe-docker.pkg.dev/kyma-project/prod/test-infra/golangci-lint:v20230821-fdb47ca7"
@@ -482,14 +484,47 @@ presubmits: # runs on PRs
                 type: RuntimeDefault
               allowPrivilegeEscalation: false
             command:
-              - "/bin/sh"
+              - "bash"
             args:
               - "-c"
-              - "cd components/serverless && golangci-lint run --new-from-rev=$PULL_BASE_SHA ./... --timeout=15m"
+              - "cd components/serverless && golangci-lint run -v && echo 'OK!'"
             resources:
               requests:
-                memory: 200Mi
-                cpu: 80m
+                memory: 3Gi
+                cpu: 2
+    - name: pre-serverless-operator-lint
+      annotations:
+        description: "serverless operator linting job"
+        owner: "otters"
+      labels:
+        prow.k8s.io/pubsub.project: "sap-kyma-prow"
+        prow.k8s.io/pubsub.runID: "pre-serverless-operator-lint"
+        prow.k8s.io/pubsub.topic: "prowjobs"
+      run_if_changed: '^components/operator/(.*\.go|.golangci.yaml)$'
+      optional: true
+      skip_report: false
+      decorate: true
+      cluster: untrusted-workload
+      max_concurrency: 10
+      branches:
+        - ^main$
+      spec:
+        containers:
+          - image: "europe-docker.pkg.dev/kyma-project/prod/test-infra/golangci-lint:v20230821-fdb47ca7"
+            securityContext:
+              privileged: false
+              seccompProfile:
+                type: RuntimeDefault
+              allowPrivilegeEscalation: false
+            command:
+              - "bash"
+            args:
+              - "-c"
+              - "cd components/operator && golangci-lint run -v && echo 'OK!'"
+            resources:
+              requests:
+                memory: 3Gi
+                cpu: 2
     - name: pre-serverless-module-build
       annotations:
         description: "build serverless module"

--- a/prow/jobs/kyma-project/warden/warden.yaml
+++ b/prow/jobs/kyma-project/warden/warden.yaml
@@ -143,7 +143,7 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
         prow.k8s.io/pubsub.runID: "pre-warden-lint"
         prow.k8s.io/pubsub.topic: "prowjobs"
-      run_if_changed: '^(go.mod|go.sum)$|^*/(.*.go|Makefile|.*.sh)'
+      run_if_changed: '^(go.mod|go.sum|.golangci.yaml)$|^*/(.*.go|Makefile|.*.sh)$'
       optional: true
       skip_report: false
       decorate: true
@@ -163,7 +163,7 @@ presubmits: # runs on PRs
               - "bash"
             args:
               - "-c"
-              - "golangci-lint run --timeout=15m && echo 'OK!'"
+              - "golangci-lint run -v && echo 'OK!'"
             resources:
               requests:
                 memory: 3Gi

--- a/templates/data/generic_module_data.yaml
+++ b/templates/data/generic_module_data.yaml
@@ -126,7 +126,7 @@ templates:
               - jobConfig:
                   name: pre-keda-manager-operator-lint
                   image: "europe-docker.pkg.dev/kyma-project/prod/test-infra/golangci-lint:v20230821-fdb47ca7"
-                  run_if_changed: "^(go.mod|go.sum|main.go)$|^*/(.*.go|Makefile|.*.sh)"
+                  run_if_changed: "^(go.mod|go.sum|main.go|.golangci.yaml)$|^*/(.*.go|Makefile|.*.sh)$"
                   annotations:
                     owner: otters
                     description: executes the 'golangci-lint lint' command on keda-manager before any pull request.
@@ -134,7 +134,7 @@ templates:
                   optional: "true"
                   args:
                     - "-c"
-                    - "golangci-lint run --timeout=15m && echo 'OK!'"
+                    - "golangci-lint run -v && echo 'OK!'"
                   branches:
                     - ^main$
                 inheritedConfigs:
@@ -655,19 +655,40 @@ templates:
                     - unprivileged
               - jobConfig:
                   name: pre-serverless-controller-lint
+                  image: "europe-docker.pkg.dev/kyma-project/prod/test-infra/golangci-lint:v20230821-fdb47ca7"
                   annotations:
                     owner: otters
                     description: function controller linting job
-                  command: "/bin/sh"
+                  optional: "true"
+                  command: "bash"
                   args:
                     - "-c"
-                    - "cd components/serverless && golangci-lint run --new-from-rev=$PULL_BASE_SHA ./... --timeout=15m"
-                  run_if_changed: '^components/serverless/(.*\.go$|.golangcilint.yaml)'
+                    - "cd components/serverless && golangci-lint run -v && echo 'OK!'"
+                  run_if_changed: '^components/serverless/(.*\.go|.golangci.yaml)$'
+                  branches:
+                    - ^main$
                 inheritedConfigs:
                   global:
                     - jobConfig_presubmit
-                    - linting
-                    - unprivileged
+                    - jobConfig_default
+              - jobConfig:
+                  name: pre-serverless-operator-lint
+                  image: "europe-docker.pkg.dev/kyma-project/prod/test-infra/golangci-lint:v20230821-fdb47ca7"
+                  annotations:
+                    owner: otters
+                    description: serverless operator linting job
+                  optional: "true"
+                  command: "bash"
+                  args:
+                    - "-c"
+                    - "cd components/operator && golangci-lint run -v && echo 'OK!'"
+                  run_if_changed: '^components/operator/(.*\.go|.golangci.yaml)$'
+                  branches:
+                    - ^main$
+                inheritedConfigs:
+                  global:
+                    - jobConfig_presubmit
+                    - jobConfig_default
               - jobConfig:
                   name: serverless-operator-nightly-periodic
                   cron: "0 6 * * 1-5" # "Runs on 7 am every day-of-week from Monday through Friday."

--- a/templates/data/warden.yaml
+++ b/templates/data/warden.yaml
@@ -153,14 +153,14 @@ templates:
                   image: "europe-docker.pkg.dev/kyma-project/prod/test-infra/golangci-lint:v20230821-fdb47ca7"
                   name: pre-warden-lint
                   optional: true
-                  run_if_changed: "^(go.mod|go.sum)$|^*/(.*.go|Makefile|.*.sh)"
+                  run_if_changed: "^(go.mod|go.sum|.golangci.yaml)$|^*/(.*.go|Makefile|.*.sh)$"
                   annotations:
                     owner: otters
                     description: executes the 'golangci-lint lint' command before any pull request.
                   command: "bash"
                   args:
                     - "-c"
-                    - "golangci-lint run --timeout=15m && echo 'OK!'"
+                    - "golangci-lint run -v && echo 'OK!'"
                   branches:
                     - ^main$
                 inheritedConfigs:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- adapting golangcli-lint targets to work with configuration files for serverless, keda and warden
- unification of jobs using golangci-lint
- add golangcli-lint target for serverless operator
