### PR TITLE
feat: Increase cli unit test memory

### DIFF
--- a/prow/jobs/kyma-project/cli/cli.yaml
+++ b/prow/jobs/kyma-project/cli/cli.yaml
@@ -66,7 +66,7 @@ presubmits: # runs on PRs
                 memory: 1Gi
                 cpu: 100m
               limits:
-                memory: 2Gi
+                memory: 4Gi
   
 postsubmits: # runs on main
   kyma-project/cli:

--- a/prow/jobs/kyma-project/cli/cli.yaml
+++ b/prow/jobs/kyma-project/cli/cli.yaml
@@ -65,6 +65,8 @@ presubmits: # runs on PRs
               requests:
                 memory: 1Gi
                 cpu: 100m
+              limits:
+                memory: 2Gi
   
 postsubmits: # runs on main
   kyma-project/cli:

--- a/prow/jobs/kyma-project/cli/cli.yaml
+++ b/prow/jobs/kyma-project/cli/cli.yaml
@@ -66,7 +66,7 @@ presubmits: # runs on PRs
                 memory: 1Gi
                 cpu: 100m
               limits:
-                memory: 4Gi
+                memory: 5Gi
   
 postsubmits: # runs on main
   kyma-project/cli:

--- a/templates/data/cli-data.yaml
+++ b/templates/data/cli-data.yaml
@@ -78,7 +78,7 @@ templates:
                     - "-c"
                     - "go test `go list ./... | grep -v /tests/e2e` -coverprofile=$ARTIFACTS/filtered.cov"
                   always_run: true
-                  limits_memory: 2Gi
+                  limits_memory: 4Gi
                 inheritedConfigs:
                   global:
                     - "jobConfig_presubmit"

--- a/templates/data/cli-data.yaml
+++ b/templates/data/cli-data.yaml
@@ -78,6 +78,7 @@ templates:
                     - "-c"
                     - "go test `go list ./... | grep -v /tests/e2e` -coverprofile=$ARTIFACTS/filtered.cov"
                   always_run: true
+                  limits_memory: 2Gi
                 inheritedConfigs:
                   global:
                     - "jobConfig_presubmit"

--- a/templates/data/cli-data.yaml
+++ b/templates/data/cli-data.yaml
@@ -78,7 +78,7 @@ templates:
                     - "-c"
                     - "go test `go list ./... | grep -v /tests/e2e` -coverprofile=$ARTIFACTS/filtered.cov"
                   always_run: true
-                  limits_memory: 4Gi
+                  limits_memory: 5Gi
                 inheritedConfigs:
                   global:
                     - "jobConfig_presubmit"

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,0 +1,9 @@
+pjConfigs:
+  prowJobs:
+    kyma-project:
+      cli:
+      - pjName: "pull-cli-unit-test"
+prConfigs: #
+  kyma-project:
+    cli: 
+      prNumber: 1847

--- a/vpath/pjtester.yaml
+++ b/vpath/pjtester.yaml
@@ -1,9 +1,0 @@
-pjConfigs:
-  prowJobs:
-    kyma-project:
-      cli:
-      - pjName: "pull-cli-unit-test"
-prConfigs: #
-  kyma-project:
-    cli: 
-      prNumber: 1847


### PR DESCRIPTION
**Description**

Because of [jobs failing](https://storage.googleapis.com/kyma-prow-logs/pr-logs/pull/kyma-project_cli/1847/pull-cli-unit-test/1725054188628480000/build-log.txt) because of OOM (most likely), there's a need to increase memory limits for the involved pods.

```
github.com/kyma-project/cli/cmd/kyma/sync/function.test: /usr/local/go/pkg/tool/linux_amd64/link: signal: killed
[...]
FAIL	github.com/kyma-project/cli/cmd/kyma/sync/function [build failed]
```

Changes proposed in this pull request:

- increase memory limit for the Pods running `pull-cli-unit-test` prowjob

**Related issue(s)**
