### PR TITLE
Add Istio 1.12.0 distroless images to external-images.yaml for image-syncer

### DIFF
--- a/cmd/image-syncer/external-images.yaml
+++ b/cmd/image-syncer/external-images.yaml
@@ -21,9 +21,9 @@ images:
   amd64Only: true
 - source: "hudymi/mockice:0.1.3"
   amd64Only: true
-- source: "istio/pilot:1.19.3-distroless"
-- source: "istio/proxyv2:1.19.3-distroless"
-- source: "istio/install-cni:1.19.3-distroless"
+- source: "istio/pilot:1.20.0-distroless"
+- source: "istio/proxyv2:1.20.0-distroless"
+- source: "istio/install-cni:1.20.0-distroless"
 - source: "jettech/kube-webhook-certgen:v1.5.0"
 - source: "kennethreitz/httpbin:latest"
   amd64Only: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add Istio 1.12.0 distroless images to external-images.yaml for image-syncer

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
