### PR TITLE
OPA constraints update for release-template-operator-assets prowjob.

### DIFF
--- a/prow/cluster/resources/gatekeeper-constraints/workloads/kymaBotGithubSecretTrustedUsage.yaml
+++ b/prow/cluster/resources/gatekeeper-constraints/workloads/kymaBotGithubSecretTrustedUsage.yaml
@@ -164,3 +164,9 @@ spec:
       - image: "europe-docker.pkg.dev/kyma-project/prod/k8s-prow/sidecar:*"
         command: []
         args: []
+      # Upload template-operator release assets to the GitHub release. https://github.com/kyma-project/test-infra/issues/9338
+      - image: "europe-docker.pkg.dev/kyma-project/prod/testimages/buildpack-go:*"
+        command:
+          - /tools/entrypoint
+        args: []
+        entrypoint_options: '^{.*"args":\["\.\/scripts\/release\/upload_assets\.sh","ci"\],"container_name":"test",.*}$'


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Template-operator release requires GitHub bot token for uploading assets to the release in `release-template-operator-assets` prowjob.

Changes proposed in this pull request:


*  Add a new constraint to allow access to kyma-bot github token in prowjob.



**Related issue(s)**
resolves #9338 
