### PR TITLE
add libgit2 to image golangci-lint

### DIFF
--- a/prow/images/golangci-lint/Dockerfile
+++ b/prow/images/golangci-lint/Dockerfile
@@ -11,4 +11,9 @@ ENV LANG C.UTF-8
 
 WORKDIR /workspace
 COPY golangci-lint.sh /golangci-lint.sh
+
+# install libgit2 for serverless components
+RUN apt-get update && apt-get install --no-install-recommends --yes libgit2-dev \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 ENTRYPOINT ["/golangci-lint.sh"]


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

Add libgit2 to golangci-lint image - libgit2 is included in serverless code and needs to be installed. 

This change replace PR:
https://github.com/kyma-project/test-infra/pull/9394
because:
https://github.com/kyma-project/test-infra/pull/9394#issuecomment-1827524170
