### PR TITLE
Update image-builder run-if-changed and add post-build job

### DIFF
--- a/prow/jobs/kyma-project/test-infra/images.yaml
+++ b/prow/jobs/kyma-project/test-infra/images.yaml
@@ -9,7 +9,7 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.runID: "pull-build-image-builder"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
-      run_if_changed: ^development/.*.go|cmd/.*.go|^go.mod
+      run_if_changed: ^pkg/.*.go|cmd/image-builder/.*.go|^go.mod
       decorate: true
       cluster: untrusted-workload
       max_concurrency: 10
@@ -28,7 +28,6 @@ presubmits: # runs on PRs
               - "--config=/config/kaniko-build-config.yaml"
               - "--context=."
               - "--dockerfile=cmd/image-builder/images/kaniko/Dockerfile"
-              - "--export-tags=true"
             resources:
               requests:
                 memory: 500Mi
@@ -82,6 +81,54 @@ presubmits: # runs on PRs
             allowPrivilegeEscalation: true
 postsubmits:
   kyma-project/test-infra:
+    - name: post-build-image-builder
+      annotations:
+        description: "build image-builder image"
+        owner: "neighbors"
+      labels:
+        prow.k8s.io/pubsub.project: "sap-kyma-prow"
+        prow.k8s.io/pubsub.runID: "pull-build-image-builder"
+        prow.k8s.io/pubsub.topic: "prowjobs"
+        preset-sa-kyma-push-images: "true"
+      run_if_changed: ^pkg/.*.go|cmd/image-builder/.*.go|^go.mod
+      branches:
+        - main
+      decorate: true
+      cluster: trusted-workload
+      max_concurrency: 10
+      spec:
+        containers:
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230313-8dfce5f0b"
+            securityContext:
+              privileged: false
+              seccompProfile:
+                type: RuntimeDefault
+              allowPrivilegeEscalation: false
+            command:
+              - "/image-builder"
+            args:
+              - "--name=image-builder"
+              - "--config=/config/kaniko-build-config.yaml"
+              - "--context=."
+              - "--dockerfile=cmd/image-builder/images/kaniko/Dockerfile"
+            resources:
+              requests:
+                memory: 500Mi
+                cpu: 500m
+            volumeMounts:
+              - name: config
+                mountPath: /config
+                readOnly: true
+              - name: signify-secret
+                mountPath: /secret
+                readOnly: true
+        volumes:
+          - name: config
+            configMap:
+              name: kaniko-build-config
+          - name: signify-secret
+            secret:
+              secretName: signify-dev-secret
     - name: post-main-build-testimages
       decorate: true
       labels:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Updated the 'run_if_changed' patterns for building image-builder for more precise reaction to changes. Furthermore, '--export-tags' option was removed for building image-builder as tags are not used in build process.

A post-build job for image-builder was added. Now, every time changes are detected in the specified paths in 'main' branch, the image-builder image will be built automatically. This reduces manual effort and ensures that the latest code changes are incorporated in the image-builder.
