### PR TITLE
Add a setting to ignore non-required tide contexts for the lifecycle-manager repository

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -452,6 +452,11 @@ tide:
         - kyma-project/k8s-prow
   context_options:
     from-branch-protection: true
+    orgs:
+      kyma-project:
+        repos:
+          lifecycle-manager:
+            skip-unknown-contexts: true
 
 presets:
   - labels:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Configures the tide to tolerate the failing of the unknown contexts for the lifecycle-manager.