### PR TITLE
Ignore docker images based on regexp

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -396,6 +396,10 @@ keywords = [
 ]
 [rules.allowlist]
 paths = ['''Database.refactorlog''']
+regexTarget = "line"
+regexes = [
+  '''([a-z0-9]+(?:[.-][a-z0-9]+)*/)*([a-z0-9]+(?:[.-][a-z0-9]+)*)(?::[a-z0-9.-]+)?/([a-z0-9-]+)/([a-z0-9-]+)(?::[a-z0-9.-]+)''',
+]
 stopwords = [
     "client",
     "endpoint",

--- a/cmd/cloud-run/scan-logs-for-secrets/kodata/gitleaks.toml
+++ b/cmd/cloud-run/scan-logs-for-secrets/kodata/gitleaks.toml
@@ -395,6 +395,10 @@ keywords = [
 ]
 [rules.allowlist]
 paths = ['''Database.refactorlog''']
+regexTarget = "line"
+regexes = [
+  '''([a-z0-9]+(?:[.-][a-z0-9]+)*/)*([a-z0-9]+(?:[.-][a-z0-9]+)*)(?::[a-z0-9.-]+)?/([a-z0-9-]+)/([a-z0-9-]+)(?::[a-z0-9.-]+)''',
+]
 stopwords = [
     "client",
     "endpoint",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

We struggle with false positives detection due to name of our docker images (which contains restricted keywords).
This fix that by adding a regex that matches docker images (and it's field tested in our image-detector) to generic-api-key rule's allowlist.

Changes proposed in this pull request:

- Exclude docker images from being a secret value.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Will unblock: https://github.com/kyma-project/test-infra/pull/9483