### PR TITLE
Ignore reconciler results as no non-migrated modules are left

### DIFF
--- a/prow/scripts/reconciler/reconciler-e2e-gardener.sh
+++ b/prow/scripts/reconciler/reconciler-e2e-gardener.sh
@@ -101,7 +101,7 @@ reconciler::initialize_test_pod
 reconciler::trigger_kyma_reconcile
 
 # Wait until reconciliation is complete
-reconciler::wait_until_kyma_reconciled
+#reconciler::wait_until_kyma_reconciled
 
 #!!! Must be at the end of the script !!!
 ERROR_LOGGING_GUARD="false"

--- a/prow/scripts/reconciler/reconciler-upgrade-kyma2-latest-to-main-gardener.sh
+++ b/prow/scripts/reconciler/reconciler-upgrade-kyma2-latest-to-main-gardener.sh
@@ -148,7 +148,7 @@ echo ">>> Reconcile Kyma2 version: ${KYMA_UPGRADE_SOURCE}"
 reconciler::trigger_kyma_reconcile
 
 # Wait until reconciliation is complete
-reconciler::wait_until_kyma_reconciled
+#reconciler::wait_until_kyma_reconciled
 
 # Must be at the end of the script
 ERROR_LOGGING_GUARD="false"


### PR DESCRIPTION


**Description**

Just leave the test in place to detect cases when the MS is not even starting anymore.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
