### PR TITLE
Rename post verify target for warden

### DIFF
--- a/prow/jobs/kyma-project/warden/warden-verify.yaml
+++ b/prow/jobs/kyma-project/warden/warden-verify.yaml
@@ -81,7 +81,7 @@ postsubmits: # runs on main
   kyma-project/warden:
     - name: post-warden-verify
       annotations:
-        description: "LM intergration test"
+        description: "Warden intergration test"
         owner: "otters"
       labels:
         prow.k8s.io/pubsub.project: "sap-kyma-prow"
@@ -111,7 +111,7 @@ postsubmits: # runs on main
             args:
               - "bash"
               - "-c"
-              - "make k3d-lm-integration-test"
+              - "make k3d-integration-test"
             resources:
               requests:
                 memory: 3Gi

--- a/templates/data/warden.yaml
+++ b/templates/data/warden.yaml
@@ -217,12 +217,12 @@ templates:
                   name: post-warden-verify
                   annotations:
                     owner: otters
-                    description: LM intergration test
+                    description: Warden intergration test
                   optional: true
                   args:
                     - "bash"
                     - "-c"
-                    - "make k3d-lm-integration-test"
+                    - "make k3d-integration-test"
                 inheritedConfigs:
                   global:
                     - jobConfig_default


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- rename post CI job for warden to run tests w/o LM

**Related issue(s)**
https://github.com/kyma-project/warden/issues/159