### PR TITLE
chore: bump istio to 1.20.1-distroless

### DIFF
--- a/cmd/image-syncer/external-images.yaml
+++ b/cmd/image-syncer/external-images.yaml
@@ -21,9 +21,9 @@ images:
   amd64Only: true
 - source: "hudymi/mockice:0.1.3"
   amd64Only: true
-- source: "istio/pilot:1.20.0-distroless"
-- source: "istio/proxyv2:1.20.0-distroless"
-- source: "istio/install-cni:1.20.0-distroless"
+- source: "istio/pilot:1.20.1-distroless"
+- source: "istio/proxyv2:1.20.1-distroless"
+- source: "istio/install-cni:1.20.1-distroless"
 - source: "jettech/kube-webhook-certgen:v1.5.0"
 - source: "kennethreitz/httpbin:latest"
   amd64Only: true


### PR DESCRIPTION
/kind chore
/area service-mesh

istio components 1.20.0-distroless -> 1.20.1-distroless
