### PR TITLE
chore: Update nightly-reconciler machine image version

### DIFF
--- a/prow/scripts/reconciler/common.sh
+++ b/prow/scripts/reconciler/common.sh
@@ -97,7 +97,7 @@ spec:
       - machine:
           image:
             name: gardenlinux
-            version: 934.8.0
+            version: 934.11.0
           type: n1-standard-4
         maxSurge: 1
         maxUnavailable: 0

--- a/prow/scripts/reconciler/shoot-template.yaml
+++ b/prow/scripts/reconciler/shoot-template.yaml
@@ -22,7 +22,7 @@ spec:
       - machine:
           image:
             name: gardenlinux
-            version: 934.8.0
+            version: 934.11.0
           type: n1-standard-4
         maxSurge: 1
         maxUnavailable: 0


### PR DESCRIPTION
**Description**

The [nightly-main-reconciler](https://status.build.kyma-project.io/view/gs/kyma-prow-logs/logs/nightly-main-reconciler/1742335028223807488) is currently failing because of: 
```
 machine image version 'gardenlinux:934.8.0' is expired,
```

Changes proposed in this pull request:

- Update machine image version of `nightly-reconciler ` related jobs to `934.11.0`

