### PR TITLE
changes the regex that triggers the nats-manager-release-build job

### DIFF
--- a/prow/jobs/kyma-project/nats-manager/nats-manager-generic.yaml
+++ b/prow/jobs/kyma-project/nats-manager/nats-manager-generic.yaml
@@ -111,7 +111,7 @@ postsubmits: # runs on main
       cluster: trusted-workload
       max_concurrency: 10
       branches:
-        - ^\w+\d+\.\d+\.\d+(?:-.*)?$
+        - ^\d+\.\d+\.\d+(?:-.*)?$ # Watches for new Tag with the format x.y.z where x, y and z are multi-digit integers.
       spec:
         containers:
           - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230313-8dfce5f0b"
@@ -286,4 +286,3 @@ postsubmits: # runs on main
               requests:
                 memory: 3Gi
                 cpu: 2
-


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- changes the regex that triggers the release build job for nats-manager; before it was triggered by a tag with a leading letter like `v1.1.1`. Now it will be triggered by a ticket that only contains the dot-separated integers like `1.1.1`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
