### PR TITLE
remove restrictions on pull-nats-module-build to only run on main

### DIFF
--- a/prow/jobs/kyma-project/nats-manager/nats-manager-generic.yaml
+++ b/prow/jobs/kyma-project/nats-manager/nats-manager-generic.yaml
@@ -63,8 +63,6 @@ presubmits: # runs on PRs
       decorate: true
       cluster: untrusted-workload
       max_concurrency: 10
-      branches:
-        - ^main$
       spec:
         containers:
           - image: "europe-docker.pkg.dev/kyma-project/prod/testimages/e2e-gcloud:v20231228-b1e22a33"

--- a/prow/jobs/kyma-project/nats-manager/nats-manager-generic.yaml
+++ b/prow/jobs/kyma-project/nats-manager/nats-manager-generic.yaml
@@ -49,6 +49,7 @@ presubmits: # runs on PRs
           - name: signify-secret
             secret:
               secretName: signify-dev-secret
+
     - name: pull-nats-module-build
       annotations:
         description: "NATS module build pre-main job"
@@ -147,6 +148,7 @@ postsubmits: # runs on main
           - name: signify-secret
             secret:
               secretName: signify-dev-secret
+
     - name: release-nats-manager-module-build
       annotations:
         description: "Job to build nats module for a release."
@@ -190,6 +192,7 @@ postsubmits: # runs on main
               limits:
                 memory: 3Gi
                 cpu: 2
+
     - name: post-nats-manager-build
       annotations:
         description: "build nats manager image"
@@ -241,6 +244,7 @@ postsubmits: # runs on main
           - name: signify-secret
             secret:
               secretName: signify-dev-secret
+
     - name: post-nats-module-build
       annotations:
         description: "NATS module build post-main job"

--- a/prow/jobs/kyma-project/nats-manager/nats-manager-generic.yaml
+++ b/prow/jobs/kyma-project/nats-manager/nats-manager-generic.yaml
@@ -66,6 +66,7 @@ presubmits: # runs on PRs
       max_concurrency: 10
       branches:
         - ^main$
+        - ^release-\d+\.\d+$
       spec:
         containers:
           - image: "europe-docker.pkg.dev/kyma-project/prod/testimages/e2e-gcloud:v20231228-b1e22a33"

--- a/prow/jobs/kyma-project/nats-manager/nats-manager-generic.yaml
+++ b/prow/jobs/kyma-project/nats-manager/nats-manager-generic.yaml
@@ -64,6 +64,8 @@ presubmits: # runs on PRs
       decorate: true
       cluster: untrusted-workload
       max_concurrency: 10
+      branches:
+        - ^main$
       spec:
         containers:
           - image: "europe-docker.pkg.dev/kyma-project/prod/testimages/e2e-gcloud:v20231228-b1e22a33"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

In the nats-manager in PR on `release-` branches we need to be able to run `pull-nats-module-build`, otherwise PRs on these branches will always fail: https://github.com/kyma-project/nats-manager/pull/281

- remove the restriction of `pull-nats-module-build` to only run on `main`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
