### PR TITLE
feat: Increase 'pre-kyma-cli' job memory limit

### DIFF
--- a/prow/jobs/kyma-project/cli/cli.yaml
+++ b/prow/jobs/kyma-project/cli/cli.yaml
@@ -35,6 +35,8 @@ presubmits: # runs on PRs
               requests:
                 memory: 3Gi
                 cpu: 2
+              limits:
+                memory: 5Gi
     - name: pull-cli-unit-test
       annotations:
         description: "Go test"

--- a/templates/data/cli-data.yaml
+++ b/templates/data/cli-data.yaml
@@ -19,6 +19,7 @@ templates:
                   branches:
                     - "^main$"
                     - "^release-\\d+\\.\\d+$"
+                  limits_memory: 5Gi
                 inheritedConfigs:
                   global:
                     - jobConfig_default


### PR DESCRIPTION
**Description**

Because of [jobs failing](https://storage.googleapis.com/kyma-prow-logs/pr-logs/pull/kyma-project_cli/1899/pre-kyma-cli/1744648467306778624/build-log.txt) due to OOM (most likely), there's a need to increase memory limits for the involved pods.

Changes proposed in this pull request:

- increase memory limit for the Pods running `pre-kyma-cli` prowjob

**Related issue(s)**
n/a