### PR TITLE
feat: Add runtime-watcher e2e test as required status check

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -322,6 +322,10 @@ branch-protection:
               - "lint"
               - "Kustomize (dry-run)"
               - "Kustomize (dry-run-control-plane)"
+        runtime-watcher:
+          required_status_checks:
+            contexts:
+            - "E2E (watcher-enqueue)"
         cli:
           required_status_checks:
             contexts:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- we newly introduced a e2e test suite for runtime-watcher on PRs
- make it required to pass to enable merge

**Related issue(s)**
* https://github.com/kyma-project/runtime-watcher/issues/176
