### PR TITLE
Allow image-builder from prod registry to use restricted secret.

### DIFF
--- a/prow/cluster/resources/gatekeeper-constraints/workloads/saKymaPushImagesSecretTrustedUsage.yaml
+++ b/prow/cluster/resources/gatekeeper-constraints/workloads/saKymaPushImagesSecretTrustedUsage.yaml
@@ -21,6 +21,16 @@ spec:
           - /tools/entrypoint
         args: [ ]
         entrypoint_options: '^{.*"args":\[.*"\/image-builder".*,"--config=/config/kaniko-build-config.yaml".*\],"container_name":"test",.*}$'
+      - image: "europe-docker.pkg.dev/kyma-project/prod/image-builder:*"
+        command:
+          - /tools/entrypoint
+        args: [ ]
+        entrypoint_options: '^{.*"args":\[.*"\/image-builder".*,"--config=/config/kaniko-build-config.yaml".*\],"container_name":"test",.*}$'
+      - image: "europe-docker.pkg.dev/kyma-project/prod/buildkit-image-builder:*"
+        command:
+          - /tools/entrypoint
+        args: [ ]
+        entrypoint_options: '^{.*"args":\[.*"\/image-builder".*,"--config=/config/kaniko-build-config.yaml".*\],"container_name":"test",.*}$'
         #kyma-dashboard-dev, kyma-dashboard-stage, kyma-dashboard-prod and post-k8s-prow-build-release
       - image: "europe-docker.pkg.dev/kyma-project/prod/testimages/e2e-dind-k3d:*"
         command:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Allow image-builder images in kaniko and buildkit versions from production registry to use a restricted secret.
