### PR TITLE
Build different image for buildkit.

### DIFF
--- a/prow/jobs/kyma-project/test-infra/images.yaml
+++ b/prow/jobs/kyma-project/test-infra/images.yaml
@@ -77,12 +77,11 @@ presubmits: # runs on PRs
             command:
               - "/image-builder"
             args:
-              - "--name=image-builder"
+              - "--name=buildkit-image-builder"
               - "--config=/config/kaniko-build-config.yaml"
               - "--context=."
               - "--dockerfile=cmd/image-builder/images/buildkit/Dockerfile"
               - "--build-in-ado=true"
-              - "--tag=v{{ .Date }}-{{ .ShortSHA }}-buildkit"
             resources:
               requests:
                 memory: 500Mi
@@ -209,12 +208,11 @@ postsubmits:
             command:
               - "/image-builder"
             args:
-              - "--name=image-builder"
+              - "--name=buildkit-image-builder"
               - "--config=/config/kaniko-build-config.yaml"
               - "--context=."
               - "--dockerfile=cmd/image-builder/images/buildkit/Dockerfile"
               - "--build-in-ado=true"
-              - "--tag=v{{ .Date }}-{{ .ShortSHA }}-buildkit"
             resources:
               requests:
                 memory: 500Mi


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Build different image for buildkit. This allows kaniko and buildkit version automatic bumps as they will have different image name thus avoiding a race condition between prowjobs building two different versions of image on the same commit.

When building image in CI, we always add default tag to image build on main. Without separate image name, a kaniko and buildkit versions of the same image would be tagged with default tag. The value of this tag will be different and image which would be build last will be used for autobump image-builder usages causing a race condition problem.
