### PR TITLE
Disable post-submit serverless verification jobs

### DIFF
--- a/prow/jobs/kyma-project/serverless/serverless-verify.yaml
+++ b/prow/jobs/kyma-project/serverless/serverless-verify.yaml
@@ -51,8 +51,7 @@ presubmits: # runs on PRs
       cluster: untrusted-workload
       max_concurrency: 10
       branches:
-        - ^main$
-        - ^release-*
+        - ^release-1.2
       spec:
         containers:
           - image: "europe-docker.pkg.dev/kyma-project/prod/testimages/buildpack-go:v20231228-b1e22a33"
@@ -89,8 +88,7 @@ presubmits: # runs on PRs
       cluster: untrusted-workload
       max_concurrency: 10
       branches:
-        - ^main$
-        - ^release-*
+        - ^release-1.2
       extra_refs:
         - org: kyma-project
           repo: test-infra
@@ -142,8 +140,7 @@ postsubmits: # runs on main
       cluster: trusted-workload
       max_concurrency: 10
       branches:
-        - ^main$
-        - ^release-*
+        - ^release-1.2
       extra_refs:
         - org: kyma-project
           repo: test-infra
@@ -192,8 +189,7 @@ postsubmits: # runs on main
       cluster: trusted-workload
       max_concurrency: 10
       branches:
-        - ^main$
-        - ^release-*
+        - ^release-1.2
       extra_refs:
         - org: kyma-project
           repo: test-infra

--- a/templates/data/serverless.yaml
+++ b/templates/data/serverless.yaml
@@ -732,8 +732,7 @@ templates:
         localSets:
           job_branches:
             branches:
-              - "^main$"
-              - "^release-*"
+              - "^release-1.2" # prow based verification jobs need to happen only on previous release-1.2. Post submit verification on main ( and newer release branches is happening via GH actions)
           skip_if_only_changed_documentation:
             # verification jobs that are based on build jobs need to have at least the same restricted
             skip_if_only_changed: '^docs/|^examples/'


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- serverless post-submit jobs should only be triggered when patching `release-1.2` branch. On main ( and future releases ) verification is happening via GH actions triggered by `push` event 

**Related issue(s)**
https://github.com/kyma-project/test-infra/issues/9463