### PR TITLE
Update security-dashboard-token module to fix autogenerate_revision_name issue

### DIFF
--- a/configs/terraform/modules/security-dashboard-token/security-dashboard-token.tf
+++ b/configs/terraform/modules/security-dashboard-token/security-dashboard-token.tf
@@ -19,6 +19,9 @@ resource "google_cloud_run_service" "security_dashboard_token" {
   name     = "security-dashboard-token"
   location = "europe-west1"
 
+  // FIX(long-apply): See https://github.com/hashicorp/terraform-provider-google/issues/5898#issuecomment-605062566
+  autogenerate_revision_name = true
+
   metadata {
     annotations = {
       "run.googleapis.com/client-name" = "terraform"


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

We have experience apply job failing due to same name for different cloud run revision

Changes proposed in this pull request:

- Add autogenerate name option set to true to securtiy-dashboard token cloud run

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

/test all
/kind bug
/area automation