### PR TITLE
Adding prow jobs to build backup and cleanup images for Connectivity Proxy migrator

### DIFF
--- a/prow/jobs/kyma-project/cp-mod-migrator/cp-mod-migrator.yaml
+++ b/prow/jobs/kyma-project/cp-mod-migrator/cp-mod-migrator.yaml
@@ -49,6 +49,52 @@ presubmits: # runs on PRs
           - name: signify-secret
             secret:
               secretName: signify-dev-secret
+    - name: pull-cp-mod-cleaner-build
+      annotations:
+        description: "run cp-mod-cleaner build"
+        owner: "framefrog"
+      labels:
+        prow.k8s.io/pubsub.project: "sap-kyma-prow"
+        prow.k8s.io/pubsub.runID: "pull-cp-mod-cleaner-build"
+        prow.k8s.io/pubsub.topic: "prowjobs"
+        preset-sa-kyma-push-images: "true"
+      run_if_changed: '^images/cleaner'
+      skip_report: false
+      decorate: true
+      cluster: untrusted-workload
+      max_concurrency: 10
+      spec:
+        containers:
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230313-8dfce5f0b"
+            securityContext:
+              privileged: false
+              seccompProfile:
+                type: RuntimeDefault
+              allowPrivilegeEscalation: false
+            command:
+              - "/image-builder"
+            args:
+              - "--name=cp-mod-cleaner"
+              - "--config=/config/kaniko-build-config.yaml"
+              - "--dockerfile=images/cleaner/Dockerfile"
+            resources:
+              requests:
+                memory: 1.5Gi
+                cpu: 1
+            volumeMounts:
+              - name: config
+                mountPath: /config
+                readOnly: true
+              - name: signify-secret
+                mountPath: /secret
+                readOnly: true
+        volumes:
+          - name: config
+            configMap:
+              name: kaniko-build-config
+          - name: signify-secret
+            secret:
+              secretName: signify-dev-secret
   
 postsubmits: # runs on main
   kyma-project/cp-mod-migrator:
@@ -83,6 +129,56 @@ postsubmits: # runs on main
               - "--name=cp-mod-migrator"
               - "--config=/config/kaniko-build-config.yaml"
               - "--dockerfile=Dockerfile"
+              - "--tag=latest"
+            resources:
+              requests:
+                memory: 1.5Gi
+                cpu: 1
+            volumeMounts:
+              - name: config
+                mountPath: /config
+                readOnly: true
+              - name: signify-secret
+                mountPath: /secret
+                readOnly: true
+        volumes:
+          - name: config
+            configMap:
+              name: kaniko-build-config
+          - name: signify-secret
+            secret:
+              secretName: signify-dev-secret
+    - name: main-cp-mod-cleaner-build
+      annotations:
+        description: "build cp-mod-cleaner"
+        owner: "framefrog"
+      labels:
+        prow.k8s.io/pubsub.project: "sap-kyma-prow"
+        prow.k8s.io/pubsub.runID: "main-cp-mod-cleaner-build"
+        prow.k8s.io/pubsub.topic: "prowjobs"
+        preset-sa-kyma-push-images: "true"
+        preset-signify-prod-secret: "true"
+      run_if_changed: '^images/cleaner'
+      skip_report: false
+      decorate: true
+      cluster: trusted-workload
+      max_concurrency: 10
+      branches:
+        - ^main$
+      spec:
+        containers:
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230313-8dfce5f0b"
+            securityContext:
+              privileged: false
+              seccompProfile:
+                type: RuntimeDefault
+              allowPrivilegeEscalation: false
+            command:
+              - "/image-builder"
+            args:
+              - "--name=cp-mod-cleaner"
+              - "--config=/config/kaniko-build-config.yaml"
+              - "--dockerfile=images/cleaner/Dockerfile"
               - "--tag=latest"
             resources:
               requests:

--- a/prow/jobs/kyma-project/cp-mod-migrator/cp-mod-migrator.yaml
+++ b/prow/jobs/kyma-project/cp-mod-migrator/cp-mod-migrator.yaml
@@ -95,6 +95,52 @@ presubmits: # runs on PRs
           - name: signify-secret
             secret:
               secretName: signify-dev-secret
+    - name: pull-cp-mod-backup-build
+      annotations:
+        description: "run cp-mod-backup build"
+        owner: "framefrog"
+      labels:
+        prow.k8s.io/pubsub.project: "sap-kyma-prow"
+        prow.k8s.io/pubsub.runID: "pull-cp-mod-backup-build"
+        prow.k8s.io/pubsub.topic: "prowjobs"
+        preset-sa-kyma-push-images: "true"
+      run_if_changed: '^images/backup'
+      skip_report: false
+      decorate: true
+      cluster: untrusted-workload
+      max_concurrency: 10
+      spec:
+        containers:
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230313-8dfce5f0b"
+            securityContext:
+              privileged: false
+              seccompProfile:
+                type: RuntimeDefault
+              allowPrivilegeEscalation: false
+            command:
+              - "/image-builder"
+            args:
+              - "--name=cp-mod-backup"
+              - "--config=/config/kaniko-build-config.yaml"
+              - "--dockerfile=images/backup/Dockerfile"
+            resources:
+              requests:
+                memory: 1.5Gi
+                cpu: 1
+            volumeMounts:
+              - name: config
+                mountPath: /config
+                readOnly: true
+              - name: signify-secret
+                mountPath: /secret
+                readOnly: true
+        volumes:
+          - name: config
+            configMap:
+              name: kaniko-build-config
+          - name: signify-secret
+            secret:
+              secretName: signify-dev-secret
   
 postsubmits: # runs on main
   kyma-project/cp-mod-migrator:
@@ -179,6 +225,56 @@ postsubmits: # runs on main
               - "--name=cp-mod-cleaner"
               - "--config=/config/kaniko-build-config.yaml"
               - "--dockerfile=images/cleaner/Dockerfile"
+              - "--tag=latest"
+            resources:
+              requests:
+                memory: 1.5Gi
+                cpu: 1
+            volumeMounts:
+              - name: config
+                mountPath: /config
+                readOnly: true
+              - name: signify-secret
+                mountPath: /secret
+                readOnly: true
+        volumes:
+          - name: config
+            configMap:
+              name: kaniko-build-config
+          - name: signify-secret
+            secret:
+              secretName: signify-dev-secret
+    - name: main-cp-mod-backup-build
+      annotations:
+        description: "build cp-mod-backup"
+        owner: "framefrog"
+      labels:
+        prow.k8s.io/pubsub.project: "sap-kyma-prow"
+        prow.k8s.io/pubsub.runID: "main-cp-mod-backup-build"
+        prow.k8s.io/pubsub.topic: "prowjobs"
+        preset-sa-kyma-push-images: "true"
+        preset-signify-prod-secret: "true"
+      run_if_changed: '^images/backup'
+      skip_report: false
+      decorate: true
+      cluster: trusted-workload
+      max_concurrency: 10
+      branches:
+        - ^main$
+      spec:
+        containers:
+          - image: "eu.gcr.io/sap-kyma-neighbors-dev/image-builder:v20230313-8dfce5f0b"
+            securityContext:
+              privileged: false
+              seccompProfile:
+                type: RuntimeDefault
+              allowPrivilegeEscalation: false
+            command:
+              - "/image-builder"
+            args:
+              - "--name=cp-mod-backup"
+              - "--config=/config/kaniko-build-config.yaml"
+              - "--dockerfile=images/backup/Dockerfile"
               - "--tag=latest"
             resources:
               requests:

--- a/templates/data/cp-mod-migrator.yaml
+++ b/templates/data/cp-mod-migrator.yaml
@@ -41,3 +41,36 @@ templates:
                   global:
                     - kaniko_buildpack
                     - jobConfig_postsubmit
+              - jobConfig:
+                  name: pull-cp-mod-cleaner-build
+                  annotations:
+                    owner: framefrog
+                    description: run cp-mod-cleaner build
+                  run_if_changed: "^images/cleaner"
+                  args:
+                    - "--name=cp-mod-cleaner"
+                    - "--config=/config/kaniko-build-config.yaml"
+                    - "--dockerfile=images/cleaner/Dockerfile"
+                inheritedConfigs:
+                  global:
+                    - kaniko_buildpack
+                    - jobConfig_presubmit
+              - jobConfig:
+                  name: main-cp-mod-cleaner-build
+                  annotations:
+                    owner: framefrog
+                    description: build cp-mod-cleaner
+                  labels:
+                    preset-signify-prod-secret: "true"
+                  branches:
+                    - ^main$ # any pr against main triggers this
+                  run_if_changed: "^images/cleaner"
+                  args:
+                    - "--name=cp-mod-cleaner"
+                    - "--config=/config/kaniko-build-config.yaml"
+                    - "--dockerfile=images/cleaner/Dockerfile"
+                    - "--tag=latest"
+                inheritedConfigs:
+                  global:
+                    - kaniko_buildpack
+                    - jobConfig_postsubmit

--- a/templates/data/cp-mod-migrator.yaml
+++ b/templates/data/cp-mod-migrator.yaml
@@ -74,3 +74,36 @@ templates:
                   global:
                     - kaniko_buildpack
                     - jobConfig_postsubmit
+              - jobConfig:
+                  name: pull-cp-mod-backup-build
+                  annotations:
+                    owner: framefrog
+                    description: run cp-mod-backup build
+                  run_if_changed: "^images/backup"
+                  args:
+                    - "--name=cp-mod-backup"
+                    - "--config=/config/kaniko-build-config.yaml"
+                    - "--dockerfile=images/backup/Dockerfile"
+                inheritedConfigs:
+                  global:
+                    - kaniko_buildpack
+                    - jobConfig_presubmit
+              - jobConfig:
+                  name: main-cp-mod-backup-build
+                  annotations:
+                    owner: framefrog
+                    description: build cp-mod-backup
+                  labels:
+                    preset-signify-prod-secret: "true"
+                  branches:
+                    - ^main$ # any pr against main triggers this
+                  run_if_changed: "^images/backup"
+                  args:
+                    - "--name=cp-mod-backup"
+                    - "--config=/config/kaniko-build-config.yaml"
+                    - "--dockerfile=images/backup/Dockerfile"
+                    - "--tag=latest"
+                inheritedConfigs:
+                  global:
+                    - kaniko_buildpack
+                    - jobConfig_postsubmit


### PR DESCRIPTION
Two pairs of jobs for PR and main build for Warden compatible images to be run as init containers  for Connectivity Proxy migrator.

**GH repo**

 https://github.com/kyma-project/cp-mod-migrator .

**Related issue(s)**

https://github.com/kyma-project/kyma/issues/18482