### PR TITLE
Fix `pull-control-plane-rec-upgrade-kyma2-stable-to-main-grdnr`

### DIFF
--- a/prow/scripts/reconciler/reconciler-upgrade-kyma2-latest-to-main-gardener.sh
+++ b/prow/scripts/reconciler/reconciler-upgrade-kyma2-latest-to-main-gardener.sh
@@ -121,6 +121,7 @@ reconciler::trigger_kyma_reconcile
 reconciler::wait_until_kyma_reconciled
 
 if [[ $KYMA_UPGRADE_SOURCE != "main" ]]; then
+  kubectl create namespace kyma-system
   kubectl apply -f https://github.com/kyma-project/serverless/releases/latest/download/serverless-operator.yaml
   respCode=$(curl -o /dev/null --silent --head --write-out '%{http_code}' https://github.com/kyma-project/serverless/releases/latest/download/default_serverless_cr.yaml)
   if [ "$respCode" = "200" ]; then


### PR DESCRIPTION
**Description**

Create namespace `kyma-system` manually, since it will not be created anymore by the old reconciler.

Fixes:
- `pull-control-plane-rec-upgrade-kyma2-stable-to-main-grdnr`