### PR TITLE
Bulid image-builder on PR or push to main branch

### DIFF
--- a/prow/jobs/kyma-project/test-infra/images.yaml
+++ b/prow/jobs/kyma-project/test-infra/images.yaml
@@ -10,6 +10,8 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
       run_if_changed: ^pkg/.*.go|cmd/image-builder/.*.go|^go.mod|cmd/image-builder/images/
+      branches:
+        - main
       decorate: true
       cluster: untrusted-workload
       max_concurrency: 10
@@ -57,6 +59,8 @@ presubmits: # runs on PRs
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
       run_if_changed: ^pkg/.*.go|cmd/image-builder/.*.go|^go.mod|cmd/image-builder/images/
+      branches:
+        - main
       decorate: true
       cluster: untrusted-workload
       max_concurrency: 10
@@ -188,6 +192,8 @@ postsubmits:
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
       run_if_changed: ^pkg/.*.go|cmd/image-builder/.*.go|^go.mod|cmd/image-builder/images/
+      branches:
+        - main
       decorate: true
       cluster: trusted-workload
       max_concurrency: 10


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Fix trigger for building image-builder images. Builds should be started on pr or push to main branch. This was causing running post prowjobs on dependabot pull requests.
