### PR TITLE
Update golang version to 1.22 for e2e-dind-k3d

### DIFF
--- a/images/e2e-dind-k3d/Dockerfile
+++ b/images/e2e-dind-k3d/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.4-alpine as base
+FROM golang:1.22.0-alpine as base
 
 
 RUN set -eux; \


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Update golang version to `1.22` for `e2e-dind-k3d`.

As part of updating he eventing-auth-manager to golang 1.22, this change is needed in the EAM integration test [job](https://github.com/kyma-project/test-infra/blob/f8948cc816b1a5907ff518ffaafa5b504bc7eae0/prow/jobs/kyma-project/eventing-auth-manager/eam-integration-test.yaml#L25).