### PR TITLE
Fix workload identity federation

### DIFF
--- a/.github/workflows/post-apply-prod-terraform.yaml
+++ b/.github/workflows/post-apply-prod-terraform.yaml
@@ -20,6 +20,7 @@ jobs:
       id-token: "write" # needed for gcp_auth to create id token
       issues: "write" # needed for tfcmt to post comments
       pull-requests: "write" # needed for tfcmt to post comments
+      actions: "write" # needed for setting variables
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/configs/terraform/environments/prod/gcp-workfload-identity-federation.tf
+++ b/configs/terraform/environments/prod/gcp-workfload-identity-federation.tf
@@ -1,7 +1,7 @@
 module "gh_com_kyma_project_workload_identity_federation" {
   source = "terraform-google-modules/github-actions-runners/google//modules/gh-oidc"
 
-  project_id  = data.google_client_config.gcp.id
+  project_id  = data.google_client_config.gcp.project
   pool_id     = "github-com-kyma-project-pool"
   provider_id = "github-com-kyma-project-provider"
   issuer_uri  = "https://token.actions.githubusercontent.com"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Use correct project id, previously it was using TF resource id, now switched to GCP project id
- Set correct permission for github variables within workflow file for post apply.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #8594 

/kind bug
/area automation
/test all