### PR TITLE
fix: Increase resource limits for LM build pipelines

### DIFF
--- a/prow/jobs/kyma-project/lifecycle-manager/lifecycle-manager.yaml
+++ b/prow/jobs/kyma-project/lifecycle-manager/lifecycle-manager.yaml
@@ -33,8 +33,11 @@ presubmits: # runs on PRs
               - "--dockerfile=Dockerfile"
             resources:
               requests:
-                memory: 1.5Gi
-                cpu: 1
+                memory: 8Gi
+                cpu: 2
+              limits:
+                memory: 16Gi
+                cpu: 4
             volumeMounts:
               - name: config
                 mountPath: /config
@@ -86,8 +89,11 @@ postsubmits: # runs on main
               - "--tag=latest"
             resources:
               requests:
-                memory: 1.5Gi
-                cpu: 1
+                memory: 8Gi
+                cpu: 2
+              limits:
+                memory: 16Gi
+                cpu: 4
             volumeMounts:
               - name: config
                 mountPath: /config
@@ -137,8 +143,11 @@ postsubmits: # runs on main
               - "--export-tags"
             resources:
               requests:
-                memory: 1.5Gi
-                cpu: 1
+                memory: 8Gi
+                cpu: 2
+              limits:
+                memory: 16Gi
+                cpu: 4
             volumeMounts:
               - name: config
                 mountPath: /config

--- a/templates/data/lifecycle-manager-data.yaml
+++ b/templates/data/lifecycle-manager-data.yaml
@@ -18,6 +18,10 @@ templates:
                     - "--name=lifecycle-manager"
                     - "--config=/config/kaniko-build-config.yaml"
                     - "--dockerfile=Dockerfile"
+                  request_memory: 8Gi
+                  request_cpu: 2
+                  limits_memory: 16Gi
+                  limits_cpu: 4
                 inheritedConfigs:
                   global:
                     - kaniko_buildpack
@@ -37,6 +41,10 @@ templates:
                     - "--config=/config/kaniko-build-config.yaml"
                     - "--dockerfile=Dockerfile"
                     - "--tag=latest"
+                  request_memory: 8Gi
+                  request_cpu: 2
+                  limits_memory: 16Gi
+                  limits_cpu: 4
                 inheritedConfigs:
                   global:
                     - kaniko_buildpack
@@ -57,6 +65,10 @@ templates:
                     - "--dockerfile=Dockerfile"
                     - "--tag=$(PULL_BASE_REF)"
                     - "--export-tags"
+                  request_memory: 8Gi
+                  request_cpu: 2
+                  limits_memory: 16Gi
+                  limits_cpu: 4
                 inheritedConfigs:
                   global:
                     - kaniko_buildpack_no_signify_secret


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Build pipelines of lifecycle-manager are flakey due to OOM kills.
Example: https://storage.googleapis.com/kyma-prow-logs/pr-logs/pull/kyma-project_lifecycle-manager/1312/pull-lifecycle-mgr-build/1759829575723913216/build-log.txt
This increases the requests and limits for 3 build pipelines.

Changes proposed in this pull request:

- Set resources for `release-lifecycle-mgr-build`, `main-lifecycle-mgr-build` and `pull-lifecycle-mgr-build` to:
                  
```
request_memory: 8Gi
request_cpu: 2
limits_memory: 16Gi
limits_cpu: 4
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
