### PR TITLE
Add temporrary owner permission to planner

### DIFF
--- a/.github/workflows/pull-plan-prod-terraform.yaml
+++ b/.github/workflows/pull-plan-prod-terraform.yaml
@@ -46,7 +46,17 @@ jobs:
         with:
           workload_identity_provider: ${{ vars.GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER }} #workload_identity_provider: "projects/351981214969/locations/global/workloadIdentityPools/github-com-kyma-project/providers/github-com-kyma-project"
           service_account: ${{ vars.GCP_TERRAFORM_PLANNER_SERVICE_ACCOUNT_EMAIL }} #service_account: "terraform-planner@sap-kyma-prow.iam.gserviceaccount.com"
-      
+
+          
+      - name: Retrieve Terraform Executor github PAT
+        id: secrets
+        uses: google-github-actions/get-secretmanager-secrets@v2
+        with:
+          secrets: |-
+             gh-terraform-executor-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_EXECUTOR_SECRET_NAME }}
+
+
+
       # Build tofu CLI from source until setup-opentofu action will become stable
 
       - name: Download the tofu source
@@ -92,7 +102,7 @@ jobs:
 
       - name: Terraform Plan
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.gh-terraform-executor-token }}
         id: terraform_plan
         run: tfcmt -owner $GITHUB_REPOSITORY_OWNER -repo ${{ github.event.repository.name }} -pr ${{ github.event.pull_request.number }} -sha ${{ github.event.pull_request.head.sha }} plan -- tofu -chdir=./configs/terraform/environments/prod plan -input=false -no-color -lock-timeout=300s
 

--- a/configs/terraform/environments/prod/terraform-service-accounts.tf
+++ b/configs/terraform/environments/prod/terraform-service-accounts.tf
@@ -51,7 +51,7 @@ resource "google_service_account" "terraform_planner" {
 # Grant browser role to terraform planner service account
 resource "google_project_iam_member" "terraform_planner_prow_project_browser" {
   project = var.terraform_planner_gcp_service_account.project_id
-  role    = "roles/browser"
+  role    = "roles/owner"
   member  = "serviceAccount:${google_service_account.terraform_planner.email}"
 }
 
@@ -65,6 +65,6 @@ resource "google_service_account_iam_binding" "terraform_planner_workload_identi
 
 resource "google_project_iam_member" "terraform_planner_workloads_project_browser" {
   project = var.workloads_project_id
-  role    = "roles/browser"
+  role    = "roles/owner"
   member  = "serviceAccount:${google_service_account.terraform_planner.email}"
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The track down of correct read only permission for planner will take a little longer, let's unblock terraform workflows with owner permission for now. See also #8594 

Changes proposed in this pull request:

- Set owner permisison for planner SA

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

/kind bug
/area autoamtion