### PR TITLE
Update docs with details about reusable workflow.

### DIFF
--- a/cmd/image-builder/github-workflow-integration.md
+++ b/cmd/image-builder/github-workflow-integration.md
@@ -7,22 +7,32 @@ process is executed in an Azure DevOps pipeline, providing an SLC-29-compliant i
 
 ## Process Flow
 
-1. **Trigger workflow**: The user or automation triggers a GitHub workflow.
+1. **Trigger workflow**: The user or automation triggers a GitHub workflow. The workflow calls reusable workflow image-builder to build the
+   OCI image. The image-builder reusable workflow is stored in the github.com/kyma-project/test-infra repository in the main branch. The
+   reusable workflow defines inputs which are used to pass user-defined parameters to the `oci-image-builder` pipeline.
 
-2. **Obtaining the OIDC Token**: The workflow uses GitHub action to call GitHub's OIDC identity provider issuing an OIDC token.
-   This token is used to securely pass information about the workflow.
+2. **Obtaining the OIDC Token**: The Image Builder reusable workflow uses GitHub action to call GitHub's OIDC identity provider issuing an
+   OIDC token.
+   This token is used to authenticate workflow in ado backend and pass information about the workflow.
 
-3. **Trigger oci-image-builder pipeline**: GitHub action running Image Builder client uses a Personal Access Token (PAT) to authenticate
-   with the Azure DevOps (ADO) API and trigger the `oci-image-builder` pipeline. The OIDC token and additional parameters required by
-   the `oci-image-builder` pipeline are passed as parameters to the pipeline. These parameters' values are collected from data defined by
-   the user and GitHub OIDC identity provider. The OIDC token is used for secure and authorized passing of information about the workflow
-   and the image to build.
+3. **Trigger oci-image-builder pipeline**:
+   The image-builder reusable workflow uses Image Builder GitHub action running Image Builder client to trigger oci-image-builder pipeline.
+   Image Builder client uses a Personal Access Token (PAT) to authenticate in the Azure DevOps (ADO) API and trigger the `oci-image-builder`
+   pipeline.
+   The OIDC token and additional parameters required by the `oci-image-builder` pipeline are passed as parameters to the pipeline.
+   These parameters' values are collected from data defined by
+   the user in Image Builder reusable workflow inputs, GitHub workflow context variables and GitHub OIDC identity provider.
+   The OIDC token is used to authenticate and authorize the workflow in oci-image-builder pipeline.
 
-4. **Validating the OIDC Token**: The `oci-image-builder` pipeline, running in Azure DevOps, detects a call originating from GitHub and
-   validates the OIDC token against GitHub's
-   OIDC identity provider. This step ensures that the token is valid and has not been tampered with.
+4. **Validating the OIDC Token**: The `oci-image-builder` pipeline, running in Azure DevOps, detects a call originating from GitHub workflow
+   and
+   validates the OIDC token against GitHub's OIDC identity provider. This step ensures that the token is valid and has not been tampered
+   with.
+   Next, the pipeline validates the claims in the OIDC token to ensure that the workflow is authorized to trigger the build process.
+   Only if the pipeline was triggered by an Image Builder reusable workflow, the pipeline will proceed to the next step.
 
-5. **OCI Image build preparation**: The `oci-image-builder` pipeline uses the information from the OIDC token to clone the appropriate
+5. **OCI Image build preparation**: The `oci-image-builder` pipeline uses the information from the OIDC token and pipeline parameters to
+   clone the appropriate
    source code for the building of the OCI image. It uses the information from the OIDC token and user-defined parameters to
    set the appropriate parameters for the image build and signing. The data from the OIDC token is used to decide whether the OCI image should
    be signed or not.
@@ -35,6 +45,24 @@ process is executed in an Azure DevOps pipeline, providing an SLC-29-compliant i
 8. **Signing the OCI Image**: If the build was triggered by a push event in GitHub, the `oci-image-builder` pipeline uses the `signify`
    service to sign the OCI image.
    This step ensures the integrity and authenticity of the OCI image.
+
+## Reusable Workflow Image Builder
+
+Reusable workflow image-builder is a GitHub workflow
+that is used to collect required data from workflow inputs and GitHub context variables,
+retrieve the OIDC token from GitHub's OIDC identity provider, and trigger the `oci-image-builder` pipeline in Azure DevOps.
+Because the oidc token does not contain all the required data for the `oci-image-builder` pipeline,
+the reusable workflow image-builder collects additional data from GitHub context variables.
+The oidc token alone does not contain enough data to clone the appropriate source code for the build process.
+Using the reusable workflow
+we bundle all the steps required to collect the data and trigger the `oci-image-builder` pipeline in a controlled and secure enviornment.
+Using an OIDC token allows us to confirm the version and identity of the workflow that triggered the build process.
+The reusable workflow is stored in the `github.com/kyma-project/test-infra` repository in the main branch and changes to the workflow are
+versioned
+and provided using pull requests.
+Together with CODEOWNERS file mechanism,
+this ensures that the changes to the workflow are reviewed and approved by the appropriate team members.
+This protects the workflow from unauthorized changes and ensures that the workflow is secure and reliable.
 
 ## GitHub OIDC Identity Token Claims
 
@@ -59,14 +87,14 @@ The OIDC token contains the following claims that can be used to identify the wo
 - **nbf**: The time before which the token must not be accepted for processing.
 - **kid**: The key ID of the key used to sign the token.
 - **alg**: The algorithm used to sign the token.
-- **run_id**: The ID of the workflow run.
-- **run_number**: The number of the workflow run.
-- **actor**: The login of the user who initiates the workflow run.
 - **event_name**: The name of the event that triggers the workflow run.
 - **workflow**: The name of the workflow that triggers the workflow run.
 - **workflow_ref**: The git ref associated with the workflow file.
 - **repository**: The repository where the workflow run occurs.
 - **repository_owner**: The owner of the repository where the workflow run occurs.
+- **job_workflow_ref**: For jobs using a reusable workflow, the ref path to the reusable workflow. For more information,
+  see [Using OpenID Connect with reusable workflows.](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/using-openid-connect-with-reusable-workflows)
+- **job_workflow_sha**: For jobs using a reusable workflow, the SHA of the reusable workflow file.
 
 ### Source Code Cloning Claims
 
@@ -75,11 +103,9 @@ The OIDC token also contains claims that can be used to clone the appropriate ve
 - **repository**: The repository where the workflow run occurs.
 - **repository_owner**: The owner of the repository where the workflow run occurs.
 - **event_name**: The name of the event that triggers the workflow run.
-- **ref**: The git ref associated with the workflow run. This can be used to checkout the correct branch, tag, or commit.
 - **ref_type**: The type of git ref associated with the workflow run. This can be used to determine whether the ref is a branch, tag, or
   commit.
 - **base_ref**: The base git ref associated with the workflow run. This can be used to determine the base branch for a pull request.
-- **head_ref**: The head git ref associated with the workflow run. This can be used to determine the head branch for a pull request.
 
 These claims ensure that the `oci-image-builder` pipeline builds the exact version of the code that was provided in the PR or merged to the
 branch, adhering to SLC-29 compliance.
@@ -87,7 +113,7 @@ branch, adhering to SLC-29 compliance.
 ## Parameters for the `oci-image-builder` Pipeline
 
 The `oci-image-builder` pipeline requires certain data to be provided in parameters to execute a build process.
-Certain parameters need to be defined by the user in addition to the data taken from the OIDC token.
+Certain parameters need to be defined by the user in addition to the data taken from the OIDC token and GitHub context variables.
 
 These parameters include user-defined parameters, parameters from the OIDC token, and computed parameters.
 
@@ -105,14 +131,11 @@ These parameters include user-defined parameters, parameters from the OIDC token
 - **RepoName**: The name of the repository.
 - **RepoOwner**: The owner of the repository. Possible values include `kyma-project` and `kyma-incubator`.
 - **JobType**: The type of job. Possible values include `presubmit` and `postsubmit`.
+
+### Parameters GitHub Context Variables
+
 - **PullBaseSHA**: The base SHA of the pull request.
 - **PullPullSHA**: The SHA of the pull request.
-
-### Computed Parameters
-
-The data for this parameter is not available in the OIDC token and should not be provided by the user.
-We can extract it from the `ref` claim of the OIDC token.
-
 - **PullNumber**: The number of the pull request.
 
 ## ProwJob Validation in Image Builder

--- a/cmd/image-builder/github-workflow-integration.md
+++ b/cmd/image-builder/github-workflow-integration.md
@@ -132,7 +132,7 @@ These parameters include user-defined parameters, parameters from the OIDC token
 - **RepoOwner**: The owner of the repository. Possible values include `kyma-project` and `kyma-incubator`.
 - **JobType**: The type of job. Possible values include `presubmit` and `postsubmit`.
 
-### Parameters GitHub Context Variables
+### Parameters from GitHub Context Variables
 
 - **PullBaseSHA**: The base SHA of the pull request.
 - **PullPullSHA**: The SHA of the pull request.

--- a/cmd/image-builder/github-workflow-integration.md
+++ b/cmd/image-builder/github-workflow-integration.md
@@ -7,13 +7,12 @@ process is executed in an Azure DevOps pipeline, providing an SLC-29-compliant i
 
 ## Process Flow
 
-1. **Trigger workflow**: The user or automation triggers a GitHub workflow. The workflow calls reusable workflow image-builder to build the
+1. **Trigger workflow**: The user or automation triggers a GitHub workflow. The workflow calls image-builder reusable workflow to build the
    OCI image. The image-builder reusable workflow is stored in the github.com/kyma-project/test-infra repository in the main branch. The
-   reusable workflow defines inputs which are used to pass user-defined parameters to the `oci-image-builder` pipeline.
+   image-builder reusable workflow defines inputs which are used to pass user-defined parameters to the `oci-image-builder` pipeline.
 
-2. **Obtaining the OIDC Token**: The Image Builder reusable workflow uses GitHub action to call GitHub's OIDC identity provider, issuing an
-   OIDC token.
-   This token is used to authenticate workflow in the ADO backend and pass information about the workflow.
+2. **Obtaining the OIDC Token**: The image-builder reusable workflow uses GitHub action to call GitHub's OIDC identity provider, issuing an
+   OIDC token. This token is used to authenticate workflow in the ADO backend and pass information about the workflow.
 
 3. **Trigger the `oci-image-builder` pipeline**:
    The image-builder reusable workflow uses Image Builder GitHub action running Image Builder client to trigger the `oci-image-builder` pipeline.
@@ -48,16 +47,17 @@ process is executed in an Azure DevOps pipeline, providing an SLC-29-compliant i
 
 ## Reusable Workflow Image Builder
 
-Reusable workflow image-builder is a GitHub workflow
+Image-builder reusable workflow is a GitHub workflow
 that is used to collect required data from workflow inputs and GitHub context variables,
 retrieve the OIDC token from GitHub's OIDC identity provider, and trigger the `oci-image-builder` pipeline in ADO.
 Because the OIDC token does not contain all the required data for the `oci-image-builder` pipeline,
-the reusable workflow image-builder collects additional data from GitHub context variables.
+the image-builder reusable workflow collects additional data from GitHub context variables.
 The OIDC token alone does not contain enough data to clone the appropriate source code for the build process.
 Using the reusable workflow
-we bundle all the steps required to collect the data and trigger the `oci-image-builder` pipeline in a controlled and secure enviornment.
+we bundle all the steps required to collect the data and trigger the `oci-image-builder` pipeline in a controlled and secure environment.
 Using an OIDC token allows us to confirm the version and identity of the workflow that triggered the build process.
-The reusable workflow is stored in the `github.com/kyma-project/test-infra` repository on the `main` branch, and changes to the workflow are
+The image-builder reusable workflow is stored in the `github.com/kyma-project/test-infra` repository on the `main` branch, and changes to
+the workflow are
 versioned
 and provided using pull requests.
 Together with CODEOWNERS file mechanism,

--- a/cmd/image-builder/github-workflow-integration.md
+++ b/cmd/image-builder/github-workflow-integration.md
@@ -11,20 +11,20 @@ process is executed in an Azure DevOps pipeline, providing an SLC-29-compliant i
    OCI image. The image-builder reusable workflow is stored in the github.com/kyma-project/test-infra repository in the main branch. The
    reusable workflow defines inputs which are used to pass user-defined parameters to the `oci-image-builder` pipeline.
 
-2. **Obtaining the OIDC Token**: The Image Builder reusable workflow uses GitHub action to call GitHub's OIDC identity provider issuing an
+2. **Obtaining the OIDC Token**: The Image Builder reusable workflow uses GitHub action to call GitHub's OIDC identity provider, issuing an
    OIDC token.
-   This token is used to authenticate workflow in ado backend and pass information about the workflow.
+   This token is used to authenticate workflow in the ADO backend and pass information about the workflow.
 
-3. **Trigger oci-image-builder pipeline**:
-   The image-builder reusable workflow uses Image Builder GitHub action running Image Builder client to trigger oci-image-builder pipeline.
-   Image Builder client uses a Personal Access Token (PAT) to authenticate in the Azure DevOps (ADO) API and trigger the `oci-image-builder`
+3. **Trigger the `oci-image-builder` pipeline**:
+   The image-builder reusable workflow uses Image Builder GitHub action running Image Builder client to trigger the `oci-image-builder` pipeline.
+   Image Builder client uses a Personal Access Token (PAT) to authenticate in the ADO API and trigger the `oci-image-builder`
    pipeline.
    The OIDC token and additional parameters required by the `oci-image-builder` pipeline are passed as parameters to the pipeline.
    These parameters' values are collected from data defined by
    the user in Image Builder reusable workflow inputs, GitHub workflow context variables and GitHub OIDC identity provider.
-   The OIDC token is used to authenticate and authorize the workflow in oci-image-builder pipeline.
+   The OIDC token is used to authenticate and authorize the workflow in the `oci-image-builder` pipeline.
 
-4. **Validating the OIDC Token**: The `oci-image-builder` pipeline, running in Azure DevOps, detects a call originating from GitHub workflow
+4. **Validating the OIDC Token**: The `oci-image-builder` pipeline, running in ADO, detects a call originating from the GitHub workflow
    and
    validates the OIDC token against GitHub's OIDC identity provider. This step ensures that the token is valid and has not been tampered
    with.
@@ -50,14 +50,14 @@ process is executed in an Azure DevOps pipeline, providing an SLC-29-compliant i
 
 Reusable workflow image-builder is a GitHub workflow
 that is used to collect required data from workflow inputs and GitHub context variables,
-retrieve the OIDC token from GitHub's OIDC identity provider, and trigger the `oci-image-builder` pipeline in Azure DevOps.
-Because the oidc token does not contain all the required data for the `oci-image-builder` pipeline,
+retrieve the OIDC token from GitHub's OIDC identity provider, and trigger the `oci-image-builder` pipeline in ADO.
+Because the OIDC token does not contain all the required data for the `oci-image-builder` pipeline,
 the reusable workflow image-builder collects additional data from GitHub context variables.
-The oidc token alone does not contain enough data to clone the appropriate source code for the build process.
+The OIDC token alone does not contain enough data to clone the appropriate source code for the build process.
 Using the reusable workflow
 we bundle all the steps required to collect the data and trigger the `oci-image-builder` pipeline in a controlled and secure enviornment.
 Using an OIDC token allows us to confirm the version and identity of the workflow that triggered the build process.
-The reusable workflow is stored in the `github.com/kyma-project/test-infra` repository in the main branch and changes to the workflow are
+The reusable workflow is stored in the `github.com/kyma-project/test-infra` repository on the `main` branch, and changes to the workflow are
 versioned
 and provided using pull requests.
 Together with CODEOWNERS file mechanism,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

During the work on #9976 we have learned that OIDC token doesn't contain all required data to clone proper source code version in oci-image-builder pipeline. This is a blocker for image-builder github workflow integration. This proposal describe how we can use a reusable workflow to collect all required data and pass them in secure way to the oci-image-builder pipeline.
