### PR TITLE
Exclude e2e-dind-nodejs image autobumps.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -296,18 +296,20 @@ updates:
     commit-message:
       prefix: "e2e-dind-garden"
       include: "scope"
-  - package-ecosystem: "docker"
-    directory: "/images/e2e-dind-nodejs"
-    labels:
-      - "docker"
-      - "skip-review"
-      - "area/dependency"
-      - "kind/chore"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "e2e-dind-nodejs"
-      include: "scope"
+  # Busola must prepare for node update to newest version.
+  # We can enable this once preparation is done.
+  #  - package-ecosystem: "docker"
+  #    directory: "/images/e2e-dind-nodejs"
+  #    labels:
+  #      - "docker"
+  #      - "skip-review"
+  #      - "area/dependency"
+  #      - "kind/chore"
+  #    schedule:
+  #      interval: "daily"
+  #    commit-message:
+  #      prefix: "e2e-dind-nodejs"
+  #      include: "scope"
   - package-ecosystem: "docker"
     directory: "/images/e2e-dind-k3d"
     labels:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Disable autobumps of e2e-dind-nodejs image. Busola must be prepared for upgrade.
