### PR TITLE
excludes application-connector-manager from tide

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -476,6 +476,8 @@ tide:
         - do-not-merge/invalid-commit-message
       repos:
         - kyma-project/k8s-prow
+      excludedRepos:
+        - kyma-project/application-connector-manager
   context_options:
     from-branch-protection: true
     orgs:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- excludes application-connector-manager from tide
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
