### PR TITLE
Update image location of `cla-assistant`

### DIFF
--- a/prow/cluster/components/cla-assistant.yaml
+++ b/prow/cluster/components/cla-assistant.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: cla-assistant
-        image: eu.gcr.io/gardener-project/ci-infra/cla-assistant:v20231121-2908159
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/cla-assistant:v20240412-d22f4bf
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/prow/cluster/resources/gatekeeper-constraints/prow/allowedImagesProwNamespace.yaml
+++ b/prow/cluster/resources/gatekeeper-constraints/prow/allowedImagesProwNamespace.yaml
@@ -21,4 +21,4 @@ spec:
       - "eu.gcr.io/sap-kyma-neighbors-dev"
       - "europe-docker.pkg.dev/kyma-project"
       - "europe-west3-docker.pkg.dev/sap-kyma-neighbors-dev"
-      - "eu.gcr.io/gardener-project/ci-infra"
+      - "europe-docker.pkg.dev/gardener-project/releases/ci-infra"

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -3,7 +3,7 @@ protecode:
     - docker.io/library/nginx:1.25.3-alpine
     - docker.io/library/nginx:1.25.4-alpine
     - docker.io/zricethezav/gitleaks:v8.18.2
-    - eu.gcr.io/gardener-project/ci-infra/cla-assistant:v20231121-2908159
+    - europe-docker.pkg.dev/gardener-project/releases/ci-infra/cla-assistant:v20240412-d22f4bf
     - europe-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli:0.11.1
     - europe-docker.pkg.dev/kyma-project/prod/buildkit-image-builder:v20240404-09b82328
     - europe-docker.pkg.dev/kyma-project/prod/image-builder:v20240409-55d111d1


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Gardener moved their images from container registry to artifact registry, so your image of `cla-assistant` is not updated anymore.

Changes proposed in this pull request:

- Update image location of `cla-assistant` to the current one (see [here](https://github.com/gardener/ci-infra/blob/03e50185e1ea0e3bb868727499385b36897f806a/config/prow/cluster/cla_assistant_deployment.yaml#L26C16-L26C104)). 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
