### PR TITLE
bug: remove running dockerd in dind-enabled image test

### DIFF
--- a/images/e2e-dind-k3d/test.sh
+++ b/images/e2e-dind-k3d/test.sh
@@ -3,14 +3,10 @@
 set -e
 
 echo "Binary existence checks"
-docker run --rm --privileged \
-  -v /sys/fs/cgroup:/sys/fs/cgroup \
-  -v /lib/modules:/lib/modules:ro \
-  -e DOCKER_IN_DOCKER_ENABLED=true \
+docker run --rm \
   "$IMG" bash -c '
   set -e
-  cat $ARTIFACTS/docker-info.log
-  docker ps -a
+  docker --version
   helm version
   kubectl version --client
   k3d version

--- a/images/e2e-dind-nodejs/test.sh
+++ b/images/e2e-dind-nodejs/test.sh
@@ -3,14 +3,10 @@
 set -e
 
 echo "Binary existence checks"
-docker run --rm --privileged \
-  -v /sys/fs/cgroup:/sys/fs/cgroup \
-  -v /lib/modules:/lib/modules:ro \
-  -e DOCKER_IN_DOCKER_ENABLED=true \
+docker run --rm \
   "$IMG" bash -c '
   set -e
-  cat $ARTIFACTS/docker-info.log
-  docker ps -a
+  docker --version
   helm version
   kubectl version --client
   k3d version


### PR DESCRIPTION
/kind bug
/area ci

It seems that running dockerd inside docker-in-docker (docker-in-docker-in-docker?) was a bad idea and resulted in some flakiness where docker ps could not be executed.

Instead, run simple binary existence check without checking if dockerd starts properly until better solution comes to mind.
