### PR TITLE
Change Tide configurations for compass and ord-service

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -341,8 +341,8 @@ branch-protection:
         runtime-watcher:
           required_status_checks:
             contexts:
-              - "E2E (watcher-enqueue)"
-              - "E2E (watcher-metrics)"
+            - "E2E (watcher-enqueue)"
+            - "E2E (watcher-metrics)"
         cli:
           required_status_checks:
             contexts:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -341,8 +341,8 @@ branch-protection:
         runtime-watcher:
           required_status_checks:
             contexts:
-              - "E2E (watcher-enqueue)"
-              - "E2E (watcher-metrics)"
+            - "E2E (watcher-enqueue)"
+            - "E2E (watcher-metrics)"
         cli:
           required_status_checks:
             contexts:
@@ -382,6 +382,9 @@ branch-protection:
           branches:
             main:
               protect: true
+              required_status_checks:
+                # Require PR branch to be up-to-date with main
+                strict: true
         compass-console:
           protect: false
           branches:
@@ -392,6 +395,9 @@ branch-protection:
           branches:
             main:
               protect: true
+              required_status_checks:
+                # Require PR branch to be up-to-date with main
+                strict: true
         reconciler:
           protect: false
           branches:
@@ -472,8 +478,20 @@ tide:
         - do-not-merge/invalid-owners-file
         - do-not-merge/invalid-commit-message
       repos:
-        - kyma-incubator/compass
         - kyma-project/k8s-prow
+      reviewApprovedRequired: true
+    - labels:
+        - lgtm
+        - approved
+        - ok-tested
+      missingLabels:
+        - do-not-merge/hold
+        - do-not-merge/work-in-progress
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/invalid-commit-message
+      repos:
+        - kyma-incubator/compass
+        - kyma-incubator/ord-service
       reviewApprovedRequired: true
     # special query for automations
     - labels:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -382,6 +382,9 @@ branch-protection:
           branches:
             main:
               protect: true
+              required_status_checks:
+                # Require PR branch to be up-to-date
+                strict: true
         compass-console:
           protect: false
           branches:
@@ -472,8 +475,19 @@ tide:
         - do-not-merge/invalid-owners-file
         - do-not-merge/invalid-commit-message
       repos:
-        - kyma-incubator/compass
         - kyma-project/k8s-prow
+      reviewApprovedRequired: true
+    - labels:
+        - lgtm
+        - approved
+        - ok-tested
+      missingLabels:
+        - do-not-merge/hold
+        - do-not-merge/work-in-progress
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/invalid-commit-message
+      repos:
+        - kyma-incubator/compass
       reviewApprovedRequired: true
     # special query for automations
     - labels:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -341,8 +341,8 @@ branch-protection:
         runtime-watcher:
           required_status_checks:
             contexts:
-            - "E2E (watcher-enqueue)"
-            - "E2E (watcher-metrics)"
+              - "E2E (watcher-enqueue)"
+              - "E2E (watcher-metrics)"
         cli:
           required_status_checks:
             contexts:
@@ -383,7 +383,7 @@ branch-protection:
             main:
               protect: true
               required_status_checks:
-                # Require PR branch to be up-to-date
+                # Require PR branch to be up-to-date with main
                 strict: true
         compass-console:
           protect: false
@@ -395,6 +395,9 @@ branch-protection:
           branches:
             main:
               protect: true
+              required_status_checks:
+                # Require PR branch to be up-to-date with main
+                strict: true
         reconciler:
           protect: false
           branches:
@@ -488,6 +491,7 @@ tide:
         - do-not-merge/invalid-commit-message
       repos:
         - kyma-incubator/compass
+        - kyma-incubator/ord-service
       reviewApprovedRequired: true
     # special query for automations
     - labels:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -480,19 +480,6 @@ tide:
       repos:
         - kyma-project/k8s-prow
       reviewApprovedRequired: true
-    - labels:
-        - lgtm
-        - approved
-        - ok-tested
-      missingLabels:
-        - do-not-merge/hold
-        - do-not-merge/work-in-progress
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/invalid-commit-message
-      repos:
-        - kyma-incubator/compass
-        - kyma-incubator/ord-service
-      reviewApprovedRequired: true
     # special query for automations
     - labels:
         - skip-review

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -341,8 +341,8 @@ branch-protection:
         runtime-watcher:
           required_status_checks:
             contexts:
-            - "E2E (watcher-enqueue)"
-            - "E2E (watcher-metrics)"
+              - "E2E (watcher-enqueue)"
+              - "E2E (watcher-metrics)"
         cli:
           required_status_checks:
             contexts:
@@ -382,9 +382,6 @@ branch-protection:
           branches:
             main:
               protect: true
-              required_status_checks:
-                # Require PR branch to be up-to-date with main
-                strict: true
         compass-console:
           protect: false
           branches:
@@ -395,9 +392,6 @@ branch-protection:
           branches:
             main:
               protect: true
-              required_status_checks:
-                # Require PR branch to be up-to-date with main
-                strict: true
         reconciler:
           protect: false
           branches:
@@ -478,6 +472,7 @@ tide:
         - do-not-merge/invalid-owners-file
         - do-not-merge/invalid-commit-message
       repos:
+        - kyma-incubator/compass
         - kyma-project/k8s-prow
       reviewApprovedRequired: true
     # special query for automations

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -29,10 +29,6 @@ plugins:
     plugins:
       - approve
       - blunderbuss
-  kyma-incubator/ord-service:
-    plugins:
-      - approve
-      - blunderbuss
   kyma-project/k8s-prow:
     plugins:
       - approve

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -29,6 +29,10 @@ plugins:
     plugins:
       - approve
       - blunderbuss
+  kyma-incubator/ord-service:
+    plugins:
+      - approve
+      - blunderbuss
   kyma-project/k8s-prow:
     plugins:
       - approve
@@ -123,6 +127,7 @@ size:
   m:   30
   l:   100
   xl:  500
+  xxl: 1000
 
 blunderbuss:
   max_request_count: 2

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -137,6 +137,7 @@ blunderbuss:
 approve:
   - repos:
       - kyma-incubator/compass
+      - kyma-incubator/ord-service
     require_self_approval: true # ignore authors of the PRs to be able to auto-approve their PR if they are owners
     ignore_review_state: false
   - repos:

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -29,6 +29,10 @@ plugins:
     plugins:
       - approve
       - blunderbuss
+  kyma-incubator/ord-service:
+    plugins:
+      - approve
+      - blunderbuss
   kyma-project/k8s-prow:
     plugins:
       - approve
@@ -119,10 +123,10 @@ label:
     - Epic
 
 size:
-  s:   10
-  m:   30
-  l:   100
-  xl:  500
+  s: 10
+  m: 30
+  l: 100
+  xl: 500
   xxl: 1000
 
 blunderbuss:

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -123,11 +123,10 @@ label:
     - Epic
 
 size:
-  s: 10
-  m: 30
-  l: 100
-  xl: 500
-  xxl: 1000
+  s:   10
+  m:   30
+  l:   100
+  xl:  500
 
 blunderbuss:
   max_request_count: 2


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
As CMP(UCL) is moving the CI outside of Prow, initial steps are made to provide the transition. The first step being extracting the E2E tests and smoke tests outside of Prow (https://github.com/kyma-project/test-infra/pull/10435). Doing this requires us to block the auto-merging and to add the branch protection to be up-to-date with main branch.


Changes proposed in this pull request:

- Enable branch protection to be up-to-date with main branch
- Allow auto-merging only when three labels `lgtm`, `approved` and `ok-tested` are present

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
