### PR TITLE
bug: use iptables-legacy docker in dind-enabled image

### DIFF
--- a/images/e2e-dind-k3d/Dockerfile
+++ b/images/e2e-dind-k3d/Dockerfile
@@ -10,11 +10,11 @@ RUN set -eux; \
     bash \
     jq \
     yq \
+    iptables-legacy \
     docker \
     btrfs-progs \
     e2fsprogs \
     e2fsprogs-extra \
-    iptables \
     xfsprogs \
     xz \
     git \
@@ -30,7 +30,14 @@ RUN set -eux; \
     addgroup -S dockremap 	&& \
     adduser -SDHs /sbin/nologin dockremap; \
     echo 'dockremap:165536:65536' >> /etc/subuid && \
-    echo 'dockremap:165536:65536' >> /etc/subgid
+    echo 'dockremap:165536:65536' >> /etc/subgid && \
+    # symlink legacy iptables for dind compatibility
+    ln -sf /sbin/iptables-legacy /sbin/iptables ; \
+    ln -sf /sbin/iptables-legacy-save /sbin/iptables-save ; \
+    ln -sf /sbin/iptables-legacy-restore /sbin/iptables-restore ; \
+    ln -sf /sbin/ip6tables-legacy /sbin/ip6tables ; \
+    ln -sf /sbin/ip6tables-legacy-save /sbin/ip6tables-save ; \
+    ln -sf /sbin/ip6tables-legacy-restore /sbin/ip6tables-restore
 
 RUN mkdir -p /workspace; \
     chmod 1777 /workspace

--- a/images/e2e-dind-k3d/init.sh
+++ b/images/e2e-dind-k3d/init.sh
@@ -28,7 +28,7 @@ if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
   dockerd --data-root=/docker-graph > "${LOG_DIR}/dockerd.log" 2>&1 &
   DOCKER_PID=$!
   echo "⏳  Waiting for Docker to be up..."
-  while [[ $(curl -s --unix-socket /var/run/docker.sock http/_ping 2>&1) != "OK" ]]; do
+  while ! curl -s --unix-socket /var/run/docker.sock http/_ping >/dev/null 2>&1; do
     sleep 1
   done
   echo "✅  Docker is up! Docker info available in ${ARTIFACTS}/docker-info.log"

--- a/images/e2e-dind-k3d/test.sh
+++ b/images/e2e-dind-k3d/test.sh
@@ -3,10 +3,14 @@
 set -e
 
 echo "Binary existence checks"
-docker run --rm \
+docker run --rm --privileged \
+  -v /sys/fs/cgroup:/sys/fs/cgroup \
+  -v /lib/modules:/lib/modules:ro \
+  -e DOCKER_IN_DOCKER_ENABLED=true \
   "$IMG" bash -c '
   set -e
-  docker --version
+  cat $ARTIFACTS/docker-info.log
+  docker ps -a
   helm version
   kubectl version --client
   k3d version

--- a/images/e2e-dind-nodejs/init.sh
+++ b/images/e2e-dind-nodejs/init.sh
@@ -28,7 +28,7 @@ if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
   dockerd --data-root=/docker-graph > "${LOG_DIR}/dockerd.log" 2>&1 &
   DOCKER_PID=$!
   echo "⏳  Waiting for Docker to be up..."
-  while [[ $(curl -s --unix-socket /var/run/docker.sock http/_ping 2>&1) != "OK" ]]; do
+  while ! curl -s --unix-socket /var/run/docker.sock http/_ping >/dev/null 2>&1; do
     sleep 1
   done
   echo "✅  Docker is up! Docker info available in ${ARTIFACTS}/docker-info.log"

--- a/images/e2e-dind-nodejs/test.sh
+++ b/images/e2e-dind-nodejs/test.sh
@@ -3,10 +3,14 @@
 set -e
 
 echo "Binary existence checks"
-docker run --rm \
+docker run --rm --privileged \
+  -v /sys/fs/cgroup:/sys/fs/cgroup \
+  -v /lib/modules:/lib/modules:ro \
+  -e DOCKER_IN_DOCKER_ENABLED=true \
   "$IMG" bash -c '
   set -e
-  docker --version
+  cat $ARTIFACTS/docker-info.log
+  docker ps -a
   helm version
   kubectl version --client
   k3d version


### PR DESCRIPTION
/kind bug
/area ci

In alpine 3.18 and earlier, `iptables` is a symlink to `iptables-legacy`, and in alpine 3.19 `iptables-nft` is the default iptables backend.

https://github.com/docker-library/docker/issues/463
https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.19.0

Docker doesn't work with `nftables` and it was somehow omitted during update.

* Revert removing tests (never remove tests)
* Rewrite checking if docker is enabled to check error code instead of relying on socket response
* Disable NFT backend using ENV variable in alpine Dockerfile.