### PR TITLE
Remove args from dockerregistry-operator dockerfile

### DIFF
--- a/prow/jobs/kyma-project/docker-registry/docker-registry-build-operator.yaml
+++ b/prow/jobs/kyma-project/docker-registry/docker-registry-build-operator.yaml
@@ -36,9 +36,6 @@ presubmits: # runs on PRs
               - "--config=/config/kaniko-build-config.yaml"
               - "--context=."
               - "--dockerfile=components/operator/Dockerfile"
-              - "--build-arg=PURPOSE=dev"
-              - "--build-arg=IMG_DIRECTORY=dev"
-              - "--build-arg=IMG_VERSION=PR-$(PULL_NUMBER)"
               - "--build-in-ado=true"
             env:
               - name: BUILDKITD_FLAGS
@@ -100,9 +97,6 @@ postsubmits: # runs on main
               - "--config=/config/kaniko-build-config.yaml"
               - "--context=."
               - "--dockerfile=components/operator/Dockerfile"
-              - "--build-arg=PURPOSE=dev"
-              - "--build-arg=IMG_DIRECTORY=prod"
-              - "--build-arg=IMG_VERSION=$(PULL_BASE_SHA)"
               - "--tag=$(PULL_BASE_SHA)"
               - "--tag=$(PULL_BASE_REF)"
               - "--build-in-ado=true"

--- a/prow/jobs/kyma-project/docker-registry/docker-registry-release.yaml
+++ b/prow/jobs/kyma-project/docker-registry/docker-registry-release.yaml
@@ -35,7 +35,6 @@ postsubmits: # runs on main
               - "--config=/config/kaniko-build-config.yaml"
               - "--context=."
               - "--dockerfile=components/operator/Dockerfile"
-              - "--build-arg=PURPOSE=release"
               - "--tag=$(PULL_BASE_REF)"
               - "--build-in-ado=true"
             env:

--- a/templates/data/docker-registry.yaml
+++ b/templates/data/docker-registry.yaml
@@ -26,9 +26,6 @@ templates:
                     - --config=/config/kaniko-build-config.yaml
                     - --context=.
                     - --dockerfile=components/operator/Dockerfile
-                    - --build-arg=PURPOSE=dev
-                    - --build-arg=IMG_DIRECTORY=dev
-                    - --build-arg=IMG_VERSION=PR-$(PULL_NUMBER)
                     - --build-in-ado=true
                 inheritedConfigs:
                   global:
@@ -51,9 +48,6 @@ templates:
                     - --config=/config/kaniko-build-config.yaml
                     - --context=.
                     - --dockerfile=components/operator/Dockerfile
-                    - --build-arg=PURPOSE=dev
-                    - --build-arg=IMG_DIRECTORY=prod
-                    - --build-arg=IMG_VERSION=$(PULL_BASE_SHA)
                     - --tag=$(PULL_BASE_SHA)
                     - --tag=$(PULL_BASE_REF)
                     - --build-in-ado=true
@@ -87,7 +81,6 @@ templates:
                     - --config=/config/kaniko-build-config.yaml
                     - --context=.
                     - --dockerfile=components/operator/Dockerfile
-                    - --build-arg=PURPOSE=release
                     - --tag=$(PULL_BASE_REF)
                     - --build-in-ado=true
                 inheritedConfigs:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Remove args from `dockerregistry-operator` `dockerfile` because we deleted it in `Docker-Registry` [repo](https://github.com/kyma-project/docker-registry/pull/1/files#diff-ea228318a371bf873e143fb48c41e2f4e66fe83e137ff509d966935e789e11c7R2-R29) 

Changes proposed in this pull request:

- Remove args from `dockerregistry-operator` dockerfile

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/serverless/issues/847