### PR TITLE
Add preset-signify-prod-secret and custom tag for ginkgo image

### DIFF
--- a/prow/jobs/kyma-project/test-infra/buildpack.yaml
+++ b/prow/jobs/kyma-project/test-infra/buildpack.yaml
@@ -259,6 +259,7 @@ postsubmits: # runs on main
         prow.k8s.io/pubsub.runID: "post-build-ginkgo"
         prow.k8s.io/pubsub.topic: "prowjobs"
         preset-sa-kyma-push-images: "true"
+        preset-signify-prod-secret: "true"
       run_if_changed: '^prow/images/ginkgo/'
       skip_report: false
       decorate: true
@@ -289,6 +290,7 @@ postsubmits: # runs on main
               - "--dockerfile=prow/images/ginkgo/Dockerfile"
               - "--env-file=.env"
               - "--build-in-ado=false"
+              - "--tag={{ .Env \"GOLANG_VERSION\" }}-{{ .ShortSHA }}"
             resources:
               requests:
                 memory: 1.5Gi


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add preset-signify-prod-secret: "true" for post ginkgo image build job
- Add custom tag with use of value from env file for post ginkgo image build job
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/test-infra/issues/10413