### PR TITLE
Add full sha tag for release serverless operator build job

### DIFF
--- a/prow/jobs/kyma-project/serverless/serverless-release.yaml
+++ b/prow/jobs/kyma-project/serverless/serverless-release.yaml
@@ -38,6 +38,7 @@ postsubmits: # runs on main
               - "--dockerfile=components/operator/Dockerfile"
               - "--build-arg=PURPOSE=release"
               - "--tag=$(PULL_BASE_REF)"
+              - "--tag=$(PULL_BASE_SHA)"
               - "--build-in-ado=true"
             env:
               - name: BUILDKITD_FLAGS

--- a/templates/data/serverless.yaml
+++ b/templates/data/serverless.yaml
@@ -447,6 +447,7 @@ templates:
                     - --dockerfile=components/operator/Dockerfile
                     - --build-arg=PURPOSE=release
                     - --tag=$(PULL_BASE_REF)
+                    - --tag=$(PULL_BASE_SHA)
                     - "--build-in-ado=true"
                 inheritedConfigs:
                   global:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add full sha tag for release serverless operator build job
- ...
- ...

**Related issue(s)**
Failing tests on release branch