### PR TITLE
Shift configuration

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -456,6 +456,19 @@ tide:
   queries:
     - labels:
         - lgtm
+        - approved
+        - ok-tested
+      missingLabels:
+        - do-not-merge/hold
+        - do-not-merge/work-in-progress
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/invalid-commit-message
+      repos:
+        - kyma-incubator/compass
+        - kyma-incubator/ord-service
+      reviewApprovedRequired: true
+    - labels:
+        - lgtm
       missingLabels:
         - do-not-merge/hold
         - do-not-merge/work-in-progress
@@ -464,6 +477,9 @@ tide:
       orgs:
         - kyma-project
         - kyma-incubator
+      excludedRepos:
+        - kyma-incubator/compass
+        - kyma-incubator/ord-service
       reviewApprovedRequired: true
     - labels:
         - lgtm
@@ -475,19 +491,6 @@ tide:
         - do-not-merge/invalid-commit-message
       repos:
         - kyma-project/k8s-prow
-      reviewApprovedRequired: true
-    - labels:
-        - lgtm
-        - approved
-        - ok-tested
-      missingLabels:
-        - do-not-merge/hold
-        - do-not-merge/work-in-progress
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/invalid-commit-message
-      repos:
-        - kyma-incubator/compass
-        - kyma-incubator/ord-service
       reviewApprovedRequired: true
     # special query for automations
     - labels:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
It seems like only the `lgtm` was required for our repositories https://github.com/kyma-incubator/compass and https://github.com/kyma-incubator/ord-service while ignoring `approved` and `ok-tested`

Changes proposed in this pull request:

- exclude https://github.com/kyma-incubator/compass and https://github.com/kyma-incubator/ord-service from `lgtm`-only requirement
- move requirement `approved` and `ok-tested` on top of queries
