### PR TITLE
Remove docker-credential-gcr

### DIFF
--- a/images/e2e-gcloud/Dockerfile
+++ b/images/e2e-gcloud/Dockerfile
@@ -33,7 +33,9 @@ ARG GCLOUD_CLI_VERSION=455.0.0
 RUN curl -fLSs -o gc-sdk.tar.gz "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GCLOUD_CLI_VERSION}-linux-$(uname -m).tar.gz" && \
     tar xzf gc-sdk.tar.gz -C / && \
     rm gc-sdk.tar.gz && \
-    gcloud components install alpha beta kubectl docker-credential-gcr gke-gcloud-auth-plugin && \
+    # Users should use gcloud auth configure-docker to authenticate with GCR instead of docker-credential-gcr, see https://github.com/GoogleCloudPlatform/docker-credential-gcr?tab=readme-ov-file#introduction
+    # gcloud components install alpha beta kubectl docker-credential-gcr gke-gcloud-auth-plugin && \
+    gcloud components install alpha beta kubectl gke-gcloud-auth-plugin && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment github_docker_image && \


### PR DESCRIPTION
…present.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Following docker-credential-gcr docs, removing vulnerable component as it should not be used.

"Note: docker-credential-gcr is primarily intended for users wishing to authenticate with GCR in the absence of gcloud, though they are [not mutually exclusive](https://github.com/GoogleCloudPlatform/docker-credential-gcr?tab=readme-ov-file#gcr-credentials). For normal development setups, users are encouraged to use [gcloud auth configure-docker](https://cloud.google.com/sdk/gcloud/reference/auth/configure-docker), instead."
