### PR TITLE
Add the `binutils-gold` to the buildpack base

### DIFF
--- a/images/buildpack/Dockerfile
+++ b/images/buildpack/Dockerfile
@@ -14,6 +14,7 @@ RUN set -eux; \
     gettext \
     yq \
     binutils \
+    binutils-gold \
     dumb-init \
     libgit2-dev \
     pkgconf \


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- add the `binutils-gold`  package to the buildpack image to avoid [this issue](https://github.com/mattn/go-sqlite3/issues/1164) and [this issue](https://github.com/golang/go/issues/22040)
- fix the `post-kyma-cli` job in the `cli` repo ([example](https://status.build.kyma-project.io/view/gs/kyma-prow-logs/logs/post-kyma-cli/1792465912457072640) run)
