### PR TITLE
Add buildkit-image-builder to test-infra-autobump-config.yaml

### DIFF
--- a/configs/autobump-config/test-infra-autobump-config.yaml
+++ b/configs/autobump-config/test-infra-autobump-config.yaml
@@ -128,3 +128,10 @@ prefixes:
     repo: "https://github.com/kyma-project/test-infra"
     summarise: true
     consistentImages: false
+  - name: "buildkit-image-builder"
+    prefix: "europe-docker.pkg.dev/kyma-project/prod/buildkit-image-builder"
+    refConfigFile: "templates/config.yaml"
+    stagingRefConfigFile: "templates/config.yaml"
+    repo: "https://github.com/kyma-project/test-infra"
+    summarise: true
+    consistentImages: false


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add missing buildkit-image-builder image to test-infra-autobump-config.yaml

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
