### PR TITLE
Read ado pat from gcp secret manager in image-builder reusable workflow.

### DIFF
--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -62,12 +62,27 @@ jobs:
         id: get_oidc
         uses: ./.github/actions/expose-jwt-action
 
-      - uses: ./.github/actions/image-builder
-        id: build
-        name: Run build in image-builder
+      
+      - name: Authenticate in GCP
+        id: 'auth'
+        uses: 'google-github-actions/auth@v2'
         with:
-          oidc-token: ${{ steps.get_oidc.outputs.token }}
-          ado-token: ${{ secrets.ADO_PAT }}
+          workload_identity_provider: ${{ vars.GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER }}
+          service_account: ${{ vars.IMAGE_BUILDER_GH_WORKFLOW_GCP_SERVICE_ACCOUNT_EMAIL }}
+      
+      - name: Get ADO PAT from Secret Manager
+        id: 'secrets'
+        uses: 'google-github-actions/get-secretmanager-secrets@v2'
+        with:
+          secrets: |-
+            ado-pat:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.IMAGE_BUILDER_ADO_PAT_GCP_SECRET_NAME }}
+      
+      - uses: ./.github/actions/image-builder
+        name: Run build in image-builder
+        id: build
+        with:
+          oidc-token: ${{ steps.get_oidc.outputs.jwt }}
+          ado-token: ${{ steps.secrets.outputs.ado-pat }}
           context: ${{ inputs.context }}
           build-args: ${{ inputs.build-args }}
           tags: ${{ inputs.tags }}

--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -49,7 +49,7 @@ jobs:
     outputs:
       token: ${{ steps.get_oidc.outputs.jwt }}
     steps:
-      - name: Checkout repository based on test flag
+      - name: Checkout test-infra repository
         uses: actions/checkout@v4
         with:
           repository: kyma-project/test-infra

--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -40,12 +40,12 @@ on:
         default: ""
 
 jobs:
-  get_oidc_token:
+  build-image:
     permissions:
       id-token: write # This is required for requesting the JWT token
       contents: read # This is required for actions/checkout
     runs-on: ubuntu-latest
-    name: A job to get OIDC token
+    name: Build image
     outputs:
       token: ${{ steps.get_oidc.outputs.jwt }}
     steps:
@@ -62,15 +62,11 @@ jobs:
         id: get_oidc
         uses: ./.github/actions/expose-jwt-action
 
-  build:
-    needs: get_oidc_token
-    runs-on: ubuntu-latest
-    steps:
       - uses: ./.github/actions/image-builder
         id: build
         name: Run build in image-builder
         with:
-          oidc-token: ${{ needs.get_oidc_token.outputs.token }}
+          oidc-token: ${{ steps.get_oidc.outputs.token }}
           ado-token: ${{ secrets.ADO_PAT }}
           context: ${{ inputs.context }}
           build-args: ${{ inputs.build-args }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ tmp/
 __debug_bin
 
 .terraform
-.terraform.lock.hcl
 
 # Ignore generated credentials from google-github-actions/auth
 gha-creds-*.json

--- a/configs/terraform/environments/prod/.terraform.lock.hcl
+++ b/configs/terraform/environments/prod/.terraform.lock.hcl
@@ -1,0 +1,99 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/alekc/kubectl" {
+  version     = "2.0.4"
+  constraints = ">= 2.0.0"
+  hashes      = [
+    "h1:TUeUq1UdVkHTxcgq7CJWWXBrc8VEQTufmgU18qDmfGE=",
+    "zh:15c227886bac78c8b8827f85595648212574ec81febc39e1055e1a6bf048fe65",
+    "zh:2211ebeeb0918dbb3587d206e32adca9e1f343a93bbffcd37d8d99bf4d8dea9a",
+    "zh:2303836cdea12ece8dbe39c2d7d30a9378fd06e9c2ebda66cbe5e01cc096ee2e",
+    "zh:3687f69e531c70845682b214888a9959b93f2be3c2531801228a4b1965d59921",
+    "zh:4dd686b4c55e2eedd80464984c9bb736c2df7a96d9dd59a692d91d09173f5f64",
+    "zh:51e29c13a87e56867b4be0b0c68da874149bf6d4014d7259b62d91162142c1bd",
+    "zh:5d9d99260f2adfb8867068a3d7644336d57cfa7710062c5221dcbb5a7ec90c7d",
+    "zh:901c19d73da6688437b19a85e3cd60e8f2090c84699e108b31953bb87f6d3141",
+    "zh:9547743606a36fa6b6748c5e2e1959b6f185730a1da53a3c351cfa0d8c096687",
+    "zh:9772a30704e69b54de5a332858a39591f52286121cffcba702346830b1c6e362",
+    "zh:b44792f99d7c90b9a364dd922f861e459ae1b1edc039f6b3078549021fec4511",
+    "zh:b5eb871ed2e39b9236dce06170b1fd5dda29f3c1d53f8e08285ccb9a4f574201",
+    "zh:e8bb4c3d9f680977b560e9dec24662650f790259b2c1311ee07a72157f6492b3",
+    "zh:f4772cfa0f9c73fdef008bb917cd268620009dc7ff270a4d819125c642b5acce",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "5.31.0"
+  constraints = ">= 4.55.0, >= 4.64.0, >= 4.76.0, >= 5.6.0"
+  hashes      = [
+    "h1:zO2PnTY7v4PLvwRZpcbHh4HqvjaCPDOwFjy2++VlByE=",
+    "zh:0aecaec7141c4c7b763826787cae7fdba0c3850d0349e78da20e19f7a36fa0bd",
+    "zh:13e5183e2b71ed26053264ce171352881be18bf5a62c14b6f5272682d7d94794",
+    "zh:2c47a1c5c121fab1fffdddb58273330f32e86e132069367d17cc67dc8e712f6d",
+    "zh:3c4b447a7ff1e290869e9738850fcba2681e34718f0e09e256be5c4e1841b9f0",
+    "zh:5ab298c2f66b76552466484faa952ddffab75f08817f16febcf19439f57ad19e",
+    "zh:690875535ae901fae6d22616799a85ec455a6674be65cc5bea60c49c836b9735",
+    "zh:8f393f166b73c717d642537d39acc50240254cb082db83a830c843e59a957c44",
+    "zh:9b775b2067352f34136a3c5e593cdd3515db4e9b194f6cfbfaafac4ab0e8d8b2",
+    "zh:d819c5ccc6cf47900d73c3e329be5af0494f5a64c1881caac63bdab20124d55a",
+    "zh:e23fd5f760040efc2fa0423eaf753b8f0b66547baf2b5d7a5095b7c5c2eaed37",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google-beta" {
+  version = "5.31.0"
+  hashes  = [
+    "h1:CGnZZNWyRlgxXk/yqKhpf8NyhQ/Dn5F5Dv1A+k0c9xM=",
+    "zh:234e0635f6b23a17f8ba6e5884235237223ee73e7f7d0cad1dd8a0b2b02b0ba6",
+    "zh:468748b01651cf57f53110488aae5e5c1fecacdcecfa37612eb451a0e245b3c7",
+    "zh:567ffe49ed5e8086e0513091e19cf1c2834bbf2275ceaa56b7855ca760c7b93e",
+    "zh:9857c4b6563420528beea91c71f0fe227245f2df873356fc3fcaf2dd800cc5db",
+    "zh:9eac584d60ee5e362b4b906ddfbcded134d14a83fa3d291d354b00e37adff53d",
+    "zh:cabc02a3d632470764f30b574d9cb8f851d394baa262e9a64f85f3a97683ff02",
+    "zh:cc005c8aefd694486b6e643eb7924457f86efa45f010ce961a9cd062a06b27fc",
+    "zh:d83aada2f55bbe3f7b80e0e46ac1608148e35dbe5cb5454a085dc860b23ce4f3",
+    "zh:e5d2e702dca7e17f6dfefc6b65bf3741ba56fdf97db02adfb9a4b304fae02964",
+    "zh:ff088057af76ac2b832e86ce9d960187f236312d7cd08b9de03cc1d31a73d682",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/kubernetes" {
+  version     = "2.22.0"
+  constraints = ">= 2.22.0, 2.22.0"
+  hashes      = [
+    "h1:5+ClgQwP1yHUjZdcI0jO6vywF2YU3v/0zcvERm1ly8w=",
+    "zh:0db2e01d756ed21aaf46b31266f9974d00ae1c520730dc2bf33e83616c2cccc1",
+    "zh:0f396d3b6c7a9a2d19030380800534f960918f04d6774dc4d789efff6cda4ac9",
+    "zh:1f7dc0f072196b999f07b82e4a0b1a3a8074c43c3b8d5d642dffdd3d0f1014e1",
+    "zh:4ea41cf73574ca55ee9ec9f8957920d045317b8b90282b46d43f2b3d6a0065ee",
+    "zh:5239a0f06570c269fc1e9fc5964c766fc2d653462d52895717619ca23d16e0ea",
+    "zh:69b8b2802344c8fc1cb1eced7c17eb7026f457d36e1c9e1f9860f64573423ffb",
+    "zh:a3d6d77c6a832f9b1cc849a85e91346bdea14e55bc5ce07bfefe67cb6d791f79",
+    "zh:a97681e00813fb120757eab873f2ea808c9f0cafdef52c6c52dd79f3dabd6d0c",
+    "zh:b014bb7f1fb58c463405136ac5d9809b3947aeb21f4171cd2c98336c98b35426",
+    "zh:b953052a312840a3792f5b882eb11bd4300802b060f295c26a557857eda5a1f5",
+  ]
+}
+
+provider "registry.opentofu.org/integrations/github" {
+  version     = "6.2.1"
+  constraints = "~> 6.2.1"
+  hashes      = [
+    "h1:rY+q+OhJm90R900HvO05YNH7Tl0EOnbCLAoG+5niLX8=",
+    "zh:172aa5141c525174f38504a0d2e69d0d16c0a0b941191b7170fe6ae4d7282e30",
+    "zh:1a098b731fa658c808b591d030cc17cc7dfca1bf001c3c32e596f8c1bf980e9f",
+    "zh:245d6a1c7e632d8ae4bdd2da2516610c50051e81505cf420a140aa5fa076ea90",
+    "zh:43c61c230fb4ed26ff1b04b857778e65be3d8f80292759abbe2a9eb3c95f6d97",
+    "zh:59bb7dd509004921e4322a196be476a2f70471b462802f09d03d6ce96f959860",
+    "zh:5cb2ab8035d015c0732107c109210243650b6eb115e872091b0f7b98c2763777",
+    "zh:69d2a6acfcd686f7e859673d1c8a07fc1fc1598a881493f19d0401eb74c0f325",
+    "zh:77f36d3f46911ace5c50dee892076fddfd64a289999a5099f8d524c0143456d1",
+    "zh:87df41097dfcde72a1fbe89caca882af257a4763c2e1af669c74dcb8530f9932",
+    "zh:899dbe621f32d58cb7c6674073a6db8328a9db66eecfb0cc3fc13299fd4e62e7",
+    "zh:ad2eb7987f02f7dd002076f65a685730705d04435313b5cf44d3a6923629fb29",
+    "zh:b2145ae7134dba893c7f74ad7dfdc65fdddf6c7b1d0ce7e2f3baa96212322fd8",
+    "zh:bd6bae3ac5c3f96ad9219d3404aa006ef1480e9041d4c95df1808737e37d911b",
+    "zh:e89758b20ae59f1b9a6d32c107b17846ddca9634b868cf8f5c927cbb894b1b1f",
+  ]
+}

--- a/configs/terraform/environments/prod/gcp-workfload-identity-federation-variables.tf
+++ b/configs/terraform/environments/prod/gcp-workfload-identity-federation-variables.tf
@@ -21,3 +21,15 @@ variable "github_terraform_apply_workflow_name" {
   default     = "Post Apply Prod Terraform"
   description = "Workflow name for terraform apply workflow"
 }
+
+variable "gh_com_kyma_project_wif_pool_id" {
+  type        = string
+  default     = "github-com-kyma-project"
+  description = "Google Cloud Platform workflow identity federation pool id used for github.com/kyma-project org identities"
+}
+
+variable "gh_com_kyma_project_wif_provider_id" {
+  type        = string
+  default     = "github-com-kyma-project"
+  description = "Google Cloud Platform workflow identity federation provider id used for github.com/kyma-project org identities"
+}

--- a/configs/terraform/environments/prod/gcp-workfload-identity-federation.tf
+++ b/configs/terraform/environments/prod/gcp-workfload-identity-federation.tf
@@ -36,7 +36,6 @@ module "gh_com_kyma_project_workload_identity_federation" {
 }
 
 # TODO(dekiel): Another GitHub variables related to workload identity federation are defined in github-com.tf file.
-
 resource "github_actions_variable" "gcp_terraform_executor_service_account_email" {
   provider      = github.kyma_project
   repository    = "test-infra"

--- a/configs/terraform/environments/prod/gcp-workfload-identity-federation.tf
+++ b/configs/terraform/environments/prod/gcp-workfload-identity-federation.tf
@@ -3,6 +3,7 @@ data "github_repository" "test_infra" {
   name     = var.github_test_infra_repository_name
 }
 
+# TODO(dekiel): Repalce pool_id and provider_id with variables.
 module "gh_com_kyma_project_workload_identity_federation" {
   source = "../../modules/gcp-workload-identity-federation"
 
@@ -34,6 +35,8 @@ module "gh_com_kyma_project_workload_identity_federation" {
   }
 }
 
+# TODO(dekiel): Another GitHub variables related to workload identity federation are defined in github-com.tf file.
+
 resource "github_actions_variable" "gcp_terraform_executor_service_account_email" {
   provider      = github.kyma_project
   repository    = "test-infra"
@@ -54,4 +57,3 @@ resource "github_actions_variable" "gh_com_kyma_project_gcp_workload_identity_fe
   variable_name = "GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER"
   value         = module.gh_com_kyma_project_workload_identity_federation.provider_name
 }
-

--- a/configs/terraform/environments/prod/github-com.tf
+++ b/configs/terraform/environments/prod/github-com.tf
@@ -3,6 +3,8 @@
 # They are required for getting terraform executor github personal access token from gcp secret manager.
 # We must develop a solution for creating a minimal initial setup to let terraform executor apply our whole config.
 
+# TODO(dekiel): Another GitHub variables related to workload identity federation are defined in gcp-workload-identity-federation.tf file.
+
 # GCP project id that contains secret manager with secrets
 resource "github_actions_variable" "gcp_kyma_project_project_id" {
   provider      = github.kyma_project
@@ -26,4 +28,9 @@ resource "github_actions_variable" "github_terraform_planner_secret_name" {
   repository    = "test-infra"
   variable_name = "GH_TERRAFORM_PLANNER_SECRET_NAME"
   value         = "kyma-bot-gh-com-terraform-planner-token"
+}
+
+data "github_organization" "kyma-project" {
+  provider = github.kyma_project
+  name     = "kyma-project"
 }

--- a/configs/terraform/environments/prod/gitleaks.tf
+++ b/configs/terraform/environments/prod/gitleaks.tf
@@ -7,12 +7,6 @@ resource "google_service_account" "gitleaks_secret_accesor" {
   description  = "Identity of gitleaks. It's used to retrieve secrets from secret manager"
 }
 
-# Retrieve id of kyma project github organization used in subject of workload identity federation.
-data "github_organization" "kyma-project" {
-  provider = github.kyma_project
-  name     = "kyma-project"
-}
-
 # Retrieval of repository id of each repository that can run gitleaks workflow
 data "github_repository" "gitleaks_repository" {
   for_each = var.gitleaks_repositories

--- a/configs/terraform/environments/prod/image-builder-variables.tf
+++ b/configs/terraform/environments/prod/image-builder-variables.tf
@@ -9,3 +9,33 @@ variable "signify_prod_secret_name" {
   description = "Name of the signify dev secret. This secret is used by image-builder to sign OCI images with signify production service."
   default     = "signify-prod-secret"
 }
+
+# GitHub resources
+
+variable "image_builder_reusable_workflow_name" {
+  type        = string
+  description = "Name of the image-builder reusable workflow in the test-infra repository."
+  default     = "image-builder.yml"
+}
+
+# GCP resources
+
+variable "image_builder_ado_pat_gcp_secret_manager_secret_name" {
+  description = "Name of the secret in GCP Secret Manager that contains the ADO PAT for image-builder to trigger ADO pipeline."
+  type        = string
+  default     = "image-builder-ado-pat"
+}
+
+variable "image_builder_gh_workflow_service_account" {
+  description = "Service account used by image-builder reusable workflow to access GCP secret manager. Reusable workflow is defined in the test-infra repository."
+
+  type = object({
+    id         = string
+    project_id = string
+  })
+
+  default = {
+    id         = "image-builder-gh-workflow"
+    project_id = "sap-kyma-prow"
+  }
+}

--- a/configs/terraform/environments/prod/image-builder.tf
+++ b/configs/terraform/environments/prod/image-builder.tf
@@ -76,6 +76,8 @@ resource "google_service_account" "image-builder-gh-workflow" {
   display_name = var.image_builder_gh_workflow_service_account.id
 }
 
+# Grant the image-builder service account the workload identity user role.
+# This role is required to impersonate the image-builder-workflow GCP service account by GitHub image-builder reusable workflow using workload identity federation.
 resource "google_service_account_iam_binding" "image_builder_gh_workflow_workload_identity" {
   service_account_id = google_service_account.image-builder-gh-workflow.name
   role               = "roles/iam.workloadIdentityUser"
@@ -84,6 +86,8 @@ resource "google_service_account_iam_binding" "image_builder_gh_workflow_workloa
   ]
 }
 
+# Grant read access to the GCP secret manager secret with ado pat to the image-builder service account.
+# This secret is used by the image-builder reusable workflow to authenticate with Azure DevOps API and trigger ADO pipeline.
 resource "google_secret_manager_secret_iam_member" "image_builder_ado_pat" {
   project   = var.gcp_project_id
   secret_id = var.image_builder_ado_pat_gcp_secret_manager_secret_name
@@ -93,6 +97,8 @@ resource "google_secret_manager_secret_iam_member" "image_builder_ado_pat" {
 
 # GitHub resources
 
+# Define GitHub Actions secrets for the image-builder reusable workflow.
+# These secret contains the values of the GCP service account email used by the image-builder reusable workflow to access GCP secret manager.
 resource "github_actions_variable" "image_builder_gh_workflow_gcp_service_account_email" {
   provider      = github.kyma_project
   repository    = "test-infra"
@@ -100,6 +106,9 @@ resource "github_actions_variable" "image_builder_gh_workflow_gcp_service_accoun
   value         = google_service_account.image-builder-gh-workflow.email
 }
 
+# Define GitHub Actions secrets for the image-builder reusable workflow.
+# These secret contains the values of the GCP secret manager secret name with ado pat
+# It's used by the image-builder reusable workflow to authenticate with Azure DevOps API and trigger ADO pipeline.
 resource "github_actions_variable" "image_builder_ado_pat_gcp_secret_name" {
   provider      = github.kyma_project
   repository    = "test-infra"

--- a/configs/terraform/environments/prod/image-builder.tf
+++ b/configs/terraform/environments/prod/image-builder.tf
@@ -66,3 +66,43 @@ resource "kubernetes_cluster_role_binding" "access_signify_prod_secret_untrusted
     name      = var.external_secrets_k8s_sa_trusted_cluster.name
   }
 }
+
+# GCP resources
+
+resource "google_service_account" "image-builder-gh-workflow" {
+  description  = "Service account used by image-builder reusable workflow to access GCP secret manager. Reusable workflow is defined in the test-infra repository."
+  project      = var.image_builder_gh_workflow_service_account.project_id
+  account_id   = var.image_builder_gh_workflow_service_account.id
+  display_name = var.image_builder_gh_workflow_service_account.id
+}
+
+resource "google_service_account_iam_binding" "image_builder_gh_workflow_workload_identity" {
+  service_account_id = google_service_account.image-builder-gh-workflow.name
+  role               = "roles/iam.workloadIdentityUser"
+  members = [
+    "principal://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/subject/repository_id:${data.github_repository.test_infra.repo_id}:repository_owner_id:${data.github_organization.kyma-project.id}:workflow${var.image_builder_reusable_workflow_name}"
+  ]
+}
+
+resource "google_secret_manager_secret_iam_member" "image_builder_ado_pat" {
+  project   = var.gcp_project_id
+  secret_id = var.image_builder_ado_pat_gcp_secret_manager_secret_name
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.image-builder-gh-workflow.email}"
+}
+
+# GitHub resources
+
+resource "github_actions_variable" "image_builder_gh_workflow_gcp_service_account_email" {
+  provider      = github.kyma_project
+  repository    = "test-infra"
+  variable_name = "IMAGE_BUILDER_GH_WORKFLOW_GCP_SERVICE_ACCOUNT_EMAIL"
+  value         = google_service_account.image-builder-gh-workflow.email
+}
+
+resource "github_actions_variable" "image_builder_ado_pat_gcp_secret_name" {
+  provider      = github.kyma_project
+  repository    = "test-infra"
+  variable_name = "IMAGE_BUILDER_ADO_PAT_GCP_SECRET_NAME"
+  value         = var.image_builder_ado_pat_gcp_secret_manager_secret_name
+}

--- a/configs/terraform/environments/prod/image-builder.tf
+++ b/configs/terraform/environments/prod/image-builder.tf
@@ -82,7 +82,7 @@ resource "google_service_account_iam_binding" "image_builder_gh_workflow_workloa
   service_account_id = google_service_account.image-builder-gh-workflow.name
   role               = "roles/iam.workloadIdentityUser"
   members = [
-    "principal://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/subject/repository_id:${data.github_repository.test_infra.repo_id}:repository_owner_id:${data.github_organization.kyma-project.id}:workflow${var.image_builder_reusable_workflow_name}"
+    "principal://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/subject/repository_id:${data.github_repository.test_infra.repo_id}:repository_owner_id:${data.github_organization.kyma-project.id}:workflow:${var.image_builder_reusable_workflow_name}"
   ]
 }
 

--- a/configs/terraform/environments/prod/provider.tf
+++ b/configs/terraform/environments/prod/provider.tf
@@ -13,8 +13,9 @@ terraform {
       version = ">= 2.0.0"
     }
     github = {
-      source  = "integrations/github"
-      version = "~> 5.0"
+      source = "integrations/github"
+      #version = "~> 5.0"
+      version = "~> 6.2.1"
     }
   }
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Read ADO PAT from GCP Secret Manager in image-builder reusable workflow.
- Authenticate in GCP using WIF.
- Add Terraform config for image-builder dedicated GCP and GitHub resources.

**Related issue(s)**
See: #10702 
