### PR TITLE
Fix reusable workflow for oci-image-builder

### DIFF
--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -40,12 +40,12 @@ on:
         default: ""
 
 jobs:
-  get_oidc_token:
+  build-image:
     permissions:
       id-token: write # This is required for requesting the JWT token
       contents: read # This is required for actions/checkout
     runs-on: ubuntu-latest
-    name: A job to get OIDC token
+    name: Build image
     outputs:
       token: ${{ steps.get_oidc.outputs.jwt }}
     steps:
@@ -62,15 +62,11 @@ jobs:
         id: get_oidc
         uses: ./.github/actions/expose-jwt-action
 
-  build:
-    needs: get_oidc_token
-    runs-on: ubuntu-latest
-    steps:
       - uses: ./.github/actions/image-builder
         id: build
         name: Run build in image-builder
         with:
-          oidc-token: ${{ needs.get_oidc_token.outputs.token }}
+          oidc-token: ${{ steps.get_oidc.outputs.token }}
           ado-token: ${{ secrets.ADO_PAT }}
           context: ${{ inputs.context }}
           build-args: ${{ inputs.build-args }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

I decided to extract fixes for workflow from #10860 to clearly see which PR fixes which issue.

Changes proposed in this pull request:

- Merge jobs into build-image
- Resolve "action.yml not found" error
