### PR TITLE
Fix reusable workflow name. The name is not a file name.

### DIFF
--- a/configs/terraform/environments/prod/image-builder-variables.tf
+++ b/configs/terraform/environments/prod/image-builder-variables.tf
@@ -15,7 +15,7 @@ variable "signify_prod_secret_name" {
 variable "image_builder_reusable_workflow_name" {
   type        = string
   description = "Name of the image-builder reusable workflow in the test-infra repository."
-  default     = "image-builder.yml"
+  default = "image-builder"
 }
 
 # GCP resources


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Fix reusable workflow name in a Terraform variable. The name of a workflow is not a file name.
