### PR TITLE
Use reusable workflow ref and sha in google wif

### DIFF
--- a/configs/terraform/environments/prod/gcp-workfload-identity-federation.tf
+++ b/configs/terraform/environments/prod/gcp-workfload-identity-federation.tf
@@ -21,6 +21,8 @@ module "gh_com_kyma_project_workload_identity_federation" {
     "attribute.workflow"            = "assertion.workflow"
     "attribute.workflow_ref"        = "assertion.workflow_ref"
     "attribute.event_name"          = "assertion.event_name"
+    "attribute.reusable_workflow_ref" = "assertion.job_workflow_ref"
+    "attribute.reusable_workflow_sha" = "assertion.job_workflow_sha"
   }
 
   sa_mapping = {

--- a/configs/terraform/environments/prod/image-builder-variables.tf
+++ b/configs/terraform/environments/prod/image-builder-variables.tf
@@ -15,12 +15,12 @@ variable "signify_prod_secret_name" {
 variable "image_builder_reusable_workflow_name" {
   type        = string
   description = "Name of the image-builder reusable workflow in the test-infra repository."
-  default = "image-builder"
+  default     = "image-builder"
 }
 
 variable "image_builder_reusable_workflow_ref" {
   type        = string
-  description = "Name of the image-builder reusable workflow in the test-infra repository."
+  description = "The value of GitHub OIDC token job_workflow_ref claim of the image-builder reusable workflow in the test-infra repository. This is used to identify token exchange requests for image-builder reusable workflow."
   default     = "kyma-project/test-infra/.github/workflows/image-builder.yml@refs/heads/main"
 }
 

--- a/configs/terraform/environments/prod/image-builder-variables.tf
+++ b/configs/terraform/environments/prod/image-builder-variables.tf
@@ -18,6 +18,12 @@ variable "image_builder_reusable_workflow_name" {
   default = "image-builder"
 }
 
+variable "image_builder_reusable_workflow_ref" {
+  type        = string
+  description = "Name of the image-builder reusable workflow in the test-infra repository."
+  default     = "kyma-project/test-infra/.github/workflows/image-builder.yml@refs/heads/main"
+}
+
 # GCP resources
 
 variable "image_builder_ado_pat_gcp_secret_manager_secret_name" {

--- a/configs/terraform/environments/prod/image-builder.tf
+++ b/configs/terraform/environments/prod/image-builder.tf
@@ -95,6 +95,13 @@ resource "google_secret_manager_secret_iam_member" "image_builder_ado_pat" {
   member    = "serviceAccount:${google_service_account.image-builder-gh-workflow.email}"
 }
 
+resource "google_secret_manager_secret_iam_member" "image_builder_ado_pat" {
+  project   = var.gcp_project_id
+  secret_id = var.image_builder_ado_pat_gcp_secret_manager_secret_name
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_ref/${var.image_builder_reusable_workflow_ref}"
+}
+
 # GitHub resources
 
 # Define GitHub Actions secrets for the image-builder reusable workflow.

--- a/configs/terraform/environments/prod/image-builder.tf
+++ b/configs/terraform/environments/prod/image-builder.tf
@@ -88,14 +88,14 @@ resource "google_service_account_iam_binding" "image_builder_gh_workflow_workloa
 
 # Grant read access to the GCP secret manager secret with ado pat to the image-builder service account.
 # This secret is used by the image-builder reusable workflow to authenticate with Azure DevOps API and trigger ADO pipeline.
-resource "google_secret_manager_secret_iam_member" "image_builder_ado_pat" {
+resource "google_secret_manager_secret_iam_member" "image_builder_gh_workflow_sa_ado_pat_reader" {
   project   = var.gcp_project_id
   secret_id = var.image_builder_ado_pat_gcp_secret_manager_secret_name
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.image-builder-gh-workflow.email}"
 }
 
-resource "google_secret_manager_secret_iam_member" "image_builder_ado_pat" {
+resource "google_secret_manager_secret_iam_member" "image_builder_reusable_workflow_principal_ado_pat_reader" {
   project   = var.gcp_project_id
   secret_id = var.image_builder_ado_pat_gcp_secret_manager_secret_name
   role      = "roles/secretmanager.secretAccessor"


### PR DESCRIPTION
Grant direct access to the secret manager secret for wif principalSet.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Use attribute.reusable_workflow_ref in principal for granting access to the image-builder-ado-pat secret in secret manager.
We can't use a standard subject based mapping as it contains the name of a workflow, which is unknown and should not be limited. The workflow name is the name of workflow where users will call our reusable workflow. We don't want to have define separate mapping for each such workflow as it will not scale at all.

Additionally, following google recommendations, granting access to the secret directly to the principal instead through service account impresonation.
