### PR TITLE
Add certificate authorities root certificates.

### DIFF
--- a/cmd/oidc-token-verifier/Dockerfile
+++ b/cmd/oidc-token-verifier/Dockerfile
@@ -1,5 +1,10 @@
 FROM golang:1.22.3-alpine as builder
 
+# Add certificate authorities certificates.
+# This let oidctokenverifier to use tls connection to the OIDC provider.
+RUN apk update && apk upgrade && apk add --no-cache ca-certificates
+RUN update-ca-certificates
+
 WORKDIR /go/src/github.com/kyma-project/test-infra
 COPY . .
 
@@ -8,4 +13,8 @@ RUN  CGO_ENABLED=0 go build -o /oidctokenverifier -ldflags="-s -w" ./cmd/oidc-to
 FROM scratch
 
 COPY --from=builder /oidctokenverifier /oidctokenverifier
+# Add certificate authorities certificates.
+# This let oidctokenverifier to use tls connection to the OIDC provider.
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
 ENTRYPOINT ["/oidctokenverifier"]


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

oci-image-builder ado pipeline is failing oidc token verification because the oidc-token-verifier image doesn't have a certificate authorities root certificates installed. The tls connection to the GitHub oidc provider is failing due to this.
