### PR TITLE
Detect workspace workdir and provide error

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -375,7 +375,7 @@ func validateDockerFile(dockerFilePath string) error {
 	// Dockerfile using /workspace
 	// see: https://github.com/GoogleContainerTools/kaniko/issues/2192
 	// see: https://github.com/GoogleContainerTools/kaniko/issues/3176
-	re := regexp.MustCompile("WORKDIR.*/workspace")
+	re := regexp.MustCompile("(WORKDIR|COPY).* /workspace")
 	if re.Match(data) {
 		return fmt.Errorf("dockerfile cannot use /workspace as working directory, please switch to other one (e.g. /<module>-workspace). See: https://github.com/GoogleContainerTools/kaniko/issues/3176 and https://github.com/GoogleContainerTools/kaniko/issues/2192")
 	}

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -356,6 +356,27 @@ func buildInADO(o options) error {
 	return nil
 }
 
+// validateDockerFile checks whether provided dockerfile
+// will run smoothly in ADO image-builder.
+// It return clear error message, including known issue urls.
+func validateDockerFile(dockerFilePath string) error {
+	// Load Dockerfile
+	data, err := os.ReadFile(dockerFilePath)
+	if err != nil {
+		return fmt.Errorf("cannot load provided dockerfile: %w", err)
+	}
+
+	// Dockerfile using /workspace
+	// see: https://github.com/GoogleContainerTools/kaniko/issues/2192
+	// see: https://github.com/GoogleContainerTools/kaniko/issues/3176
+	re := regexp.MustCompile("WORKDIR.*/workspace")
+	if re.Match(data) {
+		return fmt.Errorf("dockerfile cannot use /workspace as working directory, please switch to other one (e.g. /<module>-workspace). See: https://github.com/GoogleContainerTools/kaniko/issues/3176 and https://github.com/GoogleContainerTools/kaniko/issues/2192")
+	}
+
+	return nil
+}
+
 // buildLocally is a function that builds an image locally using either Kaniko or BuildKit.
 // It takes an options struct as an argument and returns an error.
 // The function determines the build tool to use based on the USE_BUILDKIT environment variable.

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -261,6 +261,12 @@ func prepareADOTemplateParameters(options options) (adopipelines.OCIImageBuilder
 // TODO(dekiel): refactor this function to accept clients as parameters to make it testable with mocks.
 func buildInADO(o options) error {
 	fmt.Println("Building image in ADO pipeline.")
+
+	// Validate provided dockerfile for ADO usage
+	if err := validateDockerFile(o.dockerfile); err != nil {
+		return fmt.Errorf("invalid dockerfile provided: %w", err)
+	}
+
 	// Getting Azure DevOps Personal Access Token (ADO_PAT) from environment variable for authentication with ADO API when it's not set via flag.
 	if o.azureAccessToken == "" {
 		adoPAT, present := os.LookupEnv("ADO_PAT")

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"reflect"
 	"testing"
@@ -691,6 +692,62 @@ func Test_extractImagesFromADOLogs(t *testing.T) {
 
 			if !reflect.DeepEqual(actualImages, c.expectedImages) {
 				t.Errorf("Expected %v, but got %v", c.expectedImages, actualImages)
+			}
+		})
+	}
+}
+
+func Test_validateDockerFile(t *testing.T) {
+	tc := []struct {
+		name       string
+		dockerfile string
+		expectErr  bool
+	}{
+		{
+			name: "simple dockerfile, valid",
+			dockerfile: `FROM debian
+			RUN apt-get update
+			RUN apt-get -y install gcc
+			ADD hello.c /hello.c
+			RUN gcc -static -o /hello hello.c`,
+			expectErr: false,
+		},
+		{
+			name: "dockerfile with workspace workdir, invalid",
+			dockerfile: `FROM golang:1.22.1-bullseye as builder
+
+			WORKDIR /workspace
+			# Copy the Go Modules manifests
+			COPY go.mod go.mod
+			COPY go.sum go.sum
+			
+			FROM europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.2.1-8adfb683
+			
+			WORKDIR /
+			COPY --from=builder /workspace/manager .
+			
+			USER 65532:65532`,
+			expectErr: true,
+		},
+	}
+
+	for _, c := range tc {
+		t.Run(c.name, func(t *testing.T) {
+			// Arrange
+			tempDir := t.TempDir()
+			dockerFilePath := fmt.Sprintf("%s/out_file", tempDir)
+			err := os.WriteFile(dockerFilePath, []byte(c.dockerfile), os.ModePerm)
+			if err != nil {
+				t.Errorf("failed to write dockerfile for test: %s", err)
+			}
+
+			// Act & Assert
+			err = validateDockerFile(dockerFilePath)
+			if err != nil && !c.expectErr {
+				t.Errorf("unexpected error occured: %s", err)
+			}
+			if err == nil && c.expectErr {
+				t.Errorf("expected error, but not one occured")
 			}
 		})
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add function to validate dockerfile provided for ADO backend
- Add support for detecting usage of `/workspace` working directory
- Add meaningfull error message with links to kaniko issues and proposed solution

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See https://github.com/GoogleContainerTools/kaniko/issues/2192
See https://github.com/GoogleContainerTools/kaniko/issues/3176