### PR TITLE
Remove EncodedTags param

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -234,8 +234,6 @@ func prepareADOTemplateParameters(options options) (adopipelines.OCIImageBuilder
 
 	if len(options.tags) > 0 {
 		templateParameters.SetImageTags(options.tags.String())
-		// TODO: Remove setting EncodedTags when we switch fully to base64 encoding Tags parameter.
-		templateParameters.SetEncodedTags(true)
 	}
 
 	if options.ciSystem == GithubActions {

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -639,7 +639,6 @@ func Test_prepareADOTemplateParameters(t *testing.T) {
 			want: pipelines.OCIImageBuilderTemplateParams{
 				"Context":               "",
 				"Dockerfile":            "",
-				"EncodedTags":           "true",
 				"ExportTags":            "false",
 				"JobType":               "postsubmit",
 				"Name":                  "",

--- a/pkg/azuredevops/pipelines/templatesParams.go
+++ b/pkg/azuredevops/pipelines/templatesParams.go
@@ -110,10 +110,6 @@ func (p OCIImageBuilderTemplateParams) SetImageTags(tags string) {
 	p["Tags"] = encodedTags
 }
 
-func (p OCIImageBuilderTemplateParams) SetEncodedTags(encodedTags bool) {
-	p["EncodedTags"] = strconv.FormatBool(encodedTags)
-}
-
 // SetUseKanikoConfigFromPR sets optional parameter UseKanikoConfigFromPR.
 // If true, ADO pipeline will use a Kaniko config from PR.
 // This is used for testing purposes.

--- a/pkg/azuredevops/pipelines/templatesParams_test.go
+++ b/pkg/azuredevops/pipelines/templatesParams_test.go
@@ -82,11 +82,6 @@ var _ = Describe("Test OCIImageBuilderTemplateParams", func() {
 		Expect(params["Tags"]).To(Equal(expected))
 	})
 
-	It("sets the correct EncodedTags", func() {
-		params.SetEncodedTags(true)
-		Expect(params["EncodedTags"]).To(Equal("true"))
-	})
-
 	It("sets the correct UseKanikoConfigFromPR", func() {
 		params.SetUseKanikoConfigFromPR(true)
 		Expect(params["UseKanikoConfigFromPR"]).To(Equal("true"))


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

image-builder client always send Tags parameter as base64 encoded string. After switching an oci-image-builder pipeline to always expect Tags parameter as base64 encoded, the additional EncodedTags parameter wont be needed.
