### PR TITLE
Add gitleaks allow to terrform vars

### DIFF
--- a/configs/terraform/environments/dev/secrets-rotator/terraform.tfvars
+++ b/configs/terraform/environments/dev/secrets-rotator/terraform.tfvars
@@ -1,7 +1,7 @@
 project_id                                           = "sap-kyma-neighbors-dev"
 region                                               = "europe-west3"
 service_account_keys_rotator_service_name            = "service-account-keys-rotator"
-service_account_keys_rotator_image                   = "europe-docker.pkg.dev/kyma-project/prod/test-infra/rotate-service-account:v20240627-90356fa6"
+service_account_keys_rotator_image                   = "europe-docker.pkg.dev/kyma-project/prod/test-infra/rotate-service-account:v20240627-90356fa6" #gitleaks:allow
 service_account_keys_cleaner_service_name            = "service-account-keys-cleaner"
 service_account_keys_cleaner_image                   = "europe-docker.pkg.dev/kyma-project/prod/test-infra/service-account-keys-cleaner:v20240627-90356fa6" #gitleaks:allow
 service_account_key_latest_version_min_age           = 24

--- a/configs/terraform/environments/dev/secrets-rotator/terraform.tfvars
+++ b/configs/terraform/environments/dev/secrets-rotator/terraform.tfvars
@@ -3,6 +3,6 @@ region                                               = "europe-west3"
 service_account_keys_rotator_service_name            = "service-account-keys-rotator"
 service_account_keys_rotator_image                   = "europe-docker.pkg.dev/kyma-project/prod/test-infra/rotate-service-account:v20240627-90356fa6"
 service_account_keys_cleaner_service_name            = "service-account-keys-cleaner"
-service_account_keys_cleaner_image                   = "europe-docker.pkg.dev/kyma-project/prod/test-infra/service-account-keys-cleaner:v20240627-90356fa6"
+service_account_keys_cleaner_image                   = "europe-docker.pkg.dev/kyma-project/prod/test-infra/service-account-keys-cleaner:v20240627-90356fa6" #gitleaks:allow
 service_account_key_latest_version_min_age           = 24
 service_account_keys_cleaner_scheduler_cron_schedule = "0 0 * * 1-5"

--- a/configs/terraform/environments/prod/terraform.tfvars
+++ b/configs/terraform/environments/prod/terraform.tfvars
@@ -8,8 +8,8 @@ kyma_project_artifact_registry_collection = {
   },
 }
 service_account_keys_rotator_service_name            = "service-account-keys-rotator"
-service_account_keys_rotator_image                   = "europe-docker.pkg.dev/kyma-project/prod/test-infra/rotate-service-account:v20240627-90356fa6"
+service_account_keys_rotator_image                   = "europe-docker.pkg.dev/kyma-project/prod/test-infra/rotate-service-account:v20240627-90356fa6" #gitleaks:allow
 service_account_keys_cleaner_service_name            = "service-account-keys-cleaner"
-service_account_keys_cleaner_image                   = "europe-docker.pkg.dev/kyma-project/prod/test-infra/service-account-keys-cleaner:v20240627-90356fa6"
+service_account_keys_cleaner_image                   = "europe-docker.pkg.dev/kyma-project/prod/test-infra/service-account-keys-cleaner:v20240627-90356fa6" #gitleaks:allow
 service_account_key_latest_version_min_age           = 24
 service_account_keys_cleaner_scheduler_cron_schedule = "0 0 * * 1-5"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Often gitleaks misdetec image tag as generic-api-key. 

Changes proposed in this pull request:

- Add gitleaks allow to images in tfvars to solve issue.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: https://github.com/kyma-project/test-infra/pull/11188