### PR TITLE
chore: add 3.12.2-slim-bullseye image

### DIFF
--- a/cmd/image-syncer/external-images.yaml
+++ b/cmd/image-syncer/external-images.yaml
@@ -97,6 +97,8 @@ images:
   - source: "python:3.12.3-alpine3.20"
   - source: "python@sha256:7e9400f6d73dcb6fd4ea9a2f6e5334da18631f8facb007711648d924a38cfdc6"
     tag: "3.12.4-slim-bullseye"
+  - source: "python@sha256:3c9599f1a8a5c384e3a17231dd24a32777e26b3705386b3a0403086cbbd23868"
+    tag: "3.12.2-slim-bullseye"
   - source: "fluent/fluent-bit@sha256:98fa7ea6d2585f64f75346aa196e24f134847a7741e11a6cb3c3c0c4b20671cb"
     tag: "3.1.3"
   - source: "node@sha256:ba898e86c2cc720c8cf2ae05f8d2d4697fe0c8ca3e920d6fbf14a6cbf50bb9ca"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- add python:3.12.2-slim-bullseye to external images
- get the sha256 using:
   ```
   docker run --rm mplatform/manifest-tool inspect "python:3.12.2-slim-bullseye" | grep "Digest: sha256" | head -n 1
   ```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
