### PR TITLE
Test what version of reusable workflow a run will pick up.

### DIFF
--- a/.github/workflows/pull-image-builder-test.yml
+++ b/.github/workflows/pull-image-builder-test.yml
@@ -28,24 +28,16 @@ jobs:
         run: echo ${{ steps.get_tag.outputs.TAG }}
   build-image:
     needs: compute-tag
-    steps:
-      - name: Checkout test-infra repository
-        uses: actions/checkout@v4
-        with:
-          repository: kyma-project/test-infra
-          ref: {{ github.event.pull_request_target.head.ref }}
-      - name: Build image
-        uses: ./.github/workflows/image-builder.yml
-        with:
-          name: test-infra/ginkgo
-          dockerfile: prow/images/ginkgo/Dockerfile
-          context: .
-          env-file: "envs"
-          tags: ${{ needs.compute-tag.outputs.tag }}
+    uses: ./.github/workflows/image-builder.yml
+    with:
+      name: test-infra/ginkgo
+      dockerfile: prow/images/ginkgo/Dockerfile
+      context: .
+      env-file: "envs"
+      tags: ${{ needs.compute-tag.outputs.tag }}
   test-image:
     runs-on: ubuntu-latest
     needs: build-image
     steps:
       - name: Test image
         run: echo "Testing images ${{ needs.build-image.outputs.images }}"
-


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

We can't checkout pull request head in the same job where we call reusable workflow. Testing here which version of repo a reusable workflow will use for run.

IssuE: #11614 
