### PR TITLE
Sync images with external-images.yaml on main branch

### DIFF
--- a/.github/workflows/pull-sync-external-images.yml
+++ b/.github/workflows/pull-sync-external-images.yml
@@ -2,9 +2,11 @@ name: pull-sync-external-images
 
 on:
   pull_request_target:
+    branches:
+      - main
     types: [ opened, edited, synchronize, reopened, ready_for_review ]
     paths:
-      - "./external-images.yaml"
+      - "external-images.yaml"
 
 permissions:
   id-token: write # This is required for requesting the JWT token


### PR DESCRIPTION
We will maintain a file in main branch only.
Change path definition. Trying to fix the workflow was not triggered on pr event.
