### PR TITLE
Fix sync images workflow does not start

### DIFF
--- a/.github/workflows/pull-sync-external-images.yml
+++ b/.github/workflows/pull-sync-external-images.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   sync-external-images:
-    uses: ./.github/workflows/image-syncer.yml@main
+    uses: kyma-project/test-infra/.github/workflows/image-syncer.yml@main
     with:
       dry-run: true
       debug: true


### PR DESCRIPTION
Fix error "invalid value workflow reference: cannot specify version when calling local workflows"
