### PR TITLE
Workflow to sync images on push event

### DIFF
--- a/.github/workflows/push-sync-external-images.yml
+++ b/.github/workflows/push-sync-external-images.yml
@@ -1,10 +1,9 @@
 name: pull-sync-external-images
 
 on:
-  pull_request_target:
+  push:
     branches:
       - main
-    types: [ opened, edited, synchronize, reopened, ready_for_review ]
     paths:
       - "external-images.yaml"
 
@@ -16,4 +15,5 @@ jobs:
   sync-external-images:
     uses: kyma-project/test-infra/.github/workflows/image-syncer.yml@main
     with:
-      debug: true
+      dry-run: false
+      debug: false


### PR DESCRIPTION
Added workflow to sync images on push event.
Removed setting dry-run for pr, it is forced to true in reusable workflow.


**Related issue(s)**
See #11384 
Depends on #11867 
