### PR TITLE
Mount cred.json as read only and with proper context.

### DIFF
--- a/.github/workflows/image-syncer.yml
+++ b/.github/workflows/image-syncer.yml
@@ -78,7 +78,7 @@ jobs:
           --env GOOGLE_APPLICATION_CREDENTIALS
           --entrypoint /ko-app/image-syncer
           --volume "/home/runner/work/test-infra/test-infra":"/github/workspace"
-          --volume "$GOOGLE_APPLICATION_CREDENTIALS":"/gcp-creds.json"
+          --volume "$GOOGLE_APPLICATION_CREDENTIALS:/gcp-creds.json:ro,Z"
           europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/image-syncer:v20240822-9b523f40
           --images-file=/github/workspace/external-images.yaml
           --target-repo-auth-key=/gcp-creds.json


### PR DESCRIPTION
Fixing permission denied error when opening mounted credentials file in docker container.

**Related issue(s)**
See #11384 
