### PR TITLE
Remove amd64Only flag from external-images.yaml when it is not needed

### DIFF
--- a/cmd/image-syncer/external-images.yaml
+++ b/cmd/image-syncer/external-images.yaml
@@ -3,32 +3,25 @@ images:
   - source: "alpine@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d"
     tag: "3.20.3"
   - source: "bitnami/postgres-exporter:0.11.1-debian-11-r69"
-    amd64Only: true
   - source: "busybox@sha256:3b3128d9df6bbbcc92e2358e596c9fbd722a437a62bafbc51607970e9e3b8869"
     tag: "1.34.1-v1"
   - source: "curlimages/curl:7.78.0"
   - source: "cypress/included:9.5.0" # 10.3.0+, latest is 12.0.1
-    amd64Only: true
   - source: "gcr.io/google-containers/pause:3.2"
   - source: "goreleaser/goreleaser:v1.11.5"
   # Golang image is pinned because it is force updated in the upstream
   - source: "golang@sha256:ac67716dd016429be8d4c2c53a248d7bcdf06d34127d3dc451bda6aa5a87bc06"
     tag: "1.23.1-alpine3.20"
   - source: "grafana/grafana-image-renderer:3.2.1"
-    amd64Only: true
   - source: "hudymi/mockice:0.1.3"
-    amd64Only: true
   - source: "istio/pilot:1.22.3-distroless"
   - source: "istio/proxyv2:1.22.3-distroless"
   - source: "istio/install-cni:1.22.3-distroless"
   - source: "jettech/kube-webhook-certgen:v1.5.0"
   - source: "kennethreitz/httpbin:latest"
-    amd64Only: true
   - source: "oryd/hydra-maester:v0.0.25"
-    amd64Only: true
   - source: "oryd/hydra:v1.11.8"
   - source: "oryd/oathkeeper-maester:v0.1.5"
-    amd64Only: true
   - source: "oryd/oathkeeper:v0.38.25-beta.1"
   - source: "postgres@sha256:86c55091a74b9efe95396f65ddd83f0067ff47c3f09993621d6f94c835856445"
     tag: "11.21-alpine3.18"
@@ -47,21 +40,17 @@ images:
   - source: "natsio/nats-box:0.14.1"
   - source: "natsio/prometheus-nats-exporter:0.14.0"
   - source: "mockserver/mockserver:mockserver-5.11.2"
-    amd64Only: true
   - source: "i331641/kyma-perf:v1"
-    amd64Only: true
   - source: "ghcr.io/kedacore/keda:2.15.1"
   - source: "ghcr.io/kedacore/keda-admission-webhooks:2.15.1"
   - source: "ghcr.io/kedacore/keda-metrics-apiserver:2.15.1"
   - source: "nginx:1.23.3"
-    amd64Only: true
   - source: "nginxinc/nginx-unprivileged@sha256:0065303bfa2a20793f9b5db326e94d68bdc7a69f79822091b8db5b3ec4753491"
     tag: "1.27.1-alpine3.20"
   - source: "fluent/fluentd@sha256:c8026af1f87f60db08e23ec0e62f779096abc93b2fc62aa4b57fc23a617451f6"
     tag: "v1.16-debian-1"
   - source: "gcr.io/istio-testing/ext-authz@sha256:8ffad059c8ad951102e5421562ac5b7cca129881903be8cbfdc5e910e49fd78e"
     tag: "1.22-dev"
-    amd64Only: true
   - source: "registry@sha256:12120425f07de11a1b899e418d4b0ea174c8d4d572d45bdb640f93bc7ca06a3d"
     tag: "2.8.3-v1" # latest: 3.0.0-beta.1 <- wait for a fully supported release
   - source: "gcr.io/kaniko-project/executor:v1.23.2"
@@ -79,6 +68,5 @@ images:
   - source: "golangci/golangci-lint:v1.60.3"
   - source: "node@sha256:a3816e038e05ea70d2640c845c285f49e416bdae2481a7ff94fde96647a10607"
     tag: "22.3.0"
-    amd64Only: true
   - source: "node@sha256:1a526b97cace6b4006256570efa1a29cd1fe4b96a5301f8d48e87c5139438a45"
     tag: "20.17-alpine3.20"

--- a/cmd/image-syncer/external-images.yaml
+++ b/cmd/image-syncer/external-images.yaml
@@ -33,7 +33,6 @@ images:
   - source: "quay.io/prometheus/prometheus:v2.45.0"
   - source: "natsio/nats-box:0.14.1"
   - source: "natsio/prometheus-nats-exporter:0.14.0"
-  - source: "i331641/kyma-perf:v1"
   - source: "ghcr.io/kedacore/keda:2.15.1"
   - source: "ghcr.io/kedacore/keda-admission-webhooks:2.15.1"
   - source: "ghcr.io/kedacore/keda-metrics-apiserver:2.15.1"

--- a/cmd/image-syncer/external-images.yaml
+++ b/cmd/image-syncer/external-images.yaml
@@ -11,11 +11,21 @@ images:
   # Golang image is pinned because it is force updated in the upstream
   - source: "golang@sha256:ac67716dd016429be8d4c2c53a248d7bcdf06d34127d3dc451bda6aa5a87bc06"
     tag: "1.23.1-alpine3.20"
+  - source: "grafana/grafana-image-renderer:3.2.1"
+    amd64Only: true
+  - source: "hudymi/mockice:0.1.3"
+    amd64Only: true
   - source: "istio/pilot:1.22.3-distroless"
   - source: "istio/proxyv2:1.22.3-distroless"
   - source: "istio/install-cni:1.22.3-distroless"
   - source: "jettech/kube-webhook-certgen:v1.5.0"
+  - source: "kennethreitz/httpbin:latest"
+    amd64Only: true
+  - source: "oryd/hydra-maester:v0.0.25"
+    amd64Only: true
   - source: "oryd/hydra:v1.11.8"
+  - source: "oryd/oathkeeper-maester:v0.1.5"
+    amd64Only: true
   - source: "oryd/oathkeeper:v0.38.25-beta.1"
   - source: "postgres@sha256:86c55091a74b9efe95396f65ddd83f0067ff47c3f09993621d6f94c835856445"
     tag: "11.21-alpine3.18"
@@ -33,6 +43,10 @@ images:
   - source: "quay.io/prometheus/prometheus:v2.45.0"
   - source: "natsio/nats-box:0.14.1"
   - source: "natsio/prometheus-nats-exporter:0.14.0"
+  - source: "mockserver/mockserver:mockserver-5.11.2"
+    amd64Only: true
+  - source: "i331641/kyma-perf:v1"
+    amd64Only: true
   - source: "ghcr.io/kedacore/keda:2.15.1"
   - source: "ghcr.io/kedacore/keda-admission-webhooks:2.15.1"
   - source: "ghcr.io/kedacore/keda-metrics-apiserver:2.15.1"

--- a/cmd/image-syncer/external-images.yaml
+++ b/cmd/image-syncer/external-images.yaml
@@ -11,21 +11,11 @@ images:
   # Golang image is pinned because it is force updated in the upstream
   - source: "golang@sha256:ac67716dd016429be8d4c2c53a248d7bcdf06d34127d3dc451bda6aa5a87bc06"
     tag: "1.23.1-alpine3.20"
-  - source: "grafana/grafana-image-renderer:3.2.1"
-    amd64Only: true
-  - source: "hudymi/mockice:0.1.3"
-    amd64Only: true
   - source: "istio/pilot:1.22.3-distroless"
   - source: "istio/proxyv2:1.22.3-distroless"
   - source: "istio/install-cni:1.22.3-distroless"
   - source: "jettech/kube-webhook-certgen:v1.5.0"
-  - source: "kennethreitz/httpbin:latest"
-    amd64Only: true
-  - source: "oryd/hydra-maester:v0.0.25"
-    amd64Only: true
   - source: "oryd/hydra:v1.11.8"
-  - source: "oryd/oathkeeper-maester:v0.1.5"
-    amd64Only: true
   - source: "oryd/oathkeeper:v0.38.25-beta.1"
   - source: "postgres@sha256:86c55091a74b9efe95396f65ddd83f0067ff47c3f09993621d6f94c835856445"
     tag: "11.21-alpine3.18"
@@ -43,8 +33,6 @@ images:
   - source: "quay.io/prometheus/prometheus:v2.45.0"
   - source: "natsio/nats-box:0.14.1"
   - source: "natsio/prometheus-nats-exporter:0.14.0"
-  - source: "mockserver/mockserver:mockserver-5.11.2"
-    amd64Only: true
   - source: "ghcr.io/kedacore/keda:2.15.1"
   - source: "ghcr.io/kedacore/keda-admission-webhooks:2.15.1"
   - source: "ghcr.io/kedacore/keda-metrics-apiserver:2.15.1"

--- a/cmd/image-syncer/external-images.yaml
+++ b/cmd/image-syncer/external-images.yaml
@@ -11,7 +11,6 @@ images:
   # Golang image is pinned because it is force updated in the upstream
   - source: "golang@sha256:ac67716dd016429be8d4c2c53a248d7bcdf06d34127d3dc451bda6aa5a87bc06"
     tag: "1.23.1-alpine3.20"
-  - source: "grafana/grafana-image-renderer:3.2.1"
   - source: "hudymi/mockice:0.1.3"
   - source: "istio/pilot:1.22.3-distroless"
   - source: "istio/proxyv2:1.22.3-distroless"

--- a/cmd/image-syncer/external-images.yaml
+++ b/cmd/image-syncer/external-images.yaml
@@ -15,7 +15,6 @@ images:
   - source: "istio/proxyv2:1.22.3-distroless"
   - source: "istio/install-cni:1.22.3-distroless"
   - source: "jettech/kube-webhook-certgen:v1.5.0"
-  - source: "kennethreitz/httpbin:latest"
   - source: "oryd/hydra-maester:v0.0.25"
   - source: "oryd/hydra:v1.11.8"
   - source: "oryd/oathkeeper-maester:v0.1.5"

--- a/cmd/image-syncer/external-images.yaml
+++ b/cmd/image-syncer/external-images.yaml
@@ -33,7 +33,6 @@ images:
   - source: "quay.io/prometheus/prometheus:v2.45.0"
   - source: "natsio/nats-box:0.14.1"
   - source: "natsio/prometheus-nats-exporter:0.14.0"
-  - source: "mockserver/mockserver:mockserver-5.11.2"
   - source: "i331641/kyma-perf:v1"
   - source: "ghcr.io/kedacore/keda:2.15.1"
   - source: "ghcr.io/kedacore/keda-admission-webhooks:2.15.1"

--- a/cmd/image-syncer/external-images.yaml
+++ b/cmd/image-syncer/external-images.yaml
@@ -45,8 +45,6 @@ images:
   - source: "natsio/prometheus-nats-exporter:0.14.0"
   - source: "mockserver/mockserver:mockserver-5.11.2"
     amd64Only: true
-  - source: "i331641/kyma-perf:v1"
-    amd64Only: true
   - source: "ghcr.io/kedacore/keda:2.15.1"
   - source: "ghcr.io/kedacore/keda-admission-webhooks:2.15.1"
   - source: "ghcr.io/kedacore/keda-metrics-apiserver:2.15.1"

--- a/cmd/image-syncer/external-images.yaml
+++ b/cmd/image-syncer/external-images.yaml
@@ -15,7 +15,6 @@ images:
   - source: "istio/proxyv2:1.22.3-distroless"
   - source: "istio/install-cni:1.22.3-distroless"
   - source: "jettech/kube-webhook-certgen:v1.5.0"
-  - source: "oryd/hydra-maester:v0.0.25"
   - source: "oryd/hydra:v1.11.8"
   - source: "oryd/oathkeeper-maester:v0.1.5"
   - source: "oryd/oathkeeper:v0.38.25-beta.1"

--- a/cmd/image-syncer/external-images.yaml
+++ b/cmd/image-syncer/external-images.yaml
@@ -11,7 +11,6 @@ images:
   # Golang image is pinned because it is force updated in the upstream
   - source: "golang@sha256:ac67716dd016429be8d4c2c53a248d7bcdf06d34127d3dc451bda6aa5a87bc06"
     tag: "1.23.1-alpine3.20"
-  - source: "hudymi/mockice:0.1.3"
   - source: "istio/pilot:1.22.3-distroless"
   - source: "istio/proxyv2:1.22.3-distroless"
   - source: "istio/install-cni:1.22.3-distroless"

--- a/cmd/image-syncer/external-images.yaml
+++ b/cmd/image-syncer/external-images.yaml
@@ -6,7 +6,6 @@ images:
   - source: "busybox@sha256:3b3128d9df6bbbcc92e2358e596c9fbd722a437a62bafbc51607970e9e3b8869"
     tag: "1.34.1-v1"
   - source: "curlimages/curl:7.78.0"
-  - source: "cypress/included:9.5.0" # 10.3.0+, latest is 12.0.1
   - source: "gcr.io/google-containers/pause:3.2"
   - source: "goreleaser/goreleaser:v1.11.5"
   # Golang image is pinned because it is force updated in the upstream

--- a/cmd/image-syncer/external-images.yaml
+++ b/cmd/image-syncer/external-images.yaml
@@ -16,7 +16,6 @@ images:
   - source: "istio/install-cni:1.22.3-distroless"
   - source: "jettech/kube-webhook-certgen:v1.5.0"
   - source: "oryd/hydra:v1.11.8"
-  - source: "oryd/oathkeeper-maester:v0.1.5"
   - source: "oryd/oathkeeper:v0.38.25-beta.1"
   - source: "postgres@sha256:86c55091a74b9efe95396f65ddd83f0067ff47c3f09993621d6f94c835856445"
     tag: "11.21-alpine3.18"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Remove amd64Only: true flag from image syncer external-images.yaml when it is not needed
- Remove no longer needed images for sync

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/test-infra/issues/11712