### PR TITLE
Set target repo prefix with flag

### DIFF
--- a/cmd/image-syncer/main.go
+++ b/cmd/image-syncer/main.go
@@ -19,17 +19,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	defaultTargetRepoPrefix = "europe-docker.pkg.dev/kyma-project/prod/external/"
+)
+
 var (
 	log = logrus.New()
 )
 
 // Config stores command line arguments
 type Config struct {
-	ImagesFile    string
-	TargetKeyFile string
-	AccessToken    string
-	DryRun        bool
-	Debug         bool
+	ImagesFile       string
+	TargetRepoPrefix string
+	TargetKeyFile    string
+	AccessToken      string
+	DryRun           bool
+	Debug            bool
 }
 
 func ifRefNotFound(err error) bool {
@@ -187,7 +192,7 @@ func SyncImages(ctx context.Context, cfg *Config, images *imagesync.SyncDef, aut
 		auth = &authn.Bearer{Token: string(authCfg)}
 	}
 	for _, img := range images.Images {
-		target, err := getTarget(img.Source, images.TargetRepoPrefix, img.Tag)
+		target, err := getTarget(img.Source, cfg.TargetRepoPrefix, img.Tag)
 		imageType := "Index"
 		if err != nil {
 			return err
@@ -267,6 +272,7 @@ func main() {
 	}
 
 	rootCmd.PersistentFlags().StringVarP(&cfg.ImagesFile, "images-file", "i", "", "Specifies the path to the YAML file that contains list of images")
+	rootCmd.PersistentFlags().StringVarP(&cfg.TargetRepoPrefix, "target-repo-prefix", "r", defaultTargetRepoPrefix, "Specifies the target repository prefix")
 	rootCmd.PersistentFlags().StringVarP(&cfg.TargetKeyFile, "target-repo-auth-key", "t", "", "Specifies the JSON key file used for authorization to the target repository")
 	rootCmd.PersistentFlags().StringVarP(&cfg.AccessToken, "access-token", "a", "", "Specifies the access token used for authorization to the target repository")
 	rootCmd.PersistentFlags().BoolVar(&cfg.DryRun, "dry-run", false, "Enables the dry-run mode")

--- a/cmd/image-syncer/util.go
+++ b/cmd/image-syncer/util.go
@@ -46,8 +46,5 @@ func parseImagesFile(file string) (*imagesyncer.SyncDef, error) {
 	if err := yaml.Unmarshal(f, &syncDef); err != nil {
 		return nil, err
 	}
-	if syncDef.TargetRepoPrefix == "" {
-		return nil, fmt.Errorf("targetRepoPrefix can not be empty")
-	}
 	return &syncDef, nil
 }

--- a/cmd/image-syncer/util_test.go
+++ b/cmd/image-syncer/util_test.go
@@ -81,17 +81,10 @@ var _ = Describe("getTarget", func() {
 
 var _ = Describe("parseImagesFile", func() {
 	validYAML := `
-targetRepoPrefix: "external/prod/"
 images:
   - source: "cypress/included:9.5.0"
     target: "external/prod/cypress/included:latest"
 `
-	missingTargetRepoPrefixYAML := `
-images:
-  - source: "cypress/included:9.5.0"
-    target: "external/prod/cypress/included:latest"
-`
-
 	tests := []struct {
 		name        string
 		content     string
@@ -102,12 +95,6 @@ images:
 			name:      "valid YAML",
 			content:   validYAML,
 			shouldErr: false,
-		},
-		{
-			name:        "missing targetRepoPrefix",
-			content:     missingTargetRepoPrefixYAML,
-			shouldErr:   true,
-			expectedErr: "targetRepoPrefix can not be empty",
 		},
 	}
 

--- a/cmd/image-url-helper/cmd/promote.go
+++ b/cmd/image-url-helper/cmd/promote.go
@@ -56,7 +56,7 @@ func PromoteCmd() *cobra.Command {
 			common.MergeImageMap(allImages, images)
 			common.MergeImageMap(allImages, testImages)
 
-			err = promote.PrintExternalSyncerYaml(allImages, targetContainerRegistryClean, options.targetTag)
+			err = promote.PrintExternalSyncerYaml(allImages, options.targetTag)
 			if err != nil {
 				fmt.Printf("Cannot print list of images: %s\n", err)
 				os.Exit(2)

--- a/pkg/image-url-helper/promote/externalsyncer.go
+++ b/pkg/image-url-helper/promote/externalsyncer.go
@@ -13,7 +13,7 @@ import (
 
 // PrintExternalSyncerYaml prints out a YAML file ready to be used by the image-syncer tool to copy images to new container registry, with option to retag them
 func PrintExternalSyncerYaml(images common.ComponentImageMap, targetContainerRegistry, targetTag string) error {
-	imagesConverted := convertImageslist(images, targetContainerRegistry, targetTag)
+	imagesConverted := convertImageslist(images, targetTag)
 
 	var out bytes.Buffer
 	encoder := yaml.NewEncoder(&out)

--- a/pkg/image-url-helper/promote/externalsyncer.go
+++ b/pkg/image-url-helper/promote/externalsyncer.go
@@ -3,9 +3,10 @@ package promote
 import (
 	"bytes"
 	"fmt"
+	"sort"
+
 	"github.com/kyma-project/test-infra/pkg/image-url-helper/common"
 	imagesyncer "github.com/kyma-project/test-infra/pkg/imagesync"
-	"sort"
 
 	"gopkg.in/yaml.v3"
 )
@@ -35,7 +36,6 @@ func convertImageslist(images common.ComponentImageMap, targetContainerRegistry,
 	sort.Strings(imageNames)
 
 	syncDef := imagesyncer.SyncDef{}
-	syncDef.TargetRepoPrefix = targetContainerRegistry + "/"
 	for _, fullImageURL := range imageNames {
 		tmpImage := imagesyncer.Image{}
 		tmpImage.Source = fullImageURL

--- a/pkg/image-url-helper/promote/externalsyncer.go
+++ b/pkg/image-url-helper/promote/externalsyncer.go
@@ -27,7 +27,7 @@ func PrintExternalSyncerYaml(images common.ComponentImageMap, targetContainerReg
 }
 
 // convertImageslist takes in a list of images, target repository & tag and creates a SyncDef structure that can be later marshalled and used by the image-syncer tool
-func convertImageslist(images common.ComponentImageMap, targetContainerRegistry, targetTag string) imagesyncer.SyncDef {
+func convertImageslist(images common.ComponentImageMap, targetTag string) imagesyncer.SyncDef {
 
 	imageNames := make([]string, 0)
 	for _, image := range images {

--- a/pkg/image-url-helper/promote/externalsyncer.go
+++ b/pkg/image-url-helper/promote/externalsyncer.go
@@ -12,7 +12,7 @@ import (
 )
 
 // PrintExternalSyncerYaml prints out a YAML file ready to be used by the image-syncer tool to copy images to new container registry, with option to retag them
-func PrintExternalSyncerYaml(images common.ComponentImageMap, targetContainerRegistry, targetTag string) error {
+func PrintExternalSyncerYaml(images common.ComponentImageMap, targetTag string) error {
 	imagesConverted := convertImageslist(images, targetTag)
 
 	var out bytes.Buffer

--- a/pkg/imagesync/common.go
+++ b/pkg/imagesync/common.go
@@ -2,8 +2,7 @@ package imagesync
 
 // SyncDef stores synchronisation definition
 type SyncDef struct {
-	TargetRepoPrefix string `yaml:"targetRepoPrefix"`
-	Images           []Image
+	Images []Image
 }
 
 // Image stores image location


### PR DESCRIPTION


<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Do not read a terget repo prefix from yaml file. This must not be controlled by users when using in prod scenario
- The flag has default value europe-docker.pkg.dev/kyma-project/prod/external/

**Related issue(s)**
See #11384 
