### PR TITLE
Use correct role to impersonate a service accounts

### DIFF
--- a/configs/terraform/environments/prod/image-syncer.tf
+++ b/configs/terraform/environments/prod/image-syncer.tf
@@ -5,7 +5,7 @@ resource "google_service_account" "image_syncer_reader" {
 
 resource "google_service_account_iam_member" "image_syncer_reader_workflow_sa_user" {
   service_account_id = google_service_account.image_syncer_reader.name
-  role = "roles/iam.WorkloadIdentityUser"
+  role = "roles/iam.workloadIdentityUser"
   member = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_run/event_name:pull_request_target:repository_owner_id:${data.github_organization.kyma-project.id}:reusable_workflow_ref:${var.image_syncer_reusable_workflow_ref}"
 }
 
@@ -24,7 +24,7 @@ resource "google_service_account" "image_syncer_writer" {
 
 resource "google_service_account_iam_member" "image_syncer_writer_workflow_sa_user" {
   service_account_id = google_service_account.image_syncer_writer.name
-  role = "roles/iam.WorkloadIdentityUser"
+  role = "roles/iam.workloadIdentityUser"
   member             = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_run/event_name:push:repository_owner_id:${data.github_organization.kyma-project.id}:reusable_workflow_ref:${var.image_syncer_reusable_workflow_ref}"
 }
 

--- a/configs/terraform/environments/prod/image-syncer.tf
+++ b/configs/terraform/environments/prod/image-syncer.tf
@@ -5,7 +5,7 @@ resource "google_service_account" "image_syncer_reader" {
 
 resource "google_service_account_iam_member" "image_syncer_reader_workflow_sa_user" {
   service_account_id = google_service_account.image_syncer_reader.name
-  role               = "roles/iam.serviceAccountUser"
+  role = "roles/iam.WorkloadIdentityUser"
   member = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_run/event_name:pull_request_target:repository_owner_id:${data.github_organization.kyma-project.id}:reusable_workflow_ref:${var.image_syncer_reusable_workflow_ref}"
 }
 
@@ -24,7 +24,7 @@ resource "google_service_account" "image_syncer_writer" {
 
 resource "google_service_account_iam_member" "image_syncer_writer_workflow_sa_user" {
   service_account_id = google_service_account.image_syncer_writer.name
-  role               = "roles/iam.serviceAccountUser"
+  role = "roles/iam.WorkloadIdentityUser"
   member             = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_run/event_name:push:repository_owner_id:${data.github_organization.kyma-project.id}:reusable_workflow_ref:${var.image_syncer_reusable_workflow_ref}"
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The image-syncer run on push event is failing because no permissions to use a service account. The IaC is granting wrong role on a service account for WIF identity.

**Related issue(s)**
See #11384 
