### PR TITLE
Set github-actions identity as defautl committer for image-detector

### DIFF
--- a/.github/workflows/push-update-security-config.yaml
+++ b/.github/workflows/push-update-security-config.yaml
@@ -25,6 +25,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        # Setup git config with default actions information to prevent error "Unknown committer"
+        # See https://github.com/actions/checkout/issues/13#issuecomment-2207006934
+      - name: Setup git config
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
       - name: Authenticate in GCP
         id: 'auth'
         uses: 'google-github-actions/auth@v2'


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Configure git to use github actions identity as default commiter (it's overriden by autobumper)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: #9767 