### PR TITLE
Extract default committer from autobump config

### DIFF
--- a/.github/workflows/push-update-security-config.yaml
+++ b/.github/workflows/push-update-security-config.yaml
@@ -13,6 +13,12 @@ on:
       - '**/*.tf'
       - '**/*.tfvars'
 
+env:
+  AUTOBUMP_CONFIG_PATH: configs/autobump-config/test-infra-sec-config-autobump-config.yaml
+  SEC_SCANNERS_CONFIG_PATH: sec-scanners-config.yaml
+  TERRAFORM_CONFIGS_DIR: configs/terraform
+
+
 jobs:
   autobump:
     runs-on: ubuntu-latest
@@ -20,17 +26,20 @@ jobs:
       id-token: write # This is required for requesting the JWT token
       contents: read # This is required for actions/checkout
     concurrency:
+      # Prevent merge conflicts on pushing to fork repo between different runs. 
+      # Image detector will update already existing PR with new changes, to keep clean history it's preferd to do it one by one.
       group: post-test-infra-image-detector-autobump
       cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v4
-        # Setup git config with default actions information to prevent error "Unknown committer"
-        # See https://github.com/actions/checkout/issues/13#issuecomment-2207006934
+        # Setup git config with commiter data from config
       - name: Setup git config
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          GIT_USERNAME=$(grep "gitName" $AUTOBUMP_CONFIG_PATH | cut -d '"' -f 2)
+          GIT_EMAIL=$(grep "gitEmail" $AUTOBUMP_CONFIG_PATH | cut -d '"' -f 2)
+          git config user.name $GIT_USERNAME
+          git config user.email $GIT_EMAIL
       - name: Authenticate in GCP
         id: 'auth'
         uses: 'google-github-actions/auth@v2'
@@ -58,6 +67,6 @@ jobs:
             --rm \
             --user $UID \
             europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/image-detector:v20240926-400a7c63 \
-            --terraform-dir=configs/terraform \
-            --sec-scanner-config=sec-scanners-config.yaml \
-            --autobump-config=configs/autobump-config/test-infra-sec-config-autobump-config.yaml
+            --terraform-dir=${{ env.TERRAFORM_CONFIGS_DIR}} \
+            --sec-scanner-config=${{ env.SEC_SCANNERS_CONFIG_PATH }} \
+            --autobump-config=${{ env.AUTOBUMP_CONFIG_PATH }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

To prevent issues when pushing changes to the autobumper fork, we need to set default commiter.
Ideally it should be the same user as owner of the fork. To achieve that, we need to extract information before actuall bumper run.

Changes proposed in this pull request:

- Use autobump config to extract information about committer and set it as default commiter

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: #9767 