### PR TITLE
Prevent siletnly pass GITHUB_TOKEN in authorization header

### DIFF
--- a/.github/workflows/push-update-security-config.yaml
+++ b/.github/workflows/push-update-security-config.yaml
@@ -34,12 +34,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         # Setup git config with commiter data from config
+        # Prevent silent passing github token
+        # see https://stackoverflow.com/a/69979203/23148781
       - name: Setup git config
         run: |
-          GIT_USERNAME=$(grep "gitName" $AUTOBUMP_CONFIG_PATH | cut -d '"' -f 2)
-          GIT_EMAIL=$(grep "gitEmail" $AUTOBUMP_CONFIG_PATH | cut -d '"' -f 2)
+          GIT_USERNAME=$(grep "gitName" ${{ env.AUTOBUMP_CONFIG_PATH }} | cut -d '"' -f 2)
+          GIT_EMAIL=$(grep "gitEmail" ${{ env.AUTOBUMP_CONFIG_PATH }} | cut -d '"' -f 2)
           git config user.name $GIT_USERNAME
           git config user.email $GIT_EMAIL
+
+          git config --unset-all http.https://github.com/.extraheader
       - name: Authenticate in GCP
         id: 'auth'
         uses: 'google-github-actions/auth@v2'
@@ -67,6 +71,6 @@ jobs:
             --rm \
             --user $UID \
             europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/image-detector:v20240926-400a7c63 \
-            --terraform-dir=${{ env.TERRAFORM_CONFIGS_DIR}} \
+            --terraform-dir=${{ env.TERRAFORM_CONFIGS_DIR }} \
             --sec-scanner-config=${{ env.SEC_SCANNERS_CONFIG_PATH }} \
             --autobump-config=${{ env.AUTOBUMP_CONFIG_PATH }}

--- a/.github/workflows/push-update-security-config.yaml
+++ b/.github/workflows/push-update-security-config.yaml
@@ -13,6 +13,12 @@ on:
       - '**/*.tf'
       - '**/*.tfvars'
 
+env:
+  AUTOBUMP_CONFIG_PATH: configs/autobump-config/test-infra-sec-config-autobump-config.yaml
+  SEC_SCANNERS_CONFIG_PATH: sec-scanners-config.yaml
+  TERRAFORM_CONFIGS_DIR: configs/terraform
+
+
 jobs:
   autobump:
     runs-on: ubuntu-latest
@@ -20,17 +26,20 @@ jobs:
       id-token: write # This is required for requesting the JWT token
       contents: read # This is required for actions/checkout
     concurrency:
+      # Prevent merge conflicts on pushing to fork repo between different runs. 
+      # Image detector will update already existing PR with new changes, to keep clean history it's preferd to do it one by one.
       group: post-test-infra-image-detector-autobump
       cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v4
-        # Setup git config with default actions information to prevent error "Unknown committer"
-        # See https://github.com/actions/checkout/issues/13#issuecomment-2207006934
+        # Setup git config with commiter data from config
       - name: Setup git config
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          GIT_USERNAME=$(grep "gitName" $AUTOBUMP_CONFIG_PATH | cut -d '"' -f 2)
+          GIT_EMAIL=$(grep "gitEmail" $AUTOBUMP_CONFIG_PATH | cut -d '"' -f 2)
+          git config user.name $GIT_USERNAME
+          git config user.email $GIT_EMAIL
       - name: Authenticate in GCP
         id: 'auth'
         uses: 'google-github-actions/auth@v2'
@@ -58,6 +67,6 @@ jobs:
             --rm \
             --user $UID \
             europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/image-detector:v20240926-400a7c63 \
-            --terraform-dir=configs/terraform \
-            --sec-scanner-config=sec-scanners-config.yaml \
-            --autobump-config=configs/autobump-config/test-infra-sec-config-autobump-config.yaml
+            --terraform-dir=${{ env.TERRAFORM_CONFIGS_DIR}} \
+            --sec-scanner-config=${{ env.SEC_SCANNERS_CONFIG_PATH }} \
+            --autobump-config=${{ env.AUTOBUMP_CONFIG_PATH }}

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,54 +1,16 @@
 module-name: test-infra
 protecode:
-    - docker.io/library/nginx:1.27.1-alpine
-    - europe-docker.pkg.dev/gardener-project/releases/ci-infra/cla-assistant:v20240412-d22f4bf
-    - europe-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli:0.12.0
-    - europe-docker.pkg.dev/kyma-project/prod/image-builder:v20240924-5679cab8
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ginkgo:v20240909-95731ea6
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/golangci-lint:v20240910-83aca12b
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/automated-approver:v20240924-a3a85f88
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/clusterscollector:v20240924-a3a85f88
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/cors-proxy:v20240924-a3a85f88
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/create-github-issue:v20240924-a3a85f88
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/dashboard-token-proxy:v20240924-a3a85f88
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/diskscollector:v20240924-a3a85f88
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/dnscollector:v20240924-a3a85f88
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/gcscleaner:v20240924-a3a85f88
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/github-webhook-gateway:v20240924-a3a85f88
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/image-syncer:v20240918-20d00fb8
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/ipcleaner:v20240924-a3a85f88
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/markdown-index:v20240924-a3a85f88
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/move-gcs-bucket:v20240924-a3a85f88
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/orphanremover:v20240924-a3a85f88
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/pjtester:v20240924-a3a85f88
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/scan-logs-for-secrets:v20240924-a3a85f88
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/search-github-issue:v20240924-a3a85f88
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/usersmapchecker:v20240924-a3a85f88
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/vmscollector:v20240924-a3a85f88
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/rotate-service-account:v20240924-5679cab8
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/service-account-keys-cleaner:v20240924-5679cab8
+    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/cors-proxy:v20240926-400a7c63
+    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/create-github-issue:v20240926-400a7c63
+    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/dashboard-token-proxy:v20240926-400a7c63
+    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/github-webhook-gateway:v20240926-400a7c63
+    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/move-gcs-bucket:v20240926-400a7c63
+    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/scan-logs-for-secrets:v20240926-400a7c63
+    - europe-docker.pkg.dev/kyma-project/prod/test-infra/ko/search-github-issue:v20240926-400a7c63
+    - europe-docker.pkg.dev/kyma-project/prod/test-infra/rotate-service-account:v20240926-400a7c63
+    - europe-docker.pkg.dev/kyma-project/prod/test-infra/service-account-keys-cleaner:v20240926-400a7c63
     - europe-docker.pkg.dev/kyma-project/prod/test-infra/signify-secret-rotator:v20240924-997e8b7b
     - europe-docker.pkg.dev/kyma-project/prod/test-infra/slackmessagesender:v20240910-c199525c
-    - europe-docker.pkg.dev/kyma-project/prod/testimages/alpine-hadolint:v20240924-6fb36f45
-    - europe-docker.pkg.dev/kyma-project/prod/testimages/alpine-shellcheck:v20240924-6fb36f45
-    - europe-docker.pkg.dev/kyma-project/prod/testimages/alpine:v20240924-6fb36f45
-    - europe-docker.pkg.dev/kyma-project/prod/testimages/buildpack-go:v20240924-6fb36f45
-    - europe-docker.pkg.dev/kyma-project/prod/testimages/e2e-dind-k3d:v20240924-6fb36f45
-    - europe-docker.pkg.dev/kyma-project/prod/testimages/e2e-gcloud:v20240924-6fb36f45
-    - gcr.io/k8s-prow/analyze:v20240731-a5d9345e59
-    - gcr.io/k8s-prow/crier:v20240805-37a08f946
-    - gcr.io/k8s-prow/deck:v20240805-37a08f946
-    - gcr.io/k8s-prow/gcsweb:v20240731-a5d9345e59
-    - gcr.io/k8s-prow/gencred:v20240731-a5d9345e59
-    - gcr.io/k8s-prow/generic-autobumper:v20240805-37a08f946
-    - gcr.io/k8s-prow/ghproxy:v20240805-37a08f946
-    - gcr.io/k8s-prow/hook:v20240805-37a08f946
-    - gcr.io/k8s-prow/horologium:v20240805-37a08f946
-    - gcr.io/k8s-prow/prow-controller-manager:v20240805-37a08f946
-    - gcr.io/k8s-prow/sinker:v20240805-37a08f946
-    - gcr.io/k8s-prow/status-reconciler:v20240805-37a08f946
-    - gcr.io/k8s-prow/tide:v20240805-37a08f946
-    - prom/pushgateway:v1.8.0
 whitesource:
     language: golang-mod
     exclude:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

As stated in https://stackoverflow.com/a/69979203/23148781, github silently pass $GITHUB_TOKEN in Authorizaiton header during some git operation. That behavior is causing push error when, autobumepr try to push changes into kyma-bot testinfra fork.

Changes proposed in this pull request:

- Prevent siletnly pass GITHUB_TOKEN in authorization

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: #9767 