### PR TITLE
chore: Remove tide and status check config from jellyfish components

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -334,39 +334,11 @@ branch-protection:
             - "^sec-scanners-config-"
             - "^sm-integration$"
         template-operator:
-          required_status_checks:
-            contexts:
-              - "lint"
-              - "Run integration tests"
+          unmanaged: true
         lifecycle-manager:
-          required_status_checks:
-            contexts:
-              - "E2E (kyma-metrics)"
-              - "E2E (module-without-default-cr)"
-              - "E2E (upgrade-under-deletion)"
-              - "E2E (self-signed-certificate-rotation)"
-              - "E2E (non-blocking-deletion)"
-              - "E2E (purge-controller)"
-              - "E2E (purge-metrics)"
-              - "E2E (watcher-enqueue)"
-              - "E2E (module-upgrade-channel-switch)"
-              - "E2E (module-upgrade-new-version)"
-              - "E2E (ca-certificate-rotation)"
-              - "E2E (kyma-deprovision-with-foreground-propagation)"
-              - "E2E (kyma-deprovision-with-background-propagation)"
-              - "E2E (misconfigured-kyma-secret)"
-              - "Run 'make test'"
-              - "kyma (unstable) alpha deploy -k config/control-plane"
-              - "kyma (unstable) alpha deploy -k config/default"
-              - "lint"
-              - "Kustomize (dry-run)"
-              - "Kustomize (dry-run-control-plane)"
-              - "markdown-link-check"
+          unmanaged: true
         runtime-watcher:
-          required_status_checks:
-            contexts:
-              - "E2E (watcher-enqueue)"
-              - "E2E (watcher-metrics)"
+          unmanaged: true
         modulectl:
           unmanaged: true
         cli:
@@ -458,6 +430,9 @@ tide:
         - kyma-project/btp-manager
         - kyma-project/kyma-environment-broker
         - kyma-project/modulectl
+        - kyma-project/lifecycle-manager
+        - kyma-project/runtime-watcher
+        - kyma-project/template-operator
       reviewApprovedRequired: true
     - labels:
         - lgtm


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Remove tide job from lifecycle-manager, runtime-watcher & template-operator
- Remove required status-checks config from lifecycle-manager, runtime-watcher & template-operator

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
