### PR TITLE
Revert image digest to manifest digest, Switch to use digest.Hex inst…

### DIFF
--- a/pkg/sign/notary.go
+++ b/pkg/sign/notary.go
@@ -42,10 +42,6 @@ type ReferenceInterface interface {
 type ImageInterface interface {
 	// Manifest retrieves the manifest of the image.
 	Manifest() (ManifestInterface, error)
-	// GetDigest returns the digest of the image manifest.
-	GetDigest() (string, error)
-	// GetSize returns the size of the image.
-	GetSize() (int64, error)
 }
 
 // ManifestInterface abstracts the functionality of v1.Manifest.
@@ -123,20 +119,6 @@ type ImageWrapper struct {
 	img v1.Image
 }
 
-// GetDigest returns the digest of the image manifest.
-func (iw *ImageWrapper) GetDigest() (string, error) {
-	digest, err := iw.img.Digest()
-	if err != nil {
-		return "", err
-	}
-	return digest.Hex, nil
-}
-
-// GetSize returns the size of the image.
-func (iw *ImageWrapper) GetSize() (int64, error) {
-	return iw.img.Size()
-}
-
 // Manifest retrieves the manifest of the image.
 func (iw *ImageWrapper) Manifest() (ManifestInterface, error) {
 	manifest, err := iw.img.Manifest()
@@ -156,7 +138,7 @@ func (mw *ManifestWrapper) GetConfigSize() int64 {
 	return mw.manifest.Config.Size
 }
 
-// GetConfigDigest returns the digest of the image config without the algorithm prefix.
+// GetConfigDigest returns the digest of the image config.
 func (mw *ManifestWrapper) GetConfigDigest() string {
 	return mw.manifest.Config.Digest.Hex
 }
@@ -195,23 +177,17 @@ func (pb *PayloadBuilder) BuildPayload(images []string) (SigningPayload, error) 
 			return SigningPayload{}, fmt.Errorf("failed to fetch image: %w", err)
 		}
 
-		// Retrieve the image manifest digest.
-		imageDigest, err := img.GetDigest()
+		// Retrieve the image manifest.
+		manifest, err := img.Manifest()
 		if err != nil {
-			return SigningPayload{}, fmt.Errorf("failed to get image digest: %w", err)
-		}
-
-		// Retrieve the image size.
-		imageSize, err := img.GetSize()
-		if err != nil {
-			return SigningPayload{}, fmt.Errorf("failed to get image size: %w", err)
+			return SigningPayload{}, fmt.Errorf("failed to get image manifest: %w", err)
 		}
 
 		// Build the target information.
 		target := Target{
 			Name:     tag,
-			ByteSize: imageSize,
-			Digest:   imageDigest,
+			ByteSize: manifest.GetConfigSize(),
+			Digest:   manifest.GetConfigDigest(),
 		}
 
 		// Build the GUN (Global Unique Name) targets.

--- a/pkg/sign/notary_test.go
+++ b/pkg/sign/notary_test.go
@@ -127,12 +127,6 @@ func TestImageService_GetImage_Valid(t *testing.T) {
 						},
 					}, nil
 				},
-				MockGetDigest: func() (string, error) {
-					return "dummy-digest", nil
-				},
-				MockGetSize: func() (int64, error) {
-					return 1024, nil
-				},
 			}, nil
 		},
 	}
@@ -158,23 +152,6 @@ func TestImageService_GetImage_Valid(t *testing.T) {
 	}
 	if manifest.GetConfigDigest() != "sha256:dummy-digest" {
 		t.Errorf("Expected config digest to be 'sha256:dummy-digest', got '%s'", manifest.GetConfigDigest())
-	}
-
-	// Additional checks for new methods
-	digest, err := img.GetDigest()
-	if err != nil {
-		t.Errorf("Expected no error getting digest, got %v", err)
-	}
-	if digest != "dummy-digest" {
-		t.Errorf("Expected digest to be 'dummy-digest', got '%s'", digest)
-	}
-
-	size, err := img.GetSize()
-	if err != nil {
-		t.Errorf("Expected no error getting size, got %v", err)
-	}
-	if size != 1024 {
-		t.Errorf("Expected size to be 1024, got %d", size)
 	}
 }
 
@@ -218,19 +195,13 @@ func TestPayloadBuilder_BuildPayload_Valid(t *testing.T) {
 			return 1024
 		},
 		MockGetConfigDigest: func() string {
-			return "sha256:dummy-config-digest"
+			return "sha256:dummy-digest"
 		},
 	}
 
 	mockImage := &MockImage{
 		MockManifest: func() (ManifestInterface, error) {
 			return mockManifest, nil
-		},
-		MockGetDigest: func() (string, error) {
-			return "dummy-manifest-digest", nil
-		},
-		MockGetSize: func() (int64, error) {
-			return 2048, nil
 		},
 	}
 
@@ -253,15 +224,6 @@ func TestPayloadBuilder_BuildPayload_Valid(t *testing.T) {
 	}
 	if len(payload.GunTargets) == 0 {
 		t.Errorf("Expected GunTargets to be populated")
-	}
-
-	// Additional checks
-	target := payload.GunTargets[0].Targets[0]
-	if target.Digest != "dummy-manifest-digest" {
-		t.Errorf("Expected digest to be 'dummy-manifest-digest', got '%s'", target.Digest)
-	}
-	if target.ByteSize != 2048 {
-		t.Errorf("Expected byteSize to be 2048, got %d", target.ByteSize)
 	}
 }
 
@@ -383,7 +345,7 @@ func TestNotarySigner_Sign_Valid(t *testing.T) {
 							{
 								Name:     "latest",
 								ByteSize: 1024,
-								Digest:   "dummy-manifest-digest",
+								Digest:   "sha256:dummy-digest",
 							},
 						},
 					},


### PR DESCRIPTION
…ead of digest.String()

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Revert image digest to manifest digest
- Use SHA value, instead of combination of algorithm and SHA value
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
