### PR TITLE
Switch signify secret rotator to alpine base image

### DIFF
--- a/cmd/cloud-run/signifysecretrotator/Dockerfile
+++ b/cmd/cloud-run/signifysecretrotator/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY ./cmd/cloud-run/signifysecretrotator .
 COPY ./cmd/cloud-run/signifysecretrotator/requirements.txt .
 
-RUN pip3 install --upgrade -r requirements.txt && \
-	apt-get install ca-certificates
+RUN pip install --no-cache-dir  --upgrade -r requirements.txt && \
+	apk add --no-cache ca-certificates
 
 CMD ["gunicorn", "--bind", "0.0.0.0:8080", "--workers", "4", "--timeout", "0", "signifysecretrotator:app"]

--- a/cmd/cloud-run/signifysecretrotator/Dockerfile
+++ b/cmd/cloud-run/signifysecretrotator/Dockerfile
@@ -8,6 +8,9 @@ WORKDIR /app
 COPY ./cmd/cloud-run/signifysecretrotator .
 COPY ./cmd/cloud-run/signifysecretrotator/requirements.txt .
 
+# Install the required packages
+RUN apk update \
+	&& apk add gcc g++ linux-headers
 RUN pip install --no-cache-dir  --upgrade -r requirements.txt && \
 	apk add --no-cache ca-certificates
 

--- a/cmd/cloud-run/signifysecretrotator/Dockerfile
+++ b/cmd/cloud-run/signifysecretrotator/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.6-slim
+FROM python:3.12.7-alpine3.20
 
 # Allow statements and log messages to immediately appear in the Knative logs
 ENV PYTHONUNBUFFERED True


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

To keep consistent with our images switch image from python slim (debian based) image to alpine base image.
During creation of the tool, I used slim image because I cannot find alpine based on image on the docker hub page.

Changes proposed in this pull request:

- Rename based image from `python:3.12.6-slim` to `python:3.12.7-alpine3.20`.

See: #12100 
