### PR TITLE
Rename autobump token secret for github workflows

### DIFF
--- a/configs/terraform/environments/prod/kyma-bots-secrets-variables.tf
+++ b/configs/terraform/environments/prod/kyma-bots-secrets-variables.tf
@@ -9,14 +9,13 @@ variable "kyma_autobump_bot_github_token_secret_name" {
   default     = "kyma-autobump-bot-github-token"
 }
 
-# TODO(kacpermalachowski): Rename to kyma_autobump_bot_github_token_secret_name after Prow removal
-variable "kyma_autobump_bot_github_token_sm_secret_name" {
+variable "kyma_bot_github_sap_token_secret_name" {
   type        = string
   description = "Name of the kyma-autobump-bot-github-token secret in the Google's Secret Manager. This secret is used by automatic bumpers to interact with GitHub."
-  default     = "workloads_default_kyma-autobump-bot-github-token"
+  default     = "kyma-autobump-bot-github-token"
 }
 
-variable "kyma_bot_github_sap_token_secret_name" {
+variable "kyma_bot_github_sap_token_prow_k8s_secret_name" {
   type        = string
   description = "Name of the kyma-bot-github-sap-token secret. This is used by automation to interact with SAP GitHub instance."
   default     = "kyma-bot-github-sap-token"

--- a/configs/terraform/environments/prod/kyma-bots-secrets.tf
+++ b/configs/terraform/environments/prod/kyma-bots-secrets.tf
@@ -12,7 +12,7 @@ resource "kubernetes_cluster_role" "access_kyma_bot_github_tokens_trusted_worklo
   rule {
     api_groups     = [""]
     resources      = ["secrets"]
-    resource_names = [var.kyma_autobump_bot_github_token_secret_name, var.kyma_bot_github_token_secret_name, var.kyma_bot_github_sap_token_secret_name, var.kyma_guard_bot_github_token_secret_name]
+    resource_names = [var.kyma_autobump_bot_github_token_secret_name, var.kyma_bot_github_token_secret_name, var.kyma_bot_github_sap_token_prow_k8s_secret_name, var.kyma_guard_bot_github_token_secret_name]
     verbs          = ["update", "get", "list", "watch", "patch", "create", "delete"]
   }
 }
@@ -27,7 +27,7 @@ resource "kubernetes_cluster_role" "access_kyma_bot_github_tokens_untrusted_work
   rule {
     api_groups     = [""]
     resources      = ["secrets"]
-    resource_names = [var.kyma_autobump_bot_github_token_secret_name, var.kyma_bot_github_token_secret_name, var.kyma_bot_github_sap_token_secret_name, var.kyma_guard_bot_github_token_secret_name]
+    resource_names = [var.kyma_autobump_bot_github_token_secret_name, var.kyma_bot_github_token_secret_name, var.kyma_bot_github_sap_token_prow_k8s_secret_name, var.kyma_guard_bot_github_token_secret_name]
     verbs          = ["update", "get", "list", "watch", "patch", "create", "delete"]
   }
 }
@@ -72,5 +72,5 @@ resource "github_actions_variable" "kyma_autobump_bot_github_token_secret_name" 
   provider = github.kyma_project
   repository = data.github_repository.test_infra.name
   variable_name = "KYMA_AUTOBUMP_BOT_GITHUB_SECRET_NAME"
-  value = var.kyma_autobump_bot_github_token_sm_secret_name
+  value = var.kyma_bot_github_sap_token_secret_name
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

In preparation to prow removal.
Both secrets has same permisisons set already, so it's time to update the name in the github vatiable.

Changes proposed in this pull request:

- Rename terraform variables to more descirbe purpose and difference between `workloads_defaults_kyma-autobump-bot-github-token` and `kyma-autobump-bot-github-token`.
- Rename prow related variables to contain prow in the name to easy identification during removal process,
