### PR TITLE
Rename image-autobumper reusable workflow, fix secret reference

### DIFF
--- a/.github/workflows/autobump-images.yml
+++ b/.github/workflows/autobump-images.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   autobump:
-    uses: kyma-project/test-infra/.github/workflows/reusable-image-autobumper.yml@main
+    uses: kyma-project/test-infra/.github/workflows/image-autobumper.yml@main

--- a/.github/workflows/image-autobumper.yml
+++ b/.github/workflows/image-autobumper.yml
@@ -1,4 +1,4 @@
-name: reusable-image-autobumper
+name: image-autobumper
 on:
   workflow_call:
     inputs:
@@ -24,11 +24,11 @@ jobs:
           project_id: ${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}
           workload_identity_provider: ${{ vars.GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER }}
 
-      - name: Access Google Cloud Secret
-        id: access-secret
-        uses: google-github-actions/get-secretmanager-secrets@v2
+      - name: Get kyma bot token from Secret Manager
+        id: 'secrets'
+        uses: 'google-github-actions/get-secretmanager-secrets@v2'
         with:
-          secrets: |
+          secrets: |-
             kyma-autobump-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.KYMA_AUTOBUMP_BOT_GITHUB_SECRET_NAME }}
 
       - name: Store Github Token for autobumper
@@ -37,8 +37,6 @@ jobs:
           chmod 644 ~/token
           
       - name: Checkout repository
-        with:
-          token: ${{ steps.secrets.outputs.kyma-autobump-token }}
         uses: actions/checkout@v4
 
         # Setup git config with commiter data from config


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Rename `reusable-image-autobumper` to `image-autobumper` to keep consistency
- Rename `access_secrets` to `secrets` step id to keep consistency

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: #12056 