### PR TITLE
Fix path to the github token in autobumper

### DIFF
--- a/.github/workflows/image-autobumper.yml
+++ b/.github/workflows/image-autobumper.yml
@@ -58,8 +58,8 @@ jobs:
             --rm \
             --cap-drop=ALL \
             --privileged \
-            -v "${{ github.workspace }}:/workspace" \
-            -v "~/token:/etc/github/token:ro" \
+            -v ${{ github.workspace }}:/workspace \
+            -v ~/token:/etc/github/token:ro \
             -w /workspace \
             ${{ inputs.docker-image }} \
             --autobump-config=${{ inputs.autobump-config-path }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Due to unix systems behaviour we have to unfold `~/token` before passing it to the docker run cammand as argument.

Changes proposed in this pull request:

- Unfold path before passing it to the docker run command.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: #12056 