### PR TITLE
Verify oidc token against extended expiration time

### DIFF
--- a/pkg/oidc/oidc.go
+++ b/pkg/oidc/oidc.go
@@ -155,6 +155,13 @@ type TokenVerifier struct {
 	Logger   LoggerInterface
 }
 
+func maskToken(token string) string {
+	if len(token) < 15 {
+		return "********"
+	}
+	return token[:2] + "********" + token[len(token)-2:]
+}
+
 // NewVerifierConfig creates a new VerifierConfig.
 // It verifies the clientID is not empty.
 func NewVerifierConfig(logger LoggerInterface, clientID string, options ...VerifierConfigOption) (VerifierConfig, error) {
@@ -201,7 +208,7 @@ func NewVerifierConfig(logger LoggerInterface, clientID string, options ...Verif
 func (tokenVerifier *TokenVerifier) Verify(ctx context.Context, rawToken string) (Token, error) {
 	logger := tokenVerifier.Logger
 	logger.Debugw("Verifying token")
-	logger.Debugw("Got raw token value", "rawToken", rawToken)
+	logger.Debugw("Got raw token value", "rawToken", maskToken(rawToken))
 	idToken, err := tokenVerifier.Verifier.Verify(ctx, rawToken)
 	if err != nil {
 		token := Token{}
@@ -241,7 +248,7 @@ func NewClaims(logger LoggerInterface) Claims {
 	}
 }
 
-// ValidateExpectations validates the claims against the trusted issuer expected values.
+// validateExpectations validates the claims against the trusted issuer expected values.
 // It checks audience, issuer, and job_workflow_ref claims.
 func (claims *Claims) validateExpectations(issuer Issuer) error {
 	logger := claims.LoggerInterface
@@ -300,7 +307,7 @@ func NewTokenProcessor(
 	tokenProcessor.logger = logger
 
 	tokenProcessor.rawToken = rawToken
-	logger.Debugw("Added raw token to token processor", "rawToken", rawToken)
+	logger.Debugw("Added raw token to token processor", "rawToken", maskToken(rawToken))
 
 	tokenProcessor.verifierConfig = config
 	logger.Debugw("Added Verifier config to token processor",
@@ -391,7 +398,7 @@ func (tokenProcessor *TokenProcessor) Issuer() string {
 	return tokenProcessor.issuer.IssuerURL
 }
 
-// VerifyAndExtractClaims verify and parse the token to get the token claims.
+// ValidateClaims verify and parse the token to get the token claims.
 // It uses the provided verifier to verify the token signature and expiration time.
 // It verifies if the token claims have expected values.
 // It unmarshal the claims into the provided claims struct.

--- a/pkg/oidc/oidc_test.go
+++ b/pkg/oidc/oidc_test.go
@@ -158,7 +158,6 @@ var _ = Describe("OIDC", func() {
 
 	Describe("TokenProcessor", func() {
 		var (
-			verifier       *oidcmocks.MockTokenVerifierInterface
 			Token          oidcmocks.MockTokenInterface
 			claims         tioidc.Claims
 			token          tioidc.Token
@@ -187,7 +186,6 @@ var _ = Describe("OIDC", func() {
 
 			token = tioidc.Token{}
 			mockToken = oidcmocks.MockClaimsReader{}
-			verifier = &oidcmocks.MockTokenVerifierInterface{}
 		})
 		Describe("Issuer", func() {
 			It("should return the issuer", func() {
@@ -211,7 +209,6 @@ var _ = Describe("OIDC", func() {
 					},
 				).Return(nil)
 				token.Token = &mockToken
-				// verifier.On("Verify", mock.AnythingOfType("backgroundCtx"), string(rawToken)).Return(token, nil)
 
 				// Run
 				err = tokenProcessor.ValidateClaims(&claims, &token)
@@ -236,7 +233,6 @@ var _ = Describe("OIDC", func() {
 				).Return(nil)
 				expectedError := fmt.Errorf("expecations validation failed: %w", fmt.Errorf("job_workflow_ref claim expected value validation failed, expected: kyma-project/test-infra/.github/workflows/unexpected.yml@refs/heads/main, provided: kyma-project/test-infra/.github/workflows/verify-oidc-token.yml@refs/heads/main"))
 				token.Token = &mockToken
-				// verifier.On("Verify", mock.AnythingOfType("backgroundCtx"), string(rawToken)).Return(token, nil)
 
 				// Run
 				err = tokenProcessor.ValidateClaims(&claims, &token)
@@ -245,21 +241,9 @@ var _ = Describe("OIDC", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(expectedError))
 			})
-			It("should return an error when token was not verified", func() {
-				verifier.On("Verify", mock.AnythingOfType("backgroundCtx"), string(rawToken)).Return(tioidc.Token{}, fmt.Errorf("token validation failed"))
-
-				// Run
-				err = tokenProcessor.ValidateClaims(&claims, &token)
-
-				// Verify
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError("failed to verify token: token validation failed"))
-				Expect(claims).To(Equal(tioidc.NewClaims(logger)))
-			})
 			It("should return an error when claims are not set", func() {
 				mockToken.On("Claims", &claims).Return(fmt.Errorf("claims are not set"))
 				token.Token = &mockToken
-				verifier.On("Verify", mock.AnythingOfType("backgroundCtx"), string(rawToken)).Return(token, nil)
 				Token.On("Claims", &claims).Return(fmt.Errorf("claims are not set"))
 
 				// Run


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Due to long queued time of ADO pipelines GitHub oidc tokens passed from Image builder GitHub Actions are expiring. This causes failed image builds. To prevent failed builds when high load on ADO is observed oidc token verifier will verify oidc tokens with extended expiration time.

Example error in failed ADO run: https://dev.azure.com/hyperspace-pipelines/kyma/_build/results?buildId=7329713&view=logs&j=3eaab1e8-b99d-54c2-e3b9-c8d721213979&t=94b89c64-0a6c-5eb1-9ee6-a00128da7d80&l=33

Changes proposed in this pull request:

- Verify oidc token against extended expiration time. Added function for this verification.
- Split oidc token standard verification and claims verification. These are two separate functions.
- Added flag for extended expiration time value to make it configurable. Default value is 10 minutes.
