### PR TITLE
Setup access to audit logs for kyma-project admins

### DIFF
--- a/configs/terraform/environments/prod/iam-variables.tf
+++ b/configs/terraform/environments/prod/iam-variables.tf
@@ -3,9 +3,3 @@ variable "kyma_developer_admins_email" {
   type = string
   default = "kyma_developer_admin@sap.com"
 }
-
-variable "kyma_developers_email" {
-  description = "The email of the Kyma Developers group."
-  type = string
-  default = "kyma_developers@sap.com"
-}

--- a/configs/terraform/environments/prod/iam-variables.tf
+++ b/configs/terraform/environments/prod/iam-variables.tf
@@ -1,4 +1,4 @@
-variable "kyma_developer_admins_email" {
+variable "kyma_developer_admin_email" {
   description = "The email of the Kyma Developer Admins group."
   type = string
   default = "kyma_developer_admin@sap.com"

--- a/configs/terraform/environments/prod/iam-variables.tf
+++ b/configs/terraform/environments/prod/iam-variables.tf
@@ -1,5 +1,5 @@
 variable "kyma_developer_admins_email" {
   description = "The email of the Kyma Developer Admins group."
   type = string
-  default = "kyma_developer_admin@sap.com"
+  default = "kyma_developer_admins@sap.com"
 }

--- a/configs/terraform/environments/prod/iam-variables.tf
+++ b/configs/terraform/environments/prod/iam-variables.tf
@@ -1,5 +1,5 @@
 variable "kyma_developer_admins_email" {
   description = "The email of the Kyma Developer Admins group."
   type = string
-  default = "kyma_developer_admins@sap.com"
+  default = "kyma_developer_admin@sap.com"
 }

--- a/configs/terraform/environments/prod/iam.tf
+++ b/configs/terraform/environments/prod/iam.tf
@@ -1,10 +1,10 @@
 # Setups IAM for the project administrators in the kyma-project GCP project.
 import {
   id = "kyma-project roles/editor group:kyma_developer_admin@sap.com"
-  to = google_project_iam_member.kyma_developer_admins_editor
+  to = google_project_iam_member.kyma_developer_admin_editor
 }
 
-resource "google_project_iam_member" "kyma_developer_admins_editor" {
+resource "google_project_iam_member" "kyma_developer_admin_editor" {
   provider = google.kyma_project
   project = var.kyma_project_gcp_project_id
   role = "roles/editor"
@@ -12,7 +12,7 @@ resource "google_project_iam_member" "kyma_developer_admins_editor" {
 }
 
 # Add roles required to see audit logs in kyma-project GCP project.
-resource "google_project_iam_member" "kyma_developer_admins_logging_viewer" {
+resource "google_project_iam_member" "kyma_developer_admin_logging_viewer" {
   provider = google.kyma_project
   project = var.kyma_project_gcp_project_id
   role = "roles/logging.viewer"

--- a/configs/terraform/environments/prod/iam.tf
+++ b/configs/terraform/environments/prod/iam.tf
@@ -1,4 +1,9 @@
 # Setups IAM for the project administrators in the kyma-project GCP project.
+import {
+  id = "kyma-project roles/editor group:kyma_developer_admins@sap.com"
+  to = google_project_iam_member.kyma_developer_admins_editor
+}
+
 resource "google_project_iam_member" "kyma_developer_admins_editor" {
   provider = google.kyma_project
   project = var.kyma_project_gcp_project_id
@@ -7,6 +12,10 @@ resource "google_project_iam_member" "kyma_developer_admins_editor" {
 }
 
 # Add roles required to see audit logs in kyma-project GCP project.
+import {
+  id = "kyma-project roles/logging.viewer group:kyma_developer_admins@sap.com"
+  to = google_project_iam_member.kyma_developer_admins_logging_viewer
+}
 resource "google_project_iam_member" "kyma_developer_admins_logging_viewer" {
   provider = google.kyma_project
   project = var.kyma_project_gcp_project_id

--- a/configs/terraform/environments/prod/iam.tf
+++ b/configs/terraform/environments/prod/iam.tf
@@ -1,0 +1,15 @@
+# Setups IAM for the project administrators in the kyma-project GCP project.
+resource "google_project_iam_member" "kyma_developer_admins_editor" {
+  provider = google.kyma_project
+  project = var.kyma_project_gcp_project_id
+  role = "roles/editor"
+  member = "group:${var.kyma_developer_admins_email}"
+}
+
+# Add roles required to see audit logs in kyma-project GCP project.
+resource "google_project_iam_member" "kyma_developer_admins_logging_viewer" {
+  provider = google.kyma_project
+  project = var.kyma_project_gcp_project_id
+  role = "roles/logging.viewer"
+  member = "group:${var.kyma_developer_admins_email}"
+}

--- a/configs/terraform/environments/prod/iam.tf
+++ b/configs/terraform/environments/prod/iam.tf
@@ -1,6 +1,6 @@
 # Setups IAM for the project administrators in the kyma-project GCP project.
 import {
-  id = "kyma-project roles/editor group:kyma_developer_admins@sap.com"
+  id = "kyma-project roles/editor group:kyma_developer_admin@sap.com"
   to = google_project_iam_member.kyma_developer_admins_editor
 }
 
@@ -12,10 +12,6 @@ resource "google_project_iam_member" "kyma_developer_admins_editor" {
 }
 
 # Add roles required to see audit logs in kyma-project GCP project.
-import {
-  id = "kyma-project roles/logging.viewer group:kyma_developer_admins@sap.com"
-  to = google_project_iam_member.kyma_developer_admins_logging_viewer
-}
 resource "google_project_iam_member" "kyma_developer_admins_logging_viewer" {
   provider = google.kyma_project
   project = var.kyma_project_gcp_project_id

--- a/configs/terraform/environments/prod/iam.tf
+++ b/configs/terraform/environments/prod/iam.tf
@@ -8,7 +8,7 @@ resource "google_project_iam_member" "kyma_developer_admins_editor" {
   provider = google.kyma_project
   project = var.kyma_project_gcp_project_id
   role = "roles/editor"
-  member = "group:${var.kyma_developer_admins_email}"
+  member = "group:${var.kyma_developer_admin_email}"
 }
 
 # Add roles required to see audit logs in kyma-project GCP project.
@@ -16,5 +16,5 @@ resource "google_project_iam_member" "kyma_developer_admins_logging_viewer" {
   provider = google.kyma_project
   project = var.kyma_project_gcp_project_id
   role = "roles/logging.viewer"
-  member = "group:${var.kyma_developer_admins_email}"
+  member = "group:${var.kyma_developer_admin_email}"
 }

--- a/configs/terraform/environments/prod/iamt-variables.tf
+++ b/configs/terraform/environments/prod/iamt-variables.tf
@@ -1,0 +1,11 @@
+variable "kyma_developer_admins_email" {
+  description = "The email of the Kyma Developer Admins group."
+  type = string
+  default = "kyma_developer_admin@sap.com"
+}
+
+variable "kyma_developers_email" {
+  description = "The email of the Kyma Developers group."
+  type = string
+  default = "kyma_developers@sap.com"
+}

--- a/configs/terraform/environments/prod/service_accounts.tf
+++ b/configs/terraform/environments/prod/service_accounts.tf
@@ -4,12 +4,6 @@ resource "google_service_account" "sa-gke-kyma-integration" {
   description  = "Service account is used by Prow to integrate with GKE. Will be removed with Prow"
 }
 
-resource "google_service_account" "gcr-cleaner" {
-  account_id   = "gcr-cleaner"
-  display_name = "gcr-cleaner"
-  description  = "Service account is used by gcr-cleaner tool."
-}
-
 resource "google_service_account" "control-plane" {
   account_id   = "control-plane"
   display_name = "control-plane"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Add `logging.viewer` role to identity `kyma_developer_admin` to allow access to audit logs in `kyma-project` GCP project. Using predefined class instead of custom one is dictated that I cannot find list of exact permissions to allow see the logs. See: https://cloud.google.com/logging/docs/audit#roles

Changes proposed in this pull request:

- Remove `gcr-cleaner` service account used by Prow.
- Add configuration for `kyma_developer_admins` identity on `kyma-project` GCP project. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: #9765 