### PR TITLE
Add required role to see data access logs

### DIFF
--- a/configs/terraform/environments/prod/iam.tf
+++ b/configs/terraform/environments/prod/iam.tf
@@ -18,3 +18,11 @@ resource "google_project_iam_member" "kyma_developer_admin_logging_viewer" {
   role = "roles/logging.viewer"
   member = "group:${var.kyma_developer_admin_email}"
 }
+
+# roles/logging.privateLogViewer is required to see Data Access audit logs
+resource "google_project_iam_member" "kyma_developer_admin_private_logging_viewer" {
+  provider = google.kyma_project
+  project = var.kyma_project_gcp_project_id
+  role = "roles/logging.privateLogViewer"
+  member = "group:${var.kyma_developer_admin_email}"
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add `roles/logging.privateLogViewer` role for GCP project admins

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: #9765 