### PR TITLE
Allow access to go internal modules

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -64,6 +64,7 @@ type options struct {
 	debug                 bool
 	dryRun                bool
 	tagsOutputFile        string
+	useGoInternalModules  bool
 }
 
 type Logger interface {
@@ -254,6 +255,10 @@ func prepareADOTemplateParameters(options options) (adopipelines.OCIImageBuilder
 
 	if options.ciSystem == GithubActions {
 		templateParameters.SetAuthorization(options.oidcToken)
+	}
+
+	if options.useGoInternalModules {
+		templateParameters.SetUseGoInternalModules()
 	}
 
 	err := templateParameters.Validate()
@@ -833,6 +838,7 @@ func (o *options) gatherOptions(flagSet *flag.FlagSet) *flag.FlagSet {
 	flagSet.StringVar(&o.oidcToken, "oidc-token", "", "Token used to authenticate against Azure DevOps backend service")
 	flagSet.StringVar(&o.azureAccessToken, "azure-access-token", "", "Token used to authenticate against Azure DevOps API")
 	flagSet.StringVar(&o.tagsOutputFile, "tags-output-file", "/generated-tags.json", "Path to file where generated tags will be written as JSON")
+	flagSet.BoolVar(&o.useGoInternalModules, "use-go-internal-modules", false, "Allow access to Go internal modules in ADO backend")
 
 	return flagSet
 }

--- a/pkg/azuredevops/pipelines/templatesParams.go
+++ b/pkg/azuredevops/pipelines/templatesParams.go
@@ -171,3 +171,10 @@ func (p OCIImageBuilderTemplateParams) Validate() error {
 	}
 	return nil
 }
+
+// SetUseGoInternalModules sets UseGoInternalModules parameter.
+// This parameter is used to setup access to internal Go modules.
+// Prepared file is available under <build context>/.netrc path.
+func (p OCIImageBuilderTemplateParams) SetUseGoInternalModules() {
+	p["UseGoInternalModules"] = "true"
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add option to setup access to go internal modules, while using ADO backend
