### PR TITLE
Revert "actions(deps): bump golangci/golangci-lint-action from 6.1.0 to 6.1.1"

### DIFF
--- a/.github/workflows/pull-go-lint.yaml
+++ b/.github/workflows/pull-go-lint.yaml
@@ -18,4 +18,4 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
 
-      - uses: golangci/golangci-lint-action@v6.1.1
+      - uses: golangci/golangci-lint-action@v6.1.0

--- a/pkg/github/bumper/bumper.go
+++ b/pkg/github/bumper/bumper.go
@@ -207,7 +207,7 @@ func processGitHub(ctx context.Context, o *Options, prh PRHandler) error {
 			return fmt.Errorf("process function %d: %w", i, err)
 		}
 
-		changed, err := HasChanges(o)
+		changed, err := HasChanges()
 		if err != nil {
 			return fmt.Errorf("checking changes: %w", err)
 		}
@@ -325,7 +325,7 @@ func UpdatePullRequestWithLabels(gc github.Client, org, repo, title, body, sourc
 }
 
 // HasChanges checks if the current git repo contains any changes
-func HasChanges(o *Options) (bool, error) {
+func HasChanges() (bool, error) {
 	// Check for changes using git status
 	statusArgs := []string{"status", "--porcelain"}
 	logrus.WithField("cmd", gitCmd).WithField("args", statusArgs).Info("running command ...")


### PR DESCRIPTION
Reverts kyma-project/test-infra#12068

Restore previous version until https://github.com/kyma-project/community/pull/946 is merged
Automaticall bumps are disabled since https://github.com/kyma-project/test-infra/pull/12164