### PR TITLE
Add option to use go internal modules in github actions

### DIFF
--- a/.github/actions/image-builder/action.yml
+++ b/.github/actions/image-builder/action.yml
@@ -43,7 +43,7 @@ inputs:
     required: false
     default: false
   use-go-internal-sap-modules:
-    description: Setup access to go internal SAP modules in build environment
+    description: Setup access to Go internal SAP modules in build environment
     required: false
     default: false
 

--- a/.github/actions/image-builder/action.yml
+++ b/.github/actions/image-builder/action.yml
@@ -42,6 +42,10 @@ inputs:
     description: Prevent actual triggering the image builder
     required: false
     default: false
+  use-go-internal-modules:
+    description: Setup access to go internal modules in build environment
+    required: false
+    default: false
 
 outputs:
   adoResult:
@@ -81,4 +85,4 @@ runs:
     - uses: docker://europe-docker.pkg.dev/kyma-project/prod/image-builder:v20241112-fd0d9381
       id: build
       with:
-        args: --name=${{ inputs.image-name }} --context=${{ inputs.context }} --dockerfile=${{ inputs.dockerfile }} --azure-access-token=${{ inputs.ado-token }} --oidc-token=${{ inputs.oidc-token }} ${{ steps.prepare-build-args.outputs.build-args }} ${{ steps.prepare-tags.outputs.tags }} --export-tags=${{ inputs.export-tags }} --config=${{ inputs.config }} --env-file=${{ inputs.env-file }} --build-in-ado=true
+        args: --name=${{ inputs.image-name }} --context=${{ inputs.context }} --dockerfile=${{ inputs.dockerfile }} --azure-access-token=${{ inputs.ado-token }} --oidc-token=${{ inputs.oidc-token }} ${{ steps.prepare-build-args.outputs.build-args }} ${{ steps.prepare-tags.outputs.tags }} --export-tags=${{ inputs.export-tags }} --config=${{ inputs.config }} --env-file=${{ inputs.env-file }} --build-in-ado=true --use-go-internal-modules=${{ inputs.use-go-internal-modules }}

--- a/.github/actions/image-builder/action.yml
+++ b/.github/actions/image-builder/action.yml
@@ -85,4 +85,4 @@ runs:
     - uses: docker://europe-docker.pkg.dev/kyma-project/prod/image-builder:v20241112-fd0d9381
       id: build
       with:
-        args: --name=${{ inputs.image-name }} --context=${{ inputs.context }} --dockerfile=${{ inputs.dockerfile }} --azure-access-token=${{ inputs.ado-token }} --oidc-token=${{ inputs.oidc-token }} ${{ steps.prepare-build-args.outputs.build-args }} ${{ steps.prepare-tags.outputs.tags }} --export-tags=${{ inputs.export-tags }} --config=${{ inputs.config }} --env-file=${{ inputs.env-file }} --build-in-ado=true --use-go-internal-modules=${{ inputs.use-go-internal-modules }}
+        args: --name=${{ inputs.image-name }} --context=${{ inputs.context }} --dockerfile=${{ inputs.dockerfile }} --azure-access-token=${{ inputs.ado-token }} --oidc-token=${{ inputs.oidc-token }} ${{ steps.prepare-build-args.outputs.build-args }} ${{ steps.prepare-tags.outputs.tags }} --export-tags=${{ inputs.export-tags }} --config=${{ inputs.config }} --env-file=${{ inputs.env-file }} --build-in-ado=true --use-go-internal-modules=${{ inputs.use-go-internal-sap-modules }}

--- a/.github/actions/image-builder/action.yml
+++ b/.github/actions/image-builder/action.yml
@@ -42,8 +42,8 @@ inputs:
     description: Prevent actual triggering the image builder
     required: false
     default: false
-  use-go-internal-modules:
-    description: Setup access to go internal modules in build environment
+  use-go-internal-sap-modules:
+    description: Setup access to go internal SAP modules in build environment
     required: false
     default: false
 

--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -40,8 +40,8 @@ on:
         required: false
         type: string
         default: ""
-      use-go-internal-modules:
-        description: Setup access to go internal modules in build environment
+      use-go-internal-sap-modules:
+        description: Setup access to go internal SAP modules in build environment
         required: false
         type: boolean
         default: false
@@ -114,4 +114,4 @@ jobs:
           dockerfile: ${{ inputs.dockerfile }}
           env-file: ${{ inputs.env-file }}
           config: "./configs/image-builder-client-config.yaml"
-          use-go-internal-modules: ${{ inputs.use-go-internal-modules }}
+          use-go-internal-sap-modules: ${{ inputs.use-go-internal-sap-modules }}

--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -40,6 +40,11 @@ on:
         required: false
         type: string
         default: ""
+      use-go-internal-modules:
+        description: Setup access to go internal modules in build environment
+        required: false
+        type: boolean
+        default: false
     outputs:
       images:
         description: JSON list of images built by image-builder
@@ -109,3 +114,4 @@ jobs:
           dockerfile: ${{ inputs.dockerfile }}
           env-file: ${{ inputs.env-file }}
           config: "./configs/image-builder-client-config.yaml"
+          use-go-internal-modules: ${{ inputs.use-go-internal-modules }}

--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -41,7 +41,7 @@ on:
         type: string
         default: ""
       use-go-internal-sap-modules:
-        description: Setup access to go internal SAP modules in build environment
+        description: Setup access to Go internal SAP modules in build environment
         required: false
         type: boolean
         default: false


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add option to run image builder with access to go internal modules
