### PR TITLE
Add rc-tag in the sec-scanners-config.yaml

### DIFF
--- a/pkg/securityconfig/securityconfig.go
+++ b/pkg/securityconfig/securityconfig.go
@@ -15,6 +15,7 @@ type Whitesource struct {
 
 type SecurityConfig struct {
 	ModuleName  string      `yaml:"module-name,omitempty"`
+	RcTag       string      `yaml:"rc-tag,omitempty"`
 	Images      []string    `yaml:"protecode"`
 	Whitesource Whitesource `yaml:"whitesource,omitempty"`
 }

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,4 +1,5 @@
 module-name: test-infra
+rc-tag: rc-tag
 protecode:
     - europe-docker.pkg.dev/kyma-project/prod/cors-proxy:v20241112-fd0d9381
     - europe-docker.pkg.dev/kyma-project/prod/create-github-issue:v20241112-fd0d9381


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add rc-tag in the security config pointing to the [rc-tag](https://github.com/kyma-project/test-infra/releases/tag/rc-tag) to test the migration to the Checkmarx One scanner.
- Adjust code to not remove rc-tag from security config by image detector as it was done in https://github.com/kyma-project/test-infra/pull/12346

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/test-infra/pull/12345