### PR TITLE
Fix loading git state for merge_group event

### DIFF
--- a/cmd/image-builder/config.go
+++ b/cmd/image-builder/config.go
@@ -317,7 +317,7 @@ func loadGithubActionsGitState() (GitStateConfig, error) {
 			JobType:           "merge_group",
 			BaseCommitSHA:     commitSHA,
 			BaseCommitRef:     gitRef,
-			PullHeadCommitSHA: *payload.MergeGroup.HeadSHA,
+			PullHeadCommitSHA: *payload.MergeGroup.HeadCommit.SHA,
 		}, nil
 
 	default:

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -878,6 +878,8 @@ func main() {
 		if err != nil {
 			log.Fatalf("Failed to load current git state: %s", err)
 		}
+
+		o.logger.Debugw("Git state loaded", "gitState", o.gitState)
 	}
 
 	// validate if options provided by flags and config file are fine


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Rename HeadSHA (which is SHA of the merge group) to HeadCommig.SHA (which is sha of the commit on the head of merge group).

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: #12116 