### PR TITLE
Revert "Fix digest format for Signify (#12033)"

### DIFF
--- a/pkg/sign/notary.go
+++ b/pkg/sign/notary.go
@@ -140,7 +140,7 @@ func (mw *ManifestWrapper) GetConfigSize() int64 {
 
 // GetConfigDigest returns the digest of the image config.
 func (mw *ManifestWrapper) GetConfigDigest() string {
-	return mw.manifest.Config.Digest.Hex
+	return mw.manifest.Config.Digest.String()
 }
 
 // PayloadBuilderInterface defines the method for constructing the signing payload.

--- a/pkg/sign/notary_mocks.go
+++ b/pkg/sign/notary_mocks.go
@@ -108,9 +108,7 @@ func (mr *MockReference) GetTag() (string, error) {
 
 // MockImage implements ImageInterface
 type MockImage struct {
-	MockManifest  func() (ManifestInterface, error)
-	MockGetDigest func() (string, error)
-	MockGetSize   func() (int64, error)
+	MockManifest func() (ManifestInterface, error)
 }
 
 func (mi *MockImage) Manifest() (ManifestInterface, error) {
@@ -118,20 +116,6 @@ func (mi *MockImage) Manifest() (ManifestInterface, error) {
 		return mi.MockManifest()
 	}
 	return nil, fmt.Errorf("MockManifest not implemented")
-}
-
-func (mi *MockImage) GetDigest() (string, error) {
-	if mi.MockGetDigest != nil {
-		return mi.MockGetDigest()
-	}
-	return "", fmt.Errorf("MockGetDigest not implemented")
-}
-
-func (mi *MockImage) GetSize() (int64, error) {
-	if mi.MockGetSize != nil {
-		return mi.MockGetSize()
-	}
-	return 0, fmt.Errorf("MockGetSize not implemented")
 }
 
 // MockManifest implements ManifestInterface


### PR DESCRIPTION
This reverts commit ea6bb32ea389bfb739493be29828c34c41a86673.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Sign the image descriptor's digest instead of the image config's digest.
- Revert of https://github.com/kyma-project/test-infra/pull/12033 as https://github.com/kyma-project/warden/issues/282 was implemented.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/test-infra/issues/12046
https://github.com/kyma-project/warden/issues/282