### PR TITLE
Added logger context with details about token issuer.

### DIFF
--- a/cmd/oidc-token-verifier/main.go
+++ b/cmd/oidc-token-verifier/main.go
@@ -119,7 +119,9 @@ func (opts *options) verifyToken() error {
 		return err
 	}
 
-	logger.Infow("Token processor created for trusted issuer", "issuer", tokenProcessor.Issuer())
+	logger = logger.With("issuer", tokenProcessor.Issuer(), "client-id", tokenProcessor.GetIssuer().ClientID, "github-url", tokenProcessor.GetIssuer().GithubURL)
+
+	logger.Infow("Token processor created for trusted issuer")
 
 	// TODO (dekiel): implement writing output data to the file. This will give us separated clear output for a data and logs.
 	fmt.Printf("GITHUB_URL=%s\n", tokenProcessor.GetIssuer().GetGithubURL())


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

We must log information which client and issuer requested an image build. We are going to support three different oidc providers, each with it's uniq clients. Image builder execution must provide audit logs about callers identity.

Changes proposed in this pull request:

- Adding context to the logger with issuer url, client id and github url.
