### PR TITLE
Add sre oidc provider to the trusted issuers.

### DIFF
--- a/pkg/oidc/oidc.go
+++ b/pkg/oidc/oidc.go
@@ -37,9 +37,17 @@ var (
 		GithubURL:              "https://github.tools.sap",
 		ClientID:               "image-builder",
 	}
+	SREJenkinsOIDCIssuer = Issuer{
+		Name:      "sre-jenkins",
+		IssuerURL: "https://storage.googleapis.com/kyma-mps-prod-artifacts/jaas/oidc",
+		JWKSURL:   "https://storage.googleapis.com/kyma-mps-prod-artifacts/jaas/oidc/jwks",
+		GithubURL: "https://github.tools.sap",
+		ClientID:  "sre-jenkins-image-builder",
+	}
 	TrustedOIDCIssuers = map[string]Issuer{
 		GithubOIDCIssuer.IssuerURL:         GithubOIDCIssuer,
 		GithubToolsSAPOIDCIssuer.IssuerURL: GithubToolsSAPOIDCIssuer,
+		SREJenkinsOIDCIssuer.IssuerURL:     SREJenkinsOIDCIssuer,
 	}
 )
 
@@ -325,7 +333,7 @@ func NewClaims(logger LoggerInterface) Claims {
 func (claims *Claims) validateExpectations(issuer Issuer) error {
 	logger := claims.LoggerInterface
 	logger.Debugw("Validating job_workflow_ref claim against expected value", "job_workflow_ref", claims.JobWorkflowRef, "expected", issuer.ExpectedJobWorkflowRef)
-	if claims.JobWorkflowRef != issuer.ExpectedJobWorkflowRef {
+	if issuer.ExpectedJobWorkflowRef != "" && claims.JobWorkflowRef != issuer.ExpectedJobWorkflowRef {
 		return fmt.Errorf("job_workflow_ref claim expected value validation failed, expected: %s, provided: %s", claims.JobWorkflowRef, issuer.ExpectedJobWorkflowRef)
 	}
 	logger.Debugw("Claims validated successfully")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

SRE is running an image-builder in Jenkins. The Jenkins and its OIDC provider does not provide a claim with Jenkins pipeline reference. It's SRE team responsibility to restrict access to oidc provider and allow only certain pipeline to build images. The SRE issuer does not provide job workflow ref and this calim is not validated when oidc token is verified.

Changes proposed in this pull request:

- Disable job workflow ref claim verification is it's not defined in trusted issuer.
- Added SRE issuer to the trusted issuers.

