### PR TITLE
Set authorization always when oidc token is provided

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -255,7 +255,7 @@ func prepareADOTemplateParameters(options options) (adopipelines.OCIImageBuilder
 		templateParameters.SetImageTags(options.tags.String())
 	}
 
-	if options.ciSystem == GithubActions {
+	if options.oidcToken != "" {
 		templateParameters.SetAuthorization(options.oidcToken)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/kyma-project/test-infra
 
-go 1.23
+go 1.23.0
+
 toolchain go1.23.4
 
 require (


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Currently OIDC token is set in authorizaiton parameter only for Github Actions, we need to set it always to avoid confusions.
The fix implementation was due to some security concerns about leaking the token, but now it's causing confusions. To avoid that let's move repsonsibility for token on user.

Changes proposed in this pull request:

- Update condition to check if oidc token is provided instead of if client run in github actions