### PR TITLE
Add status of pushing images to registry

### DIFF
--- a/pkg/imagebuilder/report.go
+++ b/pkg/imagebuilder/report.go
@@ -11,10 +11,16 @@ import (
 var reportRegex = regexp.MustCompile(`(?s)---IMAGE BUILD REPORT---\n(.*)\n---END OF IMAGE BUILD REPORT---`)
 
 type BuildReport struct {
-	Status       string    `json:"status"`
-	IsSigned     bool      `json:"signed"`
-	IsProduction bool      `json:"is_production"`
-	ImageSpec    ImageSpec `json:"image_spec"`
+	// Status is the overall status of the build including signing and pushing
+	Status string `json:"status"`
+	// IsPushed indicates whether the image was pushed to a registry
+	IsPushed bool `json:"pushed"`
+	// IsSigned indicates whether the image was signed
+	IsSigned bool `json:"signed"`
+	// IsProduction indicates whether the image is a production image
+	IsProduction bool `json:"is_production"`
+	// ImageSpec contains the image name, tags, and repository path
+	ImageSpec ImageSpec `json:"image_spec"`
 }
 
 type ImageSpec struct {

--- a/pkg/imagebuilder/report_test.go
+++ b/pkg/imagebuilder/report_test.go
@@ -19,6 +19,7 @@ Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/p
 ---IMAGE BUILD REPORT---
 {
     "status": "Succeeded",
+		"pushed": true,
     "signed": true,
     "is_production": true,
     "image_spec": {
@@ -38,6 +39,7 @@ Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/p
 Finishing: prepare_image_build_report`
 		expectedReport := &BuildReport{
 			Status:       "Succeeded",
+			IsPushed:     true,
 			IsSigned:     true,
 			IsProduction: true,
 			ImageSpec: ImageSpec{

--- a/pkg/imagebuilder/report_test.go
+++ b/pkg/imagebuilder/report_test.go
@@ -19,7 +19,7 @@ Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/p
 ---IMAGE BUILD REPORT---
 {
     "status": "Succeeded",
-		"pushed": true,
+    "pushed": true,
     "signed": true,
     "is_production": true,
     "image_spec": {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

SRE wants to know whether image was pushed even if overall status is failed, this change adds that information to build report.

Changes proposed in this pull request:

- Add IsPushed field in the buidl report file

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
