### PR TITLE
Strip timestamps before searching report string

### DIFF
--- a/pkg/imagebuilder/report.go
+++ b/pkg/imagebuilder/report.go
@@ -8,7 +8,11 @@ import (
 )
 
 // reportRegex is a regular expression that matches the image build report
-var reportRegex = regexp.MustCompile(`(?s)---IMAGE BUILD REPORT---\n(.*)\n---END OF IMAGE BUILD REPORT---`)
+var (
+	reportRegex = regexp.MustCompile(`(?s)---IMAGE BUILD REPORT---\n(.*)\n---END OF IMAGE BUILD REPORT---`)
+
+	timestampRegex = regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s+`)
+)
 
 type BuildReport struct {
 	// Status is the overall status of the build including signing and pushing
@@ -45,7 +49,7 @@ func (br *BuildReport) GetImages() []string {
 
 func NewBuildReportFromLogs(log string) (*BuildReport, error) {
 	// Strip all timestamps from log
-	log = regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s+`).ReplaceAllString(log, "")
+	log = timestampRegex.ReplaceAllString(log, "")
 
 	// Find the report in the log
 	matches := reportRegex.FindStringSubmatch(log)

--- a/pkg/imagebuilder/report.go
+++ b/pkg/imagebuilder/report.go
@@ -44,11 +44,16 @@ func (br *BuildReport) GetImages() []string {
 }
 
 func NewBuildReportFromLogs(log string) (*BuildReport, error) {
+	// Strip all timestamps from log
+	log = regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s+`).ReplaceAllString(log, "")
+
+	// Find the report in the log
 	matches := reportRegex.FindStringSubmatch(log)
 	if len(matches) < 2 {
 		return nil, nil
 	}
 
+	// Parse the report data
 	var report BuildReport
 	if err := json.Unmarshal([]byte(matches[1]), &report); err != nil {
 		return nil, err

--- a/pkg/imagebuilder/report_test.go
+++ b/pkg/imagebuilder/report_test.go
@@ -7,45 +7,41 @@ import (
 
 var _ = Describe("Report", func() {
 	Describe("NewReportFromLogs", func() {
-		logs := `Starting: prepare_image_build_report
-==============================================================================
-Task         : Python script
-Description  : Run a Python file or inline script
-Version      : 0.248.1
-Author       : Microsoft Corporation
-Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/python-script
-==============================================================================
-/usr/bin/python /home/vsts/work/1/s/scripts/prepare_image_build_report.py --image-build-report-file /home/vsts/work/1/s/image-report.json --image-name ginkgo-test-image/ginkgo --sign-step-succeeded true --job-status Succeeded --image-build-report-file /home/vsts/work/_temp/generated-tags.json --images-to-sign=europe-docker.pkg.dev/kyma-project/prod/ginkgo-test-image/ginkgo:1.23.0-50049457 --images-to-sign=europe-docker.pkg.dev/kyma-project/prod/ginkgo-test-image/ginkgo:wartosc --images-to-sign=europe-docker.pkg.dev/kyma-project/prod/ginkgo-test-image/ginkgo:innytag --images-to-sign=europe-docker.pkg.dev/kyma-project/prod/ginkgo-test-image/ginkgo:v20250129-50049457 --images-to-sign=europe-docker.pkg.dev/kyma-project/prod/ginkgo-test-image/ginkgo:1.23.0
----IMAGE BUILD REPORT---
-{
-    "status": "Succeeded",
-    "pushed": true,
-    "signed": true,
-    "is_production": true,
-    "image_spec": {
-        "image_name": "ginkgo-test-image/ginkgo",
-        "tags": [
-            "1.23.0-50049457",
-            "wartosc",
-            "innytag",
-            "v20250129-50049457",
-            "1.23.0"
-        ],
-        "repository_path": "europe-docker.pkg.dev/kyma-project/prod/"
-    }
-}
----END OF IMAGE BUILD REPORT---
-
-Finishing: prepare_image_build_report`
+		logs := `2025-01-31T08:32:23.5327056Z ##[section]Starting: prepare_image_build_report
+2025-01-31T08:32:23.5434336Z ==============================================================================
+2025-01-31T08:32:23.5434499Z Task         : Python script
+2025-01-31T08:32:23.5434594Z Description  : Run a Python file or inline script
+2025-01-31T08:32:23.5434703Z Version      : 0.248.1
+2025-01-31T08:32:23.5434803Z Author       : Microsoft Corporation
+2025-01-31T08:32:23.5434910Z Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/python-script
+2025-01-31T08:32:23.5435059Z ==============================================================================
+2025-01-31T08:32:23.6965198Z [command]/opt/hostedtoolcache/Python/3.13.1/x64/bin/python /home/vsts/work/1/s/scripts/prepare_image_build_report.py --image-name github-tools-sap/conduit-cli --image-build-succeeded true --sign-step-succeeded $(sign_images.signing_success) --job-status Succeeded --images-to-sign=europe-docker.pkg.dev/kyma-project/dev/github-tools-sap/conduit-cli:PR-477
+2025-01-31T08:32:23.7344251Z ---IMAGE BUILD REPORT---
+2025-01-31T08:32:23.7345746Z {
+2025-01-31T08:32:23.7346062Z     "status": "Succeeded",
+2025-01-31T08:32:23.7357582Z     "pushed": true,
+2025-01-31T08:32:23.7358184Z     "signed": false,
+2025-01-31T08:32:23.7358759Z     "is_production": false,
+2025-01-31T08:32:23.7359525Z     "image_spec": {
+2025-01-31T08:32:23.7360295Z         "image_name": "github-tools-sap/conduit-cli",
+2025-01-31T08:32:23.7360618Z         "tags": [
+2025-01-31T08:32:23.7361207Z             "PR-477"
+2025-01-31T08:32:23.7361687Z         ],
+2025-01-31T08:32:23.7362370Z         "repository_path": "europe-docker.pkg.dev/kyma-project/dev/"
+2025-01-31T08:32:23.7362690Z     }
+2025-01-31T08:32:23.7363276Z }
+2025-01-31T08:32:23.7363903Z ---END OF IMAGE BUILD REPORT---
+2025-01-31T08:32:23.7416532Z 
+2025-01-31T08:32:23.7530550Z ##[section]Finishing: prepare_image_build_report`
 		expectedReport := &BuildReport{
 			Status:       "Succeeded",
 			IsPushed:     true,
-			IsSigned:     true,
-			IsProduction: true,
+			IsSigned:     false,
+			IsProduction: false,
 			ImageSpec: ImageSpec{
-				Name:           "ginkgo-test-image/ginkgo",
-				Tags:           []string{"1.23.0-50049457", "wartosc", "innytag", "v20250129-50049457", "1.23.0"},
-				RepositoryPath: "europe-docker.pkg.dev/kyma-project/prod/",
+				Name:           "github-tools-sap/conduit-cli",
+				Tags:           []string{"PR-477"},
+				RepositoryPath: "europe-docker.pkg.dev/kyma-project/dev/",
 			},
 		}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

When fectching the logs from API, we receive timestamps that was interferring with current solution.
Strip it out with simple regex right before parsing the logs to find the reprot string.

Changes proposed in this pull request:

- Replace timestamps with empty string

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
