### PR TITLE
Rename fields in security config, support both names by custom unmarshal

### DIFF
--- a/pkg/securityconfig/securityconfig.go
+++ b/pkg/securityconfig/securityconfig.go
@@ -3,16 +3,17 @@ package securityconfig
 import (
 	"io"
 	"os"
+	"reflect"
 
 	"gopkg.in/yaml.v3"
 )
 
 type CheckmarxOne struct {
-	Preset    string   `yaml:"preset,omitempty"`
-	Exclude   []string `yaml:"exclude,omitempty"`
+	Preset  string   `yaml:"preset,omitempty"`
+	Exclude []string `yaml:"exclude,omitempty"`
 }
 
-type Whitesource struct {
+type Mend struct {
 	Language    string   `yaml:"language,omitempty"`
 	SubProjects bool     `yaml:"subprojects,omitempty"`
 	Exclude     []string `yaml:"exclude,omitempty"`
@@ -22,9 +23,45 @@ type SecurityConfig struct {
 	ModuleName   string       `yaml:"module-name,omitempty"`
 	RcTag        string       `yaml:"rc-tag,omitempty"`
 	Kind         string       `yaml:"kind,omitempty"`
-	Images       []string     `yaml:"protecode"`
-	Whitesource  Whitesource  `yaml:"whitesource,omitempty"`
+	Images       []string     `yaml:"bdba,omitempty"`
+	Mend         Mend         `yaml:"mend,omitempty"`
 	CheckmarxOne CheckmarxOne `yaml:"checkmarx-one,omitempty"`
+}
+
+// TODO(kacpermalachowski): Remove after migration to the new field names
+// see: https://github.tools.sap/kyma/test-infra/issues/491
+func (config *SecurityConfig) UnmarshalYAML(value *yaml.Node) error {
+	// Cannot use inheritance due to infinite loop
+	var cfg struct {
+		ModuleName   string       `yaml:"module-name,omitempty"`
+		RcTag        string       `yaml:"rc-tag,omitempty"`
+		Kind         string       `yaml:"kind,omitempty"`
+		Images       []string     `yaml:"bdba,omitempty"`
+		Mend         Mend         `yaml:"mend,omitempty"`
+		CheckmarxOne CheckmarxOne `yaml:"checkmarx-one,omitempty"`
+		Protecode    []string     `yaml:"protecode,omitempty"`
+		Whitesource  Mend         `yaml:"whitesource,omitempty"`
+	}
+
+	if err := value.Decode(&cfg); err != nil {
+		return err
+	}
+
+	config.ModuleName = cfg.ModuleName
+	config.RcTag = cfg.RcTag
+	config.Kind = cfg.Kind
+	config.Images = cfg.Images
+	config.Mend = cfg.Mend
+
+	if len(cfg.Protecode) > 0 {
+		config.Images = cfg.Protecode
+	}
+
+	if !reflect.DeepEqual(cfg.Whitesource, Mend{}) {
+		config.Mend = cfg.Whitesource
+	}
+
+	return nil
 }
 
 func ParseSecurityConfig(reader io.Reader) (*SecurityConfig, error) {

--- a/pkg/securityconfig/securityconfig_test.go
+++ b/pkg/securityconfig/securityconfig_test.go
@@ -19,7 +19,7 @@ func TestLoadSecurityConfig(t *testing.T) {
 			ExpectedConfig: &SecurityConfig{
 				ModuleName: "test-infra",
 				Images:     []string{"europe-docker.pkg.dev/kyma-project/prod/buildpack-go:v20230717-e09b0fee"},
-				Whitesource: Whitesource{
+				Mend: Mend{
 					Language:    "golang-mod",
 					SubProjects: true,
 					Exclude:     []string{"**/examples/**"},
@@ -39,6 +39,27 @@ whitesource:
 			WantErr:        true,
 			ExpectedConfig: nil,
 			FileContent:    ``,
+		},
+		{
+			Name:    "Valid config with mend, pass",
+			WantErr: false,
+			ExpectedConfig: &SecurityConfig{
+				ModuleName: "test-infra",
+				Images:     []string{"europe-docker.pkg.dev/kyma-project/prod/buildpack-go:v20230717-e09b0fee"},
+				Mend: Mend{
+					Language:    "golang-mod",
+					SubProjects: true,
+					Exclude:     []string{"**/examples/**"},
+				},
+			},
+			FileContent: `module-name: test-infra
+protecode:
+  - europe-docker.pkg.dev/kyma-project/prod/buildpack-go:v20230717-e09b0fee
+mend:
+  language: golang-mod
+  subprojects: true
+  exclude:
+    - "**/examples/**"`,
 		},
 	}
 

--- a/pkg/securityconfig/securityconfig_test.go
+++ b/pkg/securityconfig/securityconfig_test.go
@@ -53,7 +53,7 @@ whitesource:
 				},
 			},
 			FileContent: `module-name: test-infra
-protecode:
+bdba:
   - europe-docker.pkg.dev/kyma-project/prod/buildpack-go:v20230717-e09b0fee
 mend:
   language: golang-mod

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,19 +1,19 @@
 module-name: test-infra
 rc-tag: rc-tag
 kind: kyma
-protecode:
-    - europe-docker.pkg.dev/kyma-project/prod/cors-proxy:v20250131-b15f4e86
-    - europe-docker.pkg.dev/kyma-project/prod/create-github-issue:v20250131-b15f4e86
-    - europe-docker.pkg.dev/kyma-project/prod/dashboard-token-proxy:v20250131-b15f4e86
-    - europe-docker.pkg.dev/kyma-project/prod/github-webhook-gateway:v20250131-b15f4e86
-    - europe-docker.pkg.dev/kyma-project/prod/move-gcs-bucket:v20250131-b15f4e86
-    - europe-docker.pkg.dev/kyma-project/prod/scan-logs-for-secrets:v20250131-b15f4e86
-    - europe-docker.pkg.dev/kyma-project/prod/search-github-issue:v20250131-b15f4e86
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/rotate-service-account:v20250131-b15f4e86
-    - europe-docker.pkg.dev/kyma-project/prod/test-infra/service-account-keys-cleaner:v20250131-b15f4e86
+bdba:
+    - europe-docker.pkg.dev/kyma-project/prod/cors-proxy:v20250131-885542fa
+    - europe-docker.pkg.dev/kyma-project/prod/create-github-issue:v20250131-885542fa
+    - europe-docker.pkg.dev/kyma-project/prod/dashboard-token-proxy:v20250131-885542fa
+    - europe-docker.pkg.dev/kyma-project/prod/github-webhook-gateway:v20250131-885542fa
+    - europe-docker.pkg.dev/kyma-project/prod/move-gcs-bucket:v20250131-885542fa
+    - europe-docker.pkg.dev/kyma-project/prod/scan-logs-for-secrets:v20250131-885542fa
+    - europe-docker.pkg.dev/kyma-project/prod/search-github-issue:v20250131-885542fa
+    - europe-docker.pkg.dev/kyma-project/prod/test-infra/rotate-service-account:v20250131-885542fa
+    - europe-docker.pkg.dev/kyma-project/prod/test-infra/service-account-keys-cleaner:v20250131-885542fa
     - europe-docker.pkg.dev/kyma-project/prod/test-infra/signify-secret-rotator:v20250108-fae88ec9
     - europe-docker.pkg.dev/kyma-project/prod/test-infra/slackmessagesender:v20250108-fae88ec9
-whitesource:
+mend:
     language: golang-mod
     exclude:
         - '**/*_test.go'


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Due to recent changes in security tools names, we want to update the security config to reflect that changes.

Changes proposed in this pull request:

- Add custon UnamrshalYAML method to unmarshal both types in config
- Add test for new structure
