### PR TITLE
Fix building images by adding write permission for the default token

### DIFF
--- a/.github/workflows/build-cors-proxy.yml
+++ b/.github/workflows/build-cors-proxy.yml
@@ -19,6 +19,10 @@ on:
       - "go.sum"
   workflow_dispatch: {}
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/build-create-github-issue.yml
+++ b/.github/workflows/build-create-github-issue.yml
@@ -19,6 +19,10 @@ on:
       - "go.sum"
   workflow_dispatch: {}
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/build-dashboard-token-proxy.yml
+++ b/.github/workflows/build-dashboard-token-proxy.yml
@@ -19,6 +19,10 @@ on:
       - "go.sum"
   workflow_dispatch: {}
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/build-externalsecretschecker.yml
+++ b/.github/workflows/build-externalsecretschecker.yml
@@ -19,6 +19,10 @@ on:
       - "go.sum"
   workflow_dispatch: {}
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/build-github-webhook-gateway.yml
+++ b/.github/workflows/build-github-webhook-gateway.yml
@@ -19,6 +19,10 @@ on:
       - "go.sum"
   workflow_dispatch: {}
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/build-image-url-helper.yml
+++ b/.github/workflows/build-image-url-helper.yml
@@ -19,6 +19,10 @@ on:
       - "go.sum"
   workflow_dispatch: {}
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/build-markdown-index.yml
+++ b/.github/workflows/build-markdown-index.yml
@@ -19,6 +19,10 @@ on:
       - "go.sum"
   workflow_dispatch: {}
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/build-move-gcs-bucket.yml
+++ b/.github/workflows/build-move-gcs-bucket.yml
@@ -19,6 +19,10 @@ on:
       - "go.sum"
   workflow_dispatch: {}
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/build-scan-logs-for-secrets.yml
+++ b/.github/workflows/build-scan-logs-for-secrets.yml
@@ -19,6 +19,10 @@ on:
       - "go.sum"
   workflow_dispatch: {}
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/build-search-github-issue.yml
+++ b/.github/workflows/build-search-github-issue.yml
@@ -19,6 +19,10 @@ on:
       - "go.sum"
   workflow_dispatch: {}
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/build-usersmapchecker.yml
+++ b/.github/workflows/build-usersmapchecker.yml
@@ -19,6 +19,10 @@ on:
       - "go.sum"
   workflow_dispatch: {}
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/buildx-images.yml
+++ b/.github/workflows/buildx-images.yml
@@ -14,6 +14,10 @@ on:
       - ".github/workflows/image-builder.yml"
   workflow_dispatch: {}
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   # Build the base Alpine image
   build-alpine:

--- a/.github/workflows/pull-build-image-autobumper.yaml
+++ b/.github/workflows/pull-build-image-autobumper.yaml
@@ -8,6 +8,10 @@ on:
       - "go.mod"
       - "go.sum"
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/pull-build-image-builder.yml
+++ b/.github/workflows/pull-build-image-builder.yml
@@ -10,6 +10,10 @@ on:
       - "go.mod"
       - "go.sum"
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/pull-build-image-detector.yml
+++ b/.github/workflows/pull-build-image-detector.yml
@@ -9,6 +9,10 @@ on:
       - "go.mod"
       - "go.sum"
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/pull-build-image-syncer.yml
+++ b/.github/workflows/pull-build-image-syncer.yml
@@ -9,6 +9,10 @@ on:
       - "go.mod"
       - "go.sum"
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/pull-build-oidc-token-verifier.yml
+++ b/.github/workflows/pull-build-oidc-token-verifier.yml
@@ -9,6 +9,10 @@ on:
       - "go.mod"
       - "go.sum"
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/pull-build-rotate-service-account-keys.yml
+++ b/.github/workflows/pull-build-rotate-service-account-keys.yml
@@ -10,6 +10,10 @@ on:
       - "go.mod"
       - "go.sum"
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/pull-build-service-account-keys-cleaner.yml
+++ b/.github/workflows/pull-build-service-account-keys-cleaner.yml
@@ -10,6 +10,10 @@ on:
       - "go.mod"
       - "go.sum"
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/pull-build-signify-secret-rotator.yml
+++ b/.github/workflows/pull-build-signify-secret-rotator.yml
@@ -7,6 +7,10 @@ on:
       - "cmd/cloud-run/signifysecretrotator/**"
       - ".github/workflows/pull-build-signify-secret-rotator.yml"
  
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/pull-build-slack-message-sender.yml
+++ b/.github/workflows/pull-build-slack-message-sender.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - "cmd/cloud-run/slack-message-sender/**"
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/push-build-image-autobumper.yaml
+++ b/.github/workflows/push-build-image-autobumper.yaml
@@ -10,6 +10,10 @@ on:
       - 'go.sum'
   workflow_dispatch: {}
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+  
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/push-build-image-builder.yml
+++ b/.github/workflows/push-build-image-builder.yml
@@ -11,6 +11,10 @@ on:
       - "go.mod"
       - "go.sum"
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/push-build-image-detector.yml
+++ b/.github/workflows/push-build-image-detector.yml
@@ -10,6 +10,10 @@ on:
       - "go.mod"
       - "go.sum"
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/push-build-image-syncer.yml
+++ b/.github/workflows/push-build-image-syncer.yml
@@ -10,6 +10,10 @@ on:
       - "go.mod"
       - "go.sum"
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/push-build-oidc-token-verifier.yml
+++ b/.github/workflows/push-build-oidc-token-verifier.yml
@@ -10,6 +10,10 @@ on:
       - "go.mod"
       - "go.sum"
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/push-build-rotate-service-account-keys.yml
+++ b/.github/workflows/push-build-rotate-service-account-keys.yml
@@ -11,6 +11,10 @@ on:
       - "go.mod"
       - "go.sum"
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/push-build-service-account-keys-cleaner.yml
+++ b/.github/workflows/push-build-service-account-keys-cleaner.yml
@@ -11,6 +11,10 @@ on:
       - "go.mod"
       - "go.sum"
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/push-build-signify-secret-rotator.yml
+++ b/.github/workflows/push-build-signify-secret-rotator.yml
@@ -8,6 +8,10 @@ on:
       - "cmd/cloud-run/signifysecretrotator/**"
       - ".github/workflows/push-build-signify-secret-rotator.yml"
  
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml

--- a/.github/workflows/push-build-slack-message-sender.yml
+++ b/.github/workflows/push-build-slack-message-sender.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - "cmd/cloud-run/slack-message-sender/**"
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 jobs:
   build-image:
     uses: ./.github/workflows/image-builder.yml


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

After changing a default permissions for default GITHUB_TOKEN in GH Actions we must set them explicit on calling workflow level. Otherwise a workflow that calls image-builder reusable workflow will not be triggered due to insufficient token permissions.

This PR fixes building images by adding write permissions for the default token.