### PR TITLE
Improve artifact-registry module naming and default values.

### DIFF
--- a/configs/terraform/environments/prod/artifact-registry-variables.tf
+++ b/configs/terraform/environments/prod/artifact-registry-variables.tf
@@ -2,7 +2,6 @@
 # Artifact Registry related values
 ###################################
 variable "kyma_project_artifact_registry_collection" {
-  description = "Artifact Registry related data set"
   type = map(object({
     name  = string
     owner = string

--- a/configs/terraform/environments/prod/artifact-registry-variables.tf
+++ b/configs/terraform/environments/prod/artifact-registry-variables.tf
@@ -7,8 +7,9 @@ variable "kyma_project_artifact_registry_collection" {
     name                   = string
     owner                  = string
     type                   = string
+    repoAdmin_serviceaccounts = optional(list(string), [])
     writer_serviceaccounts = optional(list(string), [])
-    reader_serviceaccounts = list(string)
+    reader_serviceaccounts = optional(list(string), [])
     primary_area           = optional(string, "europe")
     multi_region           = optional(bool, true)
     public                 = optional(bool, false)

--- a/configs/terraform/environments/prod/artifact-registry-variables.tf
+++ b/configs/terraform/environments/prod/artifact-registry-variables.tf
@@ -6,6 +6,7 @@ variable "kyma_project_artifact_registry_collection" {
     name  = string
     owner = string
     type  = string
+    description = string
     repoAdmin_serviceaccounts = optional(list(string), [])
     writer_serviceaccounts = optional(list(string), [])
     reader_serviceaccounts = optional(list(string), [])

--- a/configs/terraform/environments/prod/artifact-registry-variables.tf
+++ b/configs/terraform/environments/prod/artifact-registry-variables.tf
@@ -4,16 +4,16 @@
 variable "kyma_project_artifact_registry_collection" {
   description = "Artifact Registry related data set"
   type = map(object({
-    name                   = string
-    owner                  = string
-    type                   = string
+    name  = string
+    owner = string
+    type  = string
     repoAdmin_serviceaccounts = optional(list(string), [])
     writer_serviceaccounts = optional(list(string), [])
     reader_serviceaccounts = optional(list(string), [])
-    primary_area           = optional(string, "europe")
-    multi_region           = optional(bool, true)
-    public                 = optional(bool, false)
-    immutable              = optional(bool, false)
+    primary_area = optional(string, "europe")
+    multi_region = optional(bool, true)
+    public = optional(bool, false)
+    immutable = optional(bool, false)
   }))
 }
 

--- a/configs/terraform/environments/prod/artifact-registry.tf
+++ b/configs/terraform/environments/prod/artifact-registry.tf
@@ -8,6 +8,7 @@ module "artifact_registry" {
 
   for_each        = var.kyma_project_artifact_registry_collection
   repository_name = each.value.name
+  description = each.value.description
   type            = each.value.type
   immutable_tags  = each.value.immutable
   multi_region    = each.value.multi_region

--- a/configs/terraform/environments/prod/artifact-registry.tf
+++ b/configs/terraform/environments/prod/artifact-registry.tf
@@ -6,12 +6,12 @@ module "artifact_registry" {
   }
 
 
-  for_each               = var.kyma_project_artifact_registry_collection
-  registry_name          = each.value.name
-  type                   = each.value.type
-  immutable_tags         = each.value.immutable
-  multi_region           = each.value.multi_region
-  owner                  = each.value.owner
+  for_each        = var.kyma_project_artifact_registry_collection
+  repository_name = each.value.name
+  type            = each.value.type
+  immutable_tags  = each.value.immutable
+  multi_region    = each.value.multi_region
+  owner           = each.value.owner
   repoAdmin_serviceaccounts = each.value.repoAdmin_serviceaccounts
   reader_serviceaccounts = each.value.reader_serviceaccounts
   public                 = each.value.public

--- a/configs/terraform/environments/prod/artifact-registry.tf
+++ b/configs/terraform/environments/prod/artifact-registry.tf
@@ -12,7 +12,7 @@ module "artifact_registry" {
   immutable_tags         = each.value.immutable
   multi_region           = each.value.multi_region
   owner                  = each.value.owner
-  writer_serviceaccounts = each.value.writer_serviceaccounts
+  repoAdmin_serviceaccounts = each.value.repoAdmin_serviceaccounts
   reader_serviceaccounts = each.value.reader_serviceaccounts
   public                 = each.value.public
 }

--- a/configs/terraform/environments/prod/terraform.tfvars
+++ b/configs/terraform/environments/prod/terraform.tfvars
@@ -3,6 +3,7 @@ kyma_project_artifact_registry_collection = {
     name = "modules-internal"
     owner = "neighbors"
     type = "production"
+    description = "modules-internal registry"
     reader_serviceaccounts = [
       "klm-controller-manager@sap-ti-dx-kyma-mps-dev.iam.gserviceaccount.com",
       "klm-controller-manager@sap-ti-dx-kyma-mps-stage.iam.gserviceaccount.com",

--- a/configs/terraform/environments/prod/terraform.tfvars
+++ b/configs/terraform/environments/prod/terraform.tfvars
@@ -1,9 +1,13 @@
 kyma_project_artifact_registry_collection = {
   modules-internal = {
-    name                   = "modules-internal"
-    owner                  = "neighbors"
-    type                   = "production"
-    reader_serviceaccounts = ["klm-controller-manager@sap-ti-dx-kyma-mps-dev.iam.gserviceaccount.com", "klm-controller-manager@sap-ti-dx-kyma-mps-stage.iam.gserviceaccount.com", "klm-controller-manager@sap-ti-dx-kyma-mps-prod.iam.gserviceaccount.com"]
+    name = "modules-internal"
+    owner = "neighbors"
+    type = "production"
+    reader_serviceaccounts = [
+      "klm-controller-manager@sap-ti-dx-kyma-mps-dev.iam.gserviceaccount.com",
+      "klm-controller-manager@sap-ti-dx-kyma-mps-stage.iam.gserviceaccount.com",
+      "klm-controller-manager@sap-ti-dx-kyma-mps-prod.iam.gserviceaccount.com"
+    ]
     repoAdmin_serviceaccounts = ["kyma-submission-pipeline@kyma-project.iam.gserviceaccount.com"]
   },
 }

--- a/configs/terraform/environments/prod/terraform.tfvars
+++ b/configs/terraform/environments/prod/terraform.tfvars
@@ -4,7 +4,7 @@ kyma_project_artifact_registry_collection = {
     owner                  = "neighbors"
     type                   = "production"
     reader_serviceaccounts = ["klm-controller-manager@sap-ti-dx-kyma-mps-dev.iam.gserviceaccount.com", "klm-controller-manager@sap-ti-dx-kyma-mps-stage.iam.gserviceaccount.com", "klm-controller-manager@sap-ti-dx-kyma-mps-prod.iam.gserviceaccount.com"]
-    writer_serviceaccounts = ["kyma-submission-pipeline@kyma-project.iam.gserviceaccount.com"]
+    repoAdmin_serviceaccounts = ["kyma-submission-pipeline@kyma-project.iam.gserviceaccount.com"]
   },
 }
 service_account_keys_rotator_service_name            = "service-account-keys-rotator"

--- a/configs/terraform/modules/artifact-registry/main.tf
+++ b/configs/terraform/modules/artifact-registry/main.tf
@@ -10,10 +10,10 @@ locals {
 }
 
 resource "google_artifact_registry_repository" "artifact_registry" {
-  location = local.location
-  repository_id = lower(var.registry_name)
-  description   = "${lower(var.registry_name)} registry"
-  format        = "DOCKER"
+  location    = local.location
+  repository_id = lower(var.repository_name)
+  description = var.description
+  format      = var.format
 
   labels = {
     name = lower(var.registry_name)

--- a/configs/terraform/modules/artifact-registry/main.tf
+++ b/configs/terraform/modules/artifact-registry/main.tf
@@ -53,7 +53,7 @@ resource "google_artifact_registry_repository_iam_member" "service_account_reade
 }
 
 resource "google_artifact_registry_repository_iam_member" "public_access" {
-  count = var.public ? 1 : 0
+  count    = var.public ? 1 : 0
   project    = data.google_client_config.this.project
   location = local.location
   repository = google_artifact_registry_repository.artifact_registry.name

--- a/configs/terraform/modules/artifact-registry/main.tf
+++ b/configs/terraform/modules/artifact-registry/main.tf
@@ -25,7 +25,7 @@ resource "google_artifact_registry_repository" "artifact_registry" {
   }
 }
 
-resource "google_artifact_registry_repository_iam_member" "repoAdmin_service_account_access" {
+resource "google_artifact_registry_repository_iam_member" "service_account_repoAdmin_access" {
   for_each = toset(var.repoAdmin_serviceaccounts)
   project    = data.google_client_config.this.project
   location = local.location
@@ -34,7 +34,7 @@ resource "google_artifact_registry_repository_iam_member" "repoAdmin_service_acc
   member     = "serviceAccount:${each.value}"
 }
 
-resource "google_artifact_registry_repository_iam_member" "writer_service_account_access" {
+resource "google_artifact_registry_repository_iam_member" "service_account_writer_access" {
   for_each = toset(var.writer_serviceaccounts)
   project    = data.google_client_config.this.project
   location   = local.location
@@ -43,7 +43,7 @@ resource "google_artifact_registry_repository_iam_member" "writer_service_accoun
   member     = "serviceAccount:${each.value}"
 }
 
-resource "google_artifact_registry_repository_iam_member" "reader_service_account_access" {
+resource "google_artifact_registry_repository_iam_member" "service_account_reader_access" {
   for_each   = toset(var.reader_serviceaccounts)
   project    = data.google_client_config.this.project
   location = local.location
@@ -55,7 +55,7 @@ resource "google_artifact_registry_repository_iam_member" "reader_service_accoun
 resource "google_artifact_registry_repository_iam_member" "public_access" {
   count = var.public ? 1 : 0
   project    = data.google_client_config.this.project
-  location   = var.multi_region == true ? var.primary_area : data.google_client_config.this.region
+  location = local.location
   repository = google_artifact_registry_repository.artifact_registry.name
   role       = "roles/artifactregistry.reader"
   member     = "allUsers"

--- a/configs/terraform/modules/artifact-registry/main.tf
+++ b/configs/terraform/modules/artifact-registry/main.tf
@@ -1,13 +1,22 @@
 data "google_client_config" "this" {}
 
+# Get correct location based on multi_region flag.
+locals {
+  location = var.multi_region ? (
+    var.primary_area != "" ? var.primary_area : error("multi_region is true, but primary_area is not set.")
+  ) : (
+    var.location != "" ? var.location : error("multi_region is false, but location is not set.")
+  )
+}
+
 resource "google_artifact_registry_repository" "artifact_registry" {
-  location      = var.multi_region == true ? var.primary_area : data.google_client_config.this.region
+  location = local.location
   repository_id = lower(var.registry_name)
   description   = "${lower(var.registry_name)} registry"
   format        = "DOCKER"
 
   labels = {
-    name  = "${lower(var.registry_name)}"
+    name = lower(var.registry_name)
     owner = var.owner
     type  = var.type
   }
@@ -16,26 +25,35 @@ resource "google_artifact_registry_repository" "artifact_registry" {
   }
 }
 
-resource "google_artifact_registry_repository_iam_member" "writer_service_account" {
-  for_each   = toset(var.writer_serviceaccounts)
+resource "google_artifact_registry_repository_iam_member" "repoAdmin_service_account_access" {
+  for_each = toset(var.repoAdmin_serviceaccounts)
   project    = data.google_client_config.this.project
-  location   = var.multi_region == true ? var.primary_area : data.google_client_config.this.region
+  location = local.location
   repository = google_artifact_registry_repository.artifact_registry.name
   role       = "roles/artifactregistry.repoAdmin"
   member     = "serviceAccount:${each.value}"
 }
 
-resource "google_artifact_registry_repository_iam_member" "reader_service_accounts" {
+resource "google_artifact_registry_repository_iam_member" "writer_service_account_access" {
+  for_each = toset(var.writer_serviceaccounts)
+  project    = data.google_client_config.this.project
+  location   = local.location
+  repository = google_artifact_registry_repository.artifact_registry.name
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:${each.value}"
+}
+
+resource "google_artifact_registry_repository_iam_member" "reader_service_account_access" {
   for_each   = toset(var.reader_serviceaccounts)
   project    = data.google_client_config.this.project
-  location   = var.multi_region == true ? var.primary_area : data.google_client_config.this.region
+  location = local.location
   repository = google_artifact_registry_repository.artifact_registry.name
   role       = "roles/artifactregistry.reader"
   member     = "serviceAccount:${each.value}"
 }
 
 resource "google_artifact_registry_repository_iam_member" "public_access" {
-  count      = var.public == true ? 1 : 0
+  count = var.public ? 1 : 0
   project    = data.google_client_config.this.project
   location   = var.multi_region == true ? var.primary_area : data.google_client_config.this.region
   repository = google_artifact_registry_repository.artifact_registry.name

--- a/configs/terraform/modules/artifact-registry/main.tf
+++ b/configs/terraform/modules/artifact-registry/main.tf
@@ -16,7 +16,7 @@ resource "google_artifact_registry_repository" "artifact_registry" {
   format      = var.format
 
   labels = {
-    name = lower(var.registry_name)
+    name = lower(var.repository_name)
     owner = var.owner
     type  = var.type
   }

--- a/configs/terraform/modules/artifact-registry/variables.tf
+++ b/configs/terraform/modules/artifact-registry/variables.tf
@@ -15,16 +15,19 @@ variable "owner" {
 variable "repoAdmin_serviceaccounts" {
   type = list(string)
   description = "Service Accounts with reapoAdmin access"
+  default = []
 }
 
 variable "writer_serviceaccounts" {
   type        = list(string)
   description = "Service Accounts with write access"
+  default = []
 }
 
 variable "reader_serviceaccounts" {
   type        = list(string)
   description = "Service Accounts with read access"
+  default = []
 }
 
 variable "type" {

--- a/configs/terraform/modules/artifact-registry/variables.tf
+++ b/configs/terraform/modules/artifact-registry/variables.tf
@@ -1,9 +1,6 @@
-###################################
-# Artifact Registry related values
-###################################
-variable "registry_name" {
+variable "repository_name" {
   type        = string
-  description = "Artifact Registry name"
+  description = "Artifact Registry repository name"
 }
 
 variable "owner" {
@@ -69,9 +66,16 @@ variable "location" {
   type        = string
   description = "Location of the Artifact Registry for non multi-region repositories"
   default     = "europe"
+}
 
-  validation {
-    condition = var.location != ""
-    error_message = "When multi_region is false, location must be set."
-  }
+variable "description" {
+  type        = string
+  description = "Description of the Artifact Registry"
+  default     = "Artifact Registry for kyma-project"
+}
+
+variable "format" {
+  type        = string
+  description = "Format of the Artifact Registry"
+  default     = "DOCKER"
 }

--- a/configs/terraform/modules/artifact-registry/variables.tf
+++ b/configs/terraform/modules/artifact-registry/variables.tf
@@ -12,14 +12,19 @@ variable "owner" {
   default     = "neighbors"
 }
 
+variable "repoAdmin_serviceaccounts" {
+  type = list(string)
+  description = "Service Accounts with reapoAdmin access"
+}
+
 variable "writer_serviceaccounts" {
   type        = list(string)
-  description = "Service Accounts with reapoAdmin access"
+  description = "Service Accounts with write access"
 }
 
 variable "reader_serviceaccounts" {
   type        = list(string)
-  description = "Service Accounts with read access (lifecycle-maneger)"
+  description = "Service Accounts with read access"
 }
 
 variable "type" {
@@ -30,14 +35,19 @@ variable "type" {
 
 variable "multi_region" {
   type        = bool
-  description = "Is Location type Multi-region"
+  description = "Is Artifact Registry location type Multi-region"
   default     = true
 }
 
 variable "primary_area" {
   type        = string
-  description = "Location type Multi-region"
+  description = "Location of primary area of the Artifact Registry for multi-region repositories"
   default     = "europe"
+
+  validation {
+    condition     = var.multi_region == false || (var.multi_region == true && var.primary_area != "")
+    error_message = "When multi_region is true, primary_area must be set."
+  }
 }
 
 variable "immutable_tags" {
@@ -50,4 +60,15 @@ variable "public" {
   type        = bool
   description = "Is Artifact registry public"
   default     = false
+}
+
+variable "location" {
+  type        = string
+  description = "Location of the Artifact Registry for non multi-region repositories"
+  default     = "europe"
+
+  validation {
+    condition     = var.multi_region == true || (var.multi_region == false && var.location != "")
+    error_message = "When multi_region is false, location must be set."
+  }
 }

--- a/configs/terraform/modules/artifact-registry/variables.tf
+++ b/configs/terraform/modules/artifact-registry/variables.tf
@@ -45,7 +45,7 @@ variable "primary_area" {
   default     = "europe"
 
   validation {
-    condition     = var.multi_region == false || (var.multi_region == true && var.primary_area != "")
+    condition = var.primary_area != ""
     error_message = "When multi_region is true, primary_area must be set."
   }
 }
@@ -68,7 +68,7 @@ variable "location" {
   default     = "europe"
 
   validation {
-    condition     = var.multi_region == true || (var.multi_region == false && var.location != "")
+    condition = var.location != ""
     error_message = "When multi_region is false, location must be set."
   }
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Existing artifact registry terraform module was setting repoAdmin permissions for service accounts specified in variable for write access. The module was setting location based on authenticated client location if no value was provided in the config. Updated module to behave more predictable.

Changes proposed in this pull request:

Remove default values coming from authenticated client.
Update module to allow setting writer access.
Rename resources in module to correctly indicate real resource. Added validation for variables values.
Set default values for module variables providing lists of service accounts. It's not required anymore to define SAs for read access.

Config changes cause destroy of IAM permissions on artifact registry and recreation the same rights with improved and corrected resource names.

**Related issue(s)**
See #12816 
