### PR TITLE
Add Terraform Configuration for dev-kyma-modules and kyma-modules Repositories  

### DIFF
--- a/configs/terraform/environments/prod/artifact-registry-variables.tf
+++ b/configs/terraform/environments/prod/artifact-registry-variables.tf
@@ -1,6 +1,3 @@
-###################################
-# Artifact Registry related values
-###################################
 variable "kyma_project_artifact_registry_collection" {
   description = "Artifact Registry related data set"
   type = map(object({
@@ -14,8 +11,20 @@ variable "kyma_project_artifact_registry_collection" {
     multi_region = optional(bool, true)
     public = optional(bool, false)
     immutable = optional(bool, false)
+    cleanup_policy_dry_run = optional(bool, false)
+    cleanup_policies = optional(list(object({
+      id     = string
+      action = string
+      condition = optional(object({
+        tag_state = string
+        tag_prefixes = optional(list(string), [])
+        package_name_prefixes = optional(list(string), [])
+        older_than = optional(string, "")
+      }))
+    })))
   }))
 }
+
 
 variable "prod_docker_repository" {
   type = object({

--- a/configs/terraform/environments/prod/artifact-registry-variables.tf
+++ b/configs/terraform/environments/prod/artifact-registry-variables.tf
@@ -1,3 +1,4 @@
+# TODO (dekiel): remove after migration to modulectl is done
 variable "kyma_project_artifact_registry_collection" {
   type = map(object({
     name  = string
@@ -26,6 +27,7 @@ variable "kyma_project_artifact_registry_collection" {
 }
 
 
+# TODO (dekiel): move to the module modules/artifact-registry
 variable "prod_docker_repository" {
   type = object({
     name                   = string
@@ -51,6 +53,7 @@ variable "prod_docker_repository" {
   }
 }
 
+# TODO (dekiel): move to the module modules/artifact-registry
 variable "docker_dev_repository" {
   type = object({
     name                   = string

--- a/configs/terraform/environments/prod/artifact-registry.tf
+++ b/configs/terraform/environments/prod/artifact-registry.tf
@@ -6,15 +6,17 @@ module "artifact_registry" {
   }
 
 
-  for_each        = var.kyma_project_artifact_registry_collection
-  repository_name = each.value.name
-  type            = each.value.type
-  immutable_tags  = each.value.immutable
-  multi_region    = each.value.multi_region
-  owner           = each.value.owner
+  for_each               = var.kyma_project_artifact_registry_collection
+  repository_name        = each.value.name
+  type                   = each.value.type
+  immutable_tags         = each.value.immutable
+  multi_region           = each.value.multi_region
+  owner                  = each.value.owner
   repoAdmin_serviceaccounts = each.value.repoAdmin_serviceaccounts
   reader_serviceaccounts = each.value.reader_serviceaccounts
   public                 = each.value.public
+  cleanup_policy_dry_run = each.value.cleanup_policy_dry_run
+  cleanup_policies       = each.value.cleanup_policies
 }
 
 resource "google_artifact_registry_repository" "prod_docker_repository" {

--- a/configs/terraform/environments/prod/artifact-registry.tf
+++ b/configs/terraform/environments/prod/artifact-registry.tf
@@ -1,3 +1,4 @@
+# TODO (dekiel): remove after migration to modulectl is done
 module "artifact_registry" {
   source = "../../modules/artifact-registry"
 
@@ -20,6 +21,7 @@ module "artifact_registry" {
   cleanup_policies       = each.value.cleanup_policies
 }
 
+# TODO (dekiel): move to the module modules/artifact-registry
 resource "google_artifact_registry_repository" "prod_docker_repository" {
   provider               = google.kyma_project
   labels                 = var.prod_docker_repository.labels
@@ -41,6 +43,7 @@ resource "google_artifact_registry_repository" "prod_docker_repository" {
   }
 }
 
+# TODO (dekiel): move to the module modules/artifact-registry
 resource "google_artifact_registry_repository" "docker_dev" {
   provider               = google.kyma_project
   location               = var.docker_dev_repository.location

--- a/configs/terraform/environments/prod/modules-submission-variables.tf
+++ b/configs/terraform/environments/prod/modules-submission-variables.tf
@@ -27,3 +27,33 @@ variable "dev_modules_internal_repository" {
     }
   }
 }
+
+variable "dev_kyma_modules_repository" {
+  type = object({
+    name        = string
+    description = string
+  })
+  default = {
+    name        = "dev-kyma-modules"
+    description = "Development Kyma modules"
+  }
+}
+
+variable "kyma_modules_repository" {
+  type = object({
+    name        = string
+    description = string
+    type        = string
+    reader_serviceaccounts = list(string)
+  })
+  default = {
+    name        = "kyma-modules"
+    description = "Production Kyma modules"
+    type        = "production"
+    reader_serviceaccounts = [
+      "klm-controller-manager@sap-ti-dx-kyma-mps-dev.iam.gserviceaccount.com",
+      "klm-controller-manager@sap-ti-dx-kyma-mps-stage.iam.gserviceaccount.com",
+      "klm-controller-manager@sap-ti-dx-kyma-mps-prod.iam.gserviceaccount.com"
+    ]
+  }
+}

--- a/configs/terraform/environments/prod/modules-submission.tf
+++ b/configs/terraform/environments/prod/modules-submission.tf
@@ -44,3 +44,29 @@ resource "google_artifact_registry_repository_iam_member" "dev_modules_internal_
   role       = "roles/artifactregistry.repoAdmin"
   member     = "serviceAccount:${google_service_account.kyma_project_kyma_submission_pipeline.email}"
 }
+
+module "dev_kyma_modules" {
+  source = "../../modules/artifact-registry"
+
+  providers = {
+    google = google.kyma_project
+  }
+
+  repository_name = var.dev_kyma_modules_repository.name
+  description     = var.dev_kyma_modules_repository.description
+  repoAdmin_serviceaccounts = [google_service_account.kyma_project_kyma_submission_pipeline.email]
+}
+
+module "kyma_modules" {
+  source = "../../modules/artifact-registry"
+
+  providers = {
+    google = google.kyma_project
+  }
+
+  repository_name        = var.kyma_modules_repository.name
+  description            = var.kyma_modules_repository.description
+  type                   = var.kyma_modules_repository.type
+  reader_serviceaccounts = var.kyma_modules_repository.reader_serviceaccounts
+  repoAdmin_serviceaccounts = [google_service_account.kyma_project_kyma_submission_pipeline.email]
+}

--- a/configs/terraform/environments/prod/modules-submission.tf
+++ b/configs/terraform/environments/prod/modules-submission.tf
@@ -3,6 +3,7 @@ import {
   id = "projects/kyma-project/locations/europe/repositories/dev-modules-internal"
 }
 
+# TODO (dekiel): remove after migration to modulectl is done
 resource "google_artifact_registry_repository" "dev_modules_internal" {
   provider               = google.kyma_project
   location               = var.dev_modules_internal_repository.location
@@ -22,8 +23,8 @@ import {
   to = google_service_account.kyma_project_kyma_submission_pipeline
 }
 
-# The submission pipeline should have only one identity in our projects.
-# The service account in kyma-project should be removed.
+# TODO (dekiel): The submission pipeline should have only one identity in our projects.
+#   The service account in kyma-project should be removed.
 resource "google_service_account" "kyma_project_kyma_submission_pipeline" {
   provider     = google.kyma_project
   account_id   = "kyma-submission-pipeline"

--- a/configs/terraform/modules/artifact-registry/main.tf
+++ b/configs/terraform/modules/artifact-registry/main.tf
@@ -10,18 +10,37 @@ locals {
 }
 
 resource "google_artifact_registry_repository" "artifact_registry" {
-  location    = local.location
+  location               = local.location
   repository_id = lower(var.repository_name)
-  description = var.description
-  format      = var.format
+  description            = var.description
+  format                 = var.format
+  cleanup_policy_dry_run = var.cleanup_policy_dry_run
 
   labels = {
-    name = lower(var.registry_name)
+    name = lower(var.repository_name)
     owner = var.owner
     type  = var.type
   }
+
   docker_config {
     immutable_tags = var.immutable_tags
+  }
+
+  dynamic "cleanup_policies" {
+    for_each = coalesce(var.cleanup_policies, [])
+    iterator = policy
+
+    content {
+      id     = policy.value.id
+      action = policy.value.action
+
+      condition {
+        tag_state = try(policy.value.condition.tag_state, null)
+        tag_prefixes = try(policy.value.condition.tag_prefixes, null)
+        older_than = try(policy.value.condition.older_than, null)
+      }
+    }
+
   }
 }
 

--- a/configs/terraform/modules/artifact-registry/variables.tf
+++ b/configs/terraform/modules/artifact-registry/variables.tf
@@ -31,6 +31,11 @@ variable "type" {
   type        = string
   description = "Environment for the resources"
   default     = "development"
+
+  validation {
+    condition = contains(["development", "production"], var.type)
+    error_message = "Type must be either 'development' or 'production'."
+  }
 }
 
 variable "multi_region" {
@@ -43,11 +48,6 @@ variable "primary_area" {
   type        = string
   description = "Location of primary area of the Artifact Registry for multi-region repositories"
   default     = "europe"
-
-  validation {
-    condition = var.primary_area != ""
-    error_message = "When multi_region is true, primary_area must be set."
-  }
 }
 
 variable "immutable_tags" {
@@ -71,11 +71,41 @@ variable "location" {
 variable "description" {
   type        = string
   description = "Description of the Artifact Registry"
-  default     = "Artifact Registry for kyma-project"
+  default = ""
 }
 
 variable "format" {
   type        = string
   description = "Format of the Artifact Registry"
   default     = "DOCKER"
+}
+
+variable "mode" {
+  type        = string
+  description = "Mode of the Artifact Registry"
+  default     = "STANDARD_REPOSITORY"
+
+  validation {
+    condition = contains(["STANDARD_REPOSITORY", "VIRTUAL_REPOSITORY"], var.mode)
+    error_message = "Mode must be either 'STANDARD_REPOSITORY' or 'VIRTUAL_REPOSITORY'."
+  }
+}
+
+variable "cleanup_policy_dry_run" {
+  type        = bool
+  description = "Is cleanup policy dry run"
+  default     = false
+}
+
+variable "cleanup_policies" {
+  type = list(object({
+    id     = string
+    action = string
+    condition = optional(object({
+      tag_state = optional(string)
+      older_than = optional(string)
+      tag_prefixes = optional(list(string))
+    }))
+  }))
+  default = []
 }


### PR DESCRIPTION
**Description:**  
This pull request introduces Terraform configurations for creating the `dev-kyma-modules` and `kyma-modules` repositories.
Additionally, it includes improvements for better maintainability and scalability of the codebase, such as:  
- Modularizing artifact registry configurations.  
- Adding new variables (e.g., `cleanup_policies`, `repoAdmin_serviceaccounts`) to enhance configurability.  
- Improving validation and error handling for multi-region and non-multi-region setups.  
- Addressing technical debt by moving repetitive configurations into reusable modules.  

These changes aim to enhance clarity, reduce potential misconfigurations, and improve the overall maintainability of the infrastructure code.

Parent: #12816 