### PR TITLE
Add support for multiple platform in image builder client

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -268,6 +268,13 @@ func prepareADOTemplateParameters(options options) (adopipelines.OCIImageBuilder
 		templateParameters.SetUseGoInternalSAPModules()
 	}
 
+	if len(options.platforms) > 0 {
+		templateParameters.SetPlatforms(options.platforms.String())
+	} else {
+		// Set default platforms to linux/amd64,linux/arm64, if not set. There is no way to set during flag parsing.
+		templateParameters.SetPlatforms("linux/amd64,linux/arm64")
+	}
+
 	err := templateParameters.Validate()
 	if err != nil {
 		return nil, fmt.Errorf("failed validating ADO template parameters, err: %w", err)
@@ -847,7 +854,7 @@ func (o *options) gatherOptions(flagSet *flag.FlagSet) *flag.FlagSet {
 	flagSet.Var(&o.tags, "tag", "Additional tag that the image will be tagged with. Optionally you can pass the name in the format name=value which will be used by export-tags")
 	flagSet.StringVar(&o.tagsBase64, "tag-base64", "", "String representation of all tags encoded by base64. String representation must be in format as output of kyma-project/test-infra/pkg/tags.Tags.String() method")
 	flagSet.Var(&o.buildArgs, "build-arg", "Flag to pass additional arguments to build dockerfile. It can be used in the name=value format.")
-	flagSet.Var(&o.platforms, "platform", "Only supported with BuildKit. Platform of the image that is built")
+	flagSet.Var(&o.platforms, "platform", "Platform of the image that is built (default: linux/amd64,linux/arm64)")
 	flagSet.BoolVar(&o.exportTags, "export-tags", false, "Export parsed tags as build-args into dockerfile. Each tag will have format TAG_x, where x is the tag name passed along with the tag")
 	flagSet.BoolVar(&o.signOnly, "sign-only", false, "Only sign the image, do not build it")
 	flagSet.Var(&o.imagesToSign, "images-to-sign", "Comma-separated list of images to sign. Only used when sign-only flag is set")

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -316,6 +316,20 @@ func TestFlags(t *testing.T) {
 				"--build-arg=BIN2=test2",
 			},
 		},
+		{
+			name: "custom platforms, pass",
+			expectedOpts: options{
+				context:        ".",
+				configPath:     "/config/image-builder-config.yaml",
+				dockerfile:     "dockerfile",
+				logDir:         "/logs/artifacts",
+				tagsOutputFile: "/generated-tags.json",
+				platforms:      []string{"linux/amd64"},
+			},
+			args: []string{
+				"--platform=linux/amd64",
+			},
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -829,6 +843,7 @@ func Test_prepareADOTemplateParameters(t *testing.T) {
 				"RepoName":    "",
 				"RepoOwner":   "",
 				"Tags":        "e3sgLkVudiAiR09MQU5HX1ZFUlNJT04iIH19LVNob3J0U0hBPXt7IC5FbnYgIkdPTEFOR19WRVJTSU9OIiB9fS17eyAuU2hvcnRTSEEgfX0=",
+				"Platforms":   "linux/amd64,linux/arm64",
 			},
 		},
 		{
@@ -854,6 +869,7 @@ func Test_prepareADOTemplateParameters(t *testing.T) {
 				"RepoName":    "",
 				"RepoOwner":   "",
 				"Tags":        "e3sgLkVudiAiR09MQU5HX1ZFUlNJT04iIH19LVNob3J0U0hBPXt7IC5FbnYgIkdPTEFOR19WRVJTSU9OIiB9fS17eyAuU2hvcnRTSEEgfX0=",
+				"Platforms":   "linux/amd64,linux/arm64",
 			},
 		},
 	}

--- a/pkg/azuredevops/pipelines/templatesParams.go
+++ b/pkg/azuredevops/pipelines/templatesParams.go
@@ -150,6 +150,15 @@ func (p OCIImageBuilderTemplateParams) SetUseGoInternalSAPModules() {
 	p["UseGoInternalSAPModules"] = "true"
 }
 
+// SetPlatform sets Platform parameter.
+// This parameter is used to set the platform for the image build.
+// It is used to specify the target architecture and OS for the image.
+// For example, "linux/amd64" or "linux/arm64".
+// Multiple platforms can be specified as a comma-separated list.
+func (p OCIImageBuilderTemplateParams) SetPlatforms(platforms string) {
+	p["Platforms"] = platforms
+}
+
 // Validate validates if required OCIImageBuilderTemplateParams are set.
 // Returns ErrRequiredParamNotSet error if any required parameter is not set.
 func (p OCIImageBuilderTemplateParams) Validate() error {

--- a/pkg/azuredevops/pipelines/templatesParams_test.go
+++ b/pkg/azuredevops/pipelines/templatesParams_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Test OCIImageBuilderTemplateParams", func() {
 
 	It("sets the correct Platform", func() {
 		params.SetPlatforms("linux/amd64")
-		Expect(params["Platform"]).To(Equal("linux/amd64"))
+		Expect(params["Platforms"]).To(Equal("linux/amd64"))
 	})
 
 	// TODO: Improve assertions with more specific matchers and values.

--- a/pkg/azuredevops/pipelines/templatesParams_test.go
+++ b/pkg/azuredevops/pipelines/templatesParams_test.go
@@ -97,6 +97,11 @@ var _ = Describe("Test OCIImageBuilderTemplateParams", func() {
 		Expect(params["UseGoInternalSAPModules"]).To(Equal("true"))
 	})
 
+	It("sets the correct Platform", func() {
+		params.SetPlatforms("linux/amd64")
+		Expect(params["Platform"]).To(Equal("linux/amd64"))
+	})
+
 	// TODO: Improve assertions with more specific matchers and values.
 	It("validates the params correctly", func() {
 		// Set all required parameters


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Default value is set during template parameters preparation as image-builder client will be reduced in [#12850](https://github.com/kyma-project/test-infra/issues/12850). We cannot set default value for `flagSet.Var` function and no other flag type is suitable for our needs.

Support in workflows will be added in separate PR together with changes from #12939 as bot hrequire image bump before.

Changes proposed in this pull request:

- Add support for platform parameter in oci image builder

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: https://github.com/kyma-project/test-infra/issues/12829