### PR TITLE
Remove print-image steps from multiple build YAML files.

### DIFF
--- a/.github/workflows/build-automated-approver.yml
+++ b/.github/workflows/build-automated-approver.yml
@@ -30,9 +30,3 @@ jobs:
       name: automated-approver
       dockerfile: cmd/external-plugins/automated-approver/Dockerfile
       context: .
-  print-image:
-    runs-on: ubuntu-latest
-    needs: build-image
-    steps:
-      - name: Print image
-        run: echo "Image built ${{ needs.build-image.outputs.images }}"

--- a/.github/workflows/build-cors-proxy.yml
+++ b/.github/workflows/build-cors-proxy.yml
@@ -30,9 +30,3 @@ jobs:
       name: cors-proxy
       dockerfile: cmd/cloud-run/cors-proxy/Dockerfile
       context: .
-  print-image:
-    runs-on: ubuntu-latest
-    needs: build-image
-    steps:
-      - name: Print image
-        run: echo "Image built ${{ needs.build-image.outputs.images }}"

--- a/.github/workflows/build-dashboard-token-proxy.yml
+++ b/.github/workflows/build-dashboard-token-proxy.yml
@@ -30,9 +30,3 @@ jobs:
       name: dashboard-token-proxy
       dockerfile: cmd/dashboard-token-proxy/Dockerfile
       context: .
-  print-image:
-    runs-on: ubuntu-latest
-    needs: build-image
-    steps:
-      - name: Print image
-        run: echo "Image built ${{ needs.build-image.outputs.images }}"

--- a/.github/workflows/build-github-webhook-gateway.yml
+++ b/.github/workflows/build-github-webhook-gateway.yml
@@ -30,9 +30,3 @@ jobs:
       name: github-webhook-gateway
       dockerfile: cmd/cloud-run/github-webhook-gateway/Dockerfile
       context: .
-  print-image:
-    runs-on: ubuntu-latest
-    needs: build-image
-    steps:
-      - name: Print image
-        run: echo "Image built ${{ needs.build-image.outputs.images }}"

--- a/.github/workflows/build-image-url-helper.yml
+++ b/.github/workflows/build-image-url-helper.yml
@@ -30,9 +30,3 @@ jobs:
       name: image-url-helper
       dockerfile: cmd/image-url-helper/Dockerfile
       context: .
-  print-image:
-    runs-on: ubuntu-latest
-    needs: build-image
-    steps:
-      - name: Print image
-        run: echo "Image built ${{ needs.build-image.outputs.images }}"

--- a/.github/workflows/build-markdown-index.yml
+++ b/.github/workflows/build-markdown-index.yml
@@ -30,9 +30,3 @@ jobs:
       name: markdown-index
       dockerfile: cmd/markdown-index/Dockerfile
       context: .
-  print-image:
-    runs-on: ubuntu-latest
-    needs: build-image
-    steps:
-      - name: Print image
-        run: echo "Image built ${{ needs.build-image.outputs.images }}"

--- a/.github/workflows/build-usersmapchecker.yml
+++ b/.github/workflows/build-usersmapchecker.yml
@@ -30,9 +30,3 @@ jobs:
       name: usersmapchecker
       dockerfile: cmd/tools/usersmapchecker/Dockerfile
       context: .
-  print-image:
-    runs-on: ubuntu-latest
-    needs: build-image
-    steps:
-      - name: Print image
-        run: echo "Image built ${{ needs.build-image.outputs.images }}"

--- a/.github/workflows/pull-build-image-autobumper.yaml
+++ b/.github/workflows/pull-build-image-autobumper.yaml
@@ -20,9 +20,3 @@ jobs:
       name: image-autobumper
       dockerfile: cmd/image-autobumper/Dockerfile
       context: .
-  print-image:
-    runs-on: ubuntu-latest
-    needs: build-image
-    steps:
-      - name: Print image
-        run: echo "Image built ${{ needs.build-image.outputs.images }}"

--- a/.github/workflows/pull-build-image-detector.yml
+++ b/.github/workflows/pull-build-image-detector.yml
@@ -20,9 +20,3 @@ jobs:
       name: image-detector
       dockerfile: cmd/image-detector/Dockerfile
       context: .
-  print-image:
-    runs-on: ubuntu-latest
-    needs: build-image
-    steps:
-      - name: Print image
-        run: echo "Image built ${{ needs.build-image.outputs.images }}"

--- a/.github/workflows/pull-build-image-syncer.yml
+++ b/.github/workflows/pull-build-image-syncer.yml
@@ -20,9 +20,3 @@ jobs:
       name: image-syncer
       dockerfile: cmd/image-syncer/Dockerfile
       context: .
-  print-image:
-    runs-on: ubuntu-latest
-    needs: build-image
-    steps:
-      - name: Print image
-        run: echo "Image built ${{ needs.build-image.outputs.images }}"

--- a/.github/workflows/push-build-image-autobumper.yaml
+++ b/.github/workflows/push-build-image-autobumper.yaml
@@ -22,9 +22,3 @@ jobs:
       name: image-autobumper
       dockerfile: cmd/image-autobumper/Dockerfile
       context: .
-  print-image:
-    runs-on: ubuntu-latest
-    needs: build-image
-    steps:
-      - name: Print image
-        run: echo "Image built ${{ needs.build-image.outputs.images }}"

--- a/.github/workflows/push-build-image-detector.yml
+++ b/.github/workflows/push-build-image-detector.yml
@@ -21,9 +21,3 @@ jobs:
       name: image-detector
       dockerfile: cmd/image-detector/Dockerfile
       context: .
-  print-image:
-    runs-on: ubuntu-latest
-    needs: build-image
-    steps:
-      - name: Print image
-        run: echo "Image built ${{ needs.build-image.outputs.images }}"

--- a/.github/workflows/push-build-image-syncer.yml
+++ b/.github/workflows/push-build-image-syncer.yml
@@ -21,9 +21,3 @@ jobs:
       name: image-syncer
       dockerfile: cmd/image-syncer/Dockerfile
       context: .
-  print-image:
-    runs-on: ubuntu-latest
-    needs: build-image
-    steps:
-      - name: Print image
-        run: echo "Image built ${{ needs.build-image.outputs.images }}"


### PR DESCRIPTION
This pull request removes the `print-image` job from multiple GitHub Actions workflow files. The `print-image` job was previously used to print built image information after the `build-image` step. At present the image-builder reusable workflow prints all built images in a workflow summary. This cleanup simplifies the workflows, decrease execution time and cost by eliminating unnecessary steps.

### Workflow cleanup:

* Removed the `print-image` job from the `.github/workflows/build-automated-approver.yml` workflow.
* Removed the `print-image` job from the `.github/workflows/build-cors-proxy.yml` workflow.
* Removed the `print-image` job from the `.github/workflows/build-dashboard-token-proxy.yml` workflow.
* Removed the `print-image` job from the `.github/workflows/build-github-webhook-gateway.yml` workflow.
* Removed the `print-image` job from the `.github/workflows/build-image-url-helper.yml` workflow.

* Removed the `print-image` job from the `.github/workflows/build-markdown-index.yml` workflow.
* Removed the `print-image` job from the `.github/workflows/build-usersmapchecker.yml` workflow.
* Removed the `print-image` job from the `.github/workflows/pull-build-image-autobumper.yaml` workflow.
* Removed the `print-image` job from the `.github/workflows/pull-build-image-detector.yml` workflow.
* Removed the `print-image` job from the `.github/workflows/pull-build-image-syncer.yml` workflow.

* Removed the `print-image` job from the `.github/workflows/push-build-image-autobumper.yaml` workflow.
* Removed the `print-image` job from the `.github/workflows/push-build-image-detector.yml` workflow.
* Removed the `print-image` job from the `.github/workflows/push-build-image-syncer.yml` workflow.