### PR TITLE
Enhance Infrastructure as Code guidelines

### DIFF
--- a/docs/guidelines_iac.md
+++ b/docs/guidelines_iac.md
@@ -21,8 +21,6 @@ and streamlined testing.
 Terraform configurations must reside within the `terraform` directory, structured and named per application or use case. Grouping by
 resource type is not permitted.
 
-For better readability and maintenance, the in config definitions must always be preferred over cli parameters or environment variables.
-
 Example structure:
 
 ```bash
@@ -46,6 +44,42 @@ terraform
         ├── output.tf
         ├── provider.tf
         └── variables.tf
+```
+
+For better readability and maintenance, the in config definitions must always be preferred over cli parameters or environment variables.
+
+When creating multiple instances of any resource—whether directly or via a module—each instance must be defined explicitly in the Terraform
+configuration.
+Avoid using `for_each`, `count`, or passing lists of values to generate multiple resources.
+This improves readability, simplifies change tracking, and reduces complexity in infrastructure code.
+
+**Example**
+
+Instead of:
+
+```hcl
+resource "google_project_iam_member" "example" {
+  for_each = toset(["user:a@example.com", "user:b@example.com"])
+  project = var.project_id
+  role    = "roles/viewer"
+  member  = each.value
+}
+```
+
+Use:
+
+```hcl
+resource "google_project_iam_member" "user_a" {
+  project = var.project_id
+  role    = "roles/viewer"
+  member  = "user:a@example.com"
+}
+
+resource "google_project_iam_member" "user_b" {
+  project = var.project_id
+  role    = "roles/viewer"
+  member  = "user:b@example.com"
+}
 ```
 
 ### Modules

--- a/docs/guidelines_iac.md
+++ b/docs/guidelines_iac.md
@@ -46,14 +46,13 @@ terraform
         └── variables.tf
 ```
 
-For better readability and maintenance, the in config definitions must always be preferred over cli parameters or environment variables.
+For better readability and maintenance, the in config definitions must always be preferred over CLI parameters or environment variables.
 
-When creating multiple instances of any resource—whether directly or via a module—each instance must be defined explicitly in the Terraform
+When creating multiple instances of any resource, whether directly or using a module, each instance must be defined explicitly in the Terraform
 configuration.
-Avoid using `for_each`, `count`, or passing lists of values to generate multiple resources.
-This improves readability, simplifies change tracking, and reduces complexity in infrastructure code.
+To improve readability, simplify change tracking, and reduce complexity in infrastructure code, avoid using `for_each`, `count`, or passing lists of values to generate multiple resources.
 
-**Example**
+See the following example.
 
 Instead of:
 


### PR DESCRIPTION
This pull request updates the Infrastructure as Code (IaC) guidelines in the `docs/guidelines_iac.md` file to enhance clarity and enforce agreements for Terraform configurations. The changes include adding a new guideline to avoid dynamic resource generation for better readability and maintainability.

### Updates to Terraform configuration guidelines:

* Added a new guideline to explicitly define multiple instances of resources in Terraform configurations, avoiding the use of `for_each`, `count`, or lists. This change aims to improve readability, simplify change tracking, and reduce complexity in infrastructure code. An example was included to illustrate the recommended approach.

See: #11946 