### PR TITLE
Remove collection suffix from output from artifact-registry module

### DIFF
--- a/configs/terraform/environments/prod/restricted-markets-delivery.tf
+++ b/configs/terraform/environments/prod/restricted-markets-delivery.tf
@@ -11,9 +11,9 @@ resource "google_service_account_iam_member" "restricted_markets_artifactregistr
 }
 
 resource "google_artifact_registry_repository_iam_member" "kyma_modules_reader" {
-  project    = module.kyma_modules.artifact_registry_collection.project
-  repository = module.kyma_modules.artifact_registry_collection.name
-  location   = module.kyma_modules.artifact_registry_collection.location
+  project    = module.kyma_modules.artifact_registry.project
+  repository = module.kyma_modules.artifact_registry.name
+  location   = module.kyma_modules.artifact_registry.location
   role       = "roles/artifactregistry.reader"
   member     = "serviceAccount:${google_service_account.restricted-markets-artifactregistry-reader.email}"
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Current output name is incorrect since the module itself is not responsible for collection of artifact registry and creates only one at the call. To align with real work of the `artifact-tegistry` module le'ts remove `collection` suffix from output name.

Changes proposed in this pull request:

- Remove `colleciton` suffix from output name

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: #13023 
See: #12925 