### PR TITLE
Use correct attribute reference to get secret path

### DIFF
--- a/configs/terraform/environments/prod/image-builder.tf
+++ b/configs/terraform/environments/prod/image-builder.tf
@@ -110,7 +110,7 @@ module "dockerhub_mirror" {
     description = var.dockerhub_mirror.remote_repository_config.description
     docker_public_repository = var.dockerhub_mirror.remote_repository_config.docker_public_repository
     upstream_username = var.dockerhub_credentials != null ? var.dockerhub_credentials.username : null
-    upstream_password_secret = data.google_secret_manager_secret_version.dockerhub_oat_secret[0].secret
+    upstream_password_secret = data.google_secret_manager_secret_version.dockerhub_oat_secret[0].name
   }
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- According to the [documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version), we should use .name reference to secret location.
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
[Error in apply tf](https://github.com/kyma-project/test-infra/actions/runs/15018176453/job/42200904977)
https://github.com/kyma-project/test-infra/pull/12929
Implements /kyma/test-infra/issues/626