### PR TITLE
Switch SA for image builder which uses ArtifactRegistry

### DIFF
--- a/configs/terraform/environments/prod/image-builder.tf
+++ b/configs/terraform/environments/prod/image-builder.tf
@@ -99,7 +99,7 @@ module "dockerhub_mirror" {
   repository_prevent_destroy = var.dockerhub_mirror.repository_prevent_destroy
   repository_name            = var.dockerhub_mirror.name
   description                = var.dockerhub_mirror.description
-  repoAdmin_serviceaccounts  = [google_service_account.kyma-oci-image-builder.email]
+  repoAdmin_serviceaccounts  = [google_service_account.kyma_project_image_builder.email]
   location                   = var.dockerhub_mirror.location
   format                     = var.dockerhub_mirror.format
   immutable_tags             = var.dockerhub_mirror.immutable_tags
@@ -125,7 +125,7 @@ module "docker_cache" {
   repository_prevent_destroy = var.docker_cache_repository.repository_prevent_destroy
   repository_name            = var.docker_cache_repository.name
   description                = var.docker_cache_repository.description
-  repoAdmin_serviceaccounts  = [google_service_account.kyma-oci-image-builder.email]
+  repoAdmin_serviceaccounts  = [google_service_account.kyma_project_image_builder.email]
   location                   = var.docker_cache_repository.location
   format                     = var.docker_cache_repository.format
   immutable_tags             = var.docker_cache_repository.immutable_tags


### PR DESCRIPTION
…mage-builder

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently we use wrong account for image builder pipeline. Thus, We have no access to artifact registry.
Changes proposed in this pull request:

- Switch from [kyma-oci-image-builder@sap-kyma-prow.iam.gserviceaccount.com](mailto:kyma-oci-image-builder@sap-kyma-prow.iam.gserviceaccount.com) to [azure-pipeline-image-builder@kyma-project.iam.gserviceaccount.com](mailto:azure-pipeline-image-builder@kyma-project.iam.gserviceaccount.com)
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/test-infra/pull/12929
Implements /kyma/test-infra/issues/626