### PR TITLE
Fix Autobumper

### DIFF
--- a/cmd/image-autobumper/imagebumper/imagebumper.go
+++ b/cmd/image-autobumper/imagebumper/imagebumper.go
@@ -17,10 +17,8 @@ limitations under the License.
 package imagebumper
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"regexp"
@@ -157,15 +155,6 @@ func (cli *Client) getManifest(imageHost, imageName string) (manifest, error) {
 		return nil, fmt.Errorf("couldn't fetch tag list: %w", err)
 	}
 	defer resp.Body.Close()
-
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't read response body: %w", err)
-	}
-
-	fmt.Println(string(bodyBytes))
-
-	resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
 	var result struct {
 		Manifest manifest `json:"manifest"`

--- a/cmd/image-autobumper/imagebumper/imagebumper_test.go
+++ b/cmd/image-autobumper/imagebumper/imagebumper_test.go
@@ -153,12 +153,12 @@ func TestPickBestTag(t *testing.T) {
 			tag:  "v20190329-811f7954b",
 			manifest: manifest{
 				"image1": {
-					TimeCreatedMs: "2000",
-					Tags:          []string{"v20190404-65af07d"},
+					TimeUploadedMs: "2000",
+					Tags:           []string{"v20190404-65af07d"},
 				},
 				"image2": {
-					TimeCreatedMs: "1000",
-					Tags:          []string{"v20190329-811f7954b"},
+					TimeUploadedMs: "1000",
+					Tags:           []string{"v20190329-811f7954b"},
 				},
 			},
 			bestTag: "v20190404-65af07d",
@@ -168,12 +168,12 @@ func TestPickBestTag(t *testing.T) {
 			tag:  "v20190329-811f7954b",
 			manifest: manifest{
 				"image1": {
-					TimeCreatedMs: "2000",
-					Tags:          []string{"v20190404-65af07d"},
+					TimeUploadedMs: "2000",
+					Tags:           []string{"v20190404-65af07d"},
 				},
 				"image2": {
-					TimeCreatedMs: "1000",
-					Tags:          []string{"v20190330-811f79999", "latest"},
+					TimeUploadedMs: "1000",
+					Tags:           []string{"v20190330-811f79999", "latest"},
 				},
 			},
 			bestTag: "v20190330-811f79999",
@@ -183,12 +183,12 @@ func TestPickBestTag(t *testing.T) {
 			tag:  "v20190329-811f7954b-experimental",
 			manifest: manifest{
 				"image1": {
-					TimeCreatedMs: "2000",
-					Tags:          []string{"v20190404-65af07d"},
+					TimeUploadedMs: "2000",
+					Tags:           []string{"v20190404-65af07d"},
 				},
 				"image2": {
-					TimeCreatedMs: "1000",
-					Tags:          []string{"v20190330-811f79999-experimental"},
+					TimeUploadedMs: "1000",
+					Tags:           []string{"v20190330-811f79999-experimental"},
 				},
 			},
 			bestTag: "v20190330-811f79999-experimental",
@@ -198,12 +198,12 @@ func TestPickBestTag(t *testing.T) {
 			tag:  "v20190329-811f7954b-experimental",
 			manifest: manifest{
 				"image1": {
-					TimeCreatedMs: "2000",
-					Tags:          []string{"v20190404-65af07d", "latest"},
+					TimeUploadedMs: "2000",
+					Tags:           []string{"v20190404-65af07d", "latest"},
 				},
 				"image2": {
-					TimeCreatedMs: "1000",
-					Tags:          []string{"v20190330-811f79999-experimental"},
+					TimeUploadedMs: "1000",
+					Tags:           []string{"v20190330-811f79999-experimental"},
 				},
 			},
 			bestTag: "v20190330-811f79999-experimental",
@@ -213,12 +213,12 @@ func TestPickBestTag(t *testing.T) {
 			tag:  "v20190329-811f7954b",
 			manifest: manifest{
 				"image1": {
-					TimeCreatedMs: "2000",
-					Tags:          []string{"v20190404-65af07d"},
+					TimeUploadedMs: "2000",
+					Tags:           []string{"v20190404-65af07d"},
 				},
 				"image2": {
-					TimeCreatedMs: "1000",
-					Tags:          []string{"v20190330-811f79999-experimental", "latest-experimental"},
+					TimeUploadedMs: "1000",
+					Tags:           []string{"v20190330-811f79999-experimental", "latest-experimental"},
 				},
 			},
 			bestTag: "v20190404-65af07d",
@@ -228,12 +228,12 @@ func TestPickBestTag(t *testing.T) {
 			tag:  "v20190329-811f7954b-experimental",
 			manifest: manifest{
 				"image1": {
-					TimeCreatedMs: "2000",
-					Tags:          []string{"v20190404-65af07d-experimental"},
+					TimeUploadedMs: "2000",
+					Tags:           []string{"v20190404-65af07d-experimental"},
 				},
 				"image2": {
-					TimeCreatedMs: "1000",
-					Tags:          []string{"v20190330-811f79999-experimental", "latest-experimental"},
+					TimeUploadedMs: "1000",
+					Tags:           []string{"v20190330-811f79999-experimental", "latest-experimental"},
 				},
 			},
 			bestTag: "v20190330-811f79999-experimental",
@@ -243,12 +243,12 @@ func TestPickBestTag(t *testing.T) {
 			tag:  "v20190329-811f7954b-master",
 			manifest: manifest{
 				"image1": {
-					TimeCreatedMs: "2000",
-					Tags:          []string{"v20190404-65af07d-experimental"},
+					TimeUploadedMs: "2000",
+					Tags:           []string{"v20190404-65af07d-experimental"},
 				},
 				"image2": {
-					TimeCreatedMs: "1000",
-					Tags:          []string{"v20190330-811f79999-experimental", "latest-experimental"},
+					TimeUploadedMs: "1000",
+					Tags:           []string{"v20190330-811f79999-experimental", "latest-experimental"},
 				},
 			},
 			expectErr: true,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

When selecting the most recent image tag from a manifest, the logic originally relied on the timeCreatedMs field to determine which image was the latest. However, a discrepancy was observed: newly pushed images have their timeCreatedMs field set to "0", whereas older images contain a valid creation timestamp. As a consequence, the selection algorithm incorrectly identifies older images as the most recent, simply because they have a non-zero timeCreatedMs value.

    "sha256:336f304895dc27accaa3bf285f074b477fb6243f52be12487dadc20975d5e0ab": {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "tag": [
        "v20241022-5fa8bfa1"
      ],
      "timeUploadedMs": "1729622564863",
      "timeCreatedMs": "1729622563897",
      "imageSizeBytes": "21407344"
    },
    "sha256:33778ae53326aad4eac3948f624b66cb516fb37f97a0aac51fb0c20e7fc5ebb0": {
      "mediaType": "application/vnd.oci.image.index.v1+json",
      "tag": [
        "v20250515-a411113a"
      ],
      "timeUploadedMs": "1747303893211",
      "timeCreatedMs": "0",
      "imageSizeBytes": "0"
    },
    
It was also noted that the timeUploadedMs field is always populated with the correct upload timestamp for all images, including the new ones. To address this inconsistency and ensure the correct (most recently uploaded) image tag is selected, the logic was updated to use the timeUploadedMs field exclusively for timestamp comparison, instead of relying on timeCreatedMs.

**Changes proposed in this pull request:**

- Swap TimeCreatedMs to TimeUploadedMs in manifest type
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
