### PR TITLE
fix: update CMD in Dockerfile to use full path for gunicorn

### DIFF
--- a/cmd/cloud-run/signifysecretrotator/Dockerfile
+++ b/cmd/cloud-run/signifysecretrotator/Dockerfile
@@ -29,4 +29,4 @@ COPY ./cmd/cloud-run/signifysecretrotator .
 COPY --from=builder /app/venv /app/venv
 ENV PATH="/app/venv/bin:$PATH"
 
-CMD ["gunicorn", "--bind", "0.0.0.0:8080", "--workers", "4", "--timeout", "0", "signifysecretrotator:app"]
+CMD ["/app/venv/bin/gunicorn", "--bind", "0.0.0.0:8080", "--workers", "4", "--timeout", "0", "signifysecretrotator:app"]

--- a/cmd/cloud-run/slack-message-sender/Dockerfile
+++ b/cmd/cloud-run/slack-message-sender/Dockerfile
@@ -29,4 +29,4 @@ COPY ./cmd/cloud-run/slack-message-sender/slack-message-sender.py .
 COPY --from=builder /app/venv /app/venv
 ENV PATH="/app/venv/bin:$PATH"
 
-CMD ["gunicorn", "--bind", "0.0.0.0:8080", "--workers", "4", "--timeout", "0", "slack-message-sender:app"]
+CMD ["/app/venv/bin/gunicorn", "--bind", "0.0.0.0:8080", "--workers", "4", "--timeout", "0", "slack-message-sender:app"]


### PR DESCRIPTION

This pull request includes updates to the Dockerfiles for two services to explicitly specify the full path to the `gunicorn` executable in the `CMD` instruction. This change ensures that the correct version of `gunicorn` is used, avoiding potential issues with path resolution.

Changes to Dockerfiles:

* [`cmd/cloud-run/signifysecretrotator/Dockerfile`](diffhunk://#diff-f97ef8130c0cf0fc5b3b33b8b062b62cadee17e0c7c324f8b34c256ab078ea9cL32-R32): Updated the `CMD` instruction to use the full path `/app/venv/bin/gunicorn` instead of relying on the `PATH` environment variable.
* [`cmd/cloud-run/slack-message-sender/Dockerfile`](diffhunk://#diff-f433bb110ac416e6e379a8f33559068c2ab83fee0aeb0dd58aa4f2ddf905ea24L32-R32): Similarly, updated the `CMD` instruction to use `/app/venv/bin/gunicorn` for consistency and reliability.
