### PR TITLE
fix: set ENTRYPOINT to use Python from virtual environment in Dockerfile

### DIFF
--- a/cmd/cloud-run/signifysecretrotator/Dockerfile
+++ b/cmd/cloud-run/signifysecretrotator/Dockerfile
@@ -29,4 +29,5 @@ COPY ./cmd/cloud-run/signifysecretrotator .
 COPY --from=builder /app/venv /app/venv
 ENV PATH="/app/venv/bin:$PATH"
 
+ENTRYPOINT ["/app/venv/bin/python"]
 CMD ["/app/venv/bin/gunicorn", "--bind", "0.0.0.0:8080", "--workers", "4", "--timeout", "0", "signifysecretrotator:app"]

--- a/cmd/cloud-run/slack-message-sender/Dockerfile
+++ b/cmd/cloud-run/slack-message-sender/Dockerfile
@@ -29,4 +29,5 @@ COPY ./cmd/cloud-run/slack-message-sender/slack-message-sender.py .
 COPY --from=builder /app/venv /app/venv
 ENV PATH="/app/venv/bin:$PATH"
 
+ENTRYPOINT ["/app/venv/bin/python"]
 CMD ["/app/venv/bin/gunicorn", "--bind", "0.0.0.0:8080", "--workers", "4", "--timeout", "0", "slack-message-sender:app"]


### PR DESCRIPTION
This pull request introduces changes to the Dockerfiles of two services to explicitly define their entry points. The updates ensure that the Python interpreter is set as the `ENTRYPOINT` for both services and containers use python from virtualenvs.

**Reason:**

This fixes error.

```
Traceback (most recent call last):
  File "/app/venv/bin/gunicorn", line 5, in <module>
    from gunicorn.app.wsgiapp import run
ModuleNotFoundError: No module named 'gunicorn'
```

**Changes:**

* [`cmd/cloud-run/signifysecretrotator/Dockerfile`](diffhunk://#diff-f97ef8130c0cf0fc5b3b33b8b062b62cadee17e0c7c324f8b34c256ab078ea9cR32): Added an `ENTRYPOINT` directive to specify `/app/venv/bin/python` as the entry point for the `signifysecretrotator` service.
* [`cmd/cloud-run/slack-message-sender/Dockerfile`](diffhunk://#diff-f433bb110ac416e6e379a8f33559068c2ab83fee0aeb0dd58aa4f2ddf905ea24R32): Added an `ENTRYPOINT` directive to specify `/app/venv/bin/python` as the entry point for the `slack-message-sender` service.