### PR TITLE
Potential fix for code scanning alert no. 56: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/workflow-controller-build-2.yml
+++ b/.github/workflows/workflow-controller-build-2.yml
@@ -6,6 +6,9 @@ on:
   push:
   merge_group: 
 
+permissions:
+  contents: read
+
 jobs:
   detect-changed-files:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kyma-project/test-infra/security/code-scanning/56](https://github.com/kyma-project/test-infra/security/code-scanning/56)

To fix the issue, we will add a `permissions` block at the workflow level to define the minimal permissions required. Based on the provided workflow, it primarily involves checking out the repository and filtering paths, which only requires `contents: read`. No write permissions are necessary unless explicitly required by the jobs. This change will ensure that the workflow operates with the least privilege necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
