### PR TITLE
Unify tofu plan options across workflows

### DIFF
--- a/.github/workflows/pull-validate-service-accounts.yaml
+++ b/.github/workflows/pull-validate-service-accounts.yaml
@@ -53,7 +53,7 @@ jobs:
         run: tofu -chdir=./configs/terraform/environments/prod init -input=false
 
       - name: Terraform plan
-        run: tofu -chdir=./configs/terraform/environments/prod plan -input=false -out=plan.out
+        run: tofu -chdir=./configs/terraform/environments/prod plan -input=false -no-color -lock-timeout=300s -out=plan.out
 
       - name: Convert plan to json
         run: tofu -chdir=./configs/terraform/environments/prod show -no-color -json plan.out > plan.json


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Currently workflow for veryfing service accounts names hangs for some time, we need to unify the plan command options to avoid that, since plan prod terraform workflow isn't behave in such way.

Changes proposed in this pull request:

- Add `-input=false -no-color -lock-timeout=300s` to `pull-verify-service-accounts-name` workflow to unify with `pull-plan-prod-terraform` workflow.