### PR TITLE
Add custom paths filter for checking our PR code changes

### DIFF
--- a/cmd/pathsfilter/main.go
+++ b/cmd/pathsfilter/main.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/kyma-project/test-infra/pkg/action"
+	"github.com/kyma-project/test-infra/pkg/configloader"
+	"github.com/kyma-project/test-infra/pkg/filter"
+	"github.com/kyma-project/test-infra/pkg/git"
+	"github.com/kyma-project/test-infra/pkg/logging"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+)
+
+var config = viper.New()
+
+var rootCmd = &cobra.Command{
+	Use:   "pathsfilter",
+	Short: "A tool to filter changed file paths based on YAML definitions.",
+	Long: `pathsfilter detects changed files between two git refs and filters them
+		against glob patterns defined in a YAML file. It's designed for use in GitHub Actions
+		to conditionally run workflow jobs.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log := logging.NewLogger()
+
+		defer func(log *zap.SugaredLogger) {
+			err := log.Sync()
+			if err != nil {
+				log.Errorw("Failed to sync logger", "error", err)
+			}
+		}(log)
+
+		log.Infow("Starting paths filter process")
+
+		gitRepo, err := git.NewRepository(config.GetString("working-dir"))
+		if err != nil {
+			return fmt.Errorf("failed to initialize git repository client: %w", err)
+		}
+
+		filtersPath := config.GetString("filters-file")
+
+		log.Infow("Loading filter definitions", "path", filtersPath)
+
+		definitions, err := configloader.Load(filtersPath)
+		if err != nil {
+			return fmt.Errorf("failed to load filter definitions: %w", err)
+		}
+
+		baseRef := config.GetString("base")
+		headRef := config.GetString("head")
+
+		log.Infow("Fetching changed files", "base", baseRef, "head", headRef)
+
+		changedFiles, err := gitRepo.GetChangedFiles(baseRef, headRef)
+		if err != nil {
+			return fmt.Errorf("failed to get changed files: %w", err)
+		}
+
+		log.Infow("Found changed files", "count", len(changedFiles))
+		log.Infow("Applying filters...")
+
+		filterProcessor := filter.NewProcessor(definitions, log)
+		filterResult := filterProcessor.Process(changedFiles)
+
+		log.Infow("Found matching filters", "count", len(filterResult.MatchedFilterKeys))
+		if config.GetBool("set-output") {
+			log.Infow("Setting outputs for GitHub Actions")
+
+			outputWriter := action.NewOutputWriter(log)
+			if err := outputWriter.Write(filterResult); err != nil {
+				return fmt.Errorf("failed to set action outputs: %w", err)
+			}
+		}
+
+		log.Infow("Paths filter process completed successfully")
+
+		return nil
+	},
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		_ = fmt.Errorf("error executing command")
+	}
+}
+
+func init() {
+	rootCmd.Flags().StringP("filters-file", "f", ".github/controller-filters.yaml", "Path to the YAML file with filter definitions")
+	rootCmd.Flags().StringP("base", "b", "main", "Base git ref for comparison")
+	rootCmd.Flags().StringP("head", "H", "HEAD", "Head git ref for comparison")
+	rootCmd.Flags().StringP("working-dir", "w", ".", "Working directory containing the .git repository")
+	rootCmd.Flags().Bool("debug", false, "Enable debug logging")
+	rootCmd.Flags().Bool("set-output", false, "Enable setting outputs for GitHub Actions")
+
+	if err := config.BindPFlags(rootCmd.Flags()); err != nil {
+		_ = fmt.Errorf("error binding flags: %w", err)
+	}
+}

--- a/cmd/pathsfilter/main.go
+++ b/cmd/pathsfilter/main.go
@@ -9,75 +9,23 @@ import (
 	"github.com/kyma-project/test-infra/pkg/git"
 	"github.com/kyma-project/test-infra/pkg/logging"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"go.uber.org/zap"
 )
 
-var config = viper.New()
-
-var rootCmd = &cobra.Command{
-	Use:   "pathsfilter",
-	Short: "A tool to filter changed file paths based on YAML definitions.",
-	Long: `pathsfilter detects changed files between two git refs and filters them
-		against glob patterns defined in a YAML file. It's designed for use in GitHub Actions
-		to conditionally run workflow jobs.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		log := logging.NewLogger()
-
-		defer func(log *zap.SugaredLogger) {
-			err := log.Sync()
-			if err != nil {
-				log.Errorw("Failed to sync logger", "error", err)
-			}
-		}(log)
-
-		log.Infow("Starting paths filter process")
-
-		gitRepo, err := git.NewRepository(config.GetString("working-dir"))
-		if err != nil {
-			return fmt.Errorf("failed to initialize git repository client: %w", err)
-		}
-
-		filtersPath := config.GetString("filters-file")
-
-		log.Infow("Loading filter definitions", "path", filtersPath)
-
-		definitions, err := configloader.Load(filtersPath)
-		if err != nil {
-			return fmt.Errorf("failed to load filter definitions: %w", err)
-		}
-
-		baseRef := config.GetString("base")
-		headRef := config.GetString("head")
-
-		log.Infow("Fetching changed files", "base", baseRef, "head", headRef)
-
-		changedFiles, err := gitRepo.GetChangedFiles(baseRef, headRef)
-		if err != nil {
-			return fmt.Errorf("failed to get changed files: %w", err)
-		}
-
-		log.Infow("Found changed files", "count", len(changedFiles))
-		log.Infow("Applying filters...")
-
-		filterProcessor := filter.NewProcessor(definitions, log)
-		filterResult := filterProcessor.Process(changedFiles)
-
-		log.Infow("Found matching filters", "count", len(filterResult.MatchedFilterKeys))
-		if config.GetBool("set-output") {
-			log.Infow("Setting outputs for GitHub Actions")
-
-			outputWriter := action.NewOutputWriter(log)
-			if err := outputWriter.Write(filterResult); err != nil {
-				return fmt.Errorf("failed to set action outputs: %w", err)
-			}
-		}
-
-		log.Infow("Paths filter process completed successfully")
-
-		return nil
-	},
+// Options holds all command-line flag values for the application.
+type Options struct {
+	FiltersFile      string
+	Base             string
+	Head             string
+	WorkingDirectory string
+	Debug            bool
+	SetOutput        bool
 }
+
+var (
+	rootCmd *cobra.Command
+	opts    Options
+)
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
@@ -86,14 +34,64 @@ func main() {
 }
 
 func init() {
-	rootCmd.Flags().StringP("filters-file", "f", ".github/controller-filters.yaml", "Path to the YAML file with filter definitions")
-	rootCmd.Flags().StringP("base", "b", "main", "Base git ref for comparison")
-	rootCmd.Flags().StringP("head", "H", "HEAD", "Head git ref for comparison")
-	rootCmd.Flags().StringP("working-dir", "w", ".", "Working directory containing the .git repository")
-	rootCmd.Flags().Bool("debug", false, "Enable debug logging")
-	rootCmd.Flags().Bool("set-output", false, "Enable setting outputs for GitHub Actions")
+	rootCmd = &cobra.Command{
+		Use:   "pathsfilter",
+		Short: "A tool to filter changed file paths based on YAML definitions.",
+		Long: `pathsfilter detects changed files between two git refs and filters them
+against glob patterns defined in a YAML file. It's designed for use in GitHub Actions
+to conditionally run workflow jobs.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			log := logging.NewLogger()
+			defer func(log *zap.SugaredLogger) {
+				err := log.Sync()
+				if err != nil {
+					fmt.Printf("error syncing log: %v\n", err)
+				}
+			}(log)
 
-	if err := config.BindPFlags(rootCmd.Flags()); err != nil {
-		_ = fmt.Errorf("error binding flags: %w", err)
+			log.Infow("Starting paths filter process")
+
+			gitRepo, err := git.NewRepository(opts.WorkingDirectory)
+			if err != nil {
+				return fmt.Errorf("failed to initialize git repository client: %w", err)
+			}
+
+			log.Infow("Loading filter definitions", "path", opts.FiltersFile)
+			definitions, err := configloader.Load(opts.FiltersFile)
+			if err != nil {
+				return fmt.Errorf("failed to load filter definitions: %w", err)
+			}
+
+			log.Infow("Fetching changed files", "base", opts.Base, "head", opts.Head)
+			changedFiles, err := gitRepo.GetChangedFiles(opts.Base, opts.Head)
+			if err != nil {
+				return fmt.Errorf("failed to get changed files: %w", err)
+			}
+			log.Infow("Found changed files", "count", len(changedFiles))
+
+			log.Infow("Applying filters...")
+			filterProcessor := filter.NewProcessor(definitions, log)
+			filterResult := filterProcessor.Process(changedFiles)
+			log.Infow("Found matching filters", "count", len(filterResult.MatchedFilterKeys))
+
+			if opts.SetOutput {
+				log.Infow("Setting outputs for GitHub Actions")
+				outputWriter := action.NewOutputWriter(log)
+				if err := outputWriter.Write(filterResult); err != nil {
+					return fmt.Errorf("failed to set action outputs: %w", err)
+				}
+			}
+
+			log.Infow("Paths filter process completed successfully")
+
+			return nil
+		},
 	}
+
+	rootCmd.Flags().StringVarP(&opts.FiltersFile, "filters-file", "f", ".github/controller-filters.yaml", "Path to the YAML file with filter definitions")
+	rootCmd.Flags().StringVarP(&opts.Base, "base", "b", "main", "Base git ref for comparison")
+	rootCmd.Flags().StringVarP(&opts.Head, "head", "H", "HEAD", "Head git ref for comparison")
+	rootCmd.Flags().StringVarP(&opts.WorkingDirectory, "working-dir", "w", ".", "Working directory containing the .git repository")
+	rootCmd.Flags().BoolVar(&opts.Debug, "debug", false, "Enable debug logging")
+	rootCmd.Flags().BoolVar(&opts.SetOutput, "set-output", false, "Enable setting outputs for GitHub Actions")
 }

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.14.1
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-jose/go-jose/v4 v4.1.0
+	github.com/gobwas/glob v0.2.3
 	github.com/google/go-containerregistry v0.20.5
 	github.com/google/go-github/v48 v48.2.0
 	github.com/jamiealquiza/envy v1.1.0
@@ -25,6 +26,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
+	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
 	github.com/zricethezav/gitleaks/v8 v8.27.0
 	go.uber.org/zap v1.27.0
@@ -173,7 +175,6 @@ require (
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
-	github.com/spf13/viper v1.20.1 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -284,6 +284,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=

--- a/pkg/action/output_writer.go
+++ b/pkg/action/output_writer.go
@@ -1,0 +1,57 @@
+package action
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/kyma-project/test-infra/pkg/filter"
+	"go.uber.org/zap"
+)
+
+// OutputWriter implements the logic for writing to the GITHUB_OUTPUT file.
+type OutputWriter struct {
+	log *zap.SugaredLogger
+}
+
+// NewOutputWriter creates a new instance of OutputWriter.
+func NewOutputWriter(log *zap.SugaredLogger) *OutputWriter {
+	return &OutputWriter{log: log}
+}
+
+// Write processes the filter result and writes it as action outputs.
+func (w *OutputWriter) Write(result filter.Result) error {
+	outputFilePath := os.Getenv("GITHUB_OUTPUT")
+	if outputFilePath == "" {
+		w.log.Infow("GITHUB_OUTPUT environment variable not set. Skipping writing outputs.")
+		return nil
+	}
+
+	file, err := os.OpenFile(outputFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("could not open GITHUB_OUTPUT file %s: %w", outputFilePath, err)
+	}
+	defer func(file *os.File) {
+		err := file.Close()
+		if err != nil {
+			w.log.Errorw("could not close the file", file.Name())
+		}
+	}(file)
+
+	for key, matched := range result.IndividualFilterResults {
+		if err := w.set(file, key, fmt.Sprintf("%t", matched)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// set is a helper to write a single key-value pair to the output file.
+func (w *OutputWriter) set(file *os.File, key, value string) error {
+	w.log.Infow("Setting output", "key", key, "value", value)
+	if _, err := fmt.Fprintf(file, "%s=%s\n", key, value); err != nil {
+		return fmt.Errorf("failed to write to GITHUB_OUTPUT for key %s: %w", key, err)
+	}
+
+	return nil
+}

--- a/pkg/configloader/loader.go
+++ b/pkg/configloader/loader.go
@@ -1,0 +1,26 @@
+package configloader
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Definition represents the structure of a filter file.
+// The key is the filter name and the value is a slice of glob patterns.
+type Definition map[string][]string
+
+// Load reads and parses a YAML filter file from the given path.
+func Load(filePath string) (Definition, error) {
+	var defs Definition
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read file %s: %w", filePath, err)
+	}
+	if err := yaml.Unmarshal(data, &defs); err != nil {
+		return nil, fmt.Errorf("cannot parse YAML file %s: %w", filePath, err)
+	}
+
+	return defs, nil
+}

--- a/pkg/filter/processor.go
+++ b/pkg/filter/processor.go
@@ -1,0 +1,102 @@
+package filter
+
+import (
+	"github.com/kyma-project/test-infra/pkg/configloader"
+	"github.com/kyma-project/test-infra/pkg/git"
+	"github.com/kyma-project/test-infra/pkg/matcher"
+	"go.uber.org/zap"
+)
+
+// Result holds the outcome of a filtering operation.
+type Result struct {
+	MatchedFilterKeys       []string
+	IndividualFilterResults map[string]bool
+	MatchedFilesByFilter    map[string][]string
+}
+
+// Filter represents a single named filter with its associated glob patterns.
+type Filter struct {
+	Name     string
+	Patterns []string
+}
+
+// findFilesMatchingPattern checks a single pattern against a list of files and returns matches.
+func findFilesMatchingPattern(pattern string, files []git.ChangedFile) []string {
+	var matchedFiles []string
+	for _, file := range files {
+		if ok, _ := matcher.Match(pattern, file.Path); ok {
+			matchedFiles = append(matchedFiles, file.Path)
+		}
+	}
+
+	return matchedFiles
+}
+
+// matches checks if this filter is matched by any of the changed files.
+func (f *Filter) matches(changedFiles []git.ChangedFile) (bool, []string) {
+	var allMatchedFiles []string
+	for _, pattern := range f.Patterns {
+		matchedForPattern := findFilesMatchingPattern(pattern, changedFiles)
+		allMatchedFiles = append(allMatchedFiles, matchedForPattern...)
+	}
+
+	if len(allMatchedFiles) > 0 {
+		return true, unique(allMatchedFiles)
+	}
+
+	return false, nil
+}
+
+// Processor encapsulates the filtering logic for a set of filter definitions.
+type Processor struct {
+	filters []Filter
+	log     *zap.SugaredLogger
+}
+
+// NewProcessor creates a new filter processor from filter definitions.
+func NewProcessor(definitions configloader.Definition, log *zap.SugaredLogger) *Processor {
+	var filters []Filter
+	for name, patterns := range definitions {
+		filters = append(filters, Filter{Name: name, Patterns: patterns})
+	}
+	return &Processor{filters: filters, log: log}
+}
+
+// Process is the primary method that applies all filters to a list of changed files.
+func (p *Processor) Process(changedFiles []git.ChangedFile) Result {
+	result := Result{
+		MatchedFilterKeys:       []string{},
+		IndividualFilterResults: make(map[string]bool),
+		MatchedFilesByFilter:    make(map[string][]string),
+	}
+
+	for _, f := range p.filters {
+		result.IndividualFilterResults[f.Name] = false
+	}
+
+	for _, f := range p.filters {
+		p.log.Debugw("Checking filter", "key", f.Name)
+		if isMatch, matchedFiles := f.matches(changedFiles); isMatch {
+			p.log.Debugw("Found match for filter", "key", f.Name, "files_count", len(matchedFiles))
+			result.MatchedFilterKeys = append(result.MatchedFilterKeys, f.Name)
+			result.IndividualFilterResults[f.Name] = true
+			result.MatchedFilesByFilter[f.Name] = matchedFiles
+		}
+	}
+
+	return result
+}
+
+// unique is a helper function to remove duplicates from a slice of strings.
+func unique(slice []string) []string {
+	keys := make(map[string]struct{})
+	var list []string
+	for _, entry := range slice {
+		if _, exists := keys[entry]; !exists {
+			keys[entry] = struct{}{}
+			list = append(list, entry)
+		}
+	}
+
+	return list
+}

--- a/pkg/git/repository.go
+++ b/pkg/git/repository.go
@@ -1,0 +1,60 @@
+package git
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// ChangedFile represents a single file that has been changed.
+type ChangedFile struct {
+	Path   string
+	Status string
+}
+
+// Repository is a client for performing local Git operations.
+type Repository struct {
+	workingDir string
+}
+
+// NewRepository creates a new local Git repository client.
+func NewRepository(workingDir string) (*Repository, error) {
+	if _, err := exec.LookPath("git"); err != nil {
+		return nil, fmt.Errorf("command 'git' not found in PATH")
+	}
+
+	return &Repository{workingDir: workingDir}, nil
+}
+
+// GetChangedFiles retrieves the list of changed files between two git refs.
+func (r *Repository) GetChangedFiles(base, head string) ([]ChangedFile, error) {
+	cmd := exec.Command("git", "-C", r.workingDir, "diff", "--name-status", fmt.Sprintf("%s...%s", base, head))
+	output, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return nil, fmt.Errorf("failed to run 'git diff': %s, stderr: %s", exitErr, string(exitErr.Stderr))
+		}
+
+		return nil, err
+	}
+
+	var files []ChangedFile
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+
+		parts := strings.Fields(line)
+		if len(parts) >= 2 {
+			files = append(files, ChangedFile{
+				Status: parts[0],
+				Path:   strings.Join(parts[1:], " "),
+			})
+		}
+	}
+
+	return files, nil
+}

--- a/pkg/matcher/glob.go
+++ b/pkg/matcher/glob.go
@@ -1,0 +1,12 @@
+package matcher
+
+import "github.com/gobwas/glob"
+
+func Match(pattern, path string) (bool, error) {
+	g, err := glob.Compile(pattern)
+	if err != nil {
+		return false, err
+	}
+
+	return g.Match(path), nil
+}


### PR DESCRIPTION
**Description**

Currently, we use GitHub Action `dorny/paths-filter` to filter modified files of our code in PR. However, it turned out that this GitHub Action neither supports filtering by branches, nor can we provide it with a `controller-filters.yaml` file with our own structure.

For this purpose, we decided to make a prototype of our own tool, which will filter both by files and branches.

We need to decide how long the final implementation of this tool will take.

The code that is in this PR is just a prototype to outline how much code there will be.

**Changes proposed in this pull request:**

- Add custom tool for filtering paths out PR changes

**What is left to do regarding file filtering:**
- Adapting the code to `test-infra` so that it is consistent with our current flow
- Checking the correctness of the logic responsible for file filtering
- Testing the tool
- Writing unit tests

**Related issue(s)**
https://github.com/kyma-project/test-infra/issues/13106

**Estimation**
In my opinion, a full implementation of file filtering with post-review fixes etc. should not take longer than 1 sprint. Branch filtering implementation should be estimated separately.
