### PR TITLE
Ignore pushes to temporary gh branch

### DIFF
--- a/.github/workflows/workflow-controller-build-1.yml
+++ b/.github/workflows/workflow-controller-build-1.yml
@@ -4,6 +4,8 @@ on:
   pull_request_target: 
     types: [opened, synchronize, reopened, ready_for_review]
   push:
+   branches-ignore:
+     - gh-readonly-*
   merge_group: 
 
 permissions:

--- a/.github/workflows/workflow-controller-build-2.yml
+++ b/.github/workflows/workflow-controller-build-2.yml
@@ -4,6 +4,8 @@ on:
   pull_request_target: 
     types: [opened, synchronize, reopened, ready_for_review]
   push:
+   branches-ignore:
+     - gh-readonly-*
   merge_group: 
 
 permissions:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

When creating a merge queue, GitHub creates temporary branch (ie. `gh-readonly-queue/main/pr-13159-6dd3f30f2a6227f57893224e113fb03acefdec7d`) we should not trigger a push event on pushes to that branches. The name is dynamic so we need to use a star. See: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore

Changes proposed in this pull request:

- Exclude `gh-readonly-*` branches from push event on workflow controllers

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: #12762 