### PR TITLE
Add Github workspace to safe.driectory in git

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -27,6 +27,14 @@ runs:
           fetch-depth: ${{ inputs.fetch-depth }}
         if: ${{ github.event_name != 'pull_request_target' && github.event_name != 'pull_request' }}
 
+      # Add current working directory to git config
+      # This is necessary to avoid the "fatal: detected dubious ownership in repository at" error
+      # It's same as the actions/checkout@v4 does, but we need to do it here because we are using a custom action.
+      # We must use GITHUB_WORKSPACE instead of ${{ github.workspace }}, see: https://github.com/actions/runner/issues/2058
+      - name: Add current github workspace to git config as safe directory
+        shell: bash
+        run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
       # Important security check: https://github.com/actions/checkout/issues/518
       - name: Sanity check
         shell: bash

--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -28,12 +28,12 @@ runs:
         if: ${{ github.event_name != 'pull_request_target' && github.event_name != 'pull_request' }}
 
       # Add current working directory to git config
-      # This is necessary to avoid the "fatal: detected dubious ownership in repository at" error
-      # It's same as the actions/checkout@v4 does, but we need to do it here because we are using a custom action.
+      # This is necessary to avoid the "fatal: detected dubious ownership in repository at" error in containerized jobs.
+      # It's a workaround for actions/checkout@v4 issue: https://github.com/actions/checkout/issues/766
       # We must use GITHUB_WORKSPACE instead of ${{ github.workspace }}, see: https://github.com/actions/runner/issues/2058
       - name: Add current github workspace to git config as safe directory
         shell: bash
-        run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+        run: git config --system --add safe.directory "${GITHUB_WORKSPACE}"
 
       # Important security check: https://github.com/actions/checkout/issues/518
       - name: Sanity check


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Used by us `actions/checkout@v4` is setting the workspace as safe directory while cloning the repository, but before that is setting temporary HOME directory, see [here](https://github.tools.sap/kyma/security-dashboard/actions/runs/15061238/job/69059711?pr=444#step:4:40), that set `HOME` is not persistent between steps and cause git commands run after checkout step to fail.

Changes proposed in this pull request:

- Add explicitly current working directory as safe directory in git

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: https://github.com/actions/checkout/issues/766
See: kyma/security-dashboard#446