### PR TITLE
Rename kyma-project submission's identity to indicated kyma-project relation

### DIFF
--- a/configs/terraform/environments/prod/modules-submission.tf
+++ b/configs/terraform/environments/prod/modules-submission.tf
@@ -39,7 +39,12 @@ resource "google_service_account" "kyma-submission-pipeline" {
   description = "The submission-pipeline ADO pipeline."
 }
 
-resource "google_artifact_registry_repository_iam_member" "dev_modules_internal_repo_admin" {
+moved {
+  from = google_artifact_registry_repository_iam_member.dev_modules_internal_repo_admin
+  to =   google_artifact_registry_repository_iam_member.dev_modules_internal_repo_admin_legacy
+}
+
+resource "google_artifact_registry_repository_iam_member" "dev_modules_internal_repo_admin_legacy" {
   provider   = google.kyma_project
   repository = google_artifact_registry_repository.dev_modules_internal.id
   role       = "roles/artifactregistry.repoAdmin"

--- a/configs/terraform/environments/prod/modules-submission.tf
+++ b/configs/terraform/environments/prod/modules-submission.tf
@@ -41,10 +41,10 @@ resource "google_service_account" "kyma-submission-pipeline" {
 
 moved {
   from = google_artifact_registry_repository_iam_member.dev_modules_internal_repo_admin
-  to =   google_artifact_registry_repository_iam_member.dev_modules_internal_repo_admin_legacy
+  to =   google_artifact_registry_repository_iam_member.dev_modules_internal_repo_admin_kyma_project
 }
 
-resource "google_artifact_registry_repository_iam_member" "dev_modules_internal_repo_admin_legacy" {
+resource "google_artifact_registry_repository_iam_member" "dev_modules_internal_repo_admin_kyma_project" {
   provider   = google.kyma_project
   repository = google_artifact_registry_repository.dev_modules_internal.id
   role       = "roles/artifactregistry.repoAdmin"


### PR DESCRIPTION
For smooth migration to one identity of kyma submission pipeline, we need to create additional resource with same permissions as current one. To do that I wanna keep naming of the `kyma-project` related resourced to strictly indicate that there are connected with kyma-project GCP project.

Resource relocation and renaming:

* In `configs/terraform/environments/prod/modules-submission.tf`, the resource `google_artifact_registry_repository_iam_member.dev_modules_internal_repo_admin` was renamed to `google_artifact_registry_repository_iam_member.dev_modules_internal_repo_admin_kyma_project` and moved using the `moved` block for better alignment with the `kyma_project` context.

See: #12926 