### PR TITLE
Remove build-engine: buildx

### DIFF
--- a/.github/actions/image-builder/README.md
+++ b/.github/actions/image-builder/README.md
@@ -40,7 +40,6 @@ If the execution fails, the image-builder action fails. If the execution succeed
           dockerfile: 'Dockerfile'
           env-file: 'envs'
           config: "./configs/kaniko-build-config.yaml"
-          build-engine: buildx
           platforms: |
             linux/amd64
 ```

--- a/cmd/image-builder/README.md
+++ b/cmd/image-builder/README.md
@@ -56,7 +56,6 @@ jobs:
          context: .
          env-file: "envs"
          tags: ${{ needs.compute-tag.outputs.tag }}
-         build-engine: buildx
          platforms: |
             linux/amd64
    test-image:


### PR DESCRIPTION
This PR removes the deprecated `build-engine: buildx` entry from workflows.