### PR TITLE
Exclude dependabot branches from workflow controller

### DIFF
--- a/.github/workflows/workflow-controller-build-1.yml
+++ b/.github/workflows/workflow-controller-build-1.yml
@@ -6,6 +6,7 @@ on:
   push:
    branches-ignore:
      - gh-readonly-*/**
+     - dependabot/**
   merge_group: 
 
 permissions:

--- a/.github/workflows/workflow-controller-build-2.yml
+++ b/.github/workflows/workflow-controller-build-2.yml
@@ -6,6 +6,7 @@ on:
   push:
    branches-ignore:
      - gh-readonly-*/**
+     - dependabot/**
   merge_group: 
 
 permissions:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Workflow controllers are not reacting on push to the dependabot branch, therefore production images will not be built
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/test-infra/issues/13303