### PR TITLE
Add renovate config for global use

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+  "extends": ["config:recommended"],
+
+  "labels": ["renovate-dependencies"],
+
+  "automerge": true,
+  "automergeType": "pr",
+  "platformAutomerge": true,
+  "rebaseWhen": "conflicted",
+
+  "packageRules": [
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "dependencies (non-major)"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "devDependencies (non-major)"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions",
+      "separateMajorMinor": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchDepNames": [
+        "wechuli/allcheckspassed",
+        "actions/deploy-pages",
+        "actions/upload-pages-artifact",
+        "actions/upload-artifact"
+      ],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "go modules (non-major)",
+      "postUpdateOptions": [
+        "gomodTidy",
+        "gomodUpdateImportPaths"
+      ]
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "go modules (major)",
+      "postUpdateOptions": [
+        "gomodTidy",
+        "gomodUpdateImportPaths"
+      ]
+    },
+    {
+    "matchManagers": ["pip_requirements"],
+    "matchUpdateTypes": ["patch", "minor"],
+    "groupName": "python deps (non-major)"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "versioning": "loose"
+    }
+  ],
+
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/.ya?ml$/", "/.sh$/", "/.json$/"],
+      "matchStrings": [
+        "(?<depName>[a-z0-9.-]+(?:\/[a-z0-9.-]+)*)[:](?<currentValue>[a-z0-9][a-z0-9._-]*)"
+      ],
+      "depNameTemplate": "{{depName}}",
+      "currentValueTemplate": "{{currentValue}}",
+      "datasourceTemplate": "docker"
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,3 @@
+{
+    "extends": ["kyma-project/test-infra//.github/renovate-sharable-config"]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,3 @@
 {
-    "extends": ["kyma-project/test-infra//.github/renovate-sharable-config"]
+    "extends": ["local>kyma-project/test-infra//.github/renovate-sharable-config"]
 }


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Create sharable config for renovate to use in every repo
- Configure also renovate on test-infra repo
