### PR TITLE
Update regex for dependency name matching

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -76,7 +76,7 @@
       "customType": "regex",
       "managerFilePatterns": ["/.ya?ml$/", "/.sh$/", "/.json$/"],
       "matchStrings": [
-        "(?<depName>[a-z0-9.-]+(?:\/[a-z0-9.-]+)*)[:](?<currentValue>[a-z0-9][a-z0-9._-]*)"
+        "(?<depName>[a-z0-9.-]+(?:\/[a-z0-9._-]+)+):(?<currentValue>(?:v?\\d[\\w.-]*))"
       ],
       "depNameTemplate": "{{depName}}",
       "currentValueTemplate": "{{currentValue}}",


### PR DESCRIPTION
The previous regex was too broad and ended up capturing non-relevant values (like config fields or system paths). The updated version is more restrictive and should now match Docker image references more accurately, without pulling in unrelated strings.