### PR TITLE
Add rangeStrategy to Go dependencies group

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -13,7 +13,8 @@
   "packageRules": [
     {
       "matchManagers": ["gomod"],
-      "groupName": "All Go dependencies"
+      "groupName": "All Go dependencies",
+      "rangeStrategy": "bump"
     },
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
Tested it on my repo. It bumps go version to the newest one.  For example go 1.20 -> go 1.25.1

