### PR TITLE
chore: Update regex for dependency name matching

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -64,7 +64,7 @@
         "/.tfvars$/"
       ],
       "matchStrings": [
-        "(?<depName>[a-z0-9.-]+(?:/[a-z0-9._-]+)+):(?<currentValue>(?:v?\\d[\\w.-]*))"
+        "(?<depName>[a-z0-9.-]*\\.[a-z0-9.-]*(?:/[a-z0-9._-]+)+):(?<currentValue>(?:v?\\d[\\w.-]*))"
       ],
       "depNameTemplate": "{{depName}}",
       "currentValueTemplate": "{{currentValue}}",


### PR DESCRIPTION
I noticed that Renovate was attempting to fetch certain Terraform packages due to a regex that wasn’t strict enough. This resulted in warnings like:
Warning

```
Renovate failed to look up the following dependencies: Failed to look up go package cloud.google.com/go/compute/metadata, Failed to look up docker package ools/github-com-kyma-project/subject/repository_id.

Files affected: go.mod, configs/terraform/environments/prod/terraform-executor.tf

```

To address this, I updated the regex to require a . in the depName, ensuring it correctly identifies a registry domain before the tag.

[here's a proof](https://regex101.com/r/aJcylf/1)