### PR TITLE
feat(renovate): add ignorePaths for node_modules, bower_components, and testdata

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -10,6 +10,12 @@
   "platformAutomerge": true,
   "rebaseWhen": "conflicted",
 
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/testdata/**"
+  ],
+
   "packageRules": [
     {
       "matchManagers": ["gomod"],


### PR DESCRIPTION
Added testdata folder to ignoredPaths, there is no need to update deps in tests


IgnorePaths overwrites default values from config:recommended template so i added back node modules and bower components.
