### PR TITLE
Update custom docker images configuration in renovate

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -53,9 +53,18 @@
     },
     {
       "matchManagers": ["regex"],
-      "groupName": "custom docker images",
-      "datasources": ["docker"],
+      "matchDatasources": ["docker"],
+      "matchCurrentVersion": "v?\\d+\\.\\d+\\.\\d+",
+      "versioning": "semver",
+      "groupName": "custom docker images (semver)",
+      "commitMessageExtra": "to the newest version",
+      "separateMajorMinor": false
+    },
+    {
+      "matchManagers": ["regex"],
+      "matchDatasources": ["docker"],
       "versioning": "loose",
+      "groupName": "custom docker images (loose)",
       "commitMessageExtra": "to the newest version",
       "separateMajorMinor": false
     }


### PR DESCRIPTION
Previously, all images were treated with loose versioning, which caused Renovate to skip updates for images using proper semver (e.g. 1.23.0). To fix this, I split the packageRules into two groups:

Semver-based images – versions matching v?\d+\.\d+\.\d+ are now handled with semver versioning.

Other images – continue to use loose versioning.