### PR TITLE
chore: Extend renovate's config with customManager which bumps *_Versions in Dockerfile

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
 
-  "extends": ["config:recommended"],
+  "extends": [
+    "config:recommended",
+    "customManagers:dockerfileVersions"
+  ],
 
   "labels": ["renovate-dependencies"],
 

--- a/images/unified-agent/go/Dockerfile
+++ b/images/unified-agent/go/Dockerfile
@@ -1,6 +1,7 @@
 ARG BASE_UNIFIED_AGENT_IMAGE
 FROM ${BASE_UNIFIED_AGENT_IMAGE}
 
+# renovate: datasource=golang-version depName=go versioning=semver
 ARG GO_VERSION=1.23.2
 
 # install go


### PR DESCRIPTION
https://docs.renovatebot.com/presets-customManagers/#custommanagersdockerfileversions

This PR introduces a custom regex manager configuration for Renovate that allows us to detect and update version variables (e.g. ENV or ARG with _VERSION) inside Dockerfiles and similar files.

### How it works

- We annotate version lines with a Renovate comment to specify the datasource and dependency name.

- The regex manager then matches both ENV and ARG lines with a _VERSION suffix and extracts the current value.

- Renovate uses the provided datasource (docker, golang-version, etc.) to look up the latest available versions.

Example usage:
```
# renovate: datasource=golang-version depName=go versioning=semver
ARG GO_VERSION=1.23.0
```