### PR TITLE
(chore): Add GitHub Action digest pinning to Renovate config and remove ignoring actions 

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -3,7 +3,8 @@
 
   "extends": [
     "config:recommended",
-    "customManagers:dockerfileVersions"
+    "customManagers:dockerfileVersions",
+    "helpers:pinGitHubActionDigests"
   ],
 
   "labels": ["renovate-dependencies"],
@@ -31,16 +32,6 @@
       "matchManagers": ["github-actions"],
       "groupName": "github actions",
       "separateMajorMinor": true
-    },
-    {
-      "matchManagers": ["github-actions"],
-      "matchDepNames": [
-        "wechuli/allcheckspassed",
-        "actions/deploy-pages",
-        "actions/upload-pages-artifact",
-        "actions/upload-artifact"
-      ],
-      "enabled": false
     },
     {
       "matchManagers": ["pip_requirements"],


### PR DESCRIPTION
This pull request updates the shared Renovate configuration to improve security and simplify the configuration for GitHub Actions. The most important changes involve adding a helper to pin GitHub Action digests and removing an explicit rule that disabled updates for several GitHub Actions.

**Security improvement:**

* Added the `helpers:pinGitHubActionDigests` extension to ensure that GitHub Action dependencies are pinned to specific digests, improving supply chain security. (`.github/renovate-sharable-config.json`)

**Configuration simplification:**

* Removed the rule that explicitly disabled updates for several GitHub Actions (`wechuli/allcheckspassed`, `actions/deploy-pages`, `actions/upload-pages-artifact`, and `actions/upload-artifact`), so these actions will now be eligible for updates according to the default Renovate behavior. (`.github/renovate-sharable-config.json`)