### PR TITLE
Feat: add target dockerfile support

### DIFF
--- a/.github/actions/image-builder/action.yml
+++ b/.github/actions/image-builder/action.yml
@@ -48,6 +48,10 @@ inputs:
     default: |
       linux/arm64
       linux/amd64
+  target:
+    description: Specify which build stage in the Dockerfile to use as the target
+    required: false
+    default: ""
 
 outputs:
   adoResult:
@@ -98,8 +102,8 @@ runs:
         echo "platforms=$result" >> $GITHUB_OUTPUT
       id: prepare-platforms
       shell: bash
-    
+
     - uses: docker://europe-docker.pkg.dev/kyma-project/prod/image-builder:v20250924-935a21c6
       id: build
       with:
-        args: --name=${{ inputs.image-name }} --context=${{ inputs.context }} --dockerfile=${{ inputs.dockerfile }} --azure-access-token=${{ inputs.ado-token }} --oidc-token=${{ inputs.oidc-token }} ${{ steps.prepare-build-args.outputs.build-args }} ${{ steps.prepare-tags.outputs.tags }} ${{ steps.prepare-platforms.outputs.platforms }} --export-tags=${{ inputs.export-tags }} --config=${{ inputs.config }} --use-go-internal-sap-modules=${{ inputs.use-go-internal-sap-modules }}
+        args: --name=${{ inputs.image-name }} --context=${{ inputs.context }} --dockerfile=${{ inputs.dockerfile }} --target=${{ inputs.target }} --azure-access-token=${{ inputs.ado-token }} --oidc-token=${{ inputs.oidc-token }} ${{ steps.prepare-build-args.outputs.build-args }} ${{ steps.prepare-tags.outputs.tags }} ${{ steps.prepare-platforms.outputs.platforms }} --export-tags=${{ inputs.export-tags }} --config=${{ inputs.config }} --use-go-internal-sap-modules=${{ inputs.use-go-internal-sap-modules }}

--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -47,6 +47,12 @@ on:
         default: |
           linux/arm64
           linux/amd64
+      target:
+        description: Specify which build stage in the Dockerfile to use as the target
+        required: false
+        type: string
+        default: ""
+
     outputs:
       images:
         description: JSON list of images built by image-builder
@@ -122,6 +128,7 @@ jobs:
           config: "./configs/image-builder-client-config.yaml"
           use-go-internal-sap-modules: ${{ inputs.use-go-internal-sap-modules }}
           platforms: ${{ inputs.platforms }}
+          target: ${{ inputs.target }}
 
       - name: Print built images
         run: |

--- a/cmd/image-builder/github-workflow-integration.md
+++ b/cmd/image-builder/github-workflow-integration.md
@@ -118,6 +118,7 @@ Certain parameters need to be defined by the user in addition to the data taken 
 - **ExportTags**: Whether to export the tags.
 - **EnvFile**: The environment variables file.
 - **Platforms**: A list of platforms to be built in the format `os/arch`. The default is `linux/amd64` and `linux/arm64`.
+- **Target**: A string which specifies the target build stage in the Dockerfile
 
 See the list of reusable workflow inputs in
 the [image-builder.yml](https://github.com/kyma-project/test-infra/blob/main/.github/workflows/image-builder.yml#L5-L40)

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -432,6 +432,20 @@ var _ = Describe("Image Builder", func() {
 			},
 			false,
 		),
+		Entry("target flag, pass",
+			[]string{
+				"--target=build",
+			},
+			options{
+				context:        ".",
+				configPath:     "/config/image-builder-config.yaml",
+				dockerfile:     "dockerfile",
+				logDir:         "/logs/artifacts",
+				tagsOutputFile: "/generated-tags.json",
+				target:         "build",
+			},
+			false,
+		),
 	)
 
 	DescribeTable("Test prepareADOTemplateParameters",
@@ -492,6 +506,27 @@ var _ = Describe("Image Builder", func() {
 				"RepoOwner":   "",
 				"Tags":        "MS4yNS4xLVNob3J0U0hBPTEuMjUuMS17eyAuU2hvcnRTSEEgfX0=",
 				"Platforms":   "linux/amd64,linux/arm64",
+			},
+			false,
+		),
+		Entry("With target set",
+			options{
+				gitState: GitStateConfig{
+					JobType: "postsubmit",
+				},
+				target: "build",
+			},
+			pipelines.OCIImageBuilderTemplateParams{
+				"Context":     "",
+				"Dockerfile":  "",
+				"ExportTags":  "false",
+				"JobType":     "postsubmit",
+				"Name":        "",
+				"PullBaseSHA": "",
+				"RepoName":    "",
+				"RepoOwner":   "",
+				"Platforms":   "linux/amd64,linux/arm64",
+				"Target":      "build",
 			},
 			false,
 		),

--- a/pkg/azuredevops/pipelines/templatesParams.go
+++ b/pkg/azuredevops/pipelines/templatesParams.go
@@ -159,6 +159,10 @@ func (p OCIImageBuilderTemplateParams) SetPlatforms(platforms string) {
 	p["Platforms"] = platforms
 }
 
+func (p OCIImageBuilderTemplateParams) SetTarget(target string) {
+	p["Target"] = target
+}
+
 // Validate validates if required OCIImageBuilderTemplateParams are set.
 // Returns ErrRequiredParamNotSet error if any required parameter is not set.
 func (p OCIImageBuilderTemplateParams) Validate() error {

--- a/pkg/azuredevops/pipelines/templatesParams_test.go
+++ b/pkg/azuredevops/pipelines/templatesParams_test.go
@@ -102,6 +102,11 @@ var _ = Describe("Test OCIImageBuilderTemplateParams", func() {
 		Expect(params["Platforms"]).To(Equal("linux/amd64"))
 	})
 
+	It("sets the correct Target", func() {
+		params.SetTarget("build")
+		Expect(params["Target"]).To(Equal("build"))
+	})
+
 	// TODO: Improve assertions with more specific matchers and values.
 	It("validates the params correctly", func() {
 		// Set all required parameters


### PR DESCRIPTION
This pull request adds support for specifying a target build stage in the Dockerfile when building images using the image-builder. This enhancement allows users to build specific stages from multi-stage Dockerfiles, both in the CLI and GitHub Actions/Workflows. The change is implemented end-to-end: from CLI flags, through workflow and action inputs, to the Azure DevOps pipeline parameters, and is covered by new tests.

**CLI and Core Functionality:**
- Added a new `--target` flag to the `image-builder` CLI, allowing users to specify which build stage in the Dockerfile to use as the target. The value is passed through the application's options and included in the Azure DevOps pipeline parameters if set. [[1]](diffhunk://#diff-a15366436dafd5b402932194d7c809db3f2c060440bee74f69e7d009e965d3dfR64) [[2]](diffhunk://#diff-a15366436dafd5b402932194d7c809db3f2c060440bee74f69e7d009e965d3dfR531) [[3]](diffhunk://#diff-a15366436dafd5b402932194d7c809db3f2c060440bee74f69e7d009e965d3dfR147-R150)
- Introduced the `SetTarget` method in `OCIImageBuilderTemplateParams` and updated related logic to handle the new target parameter.

**GitHub Actions and Workflows:**
- Added a new optional `target` input to `.github/actions/image-builder/action.yml` and `.github/workflows/image-builder.yml`, allowing workflow users to specify the Docker build target stage. The input is passed to the Docker invocation. [[1]](diffhunk://#diff-3f051056bc6ffc7a0cb5dc329a10fe8797fc8964a6e66bba8cd2aa792a4d7c46R51-R54) [[2]](diffhunk://#diff-3f051056bc6ffc7a0cb5dc329a10fe8797fc8964a6e66bba8cd2aa792a4d7c46L105-R109) [[3]](diffhunk://#diff-d2d311485583e9a96eea5dc19ecfab14f181d32934d09d005c1b5d9539fca29aR50-R55) [[4]](diffhunk://#diff-d2d311485583e9a96eea5dc19ecfab14f181d32934d09d005c1b5d9539fca29aR131)

**Documentation:**
- Updated `cmd/image-builder/github-workflow-integration.md` to document the new `Target` parameter.

**Testing:**
- Added and extended test cases in `main_test.go` and `templatesParams_test.go` to cover the new target parameter, ensuring correct parsing, propagation, and template usage. [[1]](diffhunk://#diff-1b099d1d395fe773fa0e469b67ac58548d634d80d12201746f4fe873e77626b1R435-R448) [[2]](diffhunk://#diff-1b099d1d395fe773fa0e469b67ac58548d634d80d12201746f4fe873e77626b1R512-R532) [[3]](diffhunk://#diff-3553b8992075a0fe14bb7510b98eae8c8fb0a5ae7fbac6c55c5c81ccc4d8f04bR105-R109)

**Minor Fixes:**
- Fixed a typo in a debug log message ("architetcures" → "architectures").
- Improved a comment for clarity in `getDefaultTag` function.