### PR TITLE
Hotfix: remove target argument to make image builder build

### DIFF
--- a/.github/actions/image-builder/action.yml
+++ b/.github/actions/image-builder/action.yml
@@ -106,4 +106,4 @@ runs:
     - uses: docker://europe-docker.pkg.dev/kyma-project/prod/image-builder:v20250929-835aec39
       id: build
       with:
-        args: --name=${{ inputs.image-name }} --context=${{ inputs.context }} --dockerfile=${{ inputs.dockerfile }} --target=${{ inputs.target }} --azure-access-token=${{ inputs.ado-token }} --oidc-token=${{ inputs.oidc-token }} ${{ steps.prepare-build-args.outputs.build-args }} ${{ steps.prepare-tags.outputs.tags }} ${{ steps.prepare-platforms.outputs.platforms }} --export-tags=${{ inputs.export-tags }} --config=${{ inputs.config }} --use-go-internal-sap-modules=${{ inputs.use-go-internal-sap-modules }}
+        args: --name=${{ inputs.image-name }} --context=${{ inputs.context }} --dockerfile=${{ inputs.dockerfile }} --azure-access-token=${{ inputs.ado-token }} --oidc-token=${{ inputs.oidc-token }} ${{ steps.prepare-build-args.outputs.build-args }} ${{ steps.prepare-tags.outputs.tags }} ${{ steps.prepare-platforms.outputs.platforms }} --export-tags=${{ inputs.export-tags }} --config=${{ inputs.config }} --use-go-internal-sap-modules=${{ inputs.use-go-internal-sap-modules }}


### PR DESCRIPTION
This pull request makes a minor update to the image builder GitHub Action configuration by removing the `--target` argument from the Docker build command. This is because for now, ImageBuilder image doesn't have this flag

- Removed the `--target` argument from the `args` passed to the image builder step in `.github/actions/image-builder/action.yml`, so the build will no longer specify a target stage.