### PR TITLE
Feat/add return support for --target build with bumped ImageBuilder imger 

### DIFF
--- a/.github/actions/image-builder/action.yml
+++ b/.github/actions/image-builder/action.yml
@@ -106,4 +106,4 @@ runs:
     - uses: docker://europe-docker.pkg.dev/kyma-project/prod/image-builder:v20251003-c2371fbc
       id: build
       with:
-        args: --name=${{ inputs.image-name }} --context=${{ inputs.context }} --dockerfile=${{ inputs.dockerfile }} --azure-access-token=${{ inputs.ado-token }} --oidc-token=${{ inputs.oidc-token }} ${{ steps.prepare-build-args.outputs.build-args }} ${{ steps.prepare-tags.outputs.tags }} ${{ steps.prepare-platforms.outputs.platforms }} --export-tags=${{ inputs.export-tags }} --config=${{ inputs.config }} --use-go-internal-sap-modules=${{ inputs.use-go-internal-sap-modules }}
+        args: --name=${{ inputs.image-name }} --context=${{ inputs.context }} --dockerfile=${{ inputs.dockerfile }} --target=${{ inputs.target }} --azure-access-token=${{ inputs.ado-token }} --oidc-token=${{ inputs.oidc-token }} ${{ steps.prepare-build-args.outputs.build-args }} ${{ steps.prepare-tags.outputs.tags }} ${{ steps.prepare-platforms.outputs.platforms }} --export-tags=${{ inputs.export-tags }} --config=${{ inputs.config }} --use-go-internal-sap-modules=${{ inputs.use-go-internal-sap-modules }}


### PR DESCRIPTION
This pull request updates the image builder action used in the workflow and adds support for specifying a build target when building Docker images.

Key changes:

Image builder update:
* Upgraded the `image-builder` Docker image to a newer version (`v20251003-c2371fbc`) in `.github/actions/image-builder/action.yml`.

Build argument enhancement:
* Added support for the `--target` build argument, allowing users to specify a build stage target for multi-stage Dockerfiles.