### PR TITLE
fix: update Dockerfile to specify runtime stage and ensure correct build 

### DIFF
--- a/.github/workflows/build-markdown-index.yml
+++ b/.github/workflows/build-markdown-index.yml
@@ -16,3 +16,4 @@ jobs:
       context: .
       platforms: |
         linux/amd64
+      target: runtime

--- a/cmd/markdown-index/Dockerfile
+++ b/cmd/markdown-index/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /app/cmd/markdown-index
 # Build the Go app with static linking
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
 
-FROM alpine:3.22.1
+FROM alpine:3.22.1 as runtime
 
 LABEL io.kyma-project.source=github.com/kyma-project/test-infra/cmd/markdown-index
 


### PR DESCRIPTION
This pull request introduces minor improvements for testing purposes to the Docker build process for the `markdown-index` service. The main changes involve refining the Docker build workflow to use a named build stage, which can help with multi-stage builds and clarity.

Build process improvements:

* The Dockerfile now names the runtime image stage as `runtime` by adding `as runtime` to the `FROM alpine:3.22.1` line.
* The GitHub Actions workflow (`.github/workflows/build-markdown-index.yml`) specifies the `runtime` target in the Docker build step, aligning with the Dockerfile changes.