### PR TITLE
fix: update target assignment to use SetTarget method

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -145,7 +145,7 @@ func prepareADOTemplateParameters(options options) (adopipelines.OCIImageBuilder
 	}
 
 	if options.target != "" {
-		templateParameters["Target"] = options.target
+		templateParameters.SetTarget(options.target)
 	}
 
 	err := templateParameters.Validate()


### PR DESCRIPTION
This pull request makes a small update to the way the `Target` parameter is set in the `prepareADOTemplateParameters` function. Instead of directly assigning the value to the `templateParameters` map, it now uses the `SetTarget` method, which likely will fix the issue with passing ADO template parameter