### PR TITLE
chore: update image-builder version in action.yml

### DIFF
--- a/.github/actions/image-builder/action.yml
+++ b/.github/actions/image-builder/action.yml
@@ -103,7 +103,7 @@ runs:
       id: prepare-platforms
       shell: bash
 
-    - uses: docker://europe-docker.pkg.dev/kyma-project/prod/image-builder:v20251003-c2371fbc
+    - uses: docker://europe-docker.pkg.dev/kyma-project/prod/image-builder:v20251003-b9305fe9
       id: build
       with:
         args: --name=${{ inputs.image-name }} --context=${{ inputs.context }} --dockerfile=${{ inputs.dockerfile }} --target=${{ inputs.target }} --azure-access-token=${{ inputs.ado-token }} --oidc-token=${{ inputs.oidc-token }} ${{ steps.prepare-build-args.outputs.build-args }} ${{ steps.prepare-tags.outputs.tags }} ${{ steps.prepare-platforms.outputs.platforms }} --export-tags=${{ inputs.export-tags }} --config=${{ inputs.config }} --use-go-internal-sap-modules=${{ inputs.use-go-internal-sap-modules }}


### PR DESCRIPTION
This pull request updates the image used by the `image-builder` GitHub Action to a newer version. This ensures the build process uses the latest features and fixes provided by the updated image.

Dependency update:

* Updated the `image-builder` Docker image in `.github/actions/image-builder/action.yml` from version `v20251003-c2371fbc` to `v20251003-b9305fe9`.