### PR TITLE
fix(deps): add prPriority to github actions package rule

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -31,7 +31,8 @@
     {
       "matchManagers": ["github-actions"],
       "groupName": "github actions",
-      "separateMajorMinor": true
+      "separateMajorMinor": true,
+      "prPriority": 5
     },
     {
       "matchManagers": ["pip_requirements"],


### PR DESCRIPTION

This pull request makes a minor configuration update to the `.github/renovate-sharable-config.json` file, specifically affecting how Renovate handles pull requests for GitHub Actions dependencies.

Renovate configuration change:

* Added the `prPriority` property with a value of `5` to the GitHub Actions group, which sets the priority for pull requests related to GitHub Actions updates.