### PR TITLE
fix: remove commitMessageExtra from custom docker image rules to let renovate always automerge 

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -52,7 +52,6 @@
       "matchCurrentVersion": "v?\\d+\\.\\d+\\.\\d+",
       "versioning": "semver",
       "groupName": "custom docker images (semver)",
-      "commitMessageExtra": "to the newest version",
       "separateMajorMinor": false
     },
     {
@@ -60,7 +59,6 @@
       "matchDatasources": ["docker"],
       "versioning": "loose",
       "groupName": "custom docker images (loose)",
-      "commitMessageExtra": "to the newest version",
       "separateMajorMinor": false
     }
   ],


### PR DESCRIPTION

This pull request makes a minor update to the `.github/renovate-sharable-config.json` file, simplifying the configuration by removing the extra commit message text for custom docker image updates.

I noticed that Renovate doesn’t always enable automerge on its pull requests, even when the updated dependencies are different from the previous PR.
After digging deeper into the Renovate configuration, I found out that Renovate tracks PR titles — that’s why it asks you to rename a PR if you want to re-enable automerge after it has been closed.

I removed the `extraCommitMessage` from the config (I had added it to make the PR name more convenient, but it looks like that renovate doesn't work well with that).