### PR TITLE
fix(renovate): update custom docker images group names and commit message to make PR's topic unique

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -51,15 +51,19 @@
       "matchDatasources": ["docker"],
       "matchCurrentVersion": "v?\\d+\\.\\d+\\.\\d+",
       "versioning": "semver",
-      "groupName": "custom docker images (semver)",
+      "groupName": "custom docker images (semver) to {{newVersion}}",
+      "commitMessageTopic": "custom docker images (loose) to {{newVersion}}",
+      "commitMessageExtra": "",
       "separateMajorMinor": false
     },
     {
-      "matchManagers": ["regex"],
-      "matchDatasources": ["docker"],
-      "versioning": "loose",
-      "groupName": "custom docker images (loose)",
-      "separateMajorMinor": false
+    "matchManagers": ["regex"],
+    "matchDatasources": ["docker"],
+    "versioning": "loose",
+    "groupName": "custom docker images (loose) to {{newVersion}}",
+    "commitMessageTopic": "custom docker images (loose) to {{newVersion}}",
+    "commitMessageExtra": "",
+    "separateMajorMinor": false
     }
   ],
 


### PR DESCRIPTION
I managed to create a config that groups all bumps of the same new version into one group and generates a unique PR title with the version included.
The main challenge was creating a good-looking PR title — especially ensuring that single-image bumps also follow the same naming pattern. Previously, when Renovate didn’t group images, those PRs ended up with very minimal titles.
On my test repo it looks like that:
<img width="1016" height="316" alt="image" src="https://github.com/user-attachments/assets/8d68e361-4629-4f99-b695-285680a5d42e" />

The second update is a non-grouped image bump, and it’s working as well.

---

This pull request updates the Renovate configuration to improve how Docker image updates are grouped and described in commit messages. The main change is that both the group names and commit message topics now include the new version being updated to, making it easier to identify what version changes are being made.

Renovate configuration improvements:

* Updated the `groupName` fields for both "semver" and "loose" Docker image update groups to include the new version using the `{{newVersion}}` template.
* Added `commitMessageTopic` fields for both groups to specify the new version in commit messages.
* Added empty `commitMessageExtra` fields for both groups to allow for future customization of commit messages.