### PR TITLE
fix: update variable name for RSA key size to follow naming conventions

### DIFF
--- a/cmd/cloud-run/signifysecretrotator/signifysecretrotator.py
+++ b/cmd/cloud-run/signifysecretrotator/signifysecretrotator.py
@@ -23,7 +23,7 @@ project_id: str = os.getenv("PROJECT_ID", "sap-kyma-prow")
 component_name: str = os.getenv("COMPONENT_NAME", "signify-certificate-rotator")
 application_name: str = os.getenv("APPLICATION_NAME", "secret-rotator")
 secret_rotate_message_type = os.getenv("SECRET_ROTATE_MESSAGE_TYPE", "signify")
-rsa_key_size: int = 4096
+RSA_KEY_SIZE: int = 4096
 
 
 @app.route("/", methods=["POST"])
@@ -66,7 +66,7 @@ def rotate_signify_secret() -> Response:
             # see:
             # https://cryptography.io/en/latest/hazmat/primitives/asymmetric/rsa/#cryptography.hazmat.primitives.asymmetric.rsa.generate_private_key
             public_exponent=65537,
-            key_size=rsa_key_size,
+            key_size=RSA_KEY_SIZE,
         )
 
         access_token: str = signify_client.fetch_access_token(


### PR DESCRIPTION
Change name variable to follow common naming convention and to pass pylint tests
https://github.com/kyma-project/test-infra/actions/runs/18507370157/job/52739559669?pr=13592

This pull request makes a minor change to the naming convention of the RSA key size constant in `signifysecretrotator.py` for improved code clarity and consistency.

* Renamed the variable `rsa_key_size` to `RSA_KEY_SIZE` and updated its usage in the `rotate_signify_secret` function to follow the constant naming convention. [[1]](diffhunk://#diff-13f0f4eb8f3ba99d5f58c0a271b2aadc792ddb8bd347ce52f3fd11a0f714d817L26-R26) [[2]](diffhunk://#diff-13f0f4eb8f3ba99d5f58c0a271b2aadc792ddb8bd347ce52f3fd11a0f714d817L69-R69)