### PR TITLE
feat[terraform]: move kyma-compliance-pipeline service account creation to separate file and assign secret to it

### DIFF
--- a/configs/terraform/environments/prod/compliance-verifier.tf
+++ b/configs/terraform/environments/prod/compliance-verifier.tf
@@ -1,0 +1,17 @@
+resource "google_service_account" "kyma-compliance-pipeline" {
+  account_id   = "kyma-compliance-pipeline"
+  display_name = "kyma-compliance-pipeline"
+  description  = "Service account for retrieving secrets on the compliance Azure pipeline."
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Grant read access to the sec-scanner-cfg-gcp-sa-key secret for kyma-compliance-pipeline service account.
+resource "google_secret_manager_secret_iam_member" "compliance_verifier_sec_scanner_cfg_secret_accessor" {
+  project   = data.google_client_config.gcp.project
+  secret_id = google_secret_manager_secret.sec-scanner-cfg-processor-gcp-sa-key.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.kyma-compliance-pipeline.email}"
+}

--- a/configs/terraform/environments/prod/service_accounts.tf
+++ b/configs/terraform/environments/prod/service_accounts.tf
@@ -81,16 +81,6 @@ resource "google_service_account" "kyma-security-scanners" {
   }
 }
 
-resource "google_service_account" "kyma-compliance-pipeline" {
-  account_id   = "kyma-compliance-pipeline"
-  display_name = "kyma-compliance-pipeline"
-  description  = "Service account for retrieving secrets on the compliance Azure pipeline."
-
-  lifecycle {
-    prevent_destroy = true
-  }
-}
-
 resource "google_service_account" "neighbors-conduit-cli-builder" {
   account_id   = "neighbors-conduit-cli-builder"
   display_name = "neighbors-conduit-cli-builder"


### PR DESCRIPTION
This pull request refactors the provisioning of the `kyma-compliance-pipeline` service account and its associated secret access permissions. The main change is moving the definition of this service account and its secret access from `service_accounts.tf` to a new dedicated compliance-related Terraform file, which improves code organization and clarity.

**Compliance pipeline infrastructure changes:**

* Moved the creation of the `kyma-compliance-pipeline` service account and its configuration from `service_accounts.tf` to `compliance-verifier.tf` for better separation of concerns. [[1]](diffhunk://#diff-e110d914c8ec1fe9f92cc2f60b55d319426a109c507ae581a50d92a0a39a35e5R1-R17) [[2]](diffhunk://#diff-f91c0c873ec49091af77def8aac97e00e1c00437e93a8eafc1f1d280983135f0L84-L93)
* Added a resource in `compliance-verifier.tf` to grant the `kyma-compliance-pipeline` service account read access to the `sec-scanner-cfg-gcp-sa-key` secret, ensuring it has the necessary permissions for compliance operations
