### PR TITLE
Deleting compliance-pipeline service account

### DIFF
--- a/configs/terraform/environments/prod/service_accounts.tf
+++ b/configs/terraform/environments/prod/service_accounts.tf
@@ -81,16 +81,6 @@ resource "google_service_account" "kyma-security-scanners" {
   }
 }
 
-resource "google_service_account" "kyma-compliance-pipeline" {
-  account_id   = "kyma-compliance-pipeline"
-  display_name = "kyma-compliance-pipeline"
-  description  = "Service account for retrieving secrets on the compliance Azure pipeline."
-
-  lifecycle {
-    prevent_destroy = true
-  }
-}
-
 resource "google_service_account" "neighbors-conduit-cli-builder" {
   account_id   = "neighbors-conduit-cli-builder"
   display_name = "neighbors-conduit-cli-builder"


### PR DESCRIPTION
### Removal due to decision of compliance-pipeline deprecation

This pull request removes resources related to the `kyma-compliance-pipeline` service account from the Terraform configuration for the production environment. The most important changes are:

Service account removal:

* Deleted the `google_service_account` resource for `kyma-compliance-pipeline`, which previously managed the service account used for retrieving secrets in the compliance Azure pipeline.

Secret access permissions cleanup:

* Removed the `google_secret_manager_secret_iam_member` resource that granted the `kyma-compliance-pipeline` service account read access to the `sec-scanner-cfg-gcp-sa-key` secret.