### PR TITLE
Fix env var name for custom excludes values

### DIFF
--- a/images/unified-agent/start-wssagent.sh
+++ b/images/unified-agent/start-wssagent.sh
@@ -100,8 +100,7 @@ function scanFolder() { # expects to get the fqdn of folder passed to scan
   if [[ -n "$CUSTOM_EXCLUDES" ]]; then
     WS_EXCLUDES="${WS_EXCLUDES} ${CUSTOM_EXCLUDES}"
     # Trim leading and trailing spaces.
-    WS_EXCLUDES="${WS_EXCLUDES## }"
-    WS_EXCLUDES="${WS_EXCLUDES%% }"
+    WS_EXCLUDES="$(echo "$WS_EXCLUDES" | xargs)"
     export WS_EXCLUDES
   fi
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Aligned variable name to match a value used in caller that custom excludes value is correctly passed into unified agent process.

Changes proposed in this pull request:

- Aligned variable name `CUSTOM_EXCLUDES` with name `WS_EXCLUDES` nad to match a name used at caller side.
- Added removing leading and trailing white spaces.
