### PR TITLE
Add post upgrade task to upgrade imports in golang.

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -14,16 +14,6 @@
   "platformAutomerge": true,
   "rebaseWhen": "conflicted",
 
-  "postUpgradeTasks": {
-    "commands": [
-      "go install github.com/marwan-at-work/mod/cmd/mod@latest",
-      "mod upgrade --mod-name={{{depName}}}",
-      "go mod tidy"
-    ],
-    "fileFilters": ["**/*.go", "go.mod", "go.sum"],
-    "executionMode": "update"
-  },
-
   "ignorePaths": [
     "**/node_modules/**",
     "**/bower_components/**",
@@ -36,7 +26,16 @@
     {
       "matchManagers": ["gomod"],
       "groupName": "All Go dependencies",
-      "rangeStrategy": "bump"
+      "rangeStrategy": "bump",
+      "postUpgradeTasks": {
+        "commands": [
+          "go install github.com/marwan-at-work/mod/cmd/mod@v0.6.0",
+          "mod upgrade --mod-name={{{depName}}}",
+          "go mod tidy"
+        ],
+        "fileFilters": ["**/*.go", "go.mod", "go.sum"],
+        "executionMode": "update"
+      }
     },
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

When renovate updates a golang pacakge to the new version in go.mod file it does not update imports in the code. This is causing errors when compiling a go code.

```
Error: #14 [builder 6/6] RUN CGO_ENABLED=0 go build -o ./kcpmanifestscan -ldflags="-s -w" ./cmd/kcpmanifestscan
Error: #14 0.327 go: downloading github.com/google/go-github/v75 v75.0.0
Error: #14 0.522 go: updates to go.mod needed; to update it:
Error: #14 0.522 	go mod tidy
Error: #14 ERROR: process "/bin/sh -c CGO_ENABLED=0 go build -o ./kcpmanifestscan -ldflags=\"-s -w\" ./cmd/kcpmanifestscan" did not complete successfully: exit code: 1
Error: ------
Error:  > [builder 6/6] RUN CGO_ENABLED=0 go build -o ./kcpmanifestscan -ldflags="-s -w" ./cmd/kcpmanifestscan:
Error: 0.327 go: downloading github.com/google/go-github/v75 v75.0.0
Error: 0.522 go: updates to go.mod needed; to update it:
Error: 0.522 	go mod tidy
Error: ------
Error: Dockerfile:11
Error: --------------------
Error:    9 |     COPY . .
Error:   10 |     
Error:   11 | >>> RUN CGO_ENABLED=0 go build -o ./kcpmanifestscan -ldflags="-s -w" ./cmd/kcpmanifestscan
Error:   12 |     
Error:   13 |     FROM scratch
Error: --------------------
Error: ERROR: failed to build: failed to solve: process "/bin/sh -c CGO_ENABLED=0 go build -o ./kcpmanifestscan -ldflags=\"-s -w\" ./cmd/kcpmanifestscan" did not complete successfully: exit code: 1
Error: The process '/usr/bin/docker' failed with exit code 1
```

The solution is to update the imports statements in the packages so they are compatible with `go.mod` file. The renovate can handle this automatically in a post upgrade task.

This PR adds post upgrade task for golang into shared config. The task uses dedicated tools that upgrades major versions of packages in imports statements.
