### PR TITLE
Chore: [SlackMessageSender] Remove unused packages 

### DIFF
--- a/cmd/cloud-run/slackmessagesender/requirements.txt
+++ b/cmd/cloud-run/slackmessagesender/requirements.txt
@@ -1,8 +1,5 @@
 slack_bolt==1.27.0
 slack_sdk==3.38.0
 flask>=2.3.2
-cloudevents==1.12.0
 gunicorn==23.0.0
-pygithub==2.8.1
-pyyaml==6.0.3
 werkzeug>=3.0.6


### PR DESCRIPTION
I was trying to fix cve that has occured in our BDBA scan: https://nvd.nist.gov/vuln/detail/CVE-2025-45768
During the lookup i saw that `pyGithub` package which additionally requires `pyjwt` is not actually needed in our code. So I removed that and another unused packages

This pull request updates the `requirements.txt` file for the Slack message sender service by removing several dependencies that are no longer needed.

Dependency cleanup:

* Removed `cloudevents`, `pygithub`, and `pyyaml` dependencies from `requirements.txt` to reduce unnecessary packages and potential security surface.