### PR TITLE
fix: update workload identity federation configuration for internal GitHub access

### DIFF
--- a/configs/terraform/environments/prod/dora-integration.tf
+++ b/configs/terraform/environments/prod/dora-integration.tf
@@ -82,7 +82,7 @@ resource "google_secret_manager_secret_iam_member" "dora_integration_workflow_pu
   project   = var.gcp_project_id
   secret_id = google_secret_manager_secret.kyma_bot_public_github_token.secret_id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_ref/${var.dora_integration_reusable_workflow_ref}"
+  member    = "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.reusable_workflow_ref/${var.dora_integration_reusable_workflow_ref}"
 }
 
 # dora_integration_workflow_internal_token_reader Grant the DORA integration reusable workflow access to read the internal GitHub token.
@@ -92,7 +92,7 @@ resource "google_secret_manager_secret_iam_member" "dora_integration_workflow_in
   project   = var.gcp_project_id
   secret_id = google_secret_manager_secret.dora_integration_internal_github_token.secret_id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_ref/${var.dora_integration_reusable_workflow_ref}"
+  member    = "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.reusable_workflow_ref/${var.dora_integration_reusable_workflow_ref}"
 }
 
 # ------------------------------------------------------------------------------

--- a/configs/terraform/environments/prod/gcp-workfload-identity-federation-variables.tf
+++ b/configs/terraform/environments/prod/gcp-workfload-identity-federation-variables.tf
@@ -33,3 +33,10 @@ variable "gh_com_kyma_project_wif_attribute_condition" {
   default     = "attribute.repository_owner_id == \"39153523\""
   description = "Attribute condition for workload identity pool provider"
 }
+
+# Internal GitHub Enterprise (SAP) Workload Identity Federation
+variable "internal_github_wif_pool_id" {
+  type        = string
+  default     = "github-tools-sap"
+  description = "Workload Identity Federation pool id used for internal GitHub Enterprise workflows"
+}

--- a/configs/terraform/environments/prod/gcp-workfload-identity-federation.tf
+++ b/configs/terraform/environments/prod/gcp-workfload-identity-federation.tf
@@ -3,6 +3,15 @@ data "github_repository" "test_infra" {
   name     = var.github_test_infra_repository_name
 }
 
+data "google_project" "current" {
+  project_id = var.gcp_project_id
+}
+
+locals {
+  # Full resource name of the internal GitHub Enterprise WIF pool.
+  internal_github_wif_pool_name = "projects/${data.google_project.current.number}/locations/global/workloadIdentityPools/${var.internal_github_wif_pool_id}"
+}
+
 module "gh_com_kyma_project_workload_identity_federation" {
   source = "../../modules/gcp-workload-identity-federation"
 


### PR DESCRIPTION
## Description

Running the DORA integration reusable workflow was failing with “permission denied” when trying to access GitHub token secrets from GCP Secret Manager. The root cause was that the Secret Manager IAM bindings granted access to the wrong Workload Identity Federation (WIF) pool (the github.com/kyma-project pool), while the workflow actually authenticates via the internal GitHub Enterprise WIF pool.

## What changed

Updated the Secret Manager IAM members in dora-integration.tf to use the internal GitHub WIF pool (github-tools-sap) in the principalSet://... member string.
Introduced a single-source-of-truth variable internal_github_wif_pool_id (default: github-tools-sap) in the dedicated WIF variables file:
gcp-workfload-identity-federation-variables.tf
Added logic in gcp-workfload-identity-federation.tf to compute the full WIF pool resource name from project number + pool id and reuse it in IAM bindings.

## Notes

No behavior changes for the existing github.com WIF setup; this change only corrects which pool is referenced for DORA secret access.