### PR TITLE
fix: update reusable workflow reference for DORA integration

### DIFF
--- a/configs/terraform/environments/prod/dora-integration.tf
+++ b/configs/terraform/environments/prod/dora-integration.tf
@@ -37,7 +37,7 @@ variable "dora_integration_internal_github_token_gcp_secret_name_github_organiza
 
 variable "dora_integration_reusable_workflow_ref" {
   type        = string
-  default     = "kyma/test-infra/.github/workflows/dora-integration.yml@refs/heads/main"
+  default     = "kyma/dora-integration/.github/workflows/dora-integration.yml@refs/heads/main"
   description = "Reference to the DORA integration reusable workflow"
 }
 


### PR DESCRIPTION
The dora-integration reusable workflow is located in dora-integration repository. The WIF principalSet was using wrong "kyma" repository.
