### PR TITLE
feat: add configuration for kyma-modules update components workflow

### DIFF
--- a/configs/terraform/environments/prod/kyma-runtime-update-components-config.tf
+++ b/configs/terraform/environments/prod/kyma-runtime-update-components-config.tf
@@ -37,6 +37,10 @@ variable "kyma_modules_update_components_reusable_workflow_ref" {
   default     = "kyma/test-infra/.github/workflows/reusable-update-components.yml@refs/heads/main"
   description = "Reference to the test-infra update-components reusable workflow"
 }
+data "github_repository" "kyma_modules_internal" {
+  provider = github.internal_github
+  name     = "kyma-modules"
+}
 
 # ------------------------------------------------------------------------------
 # GCP Secret Manager - Internal GitHub Token (kyma-neighbors runtime)
@@ -72,7 +76,7 @@ resource "google_secret_manager_secret_iam_member" "kyma_modules_update_componen
   project   = var.gcp_project_id
   secret_id = google_secret_manager_secret.kyma_modules_runtime_internal_github_token.secret_id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.reusable_workflow_ref/${var.kyma_modules_update_components_reusable_workflow_ref}"
+  member    = "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.repository.id/${data.github_repository.kyma_modules_internal.repo_id}/attribute.reusable_workflow_ref/${var.kyma_modules_update_components_reusable_workflow_ref}"
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces a new Terraform configuration to manage the resources required for the "update components" workflow in the `kyma-modules` project. The configuration automates the creation and management of a GCP Secret Manager secret for an internal GitHub token, grants IAM permissions for workflow access, and exposes the secret name as a repository variable in internal GitHub Enterprise.

Key infrastructure automation and security changes:

**Secret management and permissions:**
* Adds a GCP Secret Manager secret (`kyma-neighbors-runtime-serviceuser-internal-github-token`) to securely store the internal GitHub token used by the `kyma-modules` update-components workflow.
* Grants IAM permissions via a WIF principal set, allowing only the specified reusable workflow to access the secret, improving security and scoping access.

**GitHub Actions integration:**
* Adds a GitHub Actions repository variable in the internal GitHub Enterprise repository (`kyma-modules`) to expose the GCP secret name for use in workflows.

**Configurability and documentation:**
* Introduces input variables for secret names, repository names, and workflow references, making the configuration reusable and adaptable for different environments.
* Provides detailed comments and documentation within the Terraform file to clarify the purpose and usage of each resource and variable. 

For now, workflows doesn't exists yet. I would like to prepare everything before merging the workflows