### PR TITLE
feat: update variable names for internal GitHub token to kyma-prow in…

### DIFF
--- a/configs/terraform/environments/prod/kyma-runtime-update-components-config.tf
+++ b/configs/terraform/environments/prod/kyma-runtime-update-components-config.tf
@@ -14,15 +14,15 @@
 # Variables
 # ------------------------------------------------------------------------------
 
-variable "kyma_modules_runtime_internal_github_token_gcp_secret_name" {
+variable "kyma_prow_serviceuser_internal_github_token_gcp_secret_name" {
   type        = string
-  default     = "kyma-neighbors-runtime-serviceuser-internal-github-token"
-  description = "GCP Secret Manager secret name for internal GitHub token used by kyma-modules update-components workflow"
+  default     = "kyma-prow-serviceuser-internal-github-token"
+  description = "GCP Secret Manager secret name for internal GitHub kyma-prow-serviceaccount token used by kyma-modules update-components workflow"
 }
 
-variable "kyma_runtime_user_internal_github_token_gcp_secret_name_github_repository_variable" {
+variable "kyma_prow_serviceuser_internal_github_token_gcp_secret_name_github_repository_variable" {
   type        = string
-  default     = "KYMA_RUNTIME_USER_INTERNAL_GITHUB_TOKEN_GCP_SECRET_NAME"
+  default     = "KYMA_PROW_SERVICEUSER_INTERNAL_GITHUB_TOKEN_GCP_SECRET_NAME"
   description = "GitHub Actions repository variable name that holds the GCP secret name"
 }
 
@@ -46,12 +46,12 @@ data "github_repository" "kyma_modules_internal" {
 # GCP Secret Manager - Internal GitHub Token (kyma-neighbors runtime)
 # ------------------------------------------------------------------------------
 
-# kyma-neighbors-runtime-serviceuser-internal-github-token
-# This secret stores the Personal Access Token for the kyma-neighbors runtime service user
+# kyma-prow-serviceuser-internal-github-token
+# This secret stores the Personal Access Token for the kyma-prow service user
 # on internal GitHub Enterprise. The token is used by the kyma-modules update-components workflow.
 resource "google_secret_manager_secret" "kyma_modules_runtime_internal_github_token" {
   project   = var.gcp_project_id
-  secret_id = var.kyma_modules_runtime_internal_github_token_gcp_secret_name
+  secret_id = var.kyma_prow_serviceuser_internal_github_token_gcp_secret_name
 
   replication {
     auto {}
@@ -62,7 +62,7 @@ resource "google_secret_manager_secret" "kyma_modules_runtime_internal_github_to
     github-instance = "internal"
     owner           = "neighbors"
     component       = "product-kyma-runtime"
-    entity          = "kyma-neighbors-runtime-serviceuser"
+    entity          = "kyma-prow-serviceuser"
   }
 }
 
@@ -86,7 +86,7 @@ resource "google_secret_manager_secret_iam_member" "kyma_modules_update_componen
 resource "github_actions_variable" "kyma_modules_runtime_internal_github_token_gcp_secret_name" {
   provider      = github.internal_github
   repository    = var.internal_github_kyma_modules_repository_name
-  variable_name = var.kyma_runtime_user_internal_github_token_gcp_secret_name_github_repository_variable
+  variable_name = var.kyma_prow_serviceuser_internal_github_token_gcp_secret_name_github_repository_variable
   value         = google_secret_manager_secret.kyma_modules_runtime_internal_github_token.secret_id
 }
 


### PR DESCRIPTION
This pull request updates the configuration for managing the internal GitHub token used by the kyma-modules update-components workflow. The main focus is to switch from using the kyma-neighbors runtime service user to the kyma-prow service user for improved clarity and consistency. The most important changes are:

**Variable and Secret Renaming:**

* Renamed Terraform variables and their default values from `kyma_modules_runtime_internal_github_token_gcp_secret_name` and `kyma_runtime_user_internal_github_token_gcp_secret_name_github_repository_variable` to `kyma_prow_serviceuser_internal_github_token_gcp_secret_name` and `kyma_prow_serviceuser_internal_github_token_gcp_secret_name_github_repository_variable` to reflect the new service user.
* Updated the `google_secret_manager_secret` resource to use the new variable name for the secret ID, and changed references in comments and metadata from `kyma-neighbors-runtime-serviceuser` to `kyma-prow-serviceuser`. [[1]](diffhunk://#diff-7b5fcfe0c5ea521da833c9a0a5dae936a3d2ccc676f9b6166ff2bc7ab7c10bacL49-R54) [[2]](diffhunk://#diff-7b5fcfe0c5ea521da833c9a0a5dae936a3d2ccc676f9b6166ff2bc7ab7c10bacL65-R65)

**GitHub Actions Integration:**

* Changed the GitHub Actions repository variable to use the new variable name, ensuring the workflow references the correct secret.