### PR TITLE
feat: update IAM permissions for internal GitHub token access in comp…

### DIFF
--- a/configs/terraform/environments/prod/kyma-runtime-update-components-config.tf
+++ b/configs/terraform/environments/prod/kyma-runtime-update-components-config.tf
@@ -1,7 +1,3 @@
-import {
-  to = google_secret_manager_secret_iam_member.kyma_modules_update_components_workflow_internal_token_reader
-  id = "projects/351981214969/secrets/kyma-prow-serviceuser-internal-github-token roles/secretmanager.secretAccessor principal://iam.googleapis.com/projects/351981214969/locations/global/workloadIdentityPools/github-tools-sap/subject/repository_id:172960:repository_owner_id:2457:workflow:Update Component Version on Push"
-}
 # ==============================================================================
 # Update Components Configuration
 # ==============================================================================


### PR DESCRIPTION
This pull request updates the IAM permissions configuration for the Kyma modules update components workflow in the production Terraform environment. The main change is a shift from using a reusable workflow reference for granting secret access to specifying an explicit workflow principal. This simplifies the permission model and removes the need for a variable referencing the reusable workflow.

**IAM Permissions and Workflow Configuration:**

* Changed the IAM member in `google_secret_manager_secret_iam_member.kyma_modules_update_components_workflow_internal_token_reader` to use a direct principal reference for the specific workflow, instead of the previous principal set with reusable workflow attributes. [[1]](diffhunk://#diff-7b5fcfe0c5ea521da833c9a0a5dae936a3d2ccc676f9b6166ff2bc7ab7c10bacR1-R4) [[2]](diffhunk://#diff-7b5fcfe0c5ea521da833c9a0a5dae936a3d2ccc676f9b6166ff2bc7ab7c10bacL70-R77)
* Removed the `kyma_modules_update_components_reusable_workflow_ref` variable, as it is no longer needed for permission assignment.

These changes streamline how secret access is granted to the workflow, making the configuration easier to manage and less dependent on variable references.