### PR TITLE
feat: update workload identity references in terraform-executor.tf

### DIFF
--- a/configs/terraform/environments/prod/terraform-executor.tf
+++ b/configs/terraform/environments/prod/terraform-executor.tf
@@ -22,7 +22,7 @@ resource "google_project_iam_member" "terraform_executor_prow_project_owner" {
 # Authentication is done through github oidc provider and google workload identity federation.
 resource "google_service_account_iam_binding" "terraform_workload_identity" {
   members = [
-    "principal://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/subject/repository_id:147495537:repository_owner_id:39153523:workflow:Post Apply Prod Terraform"
+    "principal://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/subject/repository_id:${data.github_repository.test_infra.repo_id}:repository_owner_id:${var.github_kyma_project_organization_id}:workflow:Post Apply Prod Terraform"
   ]
   role               = "roles/iam.workloadIdentityUser"
   service_account_id = google_service_account.terraform_executor.name


### PR DESCRIPTION
This pull request updates the way workload identity pool names and repository IDs are referenced in the IAM bindings for Terraform executor and planner service accounts. The main improvement is switching from hardcoded values to dynamic references using Terraform module outputs and data sources, which increases maintainability and flexibility.

**IAM principal reference improvements:**

* Updated all `principal://` and `principalSet://` references in `google_service_account_iam_binding` resources to use `${module.gh_com_kyma_project_workload_identity_federation.pool_name}` instead of hardcoded project and pool names. This change ensures the workload identity pool name is dynamically sourced from the Terraform module, reducing manual maintenance and risk of errors. [[1]](diffhunk://#diff-ccf492cce771b884b8c0e30ef12e0b8cffb315778286cb91fad89c8cb5540bb6L25-R25) [[2]](diffhunk://#diff-ccf492cce771b884b8c0e30ef12e0b8cffb315778286cb91fad89c8cb5540bb6L64-R73)
* Replaced hardcoded GitHub repository and organization IDs in IAM member strings with `${data.github_repository.test_infra.repo_id}` and `${var.github_kyma_project_organization_id}` variables, making the configuration more reusable and adaptable to changes.