### PR TITLE
fix: add maxMajorIncrement to custom docker images configuration

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -55,7 +55,8 @@
       "groupName": "custom docker images (semver) to {{newVersion}}",
       "commitMessageTopic": "custom docker images (loose) to {{newVersion}}",
       "commitMessageExtra": "",
-      "separateMajorMinor": false
+      "separateMajorMinor": false,
+      "maxMajorIncrement": 0
     },
     {
     "matchManagers": ["regex"],
@@ -64,7 +65,8 @@
     "groupName": "custom docker images (loose) to {{newVersion}}",
     "commitMessageTopic": "custom docker images (loose) to {{newVersion}}",
     "commitMessageExtra": "",
-    "separateMajorMinor": false
+    "separateMajorMinor": false,
+    "maxMajorIncrement": 0
     }
   ],
 


### PR DESCRIPTION
This pull request makes a small update to the `.github/renovate-sharable-config.json` file, adding a `maxMajorIncrement` property to two configuration objects. This change helps control the maximum allowed major version bump for custom Docker image updates managed by Renovate. 

This was added because our current Renovate configuration struggles to parse kubernetes-like tags correctly. With the turn of the new year, Renovate is misinterpreting the date change as a major version jump, causing it to report an incorrect update.

- Renovate configuration: Added `"maxMajorIncrement": 0` to both custom Docker image update groups, ensuring that Renovate will not allow major version upgrades for these dependencies. [[1]](diffhunk://#diff-84c928d83eb1d19513f4a40592570627224902d579882cf6f12958ff0503b192L58-R59) [[2]](diffhunk://#diff-84c928d83eb1d19513f4a40592570627224902d579882cf6f12958ff0503b192L67-R69)
https://docs.renovatebot.com/configuration-options/#maxmajorincrement