### PR TITLE
fix: remove separateMajorMinor option from custom docker images confi…

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -53,7 +53,7 @@
       "matchCurrentVersion": "v?\\d+\\.\\d+\\.\\d+",
       "versioning": "semver",
       "groupName": "custom docker images (semver) to {{newVersion}}",
-      "commitMessageTopic": "custom docker images (loose) to {{newVersion}}",
+      "commitMessageTopic": "custom docker images (semver) to {{newVersion}}",
       "commitMessageExtra": "",
       "separateMajorMinor": false
     },


### PR DESCRIPTION
This pull request makes a minor change to the `.github/renovate-sharable-config.json` file by removing the `separateMajorMinor` property from one of the configuration objects. This simplifies the configuration for managing custom Docker image updates.