### PR TITLE
fix: Use discussion_forum labels instead of security labels for Cloud Identity groups

### DIFF
--- a/configs/terraform/environments/prod/restricted-registry-iam-groups.tf
+++ b/configs/terraform/environments/prod/restricted-registry-iam-groups.tf
@@ -8,7 +8,7 @@ resource "google_cloud_identity_group" "restricted_registry_prod_read" {
   }
 
   labels = {
-    "cloudidentity.googleapis.com/groups.security" = ""
+    "cloudidentity.googleapis.com/groups.discussion_forum" = ""
   }
 
   parent = "customers/${var.cloud_identity_customer_id}"
@@ -24,7 +24,7 @@ resource "google_cloud_identity_group" "restricted_registry_prod_write" {
   }
 
   labels = {
-    "cloudidentity.googleapis.com/groups.security" = ""
+    "cloudidentity.googleapis.com/groups.discussion_forum" = ""
   }
 
   parent = "customers/${var.cloud_identity_customer_id}"
@@ -40,7 +40,7 @@ resource "google_cloud_identity_group" "restricted_registry_dev_read" {
   }
 
   labels = {
-    "cloudidentity.googleapis.com/groups.security" = ""
+    "cloudidentity.googleapis.com/groups.discussion_forum" = ""
   }
 
   parent = "customers/${var.cloud_identity_customer_id}"
@@ -56,7 +56,7 @@ resource "google_cloud_identity_group" "restricted_registry_dev_write" {
   }
 
   labels = {
-    "cloudidentity.googleapis.com/groups.security" = ""
+    "cloudidentity.googleapis.com/groups.discussion_forum" = ""
   }
 
   parent = "customers/${var.cloud_identity_customer_id}"


### PR DESCRIPTION
Security labels (cloudidentity.googleapis.com/groups.security) cannot be specified directly via API and must be managed by Google Cloud Identity Admin.

Error: googleapi: Error 400: security label cannot be specified directly

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Replace cloudidentity.googleapis.com/groups.security with cloudidentity.googleapis.com/groups.discussion_forum labels
- Fix Error 400: "security label cannot be specified directly" that prevented group creation via Terraform
- Affects 4 Cloud Identity groups: kyma-restricted-registry-prod-read@sap.com, kyma-restricted-registry-prod-write@sap.com, kyma-restricted-registry-dev-read@sap.com, kyma-restricted-registry-dev-write@sap.com

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
