### PR TITLE
Add pull-only access to Prod Restricted Registry for SecScanners and RM delivery

### DIFF
--- a/configs/terraform/environments/prod/restricted-markets-delivery.tf
+++ b/configs/terraform/environments/prod/restricted-markets-delivery.tf
@@ -18,6 +18,16 @@ resource "google_artifact_registry_repository_iam_member" "kyma_modules_reader" 
   member     = "serviceAccount:${google_service_account.restricted-markets-artifactregistry-reader.email}"
 }
 
+# Grant restricted-markets-artifactregistry-reader access to Prod Restricted Registry
+resource "google_artifact_registry_repository_iam_member" "restricted_prod_markets_delivery_reader" {
+  provider   = google.kyma_project
+  project    = var.kyma_project_gcp_project_id
+  location   = module.restricted_prod.artifact_registry.location
+  repository = module.restricted_prod.artifact_registry.name
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:${google_service_account.restricted-markets-artifactregistry-reader.email}"
+}
+
 variable "sre-restricted-markets-artifactregistry-reader" {
   type = object({
     registry-reader-sa          = string

--- a/configs/terraform/environments/prod/restricted-registry.tf
+++ b/configs/terraform/environments/prod/restricted-registry.tf
@@ -158,7 +158,7 @@ module "restricted_dev" {
 
 resource "google_artifact_registry_repository_iam_member" "restricted_prod_writers" {
   provider   = google.kyma_project
-  project    = "kyma-project"
+  project    = var.kyma_project_gcp_project_id
   location   = module.restricted_prod.artifact_registry.location
   repository = module.restricted_prod.artifact_registry.name
   role       = "roles/artifactregistry.writer"
@@ -167,9 +167,19 @@ resource "google_artifact_registry_repository_iam_member" "restricted_prod_write
 
 resource "google_artifact_registry_repository_iam_member" "restricted_dev_writers" {
   provider   = google.kyma_project
-  project    = "kyma-project"
+  project    = var.kyma_project_gcp_project_id
   location   = module.restricted_dev.artifact_registry.location
   repository = module.restricted_dev.artifact_registry.name
   role       = "roles/artifactregistry.writer"
   member     = "group:${var.restricted_registry_iam_groups.dev_write}"
+}
+
+# Grant kyma-security-scanners service account PULL ONLY access to Prod Restricted Registry
+resource "google_artifact_registry_repository_iam_member" "restricted_prod_security_scanners_reader" {
+  provider   = google.kyma_project
+  project    = var.kyma_project_gcp_project_id
+  location   = module.restricted_prod.artifact_registry.location
+  repository = module.restricted_prod.artifact_registry.name
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:${google_service_account.kyma-security-scanners.email}"
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Grant kyma-security-scanners SA (kyma-security-scanners@sap-kyma-prow.iam.gserviceaccount.com) pull-only access to Prod Restricted Registry using artifactregistry.reader role.
- Grant Restricted Markets Delivery access to Prod Restricted Registry through impersonation of restricted-markets-artifactregistry-reader SA. SRE pipeline SA (gcr-writer@sap-ti-dx-kyma-mps-dev.iam.gserviceaccount.com) authenticates via service account impersonation.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
