### PR TITLE
Remove direct registry group memberships in favor of hierarchical structure

### DIFF
--- a/configs/terraform/environments/prod/restricted-markets-delivery.tf
+++ b/configs/terraform/environments/prod/restricted-markets-delivery.tf
@@ -18,19 +18,6 @@ resource "google_artifact_registry_repository_iam_member" "kyma_modules_reader" 
   member     = "serviceAccount:${google_service_account.restricted-markets-artifactregistry-reader.email}"
 }
 
-# Add restricted-markets-artifactregistry-reader to Prod Restricted Registry read group
-resource "google_cloud_identity_group_membership" "markets_delivery_prod_read" {
-  group = var.restricted_registry_iam_groups.prod_read_group_name
-
-  preferred_member_key {
-    id = google_service_account.restricted-markets-artifactregistry-reader.email
-  }
-
-  roles {
-    name = "MEMBER"
-  }
-}
-
 variable "sre-restricted-markets-artifactregistry-reader" {
   type = object({
     registry-reader-sa          = string

--- a/configs/terraform/environments/prod/service_accounts.tf
+++ b/configs/terraform/environments/prod/service_accounts.tf
@@ -81,19 +81,6 @@ resource "google_service_account" "kyma-security-scanners" {
   }
 }
 
-# Add kyma-security-scanners to Prod Restricted Registry read group
-resource "google_cloud_identity_group_membership" "security_scanners_prod_read" {
-  group = var.restricted_registry_iam_groups.prod_read_group_name
-
-  preferred_member_key {
-    id = google_service_account.kyma-security-scanners.email
-  }
-
-  roles {
-    name = "MEMBER"
-  }
-}
-
 resource "google_service_account" "neighbors-conduit-cli-builder" {
   account_id   = "neighbors-conduit-cli-builder"
   display_name = "neighbors-conduit-cli-builder"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Remove security_scanners_prod_read from service_accounts.tf
- Remove markets_delivery_prod_read from restricted-markets-delivery.tf
- Service accounts now join registry access groups only through hierarchical groups
- Eliminates duplicate memberships (direct + hierarchical)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

https://github.com/kyma-project/test-infra/pull/13714
