### PR TITLE
Fix terraform-executor access to image-builder secret

### DIFF
--- a/configs/terraform/environments/prod/image-builder.tf
+++ b/configs/terraform/environments/prod/image-builder.tf
@@ -78,14 +78,6 @@ resource "google_service_account" "kyma_project_image_builder_restricted_markets
 }
 
 # Secret in sap-kyma-prow project to store the service account key
-# Note: Service account key and secret version are managed manually.
-# To create a key and add it to the secret:
-#   gcloud iam service-accounts keys create key.json \
-#     --iam-account=img-builder-restricted-markets@kyma-project.iam.gserviceaccount.com \
-#     --project=kyma-project
-#   gcloud secrets versions add image-builder-sa-key-restricted-markets \
-#     --project=sap-kyma-prow \
-#     --data-file=key.json
 resource "google_secret_manager_secret" "image_builder_sa_key_restricted_markets" {
   project   = var.gcp_project_id
   secret_id = var.image_builder_sa_key_restricted_markets_secret_name


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add secretmanager.secretAccessor role for terraform-executor to image-builder-sa-key-restricted-markets secret
- Add lifecycle ignore_changes for secret_data to prevent unnecessary updates
- Allows terraform plan/apply to read secret version without permission errors

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/test-infra/pull/13729