### PR TITLE
feat: add use-restricted-registry handling in the reusable workflow and action

### DIFF
--- a/.github/actions/image-builder/action.yml
+++ b/.github/actions/image-builder/action.yml
@@ -107,7 +107,7 @@ runs:
       id: prepare-platforms
       shell: bash
 
-    - uses: docker://europe-docker.pkg.dev/kyma-project/prod/image-builder:v20260116-e70d97b9
+    - uses: docker://europe-docker.pkg.dev/kyma-project/prod/image-builder:v20260116-2e246fc6
       id: build
       with:
         args: --name=${{ inputs.image-name }} --context=${{ inputs.context }} --dockerfile=${{ inputs.dockerfile }} --target=${{ inputs.target }} --azure-access-token=${{ inputs.ado-token }} --oidc-token=${{ inputs.oidc-token }} ${{ steps.prepare-build-args.outputs.build-args }} ${{ steps.prepare-tags.outputs.tags }} ${{ steps.prepare-platforms.outputs.platforms }} --export-tags=${{ inputs.export-tags }} --config=${{ inputs.config }} --use-go-internal-sap-modules=${{ inputs.use-go-internal-sap-modules }} --use-restricted-registry=${{ inputs.use-restricted-registry }}

--- a/.github/actions/image-builder/action.yml
+++ b/.github/actions/image-builder/action.yml
@@ -52,6 +52,10 @@ inputs:
     description: Specify which build stage in the Dockerfile to use as the target
     required: false
     default: ""
+  use-restricted-registry:
+    description: Enable building images using Chainguard restricted base images
+    required: false
+    default: false
 
 outputs:
   adoResult:
@@ -106,4 +110,4 @@ runs:
     - uses: docker://europe-docker.pkg.dev/kyma-project/prod/image-builder:v20260116-e70d97b9
       id: build
       with:
-        args: --name=${{ inputs.image-name }} --context=${{ inputs.context }} --dockerfile=${{ inputs.dockerfile }} --target=${{ inputs.target }} --azure-access-token=${{ inputs.ado-token }} --oidc-token=${{ inputs.oidc-token }} ${{ steps.prepare-build-args.outputs.build-args }} ${{ steps.prepare-tags.outputs.tags }} ${{ steps.prepare-platforms.outputs.platforms }} --export-tags=${{ inputs.export-tags }} --config=${{ inputs.config }} --use-go-internal-sap-modules=${{ inputs.use-go-internal-sap-modules }}
+        args: --name=${{ inputs.image-name }} --context=${{ inputs.context }} --dockerfile=${{ inputs.dockerfile }} --target=${{ inputs.target }} --azure-access-token=${{ inputs.ado-token }} --oidc-token=${{ inputs.oidc-token }} ${{ steps.prepare-build-args.outputs.build-args }} ${{ steps.prepare-tags.outputs.tags }} ${{ steps.prepare-platforms.outputs.platforms }} --export-tags=${{ inputs.export-tags }} --config=${{ inputs.config }} --use-go-internal-sap-modules=${{ inputs.use-go-internal-sap-modules }} --use-restricted-registry=${{ inputs.use-restricted-registry }}

--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -52,6 +52,11 @@ on:
         required: false
         type: string
         default: ""
+      use-restricted-registry:
+        description: Enable building images using Chainguard restricted base images
+        required: false
+        type: boolean
+        default: false
 
     outputs:
       images:
@@ -129,6 +134,7 @@ jobs:
           use-go-internal-sap-modules: ${{ inputs.use-go-internal-sap-modules }}
           platforms: ${{ inputs.platforms }}
           target: ${{ inputs.target }}
+          use-restricted-registry: ${{ inputs.use-restricted-registry }}
 
       - name: Print built images
         run: |


### PR DESCRIPTION
This pull request adds support for building images using Chainguard restricted base images by introducing a new `use-restricted-registry` input parameter to both the reusable workflow and the composite GitHub Action. The parameter is properly threaded through the workflow and action, enabling users to opt in to this feature when triggering image builds.

**Support for Chainguard restricted base images:**

* Added a new `use-restricted-registry` input parameter to `.github/actions/image-builder/action.yml` and `.github/workflows/image-builder.yml`, allowing users to enable building images with Chainguard restricted base images. [[1]](diffhunk://#diff-3f051056bc6ffc7a0cb5dc329a10fe8797fc8964a6e66bba8cd2aa792a4d7c46R55-R58) [[2]](diffhunk://#diff-d2d311485583e9a96eea5dc19ecfab14f181d32934d09d005c1b5d9539fca29aR55-R59)
* Passed the `use-restricted-registry` input through the workflow and action, ensuring it is included in the arguments for the image builder step. [[1]](diffhunk://#diff-3f051056bc6ffc7a0cb5dc329a10fe8797fc8964a6e66bba8cd2aa792a4d7c46L109-R113) [[2]](diffhunk://#diff-d2d311485583e9a96eea5dc19ecfab14f181d32934d09d005c1b5d9539fca29aR137-R138)