### PR TITLE
Add Google Cloud authentication support for image signing

### DIFF
--- a/pkg/sign/notary_test.go
+++ b/pkg/sign/notary_test.go
@@ -70,7 +70,7 @@ func generateTestCert() (string, string, error) {
 
 // TestImageService_ParseReference_Valid checks the correct parsing of an image reference.
 func TestImageService_ParseReference_Valid(t *testing.T) {
-	imageService := ImageService{}
+	imageService := NewImageService()
 
 	// Use a valid image reference
 	ref, err := imageService.ParseReference("docker.io/library/alpine:latest")
@@ -84,7 +84,7 @@ func TestImageService_ParseReference_Valid(t *testing.T) {
 
 // TestImageService_ParseReference_Invalid checks the incorrect parsing of an image reference.
 func TestImageService_ParseReference_Invalid(t *testing.T) {
-	imageService := ImageService{}
+	imageService := NewImageService()
 
 	invalidReferences := []string{
 		":::",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

This change enables the image-builder application to authenticate with
Google Artifact Registry restricted repositories using service account
credentials via the GOOGLE_APPLICATION_CREDENTIALS environment variable.

Changes:
- Simplified ImageService structure by removing unnecessary state
- Added getRemoteOptions() function to dynamically configure authentication
- Use google.Keychain when GOOGLE_APPLICATION_CREDENTIALS is set
- Fall back to authn.DefaultKeychain (Docker config) otherwise
- Maintained ImageRepositoryInterface for testability
- All unit and integration tests passing

Fixes authentication error:
'DENIED: Unauthenticated request. Unauthenticated requests do not have
permission artifactregistry.repositories.downloadArtifacts'

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
