### PR TITLE
Add restricted markets image-builder SA to cache repository

### DIFF
--- a/configs/terraform/environments/prod/image-builder.tf
+++ b/configs/terraform/environments/prod/image-builder.tf
@@ -55,7 +55,10 @@ module "docker_cache" {
   repository_prevent_destroy = var.docker_cache_repository.repository_prevent_destroy
   repository_name            = var.docker_cache_repository.name
   description                = var.docker_cache_repository.description
-  repoAdmin_serviceaccounts  = [google_service_account.kyma_project_image_builder.email]
+  repoAdmin_serviceaccounts  = [
+    google_service_account.kyma_project_image_builder.email,
+    google_service_account.kyma_project_image_builder_restricted_markets.email
+  ]
   location                   = var.docker_cache_repository.location
   format                     = var.docker_cache_repository.format
   immutable_tags             = var.docker_cache_repository.immutable_tags


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Grant img-builder-restricted-markets@kyma-project.iam.gserviceaccount.com write access to europe-docker.pkg.dev/kyma-project/cache repository.

This allows the restricted markets image-builder to use cache repository for Docker layer caching during image builds.
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
