### PR TITLE
Fix dead letter terraform

### DIFF
--- a/configs/terraform/environments/prod/secrets-rotator.tf
+++ b/configs/terraform/environments/prod/secrets-rotator.tf
@@ -95,6 +95,7 @@ resource "google_pubsub_subscription" "secrets-rotator-dead-letter" {
   cloud_storage_config {
     bucket = google_storage_bucket.secret-rotator-dead-letters-bucket.name
   }
+  depends_on = [google_storage_bucket_iam_member.dead-letter-bucket-access]
 }
 
 resource "google_storage_bucket" "secret-rotator-dead-letters-bucket" {
@@ -122,7 +123,7 @@ resource "google_monitoring_alert_policy" "dead-letter-alert" {
   conditions {
     display_name = format("%s dead letter message count", var.secrets_rotator_name)
     condition_threshold {
-      filter     = "resource.type = \"pubsub_subscription\" AND (resource.labels.subscription_id = \"secrets-rotator-service-account-keys-rotator\" AND resource.labels.project_id = \"sap-kyma-prow\") AND metric.type = \"pubsub.googleapis.com/subscription/dead_letter_message_count\""
+        filter     = "resource.type = \"pubsub_subscription\" AND (resource.labels.subscription_id = \"${google_pubsub_subscription.secrets-rotator-dead-letter.name}\" AND resource.labels.project_id = \"${var.gcp_project_id}\") AND metric.type = \"pubsub.googleapis.com/subscription/dead_letter_message_count\""
       duration   = "60s"
       comparison = "COMPARISON_GT"
       aggregations {


### PR DESCRIPTION
# Fix Dead Letter Terraform Configuration

🐛 **Bug Fix**: Resolved Terraform configuration issues in the secrets-rotator dead letter setup to prevent deployment failures.

### Changes

* `configs/terraform/environments/prod/secrets-rotator.tf`: 
  - Added explicit `depends_on` dependency to ensure the GCS bucket IAM permissions are configured before the Pub/Sub subscription is created, preventing race conditions during deployment
  - Fixed hardcoded values in the dead letter monitoring alert filter by replacing static project ID and subscription name with dynamic references using Terraform variables (`${google_pubsub_subscription.secrets-rotator-dead-letter.name}` and `${var.gcp_project_id}`)

These changes ensure proper resource ordering during Terraform apply operations and make the configuration more maintainable and portable across different environments.

### Related Resources

- GitHub Actions Run: https://github.com/kyma-project/test-infra/actions/runs/21428569957/job/61702616282

- [ ] 🔄 Regenerate and Update Summary

