### PR TITLE
fix: specify exact version for @actions/core dependency

### DIFF
--- a/.github/actions/expose-jwt-action/install/action.yml
+++ b/.github/actions/expose-jwt-action/install/action.yml
@@ -9,5 +9,5 @@ runs:
     - run: |
         cd .github/actions/expose-jwt-action
         npm init -y
-        npm install @actions/core
+        npm install @actions/core@2.0.0
       shell: bash


### PR DESCRIPTION
This pull request updates the installation procedure for the `expose-jwt-action` GitHub Action to ensure a specific version of a dependency is used.
This is because of recent failure of latest version of the package, so i pinned the version to make sure the action will not fail

Example bug occurance: https://github.com/kyma-project/api-gateway/actions/runs/21468738140/job/61838382952

Dependency version pinning:

* Updated the installation command in `.github/actions/expose-jwt-action/install/action.yml` to explicitly install `@actions/core` version `2.0.0` instead of the latest version.