### PR TITLE
Add admin group as manager of restricted registry developers group.

### DIFF
--- a/configs/terraform/environments/prod/restricted-registry-hierarchical-groups.tf
+++ b/configs/terraform/environments/prod/restricted-registry-hierarchical-groups.tf
@@ -182,18 +182,6 @@ resource "google_cloud_identity_group_membership" "image_builder_group_to_prod_w
   }
 }
 
-# Manager group for kyma-restricted-registry-developers to enable management through the CLI or web console.
-resource "google_cloud_identity_group_membership" "kyma_developer_admin_as_developers_group_manager" {
-  group = var.restricted_registry_hierarchical_groups.developers_group_name
-
-  preferred_member_key {
-    id = var.kyma_developer_admin_email
-  }
-
-  roles {
-    name = "MANAGER"
-  }
-}
 
 # ------------------------------------------------------------------------------
 # Internal GitHub Team Members as Developers Group Owners
@@ -209,6 +197,12 @@ resource "google_cloud_identity_group_membership" "kyma_developer_admin_as_devel
 # Service accounts are skipped - only users with usernames starting with I or D
 # (I-numbers and D-numbers) are included.
 # ------------------------------------------------------------------------------
+
+variable "internal_github_neighbors_team_slug" {
+  type        = string
+  default     = "Neighbors"
+  description = "The slug of the neighbors team in the internal GitHub Enterprise instance."
+}
 
 # Data source to fetch the neighbors team from internal GitHub
 data "github_team" "neighbors" {

--- a/configs/terraform/environments/prod/variables.tf
+++ b/configs/terraform/environments/prod/variables.tf
@@ -59,9 +59,3 @@ variable "internal_github_base_url" {
   default     = "https://github.tools.sap/"
   description = "Base URL for the internal GitHub Enterprise instance."
 }
-
-variable "internal_github_neighbors_team_slug" {
-  type        = string
-  default     = "Neighbors"
-  description = "The slug of the neighbors team in the internal GitHub Enterprise instance. Members of this team will be granted OWNER role on the restricted registry developers hierarchical group."
-}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Add members of internal github Neighbors team as Onwers of restricted registry developers group to allow us manage members of a group from cli or web console. The users will be added manually into restricted registry developers group.

Adding a kyma_developer_admin@sap.com group is not possible, as groups can have only a Member role within another group.
