### PR TITLE
refactor: remove redundant IAM member resources for internal and public doc collector token

### DIFF
--- a/configs/terraform/environments/prod/doc-collector.tf
+++ b/configs/terraform/environments/prod/doc-collector.tf
@@ -34,13 +34,6 @@ variable "doc_collector_gcp_secret_name_internal_github_token" {
   default     = "technical-writers-docsync-workflow-gh-tools-neighbors-token"
   description = "GCP Secret Manager secret name for internal GitHub token used by documentation collector"
 }
-
-variable "doc_collector_workflow_name" {
-  type        = string
-  default     = "doc-collector"
-  description = "Name of the documentation collector workflow"
-}
-
 variable "doc_collector_reusable_workflow_ref" {
   type = string
   default = "kyma/test-infra/.github/workflows/reusable-doc-collector.yml@refs/heads/main"
@@ -50,12 +43,6 @@ variable "doc_collector_reusable_workflow_ref" {
 # ------------------------------------------------------------------------------
 # GitHub Data Sources
 # ------------------------------------------------------------------------------
-
-# Fetch the restricted-markets-docu-hub repository data from internal GitHub
-data "github_repository" "restricted_markets_docu_hub" {
-  provider = github.internal_github
-  name     = "product-kyma-runtime-fork"
-}
 
 # Fetch the kyma organization data from internal GitHub
 data "github_organization" "kyma_internal" {
@@ -92,13 +79,6 @@ resource "google_secret_manager_secret" "doc_collector_internal_github_token" {
 
 # Grant the documentation collector workflow access to read the internal GitHub token
 # via Workload Identity Federation.
-resource "google_secret_manager_secret_iam_member" "doc_collector_workflow_internal_token_reader" {
-  project   = var.gcp_project_id
-  secret_id = google_secret_manager_secret.doc_collector_internal_github_token.secret_id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "principal://iam.googleapis.com/${local.internal_github_wif_pool_name}/subject/repository_id:${data.github_repository.restricted_markets_docu_hub.repo_id}:repository_owner_id:${data.github_organization.kyma_internal.id}:workflow:${var.doc_collector_workflow_name}"
-}
-
 resource "google_secret_manager_secret_iam_member" "doc_collector_reusable_workflow_internal_token_reader" {
   for_each = toset(local.doc_collector_supported_event)
   project   = var.gcp_project_id
@@ -109,14 +89,6 @@ resource "google_secret_manager_secret_iam_member" "doc_collector_reusable_workf
 
 # Grant the documentation collector workflow access to read the public GitHub token
 # (kyma-bot-github-public-repo-token) via Workload Identity Federation.
-resource "google_secret_manager_secret_iam_member" "doc_collector_workflow_public_token_reader" {
-  project   = var.gcp_project_id
-  secret_id = google_secret_manager_secret.kyma_bot_public_github_token.secret_id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "principal://iam.googleapis.com/${local.internal_github_wif_pool_name}/subject/repository_id:${data.github_repository.restricted_markets_docu_hub.repo_id}:repository_owner_id:${data.github_organization.kyma_internal.id}:workflow:${var.doc_collector_workflow_name}"
-}
-
-
 resource "google_secret_manager_secret_iam_member" "doc_collector_reusable_workflow_public_token_reader" {
   for_each = toset(local.doc_collector_supported_event)
   project   = var.gcp_project_id


### PR DESCRIPTION
This pull request removes individual IAM bindings for the documentation collector workflow's access to both internal and public GitHub tokens in the production Terraform configuration. Instead, it relies on reusable workflow IAM bindings, likely to simplify and centralize permissions management.

Access control simplification:

* Removed the `google_secret_manager_secret_iam_member.doc_collector_workflow_internal_token_reader` resource, which previously granted the workflow direct access to the internal GitHub token.
* Removed the `google_secret_manager_secret_iam_member.doc_collector_workflow_public_token_reader` resource, which previously granted the workflow direct access to the public GitHub token.

The reusable workflow IAM bindings for both tokens remain in place, ensuring continued access via a more maintainable approach.