### PR TITLE
chore(concurrency): update concurrency handling for terraform to prevent failures on locked state

### DIFF
--- a/.github/workflows/post-apply-prod-terraform.yaml
+++ b/.github/workflows/post-apply-prod-terraform.yaml
@@ -1,7 +1,8 @@
 name: Post Apply Prod Terraform
 run-name: post-apply-prod-terraform
+
 concurrency:
-  group: terraform-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref_name}}
 
 on:
   push:
@@ -25,9 +26,11 @@ jobs:
       - name: Checkout
         id: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - name: Wait for other terraform executions
         id: wait_for_terraform
         uses: ahmadnassri/action-workflow-queue@542658b3a8270cac81ae15d401b0d974732808ac # v1.2.0
+
       - name: Authenticate to GCP
         id: gcp-auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
@@ -62,4 +65,4 @@ jobs:
           GITHUB_TOKEN: ${{ steps.secrets.outputs.gh-terraform-executor-token }}
           TF_VAR_internal_github_token: ${{ steps.secrets.outputs.internal-github-terraform-executor-token }}
         id: terraform_apply
-        run: tfcmt -owner $GITHUB_REPOSITORY_OWNER -repo ${{ github.event.repository.name }} -sha ${{ github.sha }} apply -- tofu -chdir=./configs/terraform/environments/prod apply -input=false -no-color -auto-approve
+        run: tfcmt -owner $GITHUB_REPOSITORY_OWNER -repo ${{ github.event.repository.name }} -sha ${{ github.sha }} apply -- tofu -chdir=./configs/terraform/environments/prod apply -input=false -no-color -auto-approve -lock-timeout=400s

--- a/.github/workflows/pull-plan-prod-terraform.yaml
+++ b/.github/workflows/pull-plan-prod-terraform.yaml
@@ -1,7 +1,9 @@
 name: Pull Plan Prod Terraform
 run-name: pull-plan-prod-terraform
+
 concurrency:
-  group: terraform-${{ github.base_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+
 on:
   # This workflow is triggered by workflow controller.
   workflow_call:
@@ -19,6 +21,10 @@ jobs:
     steps:
       - name: Checkout PR code
         uses: kyma-project/test-infra/.github/actions/checkout@main
+
+      - name: Wait for other terraform executions
+        id: wait_for_terraform
+        uses: ahmadnassri/action-workflow-queue@542658b3a8270cac81ae15d401b0d974732808ac # v1.2.0
 
       - name: Authenticate to GCP
         id: gcp_auth
@@ -63,7 +69,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.secrets.outputs.gh-terraform-planner-token }}
           TF_VAR_internal_github_token: ${{ steps.secrets.outputs.internal-github-terraform-planner-token }}
         id: terraform_plan
-        run: tfcmt -owner $GITHUB_REPOSITORY_OWNER -repo ${{ github.event.repository.name }} -pr ${{ github.event.pull_request.number || 0 }} -sha ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }} plan -- tofu -chdir=./configs/terraform/environments/prod plan -input=false -no-color -lock-timeout=300s
+        run: tfcmt -owner $GITHUB_REPOSITORY_OWNER -repo ${{ github.event.repository.name }} -pr ${{ github.event.pull_request.number || 0 }} -sha ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }} plan -- tofu -chdir=./configs/terraform/environments/prod plan -input=false -no-color -lock-timeout=400s
 
       - name: Hide GitHub comment
         env:


### PR DESCRIPTION
This pull request updates our Terraform GitHub Actions workflows to improve concurrency control and execution reliability. The main changes involve adding concurrency groups to prevent overlapping runs, introducing a queueing step to serialize Terraform executions, and increasing the Terraform lock timeout to handle longer operations.

**Workflow reliability and concurrency improvements:**

* Added a `concurrency` group to both `.github/workflows/post-apply-prod-terraform.yaml` and `.github/workflows/pull-plan-prod-terraform.yaml` to prevent overlapping workflow runs for the same environment or pull request. [[1]](diffhunk://#diff-d12a3660dd16433a61c729473a05b9d1b3b8e367a0d628812e707ea6dde6ffd9R3) [[2]](diffhunk://#diff-b17433ac7091b280be1c6715db2e58925475e556e5b263e4db0c36aa9376d53dR3-R6)
* Introduced the `ahmadnassri/action-workflow-queue` step in `post-apply-prod-terraform.yaml` to ensure that only one Terraform execution runs at a time, avoiding state lock conflicts.

**Terraform execution configuration:**

* Increased the `-lock-timeout` parameter from 300s to 400s in both the plan and apply steps to reduce failures due to state lock contention during longer operations. [[1]](diffhunk://#diff-d12a3660dd16433a61c729473a05b9d1b3b8e367a0d628812e707ea6dde6ffd9L65-R68) [[2]](diffhunk://#diff-b17433ac7091b280be1c6715db2e58925475e556e5b263e4db0c36aa9376d53dL70-R72)

https://github.com/kyma-project/test-infra/issues/13710