### PR TITLE
fix: update entity field for modg_bdba_bot_api_key_staging secret

### DIFF
--- a/configs/terraform/environments/prod/modg-vulnerability-management.tf
+++ b/configs/terraform/environments/prod/modg-vulnerability-management.tf
@@ -41,7 +41,7 @@ resource "google_secret_manager_secret" "modg_bdba_bot_api_key_staging" {
 		env       = "staging"
 		owner     = "neighbors"
 		component = "modg"
-		entity = "bot_kyma-modg-stage@protecode-sc.local"
+		entity = "bot_kyma-modg-stage"
 	}
 }
 


### PR DESCRIPTION
This pull request makes a minor update to the `modg-vulnerability-management.tf` Terraform configuration by changing the value of the `entity` label for the `modg_bdba_bot_api_key_staging` secret. The email domain has been removed from the entity value for consistency or standardization.

This is because '@' and '.' are not allowed. 

[Example failure](https://github.com/kyma-project/test-infra/actions/runs/21583805936/job/62186908852)

- Updated the `entity` label in the `google_secret_manager_secret.modg_bdba_bot_api_key_staging` resource from `bot_kyma-modg-stage@protecode-sc.local` to `bot_kyma-modg-stage` (`configs/terraform/environments/prod/modg-vulnerability-management.tf`).