### PR TITLE
Removed invalid characters from label value

### DIFF
--- a/configs/terraform/environments/prod/modg-vulnerability-management.tf
+++ b/configs/terraform/environments/prod/modg-vulnerability-management.tf
@@ -41,7 +41,7 @@ resource "google_secret_manager_secret" "modg_bdba_bot_api_key_staging" {
 		env       = "staging"
 		owner     = "neighbors"
 		component = "modg"
-		entity = "bot_kyma-modg-stage@protecode-sc.local"
+		entity    = "bot_kyma-modg-stage"
 	}
 }
 


### PR DESCRIPTION
Removed invalid characters from label value.

Fixing error from merge of https://github.com/kyma-project/test-infra/pull/13800

```
Error: Error creating Secret: googleapi: Error 400: Invalid field "labels.entity"; value "bot_kyma-modg-stage@protecode-sc.local" does not conform to regular expression "[\p{Ll}\p{Lo}\p{N}_-]{0,63}"; character "@" at position 19 is not a non-uppercased letter (Unicode character class Ll or Lo), digit, hyphen, or underscore

  with google_secret_manager_secret.modg_bdba_bot_api_key_staging,
  on modg-vulnerability-management.tf line 26, in resource "google_secret_manager_secret" "modg_bdba_bot_api_key_staging":
  26: resource "google_secret_manager_secret" "modg_bdba_bot_api_key_staging" {

::error::OpenTofu exited with code 1.
```


