### PR TITLE
Specify required MEMBER role.

### DIFF
--- a/configs/terraform/environments/prod/restricted-registry-hierarchical-groups.tf
+++ b/configs/terraform/environments/prod/restricted-registry-hierarchical-groups.tf
@@ -253,6 +253,11 @@ resource "google_cloud_identity_group_membership" "neighbors_team_members_as_dev
     id = each.value.email
   }
 
+  # The MEMBER role is required to assign the OWNER role. See example in provider documentation https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_identity_group_membership#example-usage---cloud-identity-group-membership-user
+  roles {
+    name = "MEMBER"
+  }
+
   roles {
     name = "OWNER"
   }


### PR DESCRIPTION
fix apply error after merge of https://github.com/kyma-project/test-infra/pull/13801.

The error.

```
Error: Error creating GroupMembership: googleapi: Error 400: MEMBER role must be specified
Details:
[
  {
    "@type": "type.googleapis.com/google.rpc.BadRequest",
    "fieldViolations": [
      {
        "description": "MEMBER role must be specified",
        "field": "resource.roles"
      }
    ]
  }
]

  with google_cloud_identity_group_membership.neighbors_team_members_as_developers_group_owners["I355770"],
  on restricted-registry-hierarchical-groups.tf line 247, in resource "google_cloud_identity_group_membership" "neighbors_team_members_as_developers_group_owners":
 247: resource "google_cloud_identity_group_membership" "neighbors_team_members_as_developers_group_owners" {
```

Using example https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_identity_group_membership#example-usage---cloud-identity-group-membership-user