### PR TITLE
Update CODEOWNERS to remove bot from owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,4 +18,4 @@
 
 # File index.md must be owned by prow group in case it will get changes in a pull request which is not allowed to be approved by approval bot.
 # In such case a human approver from prow group must approve the pull request.
-/docs/index.md @kyma-project/neighbors @neighbors-dev-bot
+/docs/index.md @kyma-project/neighbors


### PR DESCRIPTION
Removed @neighbors-dev-bot from the default owners.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Remove neighbors-dev-bot from code owners since it's no longer belogn to organisation


