### PR TITLE
chore(deps): remove gomodTidy from postUpdateOptions for Go dependencies

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -27,7 +27,7 @@
       "matchManagers": ["gomod"],
       "groupName": "All Go dependencies",
       "rangeStrategy": "bump",
-      "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"]
+      "postUpdateOptions": ["gomodUpdateImportPaths"]
     },
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
This pull request makes a minor update to the Renovate configuration for Go dependencies by removing the `gomodTidy` post-update option. This change will affect how Go modules are managed after dependency updates.

- Renovate configuration: Removed `gomodTidy` from the `postUpdateOptions` for Go dependencies in `.github/renovate-sharable-config.json`, so only `gomodUpdateImportPaths` will run after updates.

According to the Renovate documentation, go mod tidy is run automatically after major updates when gomodUpdateImportPaths is enabled.
`Run go mod tidy after Go module updates. This is implicitly enabled for major module updates when gomodUpdateImportPaths is enabled.` https://docs.renovatebot.com/configuration-options/#postupdateoptions