### PR TITLE
fix: ignore update_time drift on artifact registry repositories

### DIFF
--- a/.github/workflows/post-apply-prod-terraform.yaml
+++ b/.github/workflows/post-apply-prod-terraform.yaml
@@ -58,6 +58,14 @@ jobs:
       - name: Terraform Init
         id: terraform_init
         run: tofu -chdir=./configs/terraform/environments/prod init -input=false
+
+      - name: Terraform Refresh
+        id: terraform_refresh
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.gh-terraform-executor-token }}
+          TF_VAR_internal_github_token: ${{ steps.secrets.outputs.internal-github-terraform-executor-token }}
+        run: tofu -chdir=./configs/terraform/environments/prod apply -refresh-only -auto-approve -input=false
+
       - name: Terraform Apply
       # The IaC variables are lower case. The opentofu will remove TF_VAR prefix from this env var and match the value with variables names in IaC config case sensitive.
       # I do prefer to keep consistent format of identifiers in IaC config rather than env variables in github action workflow. Thats the reason env var name uses mixed caps.

--- a/.github/workflows/pull-plan-prod-terraform.yaml
+++ b/.github/workflows/pull-plan-prod-terraform.yaml
@@ -62,6 +62,13 @@ jobs:
         id: terraform_init
         run: tofu -chdir=./configs/terraform/environments/prod init -input=false
 
+      - name: Terraform Refresh
+        id: terraform_refresh
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.gh-terraform-planner-token }}
+          TF_VAR_internal_github_token: ${{ steps.secrets.outputs.internal-github-terraform-planner-token }}
+        run: tofu -chdir=./configs/terraform/environments/prod apply -refresh-only -auto-approve -input=false
+
       - name: Terraform Plan
       # The IaC variables are lower case. The opentofu will remove TF_VAR prefix from this env var and match the value with variables names in IaC config case sensitive.
       # I do prefer to keep consistent format of identifiers in IaC config rather than env variables in github action workflow. Thats the reason env var name uses mixed caps.

--- a/.github/workflows/tofu-drift-detection.yml
+++ b/.github/workflows/tofu-drift-detection.yml
@@ -45,6 +45,13 @@ jobs:
         id: tofu_init
         run: tofu init -input=false
 
+      - name: Tofu refresh
+        id: tofu_refresh
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.public-github-terraform-planner-token }}
+          TF_VAR_internal_github_token: ${{ steps.secrets.outputs.internal-github-terraform-planner-token }}
+        run: tofu apply -refresh-only -auto-approve -input=false
+
       - name: Tofu plan
         id: tofu_plan
         env:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add `tofu apply -refresh-only` step before plan/apply in Terraform workflows

### Problem

OpenTofu detected false drift on computed attributes that change outside of Terraform:
- `update_time` on Artifact Registry repositories (GCP updates this on any image push/pull)
- Cloud Run service metadata (`generation`, `revision_name`, `resource_version`)

This caused noise in PR comments and drift detection issues, even though no actual infrastructure changes were needed.

### Solution

Added `tofu apply -refresh-only -auto-approve` step to sync state with actual infrastructure before running plan or apply. This updates the state file with current values of computed attributes, eliminating false drift reports.

Affected workflows:
- `tofu-drift-detection.yml`
- `pull-plan-prod-terraform.yaml`
- `post-apply-prod-terraform.yaml`

### Why not `lifecycle { ignore_changes }`?

The `ignore_changes` meta-argument only works for **configurable** attributes - values you set in your Terraform code. Attributes like `update_time` are **computed-only** (set by the provider/API, not by configuration), so `ignore_changes` has no effect on them.

OpenTofu explicitly warns about this:
> The attribute update_time is decided by the provider alone and therefore there can be no configured value to compare with. Including this attribute in ignore_changes has no effect.

The `refresh-only` approach is the correct solution because it synchronizes the state with real infrastructure values before planning.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
/kyma/test-infra/issues/1193