### PR TITLE
fix(iac): do not allow update time output contribution

### DIFF
--- a/configs/terraform/modules/artifact-registry/output.tf
+++ b/configs/terraform/modules/artifact-registry/output.tf
@@ -1,4 +1,11 @@
 output "artifact_registry" {
   description = "Artifact Registry"
-  value       = local.repository
+  # Avoid update_time and create_time output contribution
+  # It shoudl work according to:
+  # See: https://github.com/hashicorp/terraform/issues/28803#issuecomment-1072740861
+  # Fixes: https://github.tools.sap/kyma/test-infra/issues/945
+  value = merge(local.repository, {
+    update_time = null
+    create_time = null
+  })
 }


### PR DESCRIPTION
Explicitly set values to null to prevent tofu from thinking it contributes to the output. That should prevent it from displaying `update_time` as changed outside teh terraform. See: https://github.com/hashicorp/terraform/issues/28803#issuecomment-1072740861 for details

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Set update_time and create_tiem explicitly to null.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
