### PR TITLE
fix(ci): disable cleanup policies on prod

### DIFF
--- a/configs/terraform/environments/prod/artifact-registry-variables.tf
+++ b/configs/terraform/environments/prod/artifact-registry-variables.tf
@@ -30,15 +30,6 @@ variable "prod_docker_repository" {
     mode                   = "STANDARD_REPOSITORY"
     type                   = "production"
     cleanup_policy_dry_run = false
-    cleanup_policies = [
-      {
-        id     = "delete-untagged"
-        action = "DELETE"
-        condition = {
-          tag_state = "UNTAGGED"
-        }
-      }
-    ]
   }
 }
 


### PR DESCRIPTION
With the mutable tags enabled on the prod registry, we can cause situation, so someone is referencing the image by it digest and when we move the tag, the digest won't be accesible anymore.

We shouldn't delete the untagged images without enabling the immutable tags first. That's fix for block of KCP scanning caused by moving the tag from digest `sha256:c135a0470ae5a78adf47f39a1ed64a165ab804122024febee6a30c62036d3662` to `sha256:35a2177725ad3b39b48e119e1bae58565f261e24a27cc9594273963a80b979b9` for `europe-docker.pkg.dev/kyma-project/prod/apps/kcp-bolt/kcp-bolt:2.22.5`. Then cleanup policy deleted `sha256:c135a0470ae5a78adf47f39a1ed64a165ab804122024febee6a30c62036d3662` causing "MANIFEST_UNKNOWN" error on security scanner for KCP.