### PR TITLE
chore: add permissions section to lint markdown links workflow

### DIFF
--- a/.github/workflows/lint-markdown-links-daily.yml
+++ b/.github/workflows/lint-markdown-links-daily.yml
@@ -6,6 +6,9 @@ on:
     - cron: "0 5 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add explicit permissions to GitHub Actions workflows

Add explicit `permissions` block to workflow files to address CodeQL security alerts about missing GITHUB_TOKEN permission scopes.

https://github.com/kyma-project/test-infra/security/code-scanning/100

