### PR TITLE
chore(deps): update matchPackageNames for github actions to exclude our own workflows

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -37,7 +37,7 @@
     },
     {
       "matchManagers": ["github-actions"],
-      "matchPackageNames": ["kyma-project/test-infra"],
+      "matchPackageNames": ["/^kyma-project\\//", "/^kyma\\//"],
       "pinDigests": false
     },
     {

--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -37,7 +37,7 @@
     },
     {
       "matchManagers": ["github-actions"],
-      "matchPackageNames": ["/^kyma-project\\//", "/^kyma\\//"],
+      "matchPackageNames": ["kyma*/**"],
       "pinDigests": false
     },
     {


### PR DESCRIPTION
## Problem

Renovate was pinning SHA digests for internal reusable workflow references within the `kyma-project` and `kyma` organizations (e.g. `kyma-project/test-infra/.github/workflows/pull-plan-prod-terraform.yaml@main` → `@<SHA>`).

When such a PR entered the merge queue, the GitHub OIDC token's `job_workflow_ref` claim contained the commit SHA instead of `refs/heads/main`. The GCP Workload Identity Federation binding for the terraform planner service account requires an exact match on `job_workflow_ref` ending with `@refs/heads/main`, so the authentication step failed with:

permission 'iam.serviceAccounts.getAccessToken' denied on resource



## Root cause

https://github.tools.sap/kyma/test-infra/pull/1287

The `helpers:pinGitHubActionDigests` preset pins all GitHub Actions and reusable workflow references to a SHA digest, including internal references to repos within our own organizations. GitHub resolves the SHA literally in the OIDC token — even if the SHA points to a commit on `main`, the `job_workflow_ref` claim contains the SHA instead of `refs/heads/main`.

## Fix

Disable `pinDigests` for all packages from the `kyma-project` and `kyma` organizations. SHA pinning external actions (e.g. `actions/checkout`, `google-github-actions/*`) remains in place as a supply chain security measure. Pinning internal reusable workflows from our own organizations provides no security benefit — these repositories are already trusted — while breaking WIF authentication.

Resources:
https://docs.renovatebot.com/configuration-options/#packagerulesmatchpackagenames
https://docs.renovatebot.com/string-pattern-matching/