### PR TITLE
feat(logger): implement new Logger to be ADR-006 compliant

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blendle/zapdriver v1.3.1 // indirect
 	github.com/bodgit/plumbing v1.3.0 // indirect
 	github.com/bodgit/sevenzip v1.6.1 // indirect
 	github.com/bodgit/windows v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/blendle/zapdriver v1.3.1 h1:C3dydBOWYRiOk+B8X9IVZ5IOe+7cl+tGOexN4QqHfpE=
+github.com/blendle/zapdriver v1.3.1/go.mod h1:mdXfREi6u5MArG4j9fewC+FGnXaBR+T4Ox4J2u4eHCc=
 github.com/bodgit/plumbing v1.3.0 h1:pf9Itz1JOQgn7vEOE7v7nlEfBykYqvUYioC61TwWCFU=
 github.com/bodgit/plumbing v1.3.0/go.mod h1:JOTb4XiRu5xfnmdnDJo6GmSbSbtSyufrsyZFByMtKEs=
 github.com/bodgit/sevenzip v1.6.1 h1:kikg2pUMYC9ljU7W9SaqHXhym5HyKm8/M/jd31fYan4=
@@ -354,6 +356,7 @@ github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+v
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pierrec/lz4/v4 v4.1.23 h1:oJE7T90aYBGtFNrI8+KbETnPymobAhzRrR8Mu8n1yfU=
 github.com/pierrec/lz4/v4 v4.1.23/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
@@ -489,10 +492,13 @@ go.opentelemetry.io/otel/trace v1.42.0 h1:OUCgIPt+mzOnaUTpOQcBiM/PLQ/Op7oq6g4Len
 go.opentelemetry.io/otel/trace v1.42.0/go.mod h1:f3K9S+IFqnumBkKhRJMeaZeNk9epyhnCmQh/EysQCdc=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
+go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.27.1 h1:08RqriUEv8+ArZRYSTXy1LeBScaMpVSTBhCeaZYfMYc=
 go.uber.org/zap v1.27.1/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=

--- a/pkg/logger/buffer.go
+++ b/pkg/logger/buffer.go
@@ -35,10 +35,17 @@ func (l *BufferLogger) Logs() string {
 	return l.Buffer.String()
 }
 
-// NewBufferLogger creates a logger that captures output in memory.
-// Uses the same JSON encoder config as ConsoleLogger (zapdriver)
-// so the format matches production output.
+// NewBufferLogger creates a logger that captures all output in memory.
+// Defaults to DebugLevel — captures every severity. Suitable for most tests.
+// Use NewBufferLoggerWithLevel when testing level-specific behavior such as audit logs.
 func NewBufferLogger() *BufferLogger {
+	return NewBufferLoggerWithLevel(zapcore.DebugLevel)
+}
+
+// NewBufferLoggerWithLevel creates a logger that captures output in memory at the given minimum level.
+// Use this when testing level-specific behavior — for example, to verify that only
+// WARNING and above entries are captured, or to simulate an audit log collector.
+func NewBufferLoggerWithLevel(level zapcore.Level) *BufferLogger {
 	var buf bytes.Buffer
 
 	// Same encoder as production — tests validate real output format.
@@ -54,8 +61,7 @@ func NewBufferLogger() *BufferLogger {
 	// so AddSync adds a no-op Sync() method.
 	writer := zapcore.AddSync(&buf)
 
-	// DebugLevel — capture everything in tests, don't filter.
-	core := zapcore.NewCore(encoder, writer, zapcore.DebugLevel)
+	core := zapcore.NewCore(encoder, writer, level)
 
 	zapLogger := zap.New(core)
 

--- a/pkg/logger/buffer.go
+++ b/pkg/logger/buffer.go
@@ -17,13 +17,13 @@ type BufferLogger struct {
 	Buffer *bytes.Buffer
 }
 
-// Compile-time check: BufferLogger must implement LoggerInterface.
-var _ LoggerInterface = (*BufferLogger)(nil)
+// Compile-time check: BufferLogger must implement Logger.
+var _ Logger = (*BufferLogger)(nil)
 
 // With creates a child logger with additional context fields.
 // Same override as ConsoleLogger — wraps the returned SugaredLogger
 // back into BufferLogger so it still writes to the same buffer.
-func (l *BufferLogger) With(args ...interface{}) LoggerInterface {
+func (l *BufferLogger) With(args ...interface{}) Logger {
 	return &BufferLogger{
 		SugaredLogger: l.SugaredLogger.With(args...),
 		Buffer:        l.Buffer,

--- a/pkg/logger/buffer.go
+++ b/pkg/logger/buffer.go
@@ -1,0 +1,66 @@
+package logger
+
+import (
+	"bytes"
+
+	"github.com/blendle/zapdriver"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// BufferLogger writes logs to an in-memory buffer for testing.
+// It uses the same GCP-compatible JSON format as ConsoleLogger,
+// so tests validate the exact output format that production uses.
+type BufferLogger struct {
+	*zap.SugaredLogger
+	// Buffer holds all log output. Read it with Logs() method.
+	Buffer *bytes.Buffer
+}
+
+// Compile-time check: BufferLogger must implement LoggerInterface.
+var _ LoggerInterface = (*BufferLogger)(nil)
+
+// With creates a child logger with additional context fields.
+// Same override as ConsoleLogger — wraps the returned SugaredLogger
+// back into BufferLogger so it still writes to the same buffer.
+func (l *BufferLogger) With(args ...interface{}) LoggerInterface {
+	return &BufferLogger{
+		SugaredLogger: l.SugaredLogger.With(args...),
+		Buffer:        l.Buffer,
+	}
+}
+
+// Logs returns all captured log output as a string.
+func (l *BufferLogger) Logs() string {
+	return l.Buffer.String()
+}
+
+// NewBufferLogger creates a logger that captures output in memory.
+// Uses the same JSON encoder config as ConsoleLogger (zapdriver)
+// so the format matches production output.
+func NewBufferLogger() *BufferLogger {
+	var buf bytes.Buffer
+
+	// Same encoder as production — tests validate real output format.
+	encoderConfig := zapdriver.NewProductionEncoderConfig()
+	// Remove timestamp — makes test assertions deterministic.
+	// Without this, every log line has a different timestamp.
+	encoderConfig.TimeKey = ""
+
+	encoder := zapcore.NewJSONEncoder(encoderConfig)
+
+	// AddSync wraps bytes.Buffer into a WriteSyncer.
+	// bytes.Buffer implements io.Writer but not Sync(),
+	// so AddSync adds a no-op Sync() method.
+	writer := zapcore.AddSync(&buf)
+
+	// DebugLevel — capture everything in tests, don't filter.
+	core := zapcore.NewCore(encoder, writer, zapcore.DebugLevel)
+
+	zapLogger := zap.New(core)
+
+	return &BufferLogger{
+		SugaredLogger: zapLogger.Sugar(),
+		Buffer:        &buf,
+	}
+}

--- a/pkg/logger/buffer_test.go
+++ b/pkg/logger/buffer_test.go
@@ -1,0 +1,151 @@
+package logger
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("BufferLogger", func() {
+	// logger is recreated before each test — fresh, empty buffer every time.
+	var buf *BufferLogger
+
+	BeforeEach(func() {
+		buf = NewBufferLogger()
+	})
+
+	// ---------------------------------------------------------------
+	// Basic creation
+	// ---------------------------------------------------------------
+	Context("when creating a new BufferLogger", func() {
+		It("should not be nil", func() {
+			Expect(buf).NotTo(BeNil())
+			Expect(buf.Buffer).NotTo(BeNil())
+		})
+
+		It("should start with an empty buffer", func() {
+			Expect(buf.Logs()).To(BeEmpty())
+		})
+	})
+
+	// ---------------------------------------------------------------
+	// Structured logging methods (Infow, Warnw, Errorw, Debugw)
+	// ---------------------------------------------------------------
+	DescribeTable("structured logging methods",
+		func(logAction func(msg string, kv ...interface{}), expectedSeverity string) {
+			// Call the logging method.
+			logAction("test message", "key", "value")
+
+			// Sync to flush any buffered data.
+			Expect(buf.Sync()).To(Succeed())
+
+			// Parse the JSON output.
+			var entry map[string]interface{}
+			err := json.Unmarshal([]byte(buf.Logs()), &entry)
+			Expect(err).NotTo(HaveOccurred(), "log output should be valid JSON")
+
+			// Check the message.
+			Expect(entry).To(HaveKeyWithValue("message", "test message"))
+
+			// Check the structured key-value pair.
+			Expect(entry).To(HaveKeyWithValue("key", "value"))
+
+			// Check severity — zapdriver uses "severity" field with uppercase values.
+			Expect(entry).To(HaveKeyWithValue("severity", expectedSeverity))
+		},
+		// zapdriver severity values: DEBUG, INFO, WARNING, ERROR
+		Entry("Infow logs at INFO", func(msg string, kv ...interface{}) { buf.Infow(msg, kv...) }, "INFO"),
+		Entry("Warnw logs at WARNING", func(msg string, kv ...interface{}) { buf.Warnw(msg, kv...) }, "WARNING"),
+		Entry("Errorw logs at ERROR", func(msg string, kv ...interface{}) { buf.Errorw(msg, kv...) }, "ERROR"),
+		Entry("Debugw logs at DEBUG", func(msg string, kv ...interface{}) { buf.Debugw(msg, kv...) }, "DEBUG"),
+	)
+
+	// ---------------------------------------------------------------
+	// With() — child logger with context
+	// ---------------------------------------------------------------
+	Context("when using With to create a child logger", func() {
+		It("should include context fields in all child log entries", func() {
+			child := buf.With("request_id", "abc-123")
+			child.Infow("handling request", "endpoint", "/info")
+
+			Expect(buf.Sync()).To(Succeed())
+
+			var entry map[string]interface{}
+			err := json.Unmarshal([]byte(buf.Logs()), &entry)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Fields from With():
+			Expect(entry).To(HaveKeyWithValue("request_id", "abc-123"))
+			// Fields from the log call:
+			Expect(entry).To(HaveKeyWithValue("endpoint", "/info"))
+			// The message:
+			Expect(entry).To(HaveKeyWithValue("message", "handling request"))
+		})
+
+		It("should return a LoggerInterface, not a concrete type", func() {
+			// This is the key difference from the old package.
+			// With() must return LoggerInterface so we maintain abstraction.
+			var child LoggerInterface = buf.With("key", "val")
+			Expect(child).NotTo(BeNil())
+		})
+
+		It("should write to the same buffer as the parent", func() {
+			child := buf.With("component", "auth")
+			child.Infow("child log")
+			buf.Infow("parent log")
+
+			Expect(buf.Sync()).To(Succeed())
+
+			// Both entries should appear in the same buffer.
+			logs := buf.Logs()
+			Expect(logs).To(ContainSubstring("child log"))
+			Expect(logs).To(ContainSubstring("parent log"))
+		})
+	})
+
+	// ---------------------------------------------------------------
+	// Sync
+	// ---------------------------------------------------------------
+	Context("when calling Sync", func() {
+		It("should not return an error", func() {
+			buf.Infow("some log")
+			Expect(buf.Sync()).To(Succeed())
+		})
+	})
+
+	// ---------------------------------------------------------------
+	// LogLabel — GCP labels
+	// ---------------------------------------------------------------
+	Context("when using LogLabel", func() {
+		It("should add labels with labels. prefix in log output", func() {
+			buf.Infow("labeled log", LogLabel("app", "test-app"), LogLabel("environment", "dev"))
+
+			Expect(buf.Sync()).To(Succeed())
+
+			var entry map[string]interface{}
+			err := json.Unmarshal([]byte(buf.Logs()), &entry)
+			Expect(err).NotTo(HaveOccurred())
+
+			// BufferLogger uses zapdriver encoder which outputs flat "labels.key" fields.
+			// ConsoleLogger and GCPLogger nest these under "logging.googleapis.com/labels".
+			Expect(entry).To(HaveKeyWithValue("labels.app", "test-app"))
+			Expect(entry).To(HaveKeyWithValue("labels.environment", "dev"))
+		})
+
+		It("should include labels from With on every log entry", func() {
+			child := buf.With(LogLabel("app", "my-service"))
+			child.Infow("first log")
+			child.Infow("second log")
+
+			Expect(buf.Sync()).To(Succeed())
+
+			logs := buf.Logs()
+			Expect(logs).To(ContainSubstring("first log"))
+			Expect(logs).To(ContainSubstring("second log"))
+
+			// Both entries should contain the label.
+			Expect(logs).To(ContainSubstring(`"labels.app":"my-service"`))
+		})
+	})
+})

--- a/pkg/logger/buffer_test.go
+++ b/pkg/logger/buffer_test.go
@@ -83,10 +83,10 @@ var _ = Describe("BufferLogger", func() {
 			Expect(entry).To(HaveKeyWithValue("message", "handling request"))
 		})
 
-		It("should return a LoggerInterface, not a concrete type", func() {
+		It("should return a Logger, not a concrete type", func() {
 			// This is the key difference from the old package.
-			// With() must return LoggerInterface so we maintain abstraction.
-			var child LoggerInterface = buf.With("key", "val")
+			// With() must return Logger so we maintain abstraction.
+			var child Logger = buf.With("key", "val")
 			Expect(child).NotTo(BeNil())
 		})
 

--- a/pkg/logger/console.go
+++ b/pkg/logger/console.go
@@ -11,17 +11,17 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-// ConsoleLogger wraps zap.SugaredLogger to implement LoggerInterface.
+// ConsoleLogger wraps zap.SugaredLogger to implement Logger.
 // It outputs GCP-compatible JSON to stdout (info and below) and stderr (errors).
 type ConsoleLogger struct {
 	*zap.SugaredLogger
 }
 
-// Compile-time check: ConsoleLogger must implement LoggerInterface.
-var _ LoggerInterface = (*ConsoleLogger)(nil)
+// Compile-time check: ConsoleLogger must implement Logger.
+var _ Logger = (*ConsoleLogger)(nil)
 
 // With creates a child logger with additional context fields.
-func (l *ConsoleLogger) With(args ...interface{}) LoggerInterface {
+func (l *ConsoleLogger) With(args ...interface{}) Logger {
 	return &ConsoleLogger{
 		SugaredLogger: l.SugaredLogger.With(args...),
 	}

--- a/pkg/logger/console.go
+++ b/pkg/logger/console.go
@@ -1,0 +1,171 @@
+package logger
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// ConsoleLogger wraps zap.SugaredLogger to implement LoggerInterface.
+// It outputs GCP-compatible JSON to stdout (info and below) and stderr (errors).
+type ConsoleLogger struct {
+	*zap.SugaredLogger
+}
+
+// Compile-time check: ConsoleLogger must implement LoggerInterface.
+var _ LoggerInterface = (*ConsoleLogger)(nil)
+
+// With creates a child logger with additional context fields.
+func (l *ConsoleLogger) With(args ...interface{}) LoggerInterface {
+	return &ConsoleLogger{
+		SugaredLogger: l.SugaredLogger.With(args...),
+	}
+}
+
+// NewConsoleLogger creates a GCP-compatible console logger.
+// level sets the minimum log severity (e.g. zapcore.InfoLevel, zapcore.DebugLevel).
+//
+// Log routing:
+//   - severity >= Error → stderr
+//   - severity < Error  → stdout
+func NewConsoleLogger(level zapcore.Level) *ConsoleLogger {
+	core := newConsoleCore(level)
+	zapLogger := zap.New(core, zap.AddCaller(), zap.AddStacktrace(zapcore.ErrorLevel))
+	return &ConsoleLogger{
+		SugaredLogger: zapLogger.Sugar(),
+	}
+}
+
+// newConsoleCore builds a consoleCore that writes GCP-compatible structured JSON
+// to stdout (info and below) and stderr (errors).
+// Labels are nested under "logging.googleapis.com/labels" so Cloud Run agents
+// extract them as proper Cloud Logging labels — identical structure to the API logger.
+func newConsoleCore(level zapcore.Level) *consoleCore {
+	return &consoleCore{
+		level:  level,
+		out:    zapcore.Lock(os.Stdout),
+		errOut: zapcore.Lock(os.Stderr),
+	}
+}
+
+// consoleCore is a custom zapcore.Core that writes GCP-compatible structured JSON
+// to stdout/stderr. Labels are output as a nested "logging.googleapis.com/labels"
+// object so Cloud Run log agents recognise them as Cloud Logging labels.
+//
+// This mirrors the structure produced by gcpCore — both loggers emit identical JSON.
+type consoleCore struct {
+	level  zapcore.Level
+	fields []zapcore.Field
+	out    zapcore.WriteSyncer
+	errOut zapcore.WriteSyncer
+}
+
+func (c *consoleCore) Enabled(level zapcore.Level) bool {
+	return level >= c.level
+}
+
+func (c *consoleCore) With(fields []zapcore.Field) zapcore.Core {
+	return &consoleCore{
+		level:  c.level,
+		fields: append(append([]zapcore.Field{}, c.fields...), fields...),
+		out:    c.out,
+		errOut: c.errOut,
+	}
+}
+
+func (c *consoleCore) Check(entry zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.Enabled(entry.Level) {
+		return ce.AddCore(entry, c)
+	}
+	return ce
+}
+
+// Write converts a zap log entry into a GCP-compatible JSON line.
+// It mirrors the logic in gcpCore.Write so both loggers produce identical structure.
+func (c *consoleCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
+	allFields := append(c.fields, fields...)
+
+	enc := zapcore.NewMapObjectEncoder()
+	for _, field := range allFields {
+		field.AddTo(enc)
+	}
+
+	// Separate labels from regular fields.
+	labels := make(map[string]interface{})
+	payload := map[string]interface{}{
+		"severity":  consoleSeverityString(entry.Level),
+		"timestamp": entry.Time.Format(time.RFC3339Nano),
+		"message":   entry.Message,
+	}
+
+	for key, val := range enc.Fields {
+		if strings.HasPrefix(key, "labels.") {
+			labels[strings.TrimPrefix(key, "labels.")] = fmt.Sprint(val)
+			continue
+		}
+		payload[key] = val
+	}
+
+	// Nest labels under "logging.googleapis.com/labels" so Cloud Run agents
+	// extract them as proper Cloud Logging labels.
+	if len(labels) > 0 {
+		payload["logging.googleapis.com/labels"] = labels
+	}
+
+	if entry.Caller.Defined {
+		payload["logging.googleapis.com/sourceLocation"] = map[string]interface{}{
+			"file":     entry.Caller.File,
+			"line":     entry.Caller.Line,
+			"function": entry.Caller.Function,
+		}
+	}
+
+	if entry.Stack != "" {
+		payload["stacktrace"] = entry.Stack
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+
+	if entry.Level >= zapcore.ErrorLevel {
+		_, err = c.errOut.Write(data)
+	} else {
+		_, err = c.out.Write(data)
+	}
+	return err
+}
+
+func (c *consoleCore) Sync() error {
+	outErr := c.out.Sync()
+	errOutErr := c.errOut.Sync()
+	if outErr != nil {
+		return outErr
+	}
+	return errOutErr
+}
+
+// consoleSeverityString maps zap levels to Cloud Logging severity strings.
+func consoleSeverityString(level zapcore.Level) string {
+	switch level {
+	case zapcore.DebugLevel:
+		return "DEBUG"
+	case zapcore.InfoLevel:
+		return "INFO"
+	case zapcore.WarnLevel:
+		return "WARNING"
+	case zapcore.ErrorLevel:
+		return "ERROR"
+	case zapcore.DPanicLevel, zapcore.PanicLevel, zapcore.FatalLevel:
+		return "CRITICAL"
+	default:
+		return "DEFAULT"
+	}
+}

--- a/pkg/logger/console.go
+++ b/pkg/logger/console.go
@@ -97,8 +97,12 @@ func (c *consoleCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
 
 	// Separate labels from regular fields.
 	labels := make(map[string]interface{})
+	severity, err := consoleSeverityString(entry.Level)
+	if err != nil {
+		return err
+	}
 	payload := map[string]interface{}{
-		"severity":  consoleSeverityString(entry.Level),
+		"severity":  severity,
 		"timestamp": entry.Time.Format(time.RFC3339Nano),
 		"message":   entry.Message,
 	}
@@ -153,19 +157,20 @@ func (c *consoleCore) Sync() error {
 }
 
 // consoleSeverityString maps zap levels to Cloud Logging severity strings.
-func consoleSeverityString(level zapcore.Level) string {
+// Returns an error if the level is not supported.
+func consoleSeverityString(level zapcore.Level) (string, error) {
 	switch level {
 	case zapcore.DebugLevel:
-		return "DEBUG"
+		return "DEBUG", nil
 	case zapcore.InfoLevel:
-		return "INFO"
+		return "INFO", nil
 	case zapcore.WarnLevel:
-		return "WARNING"
+		return "WARNING", nil
 	case zapcore.ErrorLevel:
-		return "ERROR"
+		return "ERROR", nil
 	case zapcore.DPanicLevel, zapcore.PanicLevel, zapcore.FatalLevel:
-		return "CRITICAL"
+		return "CRITICAL", nil
 	default:
-		return "DEFAULT"
+		return "", fmt.Errorf("unsupported log level: %v", level)
 	}
 }

--- a/pkg/logger/factory.go
+++ b/pkg/logger/factory.go
@@ -1,0 +1,150 @@
+package logger
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"cloud.google.com/go/compute/metadata"
+	"go.uber.org/zap/zapcore"
+)
+
+// Environment variable names used to configure the logger.
+const (
+	// EnvLogDestination controls where logs are sent.
+	// Values: "console", "api", "console-and-api", "auto" (default: "auto").
+	EnvLogDestination = "LOG_DESTINATION"
+
+	// EnvLogLevel controls the minimum log severity.
+	// Values: "debug", "info" (default: "info").
+	EnvLogLevel = "LOG_LEVEL"
+
+	// EnvGCPProjectID is the GCP project to send logs to.
+	// Required when LOG_DESTINATION is "api".
+	EnvGCPProjectID = "GCP_PROJECT_ID"
+
+	// EnvGCPLogName is the log name in Cloud Logging.
+	// Optional, defaults to "application".
+	EnvGCPLogName = "GCP_LOG_NAME"
+)
+
+// New creates a logger based on environment variables.
+// This is the main entry point — use this in your applications:
+//
+//	logger, err := logger.New()
+//	if err != nil {
+//	    panic(err)
+//	}
+//	defer logger.Sync()
+func New() (LoggerInterface, error) {
+	level, err := parseLogLevel()
+	if err != nil {
+		return nil, err
+	}
+
+	destination, err := parseDestination()
+	if err != nil {
+		return nil, err
+	}
+
+	switch destination {
+	case "console":
+		return NewConsoleLogger(level).With(LogLabel("team", "neighbors-team")), nil
+	case "api":
+		l, err := newAPILogger(level)
+		if err != nil {
+			return nil, err
+		}
+		return l.With(LogLabel("team", "neighbors-team")), nil
+	case "console-and-api":
+		l, err := newCombinedLogger(level)
+		if err != nil {
+			return nil, err
+		}
+		return l.With(LogLabel("team", "neighbors-team")), nil
+	default:
+		return nil, fmt.Errorf("unknown log destination: %s", destination)
+	}
+}
+
+// newAPILogger creates a GCP API-only logger from env vars.
+func newAPILogger(level zapcore.Level) (LoggerInterface, error) {
+	projectID := os.Getenv(EnvGCPProjectID)
+	if projectID == "" {
+		return nil, fmt.Errorf("%s is required when %s is %q", EnvGCPProjectID, EnvLogDestination, "api")
+	}
+	logName := os.Getenv(EnvGCPLogName)
+	if logName == "" {
+		logName = "application"
+	}
+	taskID, _ := os.Hostname()
+	if taskID == "" {
+		taskID = "unknown"
+	}
+	return NewGCPLogger(context.Background(), projectID, logName, taskID, level)
+}
+
+// newCombinedLogger creates a logger that writes to both console and GCP API
+// simultaneously. Each log entry goes to stdout/stderr AND to Cloud Logging.
+func newCombinedLogger(level zapcore.Level) (LoggerInterface, error) {
+	projectID := os.Getenv(EnvGCPProjectID)
+	if projectID == "" {
+		return nil, fmt.Errorf("%s is required when %s is %q", EnvGCPProjectID, EnvLogDestination, "console-and-api")
+	}
+	logName := os.Getenv(EnvGCPLogName)
+	if logName == "" {
+		logName = "application"
+	}
+	taskID, _ := os.Hostname()
+	if taskID == "" {
+		taskID = "unknown"
+	}
+	return NewCombinedLogger(context.Background(), projectID, logName, taskID, level)
+}
+
+// parseDestination reads LOG_DESTINATION and resolves "auto" to a concrete value.
+//
+// "auto" logic:
+//   - Calls metadata.OnGCE() which makes an HTTP request to 169.254.169.254
+//   - If reachable → we're inside GCP → use "console" (agent collects stdout)
+//   - If not reachable → we're outside GCP → use "console-and-api" (console + API simultaneously)
+func parseDestination() (string, error) {
+	dest := strings.ToLower(strings.TrimSpace(os.Getenv(EnvLogDestination)))
+
+	switch dest {
+	case "console":
+		return "console", nil
+	case "api":
+		return "api", nil
+	case "console-and-api":
+		return "console-and-api", nil
+	case "auto", "":
+		if metadata.OnGCE() {
+			return "console", nil
+		}
+		return "console-and-api", nil
+	default:
+		return "", fmt.Errorf(
+			"invalid %s value: %q (valid: console, api, console-and-api, auto)",
+			EnvLogDestination, dest,
+		)
+	}
+}
+
+// parseLogLevel reads LOG_LEVEL and converts it to a zapcore.Level.
+func parseLogLevel() (zapcore.Level, error) {
+	lvl := strings.ToLower(strings.TrimSpace(os.Getenv(EnvLogLevel)))
+
+	switch lvl {
+	case "debug":
+		return zapcore.DebugLevel, nil
+	case "info", "":
+		return zapcore.InfoLevel, nil
+	default:
+		return zapcore.InfoLevel, fmt.Errorf(
+			"invalid %s value: %q (valid: debug, info)",
+			EnvLogLevel, lvl,
+		)
+	}
+}

--- a/pkg/logger/factory.go
+++ b/pkg/logger/factory.go
@@ -17,7 +17,7 @@ const (
 	EnvLogDestination = "LOG_DESTINATION"
 
 	// EnvLogLevel controls the minimum log severity.
-	// Values: "debug", "info" (default: "info").
+	// Values: "debug", "info", "warn", "error", "dpanic", "panic", "fatal" (default: "info").
 	EnvLogLevel = "LOG_LEVEL"
 
 	// EnvGCPProjectID is the GCP project to send logs to.
@@ -133,6 +133,7 @@ func parseDestination() (string, error) {
 }
 
 // parseLogLevel reads LOG_LEVEL and converts it to a zapcore.Level.
+// Defaults to info when LOG_LEVEL is not set.
 func parseLogLevel() (zapcore.Level, error) {
 	lvl := strings.ToLower(strings.TrimSpace(os.Getenv(EnvLogLevel)))
 
@@ -141,9 +142,19 @@ func parseLogLevel() (zapcore.Level, error) {
 		return zapcore.DebugLevel, nil
 	case "info", "":
 		return zapcore.InfoLevel, nil
+	case "warn":
+		return zapcore.WarnLevel, nil
+	case "error":
+		return zapcore.ErrorLevel, nil
+	case "dpanic":
+		return zapcore.DPanicLevel, nil
+	case "panic":
+		return zapcore.PanicLevel, nil
+	case "fatal":
+		return zapcore.FatalLevel, nil
 	default:
 		return zapcore.InfoLevel, fmt.Errorf(
-			"invalid %s value: %q (valid: debug, info)",
+			"invalid %s value: %q (valid: debug, info, warn, error, dpanic, panic, fatal)",
 			EnvLogLevel, lvl,
 		)
 	}

--- a/pkg/logger/factory.go
+++ b/pkg/logger/factory.go
@@ -37,7 +37,7 @@ const (
 //	    panic(err)
 //	}
 //	defer logger.Sync()
-func New() (LoggerInterface, error) {
+func New() (Logger, error) {
 	level, err := parseLogLevel()
 	if err != nil {
 		return nil, err
@@ -69,7 +69,7 @@ func New() (LoggerInterface, error) {
 }
 
 // newAPILogger creates a GCP API-only logger from env vars.
-func newAPILogger(level zapcore.Level) (LoggerInterface, error) {
+func newAPILogger(level zapcore.Level) (Logger, error) {
 	projectID := os.Getenv(EnvGCPProjectID)
 	if projectID == "" {
 		return nil, fmt.Errorf("%s is required when %s is %q", EnvGCPProjectID, EnvLogDestination, "api")
@@ -87,7 +87,7 @@ func newAPILogger(level zapcore.Level) (LoggerInterface, error) {
 
 // newCombinedLogger creates a logger that writes to both console and GCP API
 // simultaneously. Each log entry goes to stdout/stderr AND to Cloud Logging.
-func newCombinedLogger(level zapcore.Level) (LoggerInterface, error) {
+func newCombinedLogger(level zapcore.Level) (Logger, error) {
 	projectID := os.Getenv(EnvGCPProjectID)
 	if projectID == "" {
 		return nil, fmt.Errorf("%s is required when %s is %q", EnvGCPProjectID, EnvLogDestination, "console-and-api")

--- a/pkg/logger/factory_test.go
+++ b/pkg/logger/factory_test.go
@@ -47,6 +47,20 @@ var _ = Describe("Factory", func() {
 			Expect(level.String()).To(Equal("debug"))
 		})
 
+		DescribeTable("should return correct level",
+			func(input string, expected string) {
+				os.Setenv(EnvLogLevel, input)
+				level, err := parseLogLevel()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(level.String()).To(Equal(expected))
+			},
+			Entry("warn", "warn", "warn"),
+			Entry("error", "error", "error"),
+			Entry("dpanic", "dpanic", "dpanic"),
+			Entry("panic", "panic", "panic"),
+			Entry("fatal", "fatal", "fatal"),
+		)
+
 		It("should return error for invalid values", func() {
 			os.Setenv(EnvLogLevel, "trace")
 			_, err := parseLogLevel()

--- a/pkg/logger/factory_test.go
+++ b/pkg/logger/factory_test.go
@@ -1,0 +1,145 @@
+package logger
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Factory", func() {
+
+	// ---------------------------------------------------------------
+	// parseLogLevel
+	// ---------------------------------------------------------------
+	Describe("parseLogLevel", func() {
+		// After each test, clean up the env var so tests don't affect each other.
+		AfterEach(func() {
+			os.Unsetenv(EnvLogLevel)
+		})
+
+		It("should default to info when LOG_LEVEL is not set", func() {
+			os.Unsetenv(EnvLogLevel)
+			level, err := parseLogLevel()
+			Expect(err).NotTo(HaveOccurred())
+			// zapcore.InfoLevel == -1... but we can check the string
+			Expect(level.String()).To(Equal("info"))
+		})
+
+		It("should return debug level for LOG_LEVEL=debug", func() {
+			os.Setenv(EnvLogLevel, "debug")
+			level, err := parseLogLevel()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(level.String()).To(Equal("debug"))
+		})
+
+		It("should return info level for LOG_LEVEL=info", func() {
+			os.Setenv(EnvLogLevel, "info")
+			level, err := parseLogLevel()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(level.String()).To(Equal("info"))
+		})
+
+		It("should handle uppercase and spaces", func() {
+			os.Setenv(EnvLogLevel, "  DEBUG  ")
+			level, err := parseLogLevel()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(level.String()).To(Equal("debug"))
+		})
+
+		It("should return error for invalid values", func() {
+			os.Setenv(EnvLogLevel, "trace")
+			_, err := parseLogLevel()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("trace"))
+		})
+	})
+
+	// ---------------------------------------------------------------
+	// parseDestination
+	// ---------------------------------------------------------------
+	Describe("parseDestination", func() {
+		AfterEach(func() {
+			os.Unsetenv(EnvLogDestination)
+		})
+
+		It("should return console for LOG_DESTINATION=console", func() {
+			os.Setenv(EnvLogDestination, "console")
+			dest, err := parseDestination()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dest).To(Equal("console"))
+		})
+
+		It("should return api for LOG_DESTINATION=api", func() {
+			os.Setenv(EnvLogDestination, "api")
+			dest, err := parseDestination()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dest).To(Equal("api"))
+		})
+
+		It("should return console-and-api for LOG_DESTINATION=console-and-api", func() {
+			os.Setenv(EnvLogDestination, "console-and-api")
+			dest, err := parseDestination()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dest).To(Equal("console-and-api"))
+		})
+
+		It("should return error for invalid values", func() {
+			os.Setenv(EnvLogDestination, "kafka")
+			_, err := parseDestination()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("kafka"))
+		})
+
+		It("should return error for old 'both' value", func() {
+			os.Setenv(EnvLogDestination, "both")
+			_, err := parseDestination()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("both"))
+		})
+	})
+
+	// ---------------------------------------------------------------
+	// New (full factory)
+	// ---------------------------------------------------------------
+	Describe("New", func() {
+		AfterEach(func() {
+			os.Unsetenv(EnvLogDestination)
+			os.Unsetenv(EnvLogLevel)
+		})
+
+		It("should create a ConsoleLogger when LOG_DESTINATION=console", func() {
+			os.Setenv(EnvLogDestination, "console")
+			logger, err := New()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(logger).NotTo(BeNil())
+
+			// Verify it's a ConsoleLogger under the hood.
+			_, ok := logger.(*ConsoleLogger)
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should return error when LOG_DESTINATION=api without GCP_PROJECT_ID", func() {
+			os.Setenv(EnvLogDestination, "api")
+			os.Unsetenv(EnvGCPProjectID)
+			_, err := New()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("GCP_PROJECT_ID"))
+		})
+
+		It("should return error when LOG_DESTINATION=console-and-api without GCP_PROJECT_ID", func() {
+			os.Setenv(EnvLogDestination, "console-and-api")
+			os.Unsetenv(EnvGCPProjectID)
+			_, err := New()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("GCP_PROJECT_ID"))
+		})
+
+		It("should return error for invalid LOG_LEVEL", func() {
+			os.Setenv(EnvLogDestination, "console")
+			os.Setenv(EnvLogLevel, "verbose")
+			_, err := New()
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/pkg/logger/gcp.go
+++ b/pkg/logger/gcp.go
@@ -1,0 +1,248 @@
+package logger
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"cloud.google.com/go/logging"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/genproto/googleapis/api/monitoredres"
+)
+
+// GCPLogger sends logs to Google Cloud Logging via API.
+// Use this for workloads running outside GCP that need to send
+// logs to the centralized logging system.
+type GCPLogger struct {
+	*zap.SugaredLogger
+	client *logging.Client
+}
+
+// Compile-time check: GCPLogger must implement LoggerInterface.
+var _ LoggerInterface = (*GCPLogger)(nil)
+
+// With creates a child logger with additional context fields.
+func (l *GCPLogger) With(args ...interface{}) LoggerInterface {
+	return &GCPLogger{
+		SugaredLogger: l.SugaredLogger.With(args...),
+		client:        l.client,
+	}
+}
+
+// Close flushes pending logs and closes the underlying GCP client.
+// Call this before application exit (in addition to Sync).
+func (l *GCPLogger) Close() error {
+	if err := l.Sync(); err != nil {
+		return fmt.Errorf("failed to sync logger: %w", err)
+	}
+	if l.client != nil {
+		return l.client.Close()
+	}
+	return nil
+}
+
+// NewGCPLogger creates a logger that sends logs to Google Cloud Logging API.
+//
+// Parameters:
+//   - ctx: context for creating the GCP client
+//   - projectID: GCP project to send logs to (e.g. "sap-kyma-neighbors-dev")
+//   - logName: log name in Cloud Logging (e.g. "application"). Under this log name, logs from every application will be
+//     grouped in Cloud Logging UI.
+//   - namespace: logical grouping for the workload (e.g. "neighbors-team")
+//   - level: minimum log severity
+func NewGCPLogger(ctx context.Context, projectID, logName, taskID string, level zapcore.Level) (*GCPLogger, error) {
+	client, gcpCore, err := newGCPCore(ctx, projectID, logName, taskID, level)
+	if err != nil {
+		return nil, err
+	}
+
+	zapLogger := zap.New(gcpCore, zap.AddCaller(), zap.AddStacktrace(zapcore.ErrorLevel))
+
+	return &GCPLogger{
+		SugaredLogger: zapLogger.Sugar(),
+		client:        client,
+	}, nil
+}
+
+// NewCombinedLogger creates a logger that writes to both console (stdout/stderr)
+// and GCP Cloud Logging API simultaneously. Used for workloads outside GCP
+// that need both local visibility and centralized logging.
+func NewCombinedLogger(ctx context.Context, projectID, logName, taskID string, level zapcore.Level) (*GCPLogger, error) {
+	client, gcpAPICore, err := newGCPCore(ctx, projectID, logName, taskID, level)
+	if err != nil {
+		return nil, err
+	}
+
+	consoleCore := newConsoleCore(level)
+
+	// Tee combines both cores — each log entry goes to both destinations.
+	combined := zapcore.NewTee(consoleCore, gcpAPICore)
+	zapLogger := zap.New(combined, zap.AddCaller(), zap.AddStacktrace(zapcore.ErrorLevel))
+
+	return &GCPLogger{
+		SugaredLogger: zapLogger.Sugar(),
+		client:        client,
+	}, nil
+}
+
+// newGCPCore creates the Cloud Logging client and a gcpCore.
+// Shared by NewGCPLogger and NewCombinedLogger.
+func newGCPCore(ctx context.Context, projectID, logName, taskID string, level zapcore.Level) (*logging.Client, *gcpCore, error) {
+	client, err := logging.NewClient(ctx, projectID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create GCP logging client: %w", err)
+	}
+
+	gcpLogger := client.Logger(logName, logging.CommonResource(&monitoredres.MonitoredResource{
+		Type: "generic_task",
+		Labels: map[string]string{
+			"project_id": projectID,
+			"namespace":  "neighbors-team",
+			"job":        logName,
+			"task_id":    taskID,
+			"location":   "global",
+		},
+	}))
+
+	core := &gcpCore{
+		level:     zapcore.Level(level),
+		gcpLogger: gcpLogger,
+	}
+
+	return client, core, nil
+}
+
+// gcpCore is a custom zapcore.Core that sends log entries to Cloud Logging API
+// instead of writing to stdout/stderr.
+//
+// How it works:
+//  1. zap calls Write() with a log entry and fields
+//  2. We collect all fields into a map
+//  3. Extract labels (fields with "labels." prefix from zapdriver)
+//  4. Extract trace ID if present
+//  5. Map zap severity to GCP severity
+//  6. Build a logging.Entry and send it via the GCP client
+type gcpCore struct {
+	level     zapcore.Level
+	gcpLogger *logging.Logger
+	fields    []zapcore.Field // fields accumulated via With()
+}
+
+// Enabled checks if the given log level should be logged.
+func (c *gcpCore) Enabled(level zapcore.Level) bool {
+	return level >= c.level
+}
+
+// With returns a new core with additional fields.
+// Called when user does logger.With("key", "val") — the fields
+// are stored and included in every subsequent log entry.
+func (c *gcpCore) With(fields []zapcore.Field) zapcore.Core {
+	return &gcpCore{
+		level:     c.level,
+		gcpLogger: c.gcpLogger,
+		fields:    append(append([]zapcore.Field{}, c.fields...), fields...),
+	}
+}
+
+// Check determines whether the entry should be logged.
+// Standard boilerplate — just adds this core to the checked entry.
+func (c *gcpCore) Check(entry zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.Enabled(entry.Level) {
+		return ce.AddCore(entry, c)
+	}
+	return ce
+}
+
+// Write takes a log entry from zap
+// and converts it into a Cloud Logging API call.
+func (c *gcpCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
+	// Merge stored fields (from With()) with per-entry fields.
+	allFields := append(c.fields, fields...)
+
+	// Use zap's MapObjectEncoder to convert fields into a map.
+	// This handles all zap field types (String, Int, Bool, etc.)
+	encoder := zapcore.NewMapObjectEncoder()
+	for _, field := range allFields {
+		field.AddTo(encoder)
+	}
+
+	// Separate labels from regular fields.
+	// zapdriver labels appear as "labels.key" in the encoder output.
+	labels := make(map[string]string)
+	payload := map[string]interface{}{
+		"message": entry.Message,
+	}
+
+	for key, val := range encoder.Fields {
+		if strings.HasPrefix(key, "labels.") {
+			// "labels.app" → label key "app"
+			labelKey := strings.TrimPrefix(key, "labels.")
+			labels[labelKey] = fmt.Sprint(val)
+			continue
+		}
+		// Regular field — goes into the payload.
+		payload[key] = val
+	}
+
+	// Add source location to payload if available.
+	if entry.Caller.Defined {
+		payload["caller"] = entry.Caller.String()
+	}
+
+	// Add stacktrace if present (errors).
+	if entry.Stack != "" {
+		payload["stacktrace"] = entry.Stack
+	}
+
+	// Map zap severity to Cloud Logging severity.
+	severity := mapSeverity(entry.Level)
+
+	// Extract trace ID if present.
+	trace := ""
+	if t, ok := payload["logging.googleapis.com/trace"].(string); ok {
+		trace = t
+		delete(payload, "logging.googleapis.com/trace")
+	}
+
+	// Build and send the Cloud Logging entry.
+	logEntry := logging.Entry{
+		Timestamp: entry.Time,
+		Severity:  severity,
+		Payload:   payload,
+		Labels:    labels,
+		Trace:     trace,
+	}
+
+	c.gcpLogger.Log(logEntry)
+
+	// Auto-flush on errors to ensure they're delivered immediately.
+	if entry.Level >= zapcore.ErrorLevel {
+		_ = c.Sync()
+	}
+
+	return nil
+}
+
+// Sync flushes all buffered log entries to Cloud Logging.
+func (c *gcpCore) Sync() error {
+	return c.gcpLogger.Flush()
+}
+
+// mapSeverity converts a zap log level to a Cloud Logging severity.
+func mapSeverity(level zapcore.Level) logging.Severity {
+	switch level {
+	case zapcore.DebugLevel:
+		return logging.Debug
+	case zapcore.InfoLevel:
+		return logging.Info
+	case zapcore.WarnLevel:
+		return logging.Warning
+	case zapcore.ErrorLevel:
+		return logging.Error
+	case zapcore.DPanicLevel, zapcore.PanicLevel, zapcore.FatalLevel:
+		return logging.Critical
+	default:
+		return logging.Default
+	}
+}

--- a/pkg/logger/gcp.go
+++ b/pkg/logger/gcp.go
@@ -19,11 +19,11 @@ type GCPLogger struct {
 	client *logging.Client
 }
 
-// Compile-time check: GCPLogger must implement LoggerInterface.
-var _ LoggerInterface = (*GCPLogger)(nil)
+// Compile-time check: GCPLogger must implement Logger.
+var _ Logger = (*GCPLogger)(nil)
 
 // With creates a child logger with additional context fields.
-func (l *GCPLogger) With(args ...interface{}) LoggerInterface {
+func (l *GCPLogger) With(args ...interface{}) Logger {
 	return &GCPLogger{
 		SugaredLogger: l.SugaredLogger.With(args...),
 		client:        l.client,

--- a/pkg/logger/gcp_test.go
+++ b/pkg/logger/gcp_test.go
@@ -1,0 +1,92 @@
+package logger
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
+
+	"cloud.google.com/go/logging"
+)
+
+var _ = Describe("GCP Logger", func() {
+
+	// ---------------------------------------------------------------
+	// mapSeverity — zap level to GCP severity mapping
+	// ---------------------------------------------------------------
+	Describe("mapSeverity", func() {
+		DescribeTable("should map zap levels to GCP severities",
+			func(zapLevel zapcore.Level, expected logging.Severity) {
+				Expect(mapSeverity(zapLevel)).To(Equal(expected))
+			},
+			Entry("Debug → Debug", zapcore.DebugLevel, logging.Debug),
+			Entry("Info → Info", zapcore.InfoLevel, logging.Info),
+			Entry("Warn → Warning", zapcore.WarnLevel, logging.Warning),
+			Entry("Error → Error", zapcore.ErrorLevel, logging.Error),
+			Entry("DPanic → Critical", zapcore.DPanicLevel, logging.Critical),
+			Entry("Panic → Critical", zapcore.PanicLevel, logging.Critical),
+			Entry("Fatal → Critical", zapcore.FatalLevel, logging.Critical),
+		)
+	})
+
+	// ---------------------------------------------------------------
+	// gcpCore.Enabled — level filtering
+	// ---------------------------------------------------------------
+	Describe("gcpCore.Enabled", func() {
+		It("should filter levels below the configured minimum", func() {
+			core := &gcpCore{level: zapcore.InfoLevel}
+
+			Expect(core.Enabled(zapcore.DebugLevel)).To(BeFalse())
+			Expect(core.Enabled(zapcore.InfoLevel)).To(BeTrue())
+			Expect(core.Enabled(zapcore.WarnLevel)).To(BeTrue())
+			Expect(core.Enabled(zapcore.ErrorLevel)).To(BeTrue())
+		})
+
+		It("should pass all levels when set to Debug", func() {
+			core := &gcpCore{level: zapcore.DebugLevel}
+
+			Expect(core.Enabled(zapcore.DebugLevel)).To(BeTrue())
+			Expect(core.Enabled(zapcore.InfoLevel)).To(BeTrue())
+		})
+	})
+
+	// ---------------------------------------------------------------
+	// gcpCore.With — field accumulation
+	// ---------------------------------------------------------------
+	Describe("gcpCore.With", func() {
+		It("should return a new core with accumulated fields", func() {
+			original := &gcpCore{level: zapcore.InfoLevel}
+
+			child := original.With([]zapcore.Field{
+				zapcore.Field{Key: "request_id", Type: zapcore.StringType, String: "abc-123"},
+			})
+
+			// Original should not be modified.
+			gcpChild, ok := child.(*gcpCore)
+			Expect(ok).To(BeTrue())
+			Expect(gcpChild.fields).To(HaveLen(1))
+			Expect(original.fields).To(BeEmpty())
+		})
+	})
+
+	// ---------------------------------------------------------------
+	// Factory — API destination env var validation
+	// ---------------------------------------------------------------
+	Describe("Factory with api destination", func() {
+		AfterEach(func() {
+			os.Unsetenv(EnvLogDestination)
+			os.Unsetenv(EnvGCPProjectID)
+			os.Unsetenv(EnvGCPLogName)
+		})
+
+		It("should return error when GCP_PROJECT_ID is missing", func() {
+			os.Setenv(EnvLogDestination, "api")
+			os.Unsetenv(EnvGCPProjectID)
+
+			_, err := New()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("GCP_PROJECT_ID"))
+		})
+	})
+})

--- a/pkg/logger/logger_suite_test.go
+++ b/pkg/logger/logger_suite_test.go
@@ -1,0 +1,13 @@
+package logger
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestLogger(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Logger Suite")
+}

--- a/pkg/logger/types.go
+++ b/pkg/logger/types.go
@@ -1,0 +1,64 @@
+package logger
+
+import (
+	"github.com/blendle/zapdriver"
+	"go.uber.org/zap"
+)
+
+// LoggerInterface is the primary logger interface.
+// Accept this interface in all function and method signatures that require logging.
+// It composes structured logging, child logger creation, and log flushing.
+type LoggerInterface interface {
+	StructuredLoggerInterface
+	WithLoggerInterface
+	SyncLoggerInterface
+}
+
+// StructuredLoggerInterface defines structured logging methods.
+// All log messages use key-value pairs for structured data.
+// The "w" suffix stands for "with" — each method accepts a message
+// followed by alternating key-value pairs:
+//
+//	logger.Infow("user logged in", "user_id", "123", "ip", "10.0.0.1")
+type StructuredLoggerInterface interface {
+	Infow(message string, keysAndValues ...interface{})
+	Warnw(message string, keysAndValues ...interface{})
+	Errorw(message string, keysAndValues ...interface{})
+	Debugw(message string, keysAndValues ...interface{})
+}
+
+// WithLoggerInterface defines a method to create a child logger
+// with additional context fields. Every log entry from the child logger
+// will include these fields automatically.
+//
+// Example:
+//
+//	child := logger.With("request_id", "abc-123", "component", "auth")
+//	child.Infow("processing request")  // includes request_id and component
+//
+// Returns LoggerInterface (not a concrete type) to maintain abstraction.
+type WithLoggerInterface interface {
+	With(args ...interface{}) LoggerInterface
+}
+
+// SyncLoggerInterface defines a method to flush buffered log entries.
+// Call Sync before application exit to ensure all logs are delivered.
+type SyncLoggerInterface interface {
+	Sync() error
+}
+
+// LogLabel creates a GCP Cloud Logging label field.
+//
+// Labels are special — in GCP they land in a separate "labels" field,
+// not in the JSON payload. This makes them indexed and filterable
+// in Cloud Logging console.
+//
+// Use LogLabel for metadata like app name, version, environment.
+// Use regular key-value pairs for dynamic data like request_id, user_id.
+//
+// Example:
+//
+//	appLogger := logger.With(logger.LogLabel("app", "image-builder"), logger.LogLabel("version", "1.0.0"))
+func LogLabel(key, value string) zap.Field {
+	return zapdriver.Label(key, value)
+}

--- a/pkg/logger/types.go
+++ b/pkg/logger/types.go
@@ -5,29 +5,29 @@ import (
 	"go.uber.org/zap"
 )
 
-// LoggerInterface is the primary logger interface.
+// Logger is the primary logger interface.
 // Accept this interface in all function and method signatures that require logging.
 // It composes structured logging, child logger creation, and log flushing.
-type LoggerInterface interface {
-	StructuredLoggerInterface
-	WithLoggerInterface
-	SyncLoggerInterface
+type Logger interface {
+	StructuredLogger
+	WithLogger
+	SyncLogger
 }
 
-// StructuredLoggerInterface defines structured logging methods.
+// StructuredLogger defines structured logging methods.
 // All log messages use key-value pairs for structured data.
 // The "w" suffix stands for "with" — each method accepts a message
 // followed by alternating key-value pairs:
 //
 //	logger.Infow("user logged in", "user_id", "123", "ip", "10.0.0.1")
-type StructuredLoggerInterface interface {
+type StructuredLogger interface {
 	Infow(message string, keysAndValues ...interface{})
 	Warnw(message string, keysAndValues ...interface{})
 	Errorw(message string, keysAndValues ...interface{})
 	Debugw(message string, keysAndValues ...interface{})
 }
 
-// WithLoggerInterface defines a method to create a child logger
+// WithLogger defines a method to create a child logger
 // with additional context fields. Every log entry from the child logger
 // will include these fields automatically.
 //
@@ -36,14 +36,14 @@ type StructuredLoggerInterface interface {
 //	child := logger.With("request_id", "abc-123", "component", "auth")
 //	child.Infow("processing request")  // includes request_id and component
 //
-// Returns LoggerInterface (not a concrete type) to maintain abstraction.
-type WithLoggerInterface interface {
-	With(args ...interface{}) LoggerInterface
+// Returns Logger (not a concrete type) to maintain abstraction.
+type WithLogger interface {
+	With(args ...interface{}) Logger
 }
 
-// SyncLoggerInterface defines a method to flush buffered log entries.
+// SyncLogger defines a method to flush buffered log entries.
 // Call Sync before application exit to ensure all logs are delivered.
-type SyncLoggerInterface interface {
+type SyncLogger interface {
 	Sync() error
 }
 


### PR DESCRIPTION
## Add `pkg/logger` — ADR-006 compliant structured logging

### Context

`test-infra` has two existing logging packages: `pkg/logging` (general-purpose, logrus-based) and `pkg/gcp/logging` (Cloud Logging API wrapper). Neither satisfies ADR-006 — they have different interfaces, no unified entry point, and no environment-aware routing. Modifying them would break existing callers across the repository and add Cloud Logging dependencies to tools that don't need them.

### What this PR adds

A new `pkg/logger` package with:

- **`LoggerInterface`** — unified interface accepted by all function signatures
- **`New()`** — single entry point, fully configured via environment variables
- **`ConsoleLogger`** — structured JSON to stdout/stderr, compatible with Cloud Logging agent
- **`GCPLogger`** — sends logs directly to Cloud Logging API
- **`CombinedLogger`** — both destinations simultaneously
- **`BufferLogger`** — in-memory logger for unit tests
- **`LogLabel()`** — helper for creating GCP-indexed labels

### Environment variables

| Variable | Default | Description |
|---|---|---|
| `LOG_DESTINATION` | `auto` | `console`, `api`, `console-and-api`, `auto` |
| `LOG_LEVEL` | `info` | `debug`, `info` |
| `GCP_PROJECT_ID` | — | Required for `api` and `console-and-api` |
| `GCP_LOG_NAME` | `application` | Log name in Cloud Logging |

`auto` detects GCP via [metadata server](https://github.com/kyma-project/test-infra/pull/14047/changes#diff-e75f2ab5732d61314d4c7c97dd0d7cbf58628d86a75ecc92504506e964e0f870R123) — on GCP uses `console`, outside GCP uses `console-and-api`.

### Testing

Tested with two apps sending logs simultaneously — one on Cloud Run (`auto` → `console`), one running locally via API. Both visible in Cloud Logging under the same filter.

### Notes

- `pkg/logging` and `pkg/gcp/logging` are untouched — existing callers unaffected
- One deliberate deviation from ADR-006: `auto` outside GCP resolves to `console-and-api` instead of `api`, so logs are always visible locally without extra setup