### PR TITLE
chore(build): enable use of internal SAP modules for builds

### DIFF
--- a/.github/workflows/build-dashboard-token-proxy.yml
+++ b/.github/workflows/build-dashboard-token-proxy.yml
@@ -18,6 +18,7 @@ jobs:
       name: dashboard-token-proxy
       dockerfile: cmd/dashboard-token-proxy/Dockerfile
       context: .
+      use-go-internal-sap-modules: true
       platforms: |
         linux/amd64
       tags: |

--- a/.github/workflows/build-github-webhook-gateway.yml
+++ b/.github/workflows/build-github-webhook-gateway.yml
@@ -18,6 +18,7 @@ jobs:
       name: github-webhook-gateway
       dockerfile: cmd/cloud-run/github-webhook-gateway/Dockerfile
       context: .
+      use-go-internal-sap-modules: true
       platforms: |
         linux/amd64
       tags: |


### PR DESCRIPTION
## Description

Enable access to private Go modules from internal SAP GitHub (`github.tools.sap`) for two build workflows that are currently failing during `go mod download` stage in Dockerfiles.

## Changes

- `build-github-webhook-gateway.yml` — added `use-go-internal-sap-modules: true`
- `build-dashboard-token-proxy.yml` — added `use-go-internal-sap-modules: true`
