### PR TITLE
feat: add dedicated GitHub-hosted larger runners for telemetry-manager

### DIFF
--- a/configs/terraform/environments/prod/github-actions-hosted-runners-variables.tf
+++ b/configs/terraform/environments/prod/github-actions-hosted-runners-variables.tf
@@ -4,32 +4,22 @@ variable "telemetry_manager_runner_group_name" {
   description = "Name of the GitHub Actions runner group for telemetry-manager"
 }
 
-variable "telemetry_manager_hosted_runner_name" {
-  type        = string
-  default     = "telemetry-4core"
-  description = "Name and label of the GitHub-hosted larger runner for telemetry-manager"
-}
+variable "telemetry_manager_hosted_runner" {
+  type = object({
+    name         = string
+    size         = string
+    max_runners  = number
+    image_id     = string
+    image_source = string
+  })
 
-variable "telemetry_manager_hosted_runner_size" {
-  type        = string
-  default     = "4-core"
-  description = "Machine size for the hosted runner (e.g., 4-core, 8-core, 16-core)"
-}
+  default = {
+    name         = "telemetry-4core"
+    size         = "4-core"
+    max_runners  = 30
+    image_id     = "2306"
+    image_source = "github"
+  }
 
-variable "telemetry_manager_hosted_runner_max_runners" {
-  type        = number
-  default     = 30
-  description = "Maximum number of runners that can be scaled up simultaneously"
-}
-
-variable "telemetry_manager_hosted_runner_image_id" {
-  type        = string
-  default     = "2306"
-  description = "Image ID for the hosted runner (2306 = Ubuntu Latest 24.04)"
-}
-
-variable "telemetry_manager_hosted_runner_image_source" {
-  type        = string
-  default     = "github"
-  description = "Image source for the hosted runner (github, partner, or custom)"
+  description = "Configuration for the telemetry-manager GitHub-hosted larger runner"
 }

--- a/configs/terraform/environments/prod/github-actions-hosted-runners-variables.tf
+++ b/configs/terraform/environments/prod/github-actions-hosted-runners-variables.tf
@@ -1,0 +1,35 @@
+variable "telemetry_manager_runner_group_name" {
+  type        = string
+  default     = "telemetry-manager-runners"
+  description = "Name of the GitHub Actions runner group for telemetry-manager"
+}
+
+variable "telemetry_manager_hosted_runner_name" {
+  type        = string
+  default     = "telemetry-4core"
+  description = "Name and label of the GitHub-hosted larger runner for telemetry-manager"
+}
+
+variable "telemetry_manager_hosted_runner_size" {
+  type        = string
+  default     = "4-core"
+  description = "Machine size for the hosted runner (e.g., 4-core, 8-core, 16-core)"
+}
+
+variable "telemetry_manager_hosted_runner_max_runners" {
+  type        = number
+  default     = 30
+  description = "Maximum number of runners that can be scaled up simultaneously"
+}
+
+variable "telemetry_manager_hosted_runner_image_id" {
+  type        = string
+  default     = "2306"
+  description = "Image ID for the hosted runner (2306 = Ubuntu Latest 24.04)"
+}
+
+variable "telemetry_manager_hosted_runner_image_source" {
+  type        = string
+  default     = "github"
+  description = "Image source for the hosted runner (github, partner, or custom)"
+}

--- a/configs/terraform/environments/prod/github-actions-hosted-runners.tf
+++ b/configs/terraform/environments/prod/github-actions-hosted-runners.tf
@@ -34,14 +34,14 @@ resource "github_actions_runner_group" "telemetry_manager" {
 resource "github_actions_hosted_runner" "telemetry_manager" {
   provider = github.kyma_project
 
-  name = var.telemetry_manager_hosted_runner_name
+  name = var.telemetry_manager_hosted_runner.name
 
   image {
-    id     = var.telemetry_manager_hosted_runner_image_id
-    source = var.telemetry_manager_hosted_runner_image_source
+    id     = var.telemetry_manager_hosted_runner.image_id
+    source = var.telemetry_manager_hosted_runner.image_source
   }
 
-  size            = var.telemetry_manager_hosted_runner_size
+  size            = var.telemetry_manager_hosted_runner.size
   runner_group_id = github_actions_runner_group.telemetry_manager.id
-  maximum_runners = var.telemetry_manager_hosted_runner_max_runners
+  maximum_runners = var.telemetry_manager_hosted_runner.max_runners
 }

--- a/configs/terraform/environments/prod/github-actions-hosted-runners.tf
+++ b/configs/terraform/environments/prod/github-actions-hosted-runners.tf
@@ -1,0 +1,47 @@
+# ------------------------------------------------------------------------------
+# GitHub Actions Hosted Runners for telemetry-manager
+# ------------------------------------------------------------------------------
+# This configuration provisions a dedicated runner group and GitHub-hosted
+# larger runner for the telemetry-manager repository's CI workloads.
+#
+# The runner group is scoped exclusively to the telemetry-manager repository
+# via visibility = "selected", ensuring isolation from other org repos.
+# This addresses CI flakiness caused by shared runner pool contention during
+# business hours (see: https://github.tools.sap/kyma/test-infra/issues/1308).
+# ------------------------------------------------------------------------------
+
+data "github_repository" "telemetry_manager" {
+  provider = github.kyma_project
+  name     = "telemetry-manager"
+}
+
+resource "github_actions_runner_group" "telemetry_manager" {
+  provider                   = github.kyma_project
+  name                       = var.telemetry_manager_runner_group_name
+  visibility                 = "selected"
+  allows_public_repositories = true
+
+  selected_repository_ids = [
+    data.github_repository.telemetry_manager.repo_id,
+  ]
+
+  restricted_to_workflows = true
+  selected_workflows = [
+    "kyma-project/telemetry-manager/.github/workflows/pr-integration.yml@refs/heads/main",
+  ]
+}
+
+resource "github_actions_hosted_runner" "telemetry_manager" {
+  provider = github.kyma_project
+
+  name = var.telemetry_manager_hosted_runner_name
+
+  image {
+    id     = var.telemetry_manager_hosted_runner_image_id
+    source = var.telemetry_manager_hosted_runner_image_source
+  }
+
+  size            = var.telemetry_manager_hosted_runner_size
+  runner_group_id = github_actions_runner_group.telemetry_manager.id
+  maximum_runners = var.telemetry_manager_hosted_runner_max_runners
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add a dedicated GitHub Actions runner group scoped to `telemetry-manager` repository via `visibility = "selected"`
- Add a GitHub-hosted larger runner (4-core, 16 GB RAM, 150 GB disk, Ubuntu 24.04)
- Set `maximum_runners = 30` matching the parallel job count in `pr-integration.yml`
- Restrict runner group to `pr-integration.yml` workflow only

### Context

The `pr-integration.yml` workflow in `telemetry-manager` runs **30 parallel jobs** per workflow run (6 e2e-logs + 3 e2e-metrics + 4 e2e-experimental + 2 e2e + 2 e2e-other + 1 selfmonitor-healthy + 12 selfmonitor). During business hours, these jobs compete with all other `kyma-project` repos for the shared runner pool, resulting in a **2x higher failure rate** compared to nights/weekends.

This PR provisions a **dedicated runner group** isolated from the rest of the org, which addresses both:
1. **Pool contention** — telemetry-manager gets its own pool of up to 30 runners
2. **Resource constraints** — 4-core runners provide 2x CPU and 2x memory vs standard runners

| Parameter | Value |
|-----------|-------|
| Runner size | 4-core (16 GB RAM, 150 GB disk) |
| Max runners | 30 |
| Workflow restriction | `pr-integration.yml` only |
| Image | Ubuntu 24.04 |
| Visibility | selected (telemetry-manager only) |

### Cost

- $0.012/min per runner (billed only during execution, $0 when idle)
- Size is mutable — can be scaled up/down without recreating the runner

**Related issue(s)**

Resolves https://github.tools.sap/kyma/test-infra/issues/1308