### PR TITLE
chore(workflows): add permissions for id-token in workflow controller

### DIFF
--- a/.github/workflows/workflow-controller-pull-requests.yml
+++ b/.github/workflows/workflow-controller-pull-requests.yml
@@ -28,6 +28,9 @@ jobs:
 
   pull-go-lint:
     uses: kyma-project/test-infra/.github/workflows/pull-go-lint.yaml@main
+    permissions:
+      contents: read
+      id-token: write
     needs: detect-changed-files
     if: ${{ contains(needs.detect-changed-files.outputs.files, 'pull-go-lint-filter') }}
 
@@ -48,6 +51,9 @@ jobs:
 
   pull-unit-test-go:
     uses: kyma-project/test-infra/.github/workflows/pull-unit-test-go.yaml@main
+    permissions:
+      contents: read
+      id-token: write
     needs: detect-changed-files
     if: ${{ contains(needs.detect-changed-files.outputs.files, 'pull-unit-test-go-filter') }}
 

--- a/.github/workflows/workflow-controller-pull-requests.yml
+++ b/.github/workflows/workflow-controller-pull-requests.yml
@@ -31,6 +31,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      pull-requests: read
     needs: detect-changed-files
     if: ${{ contains(needs.detect-changed-files.outputs.files, 'pull-go-lint-filter') }}
 
@@ -54,6 +55,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      pull-requests: read
     needs: detect-changed-files
     if: ${{ contains(needs.detect-changed-files.outputs.files, 'pull-unit-test-go-filter') }}
 


### PR DESCRIPTION
## Fix: Grant `id-token: write` to reusable workflow calls

### Problem
`pull-go-lint` and `pull-unit-test-go` jobs were failing with:
> The nested job 'lint' is requesting 'id-token: write', but is only allowed 'id-token: none'.

The top-level `permissions` block in `workflow-controller-pull-requests.yml` does not grant `id-token`, so called reusable workflows inherit `id-token: none` by default.

### Change
Added explicit `permissions` blocks to the `pull-go-lint` and `pull-unit-test-go` job calls:
```yaml
permissions:
  contents: read
  id-token: write