### PR TITLE
cleanup(iac): Move resource related to go workflows into separate file

### DIFF
--- a/configs/terraform/environments/prod/go-ci-workflows.tf
+++ b/configs/terraform/environments/prod/go-ci-workflows.tf
@@ -1,0 +1,67 @@
+# ==============================================================================
+# Go CI Reusable Workflows - IAM Access
+# ==============================================================================
+# This configuration grants the generic Go CI reusable workflows from the public
+# test-infra repository access to the internal GitHub token stored in GCP Secret Manager.
+# These workflows are shared across multiple repositories.
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Variables
+# ------------------------------------------------------------------------------
+
+variable "pull_go_lint_reusable_workflow_ref" {
+  type        = string
+  default     = "kyma-project/test-infra/.github/workflows/pull-go-lint.yaml@refs/heads/main"
+  description = "Value of the GitHub OIDC token job_workflow_ref claim for the pull-go-lint reusable workflow in the public test-infra repository"
+}
+
+variable "pull_unit_test_go_reusable_workflow_ref" {
+  type        = string
+  default     = "kyma-project/test-infra/.github/workflows/pull-unit-test-go.yaml@refs/heads/main"
+  description = "Value of the GitHub OIDC token job_workflow_ref claim for the pull-unit-test-go reusable workflow in the public test-infra repository"
+}
+
+variable "gh_tools_kyma_prow_bot_token_secret_name" {
+  type        = string
+  default     = "GH_TOOLS_KYMA_PROW_BOT_TOKEN_SECRET_NAME"
+  description = "GitHub Actions repository variable name that holds the GCP secret name for the internal GitHub token used by Go CI reusable workflows"
+}
+
+# ------------------------------------------------------------------------------
+# IAM Permissions - Secret Access for Reusable Workflows via WIF
+# ------------------------------------------------------------------------------
+
+# Grant the pull-go-lint reusable workflow (public test-infra) access to read the internal GitHub token.
+resource "google_secret_manager_secret_iam_member" "pull_go_lint_workflow_internal_token_reader" {
+  project   = var.gcp_project_id
+  secret_id = google_secret_manager_secret.kyma_modules_runtime_internal_github_token.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_ref/${var.pull_go_lint_reusable_workflow_ref}"
+}
+
+# Grant the pull-unit-test-go reusable workflow (public test-infra) access to read the internal GitHub token.
+resource "google_secret_manager_secret_iam_member" "pull_unit_test_go_workflow_internal_token_reader" {
+  project   = var.gcp_project_id
+  secret_id = google_secret_manager_secret.kyma_modules_runtime_internal_github_token.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_ref/${var.pull_unit_test_go_reusable_workflow_ref}"
+}
+
+# ------------------------------------------------------------------------------
+# GitHub Actions Repository Variable (github.com/kyma-project/test-infra)
+# ------------------------------------------------------------------------------
+# Expose the GCP secret name as a repository-level variable so the reusable
+# workflows can resolve the secret at runtime.
+
+import {
+  to = github_actions_variable.gh_tools_kyma_prow_bot_token_secret_name
+  id = "test-infra:${var.gh_tools_kyma_prow_bot_token_secret_name}"
+}
+
+resource "github_actions_variable" "gh_tools_kyma_prow_bot_token_secret_name" {
+  provider      = github.kyma_project
+  repository    = data.github_repository.test_infra.name
+  variable_name = var.gh_tools_kyma_prow_bot_token_secret_name
+  value         = google_secret_manager_secret.kyma_modules_runtime_internal_github_token.secret_id
+}

--- a/configs/terraform/environments/prod/kyma-runtime-update-components-config.tf
+++ b/configs/terraform/environments/prod/kyma-runtime-update-components-config.tf
@@ -32,18 +32,6 @@ variable "internal_github_kyma_modules_repository_name" {
   description = "Repository name in internal GitHub Enterprise where the variable should be created"
 }
 
-variable "pull_go_lint_reusable_workflow_ref" {
-  type        = string
-  default     = "kyma-project/test-infra/.github/workflows/pull-go-lint.yaml@refs/heads/main"
-  description = "Value of the GitHub OIDC token job_workflow_ref claim for the pull-go-lint reusable workflow in the public test-infra repository"
-}
-
-variable "pull_unit_test_go_reusable_workflow_ref" {
-  type        = string
-  default     = "kyma-project/test-infra/.github/workflows/pull-unit-test-go.yaml@refs/heads/main"
-  description = "Value of the GitHub OIDC token job_workflow_ref claim for the pull-unit-test-go reusable workflow in the public test-infra repository"
-}
-
 data "github_repository" "kyma_modules_internal" {
   provider = github.internal_github
   name     = "kyma-modules"
@@ -83,22 +71,6 @@ resource "google_secret_manager_secret_iam_member" "kyma_modules_update_componen
   secret_id = google_secret_manager_secret.kyma_modules_runtime_internal_github_token.secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "principal://iam.googleapis.com/projects/351981214969/locations/global/workloadIdentityPools/github-tools-sap/subject/repository_id:${data.github_repository.kyma_modules_internal.repo_id}:repository_owner_id:2457:workflow:Update Component Version on Push"
-}
-
-# Grant the pull-go-lint reusable workflow (public test-infra) access to read the internal GitHub token.
-resource "google_secret_manager_secret_iam_member" "pull_go_lint_workflow_internal_token_reader" {
-  project   = var.gcp_project_id
-  secret_id = google_secret_manager_secret.kyma_modules_runtime_internal_github_token.secret_id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_ref/${var.pull_go_lint_reusable_workflow_ref}"
-}
-
-# Grant the pull-unit-test-go reusable workflow (public test-infra) access to read the internal GitHub token.
-resource "google_secret_manager_secret_iam_member" "pull_unit_test_go_workflow_internal_token_reader" {
-  project   = var.gcp_project_id
-  secret_id = google_secret_manager_secret.kyma_modules_runtime_internal_github_token.secret_id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_ref/${var.pull_unit_test_go_reusable_workflow_ref}"
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Add Terraform config for Go CI reusable workflows

### Changes

- Extracted `pull-go-lint` and `pull-unit-test-go` IAM bindings and variables into a new dedicated file `go-ci-workflows.tf`
- Added `github_actions_variable` resource to manage `GH_TOOLS_KYMA_PROW_BOT_TOKEN_SECRET_NAME` in `kyma-project/test-infra` repository with an import block for the existing variable