### PR TITLE
fix: remove workflow restriction from runner group to allow PR runs

### DIFF
--- a/configs/terraform/environments/prod/github-actions-hosted-runners.tf
+++ b/configs/terraform/environments/prod/github-actions-hosted-runners.tf
@@ -24,11 +24,6 @@ resource "github_actions_runner_group" "telemetry_manager" {
   selected_repository_ids = [
     data.github_repository.telemetry_manager.repo_id,
   ]
-
-  restricted_to_workflows = true
-  selected_workflows = [
-    "kyma-project/telemetry-manager/.github/workflows/pr-integration.yml@refs/heads/main",
-  ]
 }
 
 resource "github_actions_hosted_runner" "telemetry_manager" {


### PR DESCRIPTION
**Description**

Removes `restricted_to_workflows` and `selected_workflows` from the `telemetry_manager` runner group.

### Why

The workflow restriction `@refs/heads/main` only matches workflows triggered from the main branch. PR workflows run from `@refs/pull/<number>/merge`, which doesn't match — making the dedicated runners unavailable for PR CI jobs, which is the primary use case.

The runner group is already isolated to `telemetry-manager` via `visibility = "selected"` + `selected_repository_ids`, which provides sufficient access control.

**Related issue(s)**

Follow-up to https://github.com/kyma-project/test-infra/pull/14082
See also https://github.tools.sap/kyma/test-infra/issues/1308