### PR TITLE
fix(security): missing content-security-policy

### DIFF
--- a/cmd/dashboard-token-proxy/main.go
+++ b/cmd/dashboard-token-proxy/main.go
@@ -128,6 +128,7 @@ func HandleTokenRequest(clientID, clientSecret, ghURL, authorizationURL string) 
 		w.Header().Add("content-type", "application/json")
 		w.Header().Add("Access-Control-Allow-Origin", fmt.Sprintf("https://pages.%s", ghURL))
 		w.Header().Add("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload")
+		w.Header().Add("Content-Security-Policy", "default-src 'none'")
 		w.Write(b)
 	}
 }


### PR DESCRIPTION
Add misisng CSP header to the dashbaord-token proxy, with defaults-src: 'none', which is valid setting for the JSON-only APIs.