### PR TITLE
feat(terraform): add WIF bindings for release-log-uploader SA

### DIFF
--- a/configs/terraform/environments/prod/release-log-uploader-variables.tf
+++ b/configs/terraform/environments/prod/release-log-uploader-variables.tf
@@ -1,0 +1,17 @@
+variable "release_log_uploader_service_account_name" {
+  type        = string
+  description = "The service account name of the release-log-uploader service account."
+  default     = "release-log-uploader"
+}
+
+variable "release_log_uploader_compliancy_workflow_ref_public_github" {
+  type        = string
+  description = "The value of GitHub OIDC token job_workflow_ref claim of the release log upload workflow in kyma-project/compliancy repository on github.com."
+  default     = "compliancy/.github/workflows/release-log-upload.yaml@refs/heads/main"
+}
+
+variable "release_log_uploader_compliancy_workflow_ref_internal_github" {
+  type        = string
+  description = "The value of GitHub OIDC token job_workflow_ref claim of the release log upload workflow in kyma/compliancy repository on github.tools.sap."
+  default     = "compliancy/.github/workflows/release-log-upload.yaml@refs/heads/main"
+}

--- a/configs/terraform/environments/prod/release-log-uploader-variables.tf
+++ b/configs/terraform/environments/prod/release-log-uploader-variables.tf
@@ -4,16 +4,10 @@ variable "release_log_uploader_service_account_name" {
   default     = "release-log-uploader"
 }
 
-variable "release_log_uploader_compliancy_workflow_ref_public_github" {
+variable "release_log_uploader_workflow_name" {
   type        = string
-  description = "The value of GitHub OIDC token job_workflow_ref claim of the release log upload workflow in kyma-project/compliancy repository on github.com."
-  default     = "compliancy/.github/workflows/release-log-upload.yaml@refs/heads/main"
-}
-
-variable "release_log_uploader_compliancy_workflow_ref_internal_github" {
-  type        = string
-  description = "The value of GitHub OIDC token job_workflow_ref claim of the release log upload workflow in kyma/compliancy repository on github.tools.sap."
-  default     = "compliancy/.github/workflows/release-log-upload.yaml@refs/heads/main"
+  description = "The name of the GitHub Actions workflow (as defined in the 'name:' field) that uploads release logs."
+  default     = "Release report"
 }
 
 variable "release_log_uploader_logs_bucket_name" {

--- a/configs/terraform/environments/prod/release-log-uploader-variables.tf
+++ b/configs/terraform/environments/prod/release-log-uploader-variables.tf
@@ -15,3 +15,9 @@ variable "release_log_uploader_compliancy_workflow_ref_internal_github" {
   description = "The value of GitHub OIDC token job_workflow_ref claim of the release log upload workflow in kyma/compliancy repository on github.tools.sap."
   default     = "compliancy/.github/workflows/release-log-upload.yaml@refs/heads/main"
 }
+
+variable "release_log_uploader_logs_bucket_name" {
+  type        = string
+  description = "Name of the GCS bucket where release logs are stored."
+  default     = "kyma_release_test_logs"
+}

--- a/configs/terraform/environments/prod/release-log-uploader.tf
+++ b/configs/terraform/environments/prod/release-log-uploader.tf
@@ -16,8 +16,7 @@ resource "google_service_account_iam_member" "release_log_uploader_wif_internal_
 }
 
 resource "google_storage_bucket_iam_member" "release_log_uploader_logs_bucket_access" {
-  for_each = toset(["roles/storage.objectViewer", "roles/storage.objectCreator"])
-  bucket   = var.release_log_uploader_logs_bucket_name
-  role     = each.value
-  member   = "serviceAccount:${google_service_account.release_log_uploader.email}"
+  bucket = var.release_log_uploader_logs_bucket_name
+  role   = "roles/storage.objectUser"
+  member = "serviceAccount:${google_service_account.release_log_uploader.email}"
 }

--- a/configs/terraform/environments/prod/release-log-uploader.tf
+++ b/configs/terraform/environments/prod/release-log-uploader.tf
@@ -1,0 +1,16 @@
+resource "google_service_account" "release_log_uploader" {
+  account_id  = var.release_log_uploader_service_account_name
+  description = "Service account for release log upload workflow in kyma-project/compliancy and kyma/compliancy repositories."
+}
+
+resource "google_service_account_iam_member" "release_log_uploader_wif_public_github" {
+  service_account_id = google_service_account.release_log_uploader.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_ref/${data.github_organization.kyma_project.login}/${var.release_log_uploader_compliancy_workflow_ref_public_github}"
+}
+
+resource "google_service_account_iam_member" "release_log_uploader_wif_internal_github" {
+  service_account_id = google_service_account.release_log_uploader.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.reusable_workflow_ref/${data.github_organization.kyma_internal.login}/${var.release_log_uploader_compliancy_workflow_ref_internal_github}"
+}

--- a/configs/terraform/environments/prod/release-log-uploader.tf
+++ b/configs/terraform/environments/prod/release-log-uploader.tf
@@ -16,7 +16,7 @@ resource "google_service_account_iam_member" "release_log_uploader_wif_internal_
 }
 
 resource "google_storage_bucket_iam_member" "release_log_uploader_logs_bucket_access" {
-  for_each = toset(["roles/storage.legacyBucketReader", "roles/storage.objectAdmin"])
+  for_each = toset(["roles/storage.objectViewer", "roles/storage.objectCreator"])
   bucket   = var.release_log_uploader_logs_bucket_name
   role     = each.value
   member   = "serviceAccount:${google_service_account.release_log_uploader.email}"

--- a/configs/terraform/environments/prod/release-log-uploader.tf
+++ b/configs/terraform/environments/prod/release-log-uploader.tf
@@ -1,3 +1,13 @@
+data "github_repository" "compliancy_public" {
+  provider = github.kyma_project
+  name     = "compliancy"
+}
+
+data "github_repository" "compliancy_internal" {
+  provider = github.internal_github
+  name     = "compliancy"
+}
+
 resource "google_service_account" "release_log_uploader" {
   account_id  = var.release_log_uploader_service_account_name
   description = "Service account for release log upload workflow in kyma-project/compliancy and kyma/compliancy repositories."
@@ -6,13 +16,13 @@ resource "google_service_account" "release_log_uploader" {
 resource "google_service_account_iam_member" "release_log_uploader_wif_public_github" {
   service_account_id = google_service_account.release_log_uploader.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_ref/${data.github_organization.kyma_project.login}/${var.release_log_uploader_compliancy_workflow_ref_public_github}"
+  member             = "principal://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/subject/repository_id:${data.github_repository.compliancy_public.repo_id}:repository_owner_id:${data.github_organization.kyma_project.id}:workflow:${var.release_log_uploader_workflow_name}"
 }
 
 resource "google_service_account_iam_member" "release_log_uploader_wif_internal_github" {
   service_account_id = google_service_account.release_log_uploader.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.reusable_workflow_ref/${data.github_organization.kyma_internal.login}/${var.release_log_uploader_compliancy_workflow_ref_internal_github}"
+  member             = "principal://iam.googleapis.com/${local.internal_github_wif_pool_name}/subject/repository_id:${data.github_repository.compliancy_internal.repo_id}:repository_owner_id:${data.github_organization.kyma_internal.id}:workflow:${var.release_log_uploader_workflow_name}"
 }
 
 resource "google_storage_bucket_iam_member" "release_log_uploader_logs_bucket_access" {

--- a/configs/terraform/environments/prod/release-log-uploader.tf
+++ b/configs/terraform/environments/prod/release-log-uploader.tf
@@ -14,3 +14,10 @@ resource "google_service_account_iam_member" "release_log_uploader_wif_internal_
   role               = "roles/iam.workloadIdentityUser"
   member             = "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.reusable_workflow_ref/${data.github_organization.kyma_internal.login}/${var.release_log_uploader_compliancy_workflow_ref_internal_github}"
 }
+
+resource "google_storage_bucket_iam_member" "release_log_uploader_logs_bucket_access" {
+  for_each = toset(["roles/storage.legacyBucketReader", "roles/storage.objectAdmin"])
+  bucket   = var.release_log_uploader_logs_bucket_name
+  role     = each.value
+  member   = "serviceAccount:${google_service_account.release_log_uploader.email}"
+}


### PR DESCRIPTION
Grant release-log-uploader@sap-kyma-prow.iam.gserviceaccount.com workloadIdentityUser role for workflows in kyma-project/compliancy (github.com) and kyma/compliancy (github.tools.sap).

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

  - Add Terraform configuration for release-log-uploader service account in sap-kyma-prow GCP project
  - Grant roles/iam.workloadIdentityUser via Workload Identity Federation pool github-com-kyma-project for workflows running in kyma-project/compliancy on github.com
  - Grant roles/iam.workloadIdentityUser via Workload Identity Federation pool github-tools-sap for workflows running in kyma/compliancy on github.tools.sap

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
