### PR TITLE
feat(logger): change Config.Level to string to avoid zapcore import in callers

### DIFF
--- a/pkg/logger/factory.go
+++ b/pkg/logger/factory.go
@@ -34,8 +34,10 @@ const (
 // The caller is responsible for populating this — typically by reading
 // environment variables or flags in main().
 type Config struct {
-	// Level is the minimum log severity. Defaults to Info.
-	Level zapcore.Level
+	// Level is the minimum log severity.
+	// Accepted values (case-insensitive): "debug", "info", "warn", "error", "dpanic", "panic", "fatal".
+	// Defaults to "info".
+	Level string
 
 	// Destination controls where logs are sent.
 	// Valid values: "console", "api", "console-and-api". Defaults to "console".
@@ -56,7 +58,7 @@ type Config struct {
 // New creates a logger based on the provided Config.
 //
 //	cfg := logger.Config{
-//	    Level:       zapcore.InfoLevel,
+//	    Level:       os.Getenv(logger.EnvLogLevel),
 //	    Destination: os.Getenv(logger.EnvLogDestination),
 //	    ProjectID:   os.Getenv(logger.EnvGCPProjectID),
 //	    LogName:     os.Getenv(logger.EnvGCPLogName),
@@ -68,6 +70,11 @@ type Config struct {
 //	}
 //	defer l.Sync()
 func New(ctx context.Context, cfg Config) (logging.LoggerInterface, error) {
+	level, err := parseLevel(cfg.Level)
+	if err != nil {
+		return nil, err
+	}
+
 	logName := cfg.LogName
 	if logName == "" {
 		logName = "application"
@@ -75,20 +82,33 @@ func New(ctx context.Context, cfg Config) (logging.LoggerInterface, error) {
 
 	switch cfg.Destination {
 	case "console", "":
-		return newConsoleLogger(cfg.Level), nil
+		return newConsoleLogger(level), nil
 	case "api":
 		if cfg.ProjectID == "" {
 			return nil, fmt.Errorf("ProjectID is required when Destination is %q", cfg.Destination)
 		}
-		return newGCPLogger(ctx, cfg.ProjectID, logName, cfg.TaskID, cfg.Level)
+		return newGCPLogger(ctx, cfg.ProjectID, logName, cfg.TaskID, level)
 	case "console-and-api":
 		if cfg.ProjectID == "" {
 			return nil, fmt.Errorf("ProjectID is required when Destination is %q", cfg.Destination)
 		}
-		return newCombinedLogger(ctx, cfg.ProjectID, logName, cfg.TaskID, cfg.Level)
+		return newCombinedLogger(ctx, cfg.ProjectID, logName, cfg.TaskID, level)
 	default:
 		return nil, fmt.Errorf("invalid Destination %q (valid: console, api, console-and-api)", cfg.Destination)
 	}
+}
+
+// parseLevel converts a string log level to zapcore.Level.
+// An empty string defaults to InfoLevel.
+func parseLevel(s string) (zapcore.Level, error) {
+	if s == "" {
+		return zapcore.InfoLevel, nil
+	}
+	var lvl zapcore.Level
+	if err := lvl.UnmarshalText([]byte(s)); err != nil {
+		return zapcore.InfoLevel, fmt.Errorf("unknown log level %q: %w", s, err)
+	}
+	return lvl, nil
 }
 
 // LogLabel creates a GCP Cloud Logging label field.

--- a/pkg/logger/factory_test.go
+++ b/pkg/logger/factory_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/zap/zapcore"
 )
 
 var _ = Describe("Factory", func() {
@@ -14,7 +13,7 @@ var _ = Describe("Factory", func() {
 	Describe("New", func() {
 		It("should create a ConsoleLogger when Destination is console", func() {
 			cfg := Config{
-				Level:       zapcore.InfoLevel,
+				Level:       "info",
 				Destination: "console",
 			}
 			logger, err := New(context.Background(), cfg)
@@ -27,7 +26,7 @@ var _ = Describe("Factory", func() {
 
 		It("should default to console when Destination is empty", func() {
 			cfg := Config{
-				Level: zapcore.InfoLevel,
+				Level: "info",
 			}
 			logger, err := New(context.Background(), cfg)
 			Expect(err).NotTo(HaveOccurred())
@@ -37,9 +36,23 @@ var _ = Describe("Factory", func() {
 			Expect(ok).To(BeTrue())
 		})
 
+		It("should default Level to info when Level is empty", func() {
+			cfg := Config{}
+			logger, err := New(context.Background(), cfg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(logger).NotTo(BeNil())
+		})
+
+		It("should return error for unknown Level", func() {
+			cfg := Config{Level: "verbose"}
+			_, err := New(context.Background(), cfg)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("verbose"))
+		})
+
 		It("should return error when Destination is api without ProjectID", func() {
 			cfg := Config{
-				Level:       zapcore.InfoLevel,
+				Level:       "info",
 				Destination: "api",
 				ProjectID:   "",
 			}
@@ -50,7 +63,7 @@ var _ = Describe("Factory", func() {
 
 		It("should return error when Destination is console-and-api without ProjectID", func() {
 			cfg := Config{
-				Level:       zapcore.InfoLevel,
+				Level:       "info",
 				Destination: "console-and-api",
 				ProjectID:   "",
 			}
@@ -61,7 +74,7 @@ var _ = Describe("Factory", func() {
 
 		It("should return error for invalid Destination", func() {
 			cfg := Config{
-				Level:       zapcore.InfoLevel,
+				Level:       "info",
 				Destination: "kafka",
 			}
 			_, err := New(context.Background(), cfg)
@@ -72,14 +85,13 @@ var _ = Describe("Factory", func() {
 
 	Describe("Config env var constants", func() {
 		It("should expose env var names for callers to use", func() {
-			// Verify constants are exported and have expected values
 			Expect(EnvLogDestination).To(Equal("LOG_DESTINATION"))
 			Expect(EnvLogLevel).To(Equal("LOG_LEVEL"))
 			Expect(EnvGCPProjectID).To(Equal("GCP_PROJECT_ID"))
 			Expect(EnvGCPLogName).To(Equal("GCP_LOG_NAME"))
 		})
 
-		It("should allow caller to build Config from env vars", func() {
+		It("should allow caller to build Config from env vars without importing zapcore", func() {
 			os.Setenv(EnvLogDestination, "console")
 			os.Setenv(EnvLogLevel, "debug")
 			defer os.Unsetenv(EnvLogDestination)
@@ -87,7 +99,7 @@ var _ = Describe("Factory", func() {
 
 			cfg := Config{
 				Destination: os.Getenv(EnvLogDestination),
-				Level:       zapcore.DebugLevel,
+				Level:       os.Getenv(EnvLogLevel),
 			}
 			logger, err := New(context.Background(), cfg)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/logger/gcp_test.go
+++ b/pkg/logger/gcp_test.go
@@ -83,7 +83,7 @@ var _ = Describe("GCP Logger", func() {
 
 		It("should return error when GCP_PROJECT_ID is missing", func() {
 			cfg := Config{
-				Level:       zapcore.InfoLevel,
+				Level:       "info",
 				Destination: "api",
 				ProjectID:   "",
 			}


### PR DESCRIPTION
## Summary

Callers no longer need to import `go.uber.org/zap/zapcore` just to set the log level.

`Config.Level` is now a plain `string` — the same value as the `LOG_LEVEL` env var. Parsing and validation happen inside `New()`, which returns an error for unknown levels. An empty string defaults to `info`.

### Before

```go
import "go.uber.org/zap/zapcore"

cfg := logger.Config{
    Level:       zapcore.InfoLevel,   // zapcore leak
    Destination: os.Getenv(logger.EnvLogDestination),
}
```

### After

```go
cfg := logger.Config{
    Level:       os.Getenv(logger.EnvLogLevel),
    Destination: os.Getenv(logger.EnvLogDestination),
}
l, err := logger.New(ctx, cfg)
```