### PR TITLE
sec: add environment gate to pull_request_target jobs and extract unprivileged controller

### DIFF
--- a/.github/workflows/workflow-controller-pull-requests-unprivileged.yml
+++ b/.github/workflows/workflow-controller-pull-requests-unprivileged.yml
@@ -1,0 +1,53 @@
+# This workflow controller contains jobs that require no elevated permissions and run safely
+# in the context of the PR branch via pull_request event.
+name: workflow-controller-pull-requests-unprivileged
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  detect-changed-files:
+    runs-on: ubuntu-latest
+    outputs:
+      files: ${{ steps.pathFilters.outputs.changes }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: kyma-project/test-infra
+          ref: main
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
+        id: pathFilters
+        with:
+          filters: .github/controller-filters.yaml
+
+
+  pull-gitleaks:
+    uses: kyma-project/test-infra/.github/workflows/pull-gitleaks.yml@main
+    needs: detect-changed-files
+    if: ${{ contains(needs.detect-changed-files.outputs.files, 'pull-gitleaks-filter') }}
+
+  pull-validate-dockerfiles:
+    uses: kyma-project/test-infra/.github/workflows/pull-validate-dockerfiles.yaml@main
+    needs: detect-changed-files
+    if: ${{ contains(needs.detect-changed-files.outputs.files, 'pull-validate-dockerfiles-filter') }}
+
+  tf-lint:
+    uses: kyma-project/test-infra/.github/workflows/tf-lint.yaml@main
+    needs: detect-changed-files
+    if: ${{ contains(needs.detect-changed-files.outputs.files, 'tf-lint-filter') }}
+
+  code-checks-python:
+    uses: kyma-project/test-infra/.github/workflows/code-checks-python.yml@main
+    needs: detect-changed-files
+    if: ${{ contains(needs.detect-changed-files.outputs.files, 'code-checks-python-filter') }}
+
+  lint-markdown-links-pr:
+    uses: kyma-project/test-infra/.github/workflows/lint-markdown-links-pr.yml@main
+    needs: detect-changed-files
+    if: ${{ contains(needs.detect-changed-files.outputs.files, 'lint-markdown-links-pr-filter') }}

--- a/.github/workflows/workflow-controller-pull-requests.yml
+++ b/.github/workflows/workflow-controller-pull-requests.yml
@@ -1,10 +1,11 @@
-# This workflow controller contains the jobs that runs only on pull requests and merge groups.
+# This workflow controller contains jobs that require elevated permissions (GCP OIDC, secret access,
+# write tokens) and must run in the context of the base branch via pull_request_target.
 name: workflow-controller-pull-requests
 
 on:
-  pull_request_target: 
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
-  merge_group: 
+  merge_group:
 
 permissions:
   contents: read
@@ -15,6 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       files: ${{ steps.pathFilters.outputs.changes }}
+    environment:
+      name: prod
+      deployment: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -34,11 +38,9 @@ jobs:
       pull-requests: read
     needs: detect-changed-files
     if: ${{ contains(needs.detect-changed-files.outputs.files, 'pull-go-lint-filter') }}
-
-  pull-gitleaks:
-    uses: kyma-project/test-infra/.github/workflows/pull-gitleaks.yml@main
-    needs: detect-changed-files
-    if: ${{ contains(needs.detect-changed-files.outputs.files, 'pull-gitleaks-filter') }}
+    environment:
+      name: prod
+      deployment: false
 
   pull-plan-prod-terraform:
     uses: kyma-project/test-infra/.github/workflows/pull-plan-prod-terraform.yaml@main
@@ -49,6 +51,9 @@ jobs:
       pull-requests: "write" # needed for tfcmt to post comments
     needs: detect-changed-files
     if: ${{ contains(needs.detect-changed-files.outputs.files, 'pull-plan-prod-terraform-filter') }}
+    environment:
+      name: prod
+      deployment: false
 
   pull-unit-test-go:
     uses: kyma-project/test-infra/.github/workflows/pull-unit-test-go.yaml@main
@@ -58,23 +63,6 @@ jobs:
       pull-requests: read
     needs: detect-changed-files
     if: ${{ contains(needs.detect-changed-files.outputs.files, 'pull-unit-test-go-filter') }}
-
-  pull-validate-dockerfiles:
-    uses: kyma-project/test-infra/.github/workflows/pull-validate-dockerfiles.yaml@main
-    needs: detect-changed-files
-    if: ${{ contains(needs.detect-changed-files.outputs.files, 'pull-validate-dockerfiles-filter') }}
-
-  tf-lint:
-    uses: kyma-project/test-infra/.github/workflows/tf-lint.yaml@main
-    needs: detect-changed-files
-    if: ${{ contains(needs.detect-changed-files.outputs.files, 'tf-lint-filter') }}
-
-  code-checks-python:
-    uses: kyma-project/test-infra/.github/workflows/code-checks-python.yml@main
-    needs: detect-changed-files
-    if: ${{ contains(needs.detect-changed-files.outputs.files, 'code-checks-python-filter') }}
-
-  lint-markdown-links-pr:
-    uses: kyma-project/test-infra/.github/workflows/lint-markdown-links-pr.yml@main
-    needs: detect-changed-files
-    if: ${{ contains(needs.detect-changed-files.outputs.files, 'lint-markdown-links-pr-filter') }}
+    environment:
+      name: prod
+      deployment: false


### PR DESCRIPTION
## Summary

Addresses the vulenrbaility

### Changes

**`workflow-controller-pull-requests.yml`** — `pull_request_target` (privileged):
- Added `environment: name: prod / deployment: false` to all jobs including `detect-changed-files`, `pull-go-lint`, `pull-unit-test-go`, and `pull-plan-prod-terraform`
- The environment gate enforces human approval **before any job starts**, preventing fork PRs from accessing GCP OIDC tokens or Secret Manager without explicit team member approval

**`workflow-controller-pull-requests-unprivileged.yml`** — new file, `pull_request` (unprivileged):
- Extracts jobs that do not require elevated permissions: `pull-gitleaks`, `pull-validate-dockerfiles`, `tf-lint`, `code-checks-python`, `lint-markdown-links-pr`
- Uses `pull_request` trigger — runs in the fork's unprivileged context with no secret access, no approval gate needed
