### PR TITLE
sec: add environment gate to privileged reusable workflow jobs

### DIFF
--- a/.github/workflows/pull-go-lint.yaml
+++ b/.github/workflows/pull-go-lint.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    environment:
+      name: prod
+      deployment: false
 
     permissions:
       contents: read # This is required for actions/checkout

--- a/.github/workflows/pull-plan-prod-terraform.yaml
+++ b/.github/workflows/pull-plan-prod-terraform.yaml
@@ -15,6 +15,9 @@ jobs:
       id-token: "write" # needed for gcp_auth to create id token
       issues: "write" # needed for tfcmt to post comments
       pull-requests: "write" # needed for tfcmt to post comments
+    environment:
+      name: prod
+      deployment: false
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/pull-unit-test-go.yaml
+++ b/.github/workflows/pull-unit-test-go.yaml
@@ -7,6 +7,9 @@ on:
 jobs:
   unittest:
     runs-on: ubuntu-latest
+    environment:
+      name: prod
+      deployment: false
 
     permissions:
       contents: read # This is required for actions/checkout

--- a/.github/workflows/workflow-controller-pull-requests.yml
+++ b/.github/workflows/workflow-controller-pull-requests.yml
@@ -38,9 +38,6 @@ jobs:
       pull-requests: read
     needs: detect-changed-files
     if: ${{ contains(needs.detect-changed-files.outputs.files, 'pull-go-lint-filter') }}
-    environment:
-      name: prod
-      deployment: false
 
   pull-plan-prod-terraform:
     uses: kyma-project/test-infra/.github/workflows/pull-plan-prod-terraform.yaml@main
@@ -51,9 +48,6 @@ jobs:
       pull-requests: "write" # needed for tfcmt to post comments
     needs: detect-changed-files
     if: ${{ contains(needs.detect-changed-files.outputs.files, 'pull-plan-prod-terraform-filter') }}
-    environment:
-      name: prod
-      deployment: false
 
   pull-unit-test-go:
     uses: kyma-project/test-infra/.github/workflows/pull-unit-test-go.yaml@main
@@ -63,6 +57,3 @@ jobs:
       pull-requests: read
     needs: detect-changed-files
     if: ${{ contains(needs.detect-changed-files.outputs.files, 'pull-unit-test-go-filter') }}
-    environment:
-      name: prod
-      deployment: false


### PR DESCRIPTION
## Summary

Follow-up to #14158.

Adds `environment: name: prod / deployment: false` directly to the job level inside each privileged reusable workflow. This is required because `environment` is not supported on `workflow_call` jobs in the caller workflow — it must be defined inside the reusable workflow itself.

### Changed files
- `.github/workflows/pull-go-lint.yaml`
- `.github/workflows/pull-unit-test-go.yaml`
- `.github/workflows/pull-plan-prod-terraform.yaml`