### PR TITLE
sec: gate workflow-controller-build workflows behind prod environment

### DIFF
--- a/.github/workflows/workflow-controller-build-1.yml
+++ b/.github/workflows/workflow-controller-build-1.yml
@@ -10,7 +10,6 @@ on:
   merge_group:
 
 permissions:
-  id-token: write # This is required for requesting the JWT token
   contents: read # This is required for actions/checkout
 
 jobs:
@@ -18,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       files: ${{ steps.pathFilters.outputs.changes }}
+    environment:
+      name: prod
+      deployment: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/workflow-controller-build-2.yml
+++ b/.github/workflows/workflow-controller-build-2.yml
@@ -10,7 +10,6 @@ on:
   merge_group: 
 
 permissions:
-  id-token: write # This is required for requesting the JWT token
   contents: read # This is required for actions/checkout
 
 jobs:
@@ -18,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       files: ${{ steps.pathFilters.outputs.changes }}
+    environment:
+      name: prod
+      deployment: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
## Summary

Adds `environment: prod` gate to the `detect-changed-files` job in `workflow-controller-build-1.yml` and `workflow-controller-build-2.yml`, and removes the overly broad workflow-level `id-token: write` permission.

## Problem

Both workflows use `pull_request_target` and had `id-token: write` set at the **workflow level**, meaning every job — including `detect-changed-files` — had access to an OIDC token. The downstream reusable build workflows (via `image-builder.yml`) use OIDC to authenticate with GCP and push images to the container registry.

Without an environment gate, **any fork PR** touching a tracked path (e.g. `cmd/image-builder/`, `pkg/`, `go.mod`) would trigger an image build and push to the container registry without any maintainer approval.

## Fix

- Add `environment: prod` (with `deployment: false`) to `detect-changed-files` — this is the gate job that controls whether downstream build jobs run at all. The `prod` environment requires review from `@kyma-project/neighbors` before the job starts.
- Remove `id-token: write` from the workflow-level `permissions` block — OIDC is only needed in the downstream reusable build workflows, not in the controller itself.

## Pattern

This follows the same approach already used in `workflow-controller-pull-requests.yml`.

## References

- Security audit: https://github.tools.sap/kyma/security-backlog/issues/114 (rows 32–33)
- Reference implementation: https://github.com/kyma-project/kyma-companion/pull/1158