### PR TITLE
sec: gate renovate-auto-approve workflow behind prod environment

### DIFF
--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   renovate-auto-approve:
     runs-on: ubuntu-latest
+    environment: prod
     permissions:
       pull-requests: write
       id-token: write


### PR DESCRIPTION
## Summary

Adds `environment: prod` gate to the `renovate-auto-approve` job in `renovate-auto-approve.yml`.

## Problem

The workflow uses `pull_request_target` with `id-token: write` (OIDC) and fetches a privileged GitHub bot token from GCP Secret Manager. The existing `if:` condition:

```yaml
if: github.actor == 'renovate[bot]' && startsWith(github.head_ref, 'renovate/')
```

is **workflow logic, not a security boundary**. It does not prevent OIDC token issuance — it only skips the job steps after the token has already been made available to the runner. An attacker controlling the `github.actor` value or exploiting edge cases in GitHub Actions evaluation could bypass this check.

## Fix

Add `environment: prod` to the job. The `prod` environment requires review from `@kyma-project/neighbors` before the job starts, ensuring no OIDC token or GCP secrets are accessed without explicit maintainer approval.

## References

- Security audit: https://github.tools.sap/kyma/security-backlog/issues/114 (row 31)
- Reference implementation: https://github.com/kyma-project/kyma-companion/pull/1158