### PR TITLE
sec: migrate auto-author-assign from pull_request_target to pull_request [REVERTED - not feasible]

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,7 +1,7 @@
 name: Auto Author Assign
 
 on:
-  pull_request_target:
+  pull_request:
     types: [ opened, reopened ]
 
 permissions:


### PR DESCRIPTION
## Summary

Migrates `auto-author-assign.yml` from `pull_request_target` to `pull_request` trigger.

## Problem

The workflow uses `pull_request_target` but does not access any secrets or OIDC tokens — it only uses the default `GITHUB_TOKEN` with `pull-requests: write` to assign the PR author via `toshimaru/auto-author-assign`.

`pull_request_target` runs in the privileged base repo context (with access to secrets) for no benefit here. This is an unnecessary attack surface.

## Fix

Replace `pull_request_target` with `pull_request`. No functional change — the action works identically with either trigger for this use case.

## References

- Security audit: https://github.tools.sap/kyma/security-backlog/issues/114 (row 30)
- Reference implementation: https://github.com/kyma-project/kyma-companion/pull/1158