### PR TITLE
fix: restore id-token: write permission in workflow-controller-build workflows

### DIFF
--- a/.github/workflows/workflow-controller-build-1.yml
+++ b/.github/workflows/workflow-controller-build-1.yml
@@ -10,6 +10,7 @@ on:
   merge_group:
 
 permissions:
+  id-token: write # This is required for requesting the JWT token
   contents: read # This is required for actions/checkout
 
 jobs:

--- a/.github/workflows/workflow-controller-build-2.yml
+++ b/.github/workflows/workflow-controller-build-2.yml
@@ -10,6 +10,7 @@ on:
   merge_group: 
 
 permissions:
+  id-token: write # This is required for requesting the JWT token
   contents: read # This is required for actions/checkout
 
 jobs:


### PR DESCRIPTION
## Problem

PR #14192 removed `id-token: write` from the workflow-level `permissions` block, causing `startup_failure` on all runs with the error:

```
The workflow is requesting 'id-token: write', but is only allowed 'id-token: none'.
```

Reusable build workflows (`build-dashboard-token-proxy.yml`, `build-image-builder.yml`, etc.) declare `id-token: write` internally and GitHub requires the **caller** to also grant this permission — otherwise the workflow is rejected at startup before any job runs.

## Fix

Restore `id-token: write` at the workflow level. The `environment: prod` gate on `detect-changed-files` (added in #14192) still provides the required security boundary — no OIDC token can be issued for a fork PR until a maintainer explicitly approves the run.

## Ref

- https://github.tools.sap/kyma/security-backlog/issues/114
- Broken by: #14192