### PR TITLE
feat: add Azure SP credentials and IAM bindings for image-builder

### DIFF
--- a/configs/terraform/environments/prod/image-builder-variables.tf
+++ b/configs/terraform/environments/prod/image-builder-variables.tf
@@ -25,12 +25,32 @@ variable "image_builder_reusable_workflow_ref" {
   default     = "kyma-project/test-infra/.github/workflows/image-builder.yml@refs/heads/main"
 }
 
+variable "image_builder_internal_github_reusable_workflow_ref" {
+  type        = string
+  description = "The value of GitHub OIDC token job_workflow_ref claim of the image-builder workflow in the oci-image-builder repository on internal GitHub. Used to identify token exchange requests from the ADO pipeline."
+  default     = "kyma/oci-image-builder/.github/workflows/image-builder.yml@refs/heads/main"
+}
+
 # GCP resources
 
 variable "image_builder_ado_pat_gcp_secret_manager_secret_name" {
   description = "Name of the secret in GCP Secret Manager that contains the ADO PAT for image-builder to trigger ADO pipeline."
   type        = string
   default     = "image-builder-ado-pat"
+}
+
+variable "image_builder_azure_sp_gcp_secret_names" {
+  description = "Names of GCP Secret Manager secrets for the Kyma-ImageBuilder-OIDC Azure Service Principal."
+  type = object({
+    tenant_id     = string
+    client_id     = string
+    client_secret = string
+  })
+  default = {
+    tenant_id     = "image-builder-kyma-imagebuilder-oidc-tenant-id"
+    client_id     = "image-builder-kyma-imagebuilder-oidc-client-id"
+    client_secret = "image-builder-kyma-imagebuilder-oidc-client-secret"
+  }
 }
 
 variable "image_builder_sa_key_restricted_markets_secret_name" {

--- a/configs/terraform/environments/prod/image-builder.tf
+++ b/configs/terraform/environments/prod/image-builder.tf
@@ -1,11 +1,44 @@
 # GCP resources
 
+locals {
+  image_builder_azure_sp_gcp_secrets = toset(values(var.image_builder_azure_sp_gcp_secret_names))
+}
+
 resource "google_secret_manager_secret_iam_member" "image_builder_reusable_workflow_principal_ado_pat_reader" {
   project   = var.gcp_project_id
   secret_id = var.image_builder_ado_pat_gcp_secret_manager_secret_name
   role      = "roles/secretmanager.secretAccessor"
   member    = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_ref/${var.image_builder_reusable_workflow_ref}"
 }
+
+resource "google_secret_manager_secret_iam_member" "image_builder_internal_github_reusable_workflow_principal_ado_pat_reader" {
+  project   = var.gcp_project_id
+  secret_id = var.image_builder_ado_pat_gcp_secret_manager_secret_name
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.reusable_workflow_ref/${var.image_builder_internal_github_reusable_workflow_ref}"
+}
+
+import {
+  to = google_secret_manager_secret_iam_member.image_builder_internal_github_reusable_workflow_principal_ado_pat_reader
+  id = "projects/sap-kyma-prow/secrets/image-builder-ado-pat roles/secretmanager.secretAccessor principalSet://iam.googleapis.com/projects/351981214969/locations/global/workloadIdentityPools/github-tools-sap/attribute.reusable_workflow_ref/kyma/oci-image-builder/.github/workflows/image-builder.yml@refs/heads/main"
+}
+
+resource "google_secret_manager_secret_iam_member" "image_builder_public_github_reusable_workflow_principal_azure_sp_secret_reader" {
+  for_each  = local.image_builder_azure_sp_gcp_secrets
+  project   = var.gcp_project_id
+  secret_id = each.value
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_ref/${var.image_builder_reusable_workflow_ref}"
+}
+
+resource "google_secret_manager_secret_iam_member" "image_builder_internal_github_reusable_workflow_principal_azure_sp_secret_reader" {
+  for_each  = local.image_builder_azure_sp_gcp_secrets
+  project   = var.gcp_project_id
+  secret_id = each.value
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.reusable_workflow_ref/${var.image_builder_internal_github_reusable_workflow_ref}"
+}
+
 
 # GitHub resources
 
@@ -17,6 +50,27 @@ resource "github_actions_organization_variable" "image_builder_ado_pat_gcp_secre
   visibility    = "all"
   variable_name = "IMAGE_BUILDER_ADO_PAT_GCP_SECRET_NAME"
   value         = var.image_builder_ado_pat_gcp_secret_manager_secret_name
+}
+
+resource "github_actions_organization_variable" "image_builder_azure_sp_tenant_id_gcp_secret_name" {
+  provider      = github.kyma_project
+  visibility    = "all"
+  variable_name = "IMAGE_BUILDER_AZURE_SP_TENANT_ID_GCP_SECRET_NAME"
+  value         = var.image_builder_azure_sp_gcp_secret_names.tenant_id
+}
+
+resource "github_actions_organization_variable" "image_builder_azure_sp_client_id_gcp_secret_name" {
+  provider      = github.kyma_project
+  visibility    = "all"
+  variable_name = "IMAGE_BUILDER_AZURE_SP_CLIENT_ID_GCP_SECRET_NAME"
+  value         = var.image_builder_azure_sp_gcp_secret_names.client_id
+}
+
+resource "github_actions_organization_variable" "image_builder_azure_sp_client_secret_gcp_secret_name" {
+  provider      = github.kyma_project
+  visibility    = "all"
+  variable_name = "IMAGE_BUILDER_AZURE_SP_CLIENT_SECRET_GCP_SECRET_NAME"
+  value         = var.image_builder_azure_sp_gcp_secret_names.client_secret
 }
 
 # This resource will be destroyed and created in case of any changes. This is not a crucial for this resource.
@@ -98,3 +152,20 @@ resource "google_secret_manager_secret" "image_builder_sa_key_restricted_markets
   }
 }
 
+# Secrets in sap-kyma-prow project to store Azure SP credentials (to be added manually)
+resource "google_secret_manager_secret" "image_builder_azure_sp" {
+  for_each  = local.image_builder_azure_sp_gcp_secrets
+  project   = var.gcp_project_id
+  secret_id = each.value
+
+  replication {
+    auto {}
+  }
+
+  labels = {
+    type      = "azure-sp-credential"
+    tool      = "image-builder"
+    owner     = "neighbors"
+    component = "oci-image-builder"
+  }
+}


### PR DESCRIPTION
## What changed
Add Terraform resources for Kyma-ImageBuilder-OIDC Azure Service Principal credentials in GCP Secret Manager. Both public GitHub (gh_com WIF pool) and internal GitHub (github-tools-sap WIF pool) principals receive access to these secrets. Also imports the existing ADO PAT IAM binding for the internal GitHub oci-image-builder workflow into Terraform state.

## Changes
- Add `image_builder_azure_sp_gcp_secret_names` object variable with GCP secret names for tenant ID, client ID, and client secret
- Add `image_builder_internal_github_reusable_workflow_ref` variable for the oci-image-builder workflow ref on internal GitHub
- Add `google_secret_manager_secret` resources for 3 Azure SP credential secrets
- Add IAM bindings granting both WIF principals (public and internal GitHub) access to Azure SP secrets and ADO PAT secret
- Add `import` block for pre-existing ADO PAT IAM binding from internal GitHub WIF principal
- Add GitHub org variables exposing GCP secret names to workflows