### PR TITLE
fix: update secret_id references for Azure SP in image-builder IAM members

### DIFF
--- a/configs/terraform/environments/prod/image-builder.tf
+++ b/configs/terraform/environments/prod/image-builder.tf
@@ -26,7 +26,7 @@ import {
 resource "google_secret_manager_secret_iam_member" "image_builder_public_github_reusable_workflow_principal_azure_sp_secret_reader" {
   for_each  = local.image_builder_azure_sp_gcp_secrets
   project   = var.gcp_project_id
-  secret_id = each.value
+  secret_id = google_secret_manager_secret.image_builder_azure_sp[each.key].secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_ref/${var.image_builder_reusable_workflow_ref}"
 }
@@ -34,7 +34,7 @@ resource "google_secret_manager_secret_iam_member" "image_builder_public_github_
 resource "google_secret_manager_secret_iam_member" "image_builder_internal_github_reusable_workflow_principal_azure_sp_secret_reader" {
   for_each  = local.image_builder_azure_sp_gcp_secrets
   project   = var.gcp_project_id
-  secret_id = each.value
+  secret_id = google_secret_manager_secret.image_builder_azure_sp[each.key].secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.reusable_workflow_ref/${var.image_builder_internal_github_reusable_workflow_ref}"
 }


### PR DESCRIPTION
# What changed
Fixes Terraform apply failures caused by IAM bindings on Azure SP secrets being planned before the secrets themselves exist.

# Changes
Changed secret_id = each.value to secret_id = google_secret_manager_secret.image_builder_azure_sp[each.key].secret_id in both image_builder_public_github_reusable_workflow_principal_azure_sp_secret_reader and image_builder_internal_github_reusable_workflow_principal_azure_sp_secret_reader, creating an explicit dependency so Terraform creates the secrets before attaching IAM policies