### PR TITLE
Terraform: Resolve Deprecation Warnings

### DIFF
--- a/configs/terraform/environments/prod/gitleaks.tf
+++ b/configs/terraform/environments/prod/gitleaks.tf
@@ -16,9 +16,9 @@ data "github_repository" "gitleaks_repository" {
 
 # Binds gitleaks service account with associated workload identity federation subject, allowing all workflows under kyma-project on github to use that service account.
 resource "google_service_account_iam_binding" "gitleaks_workload_identity_federation_binding" {
-  for_each = data.github_repository.gitleaks_repository
+  for_each = var.gitleaks_repositories
   members = [
-    "principal://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/subject/repository_id:${each.value.repo_id}:repository_owner_id:${data.github_organization.kyma_project.id}:workflow:${var.gitleaks_workflow_name}"
+    "principal://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/subject/repository_id:${data.github_repository.gitleaks_repository[each.key].repo_id}:repository_owner_id:${data.github_organization.kyma_project.id}:workflow:${var.gitleaks_workflow_name}"
   ]
   role               = "roles/iam.workloadIdentityUser"
   service_account_id = google_service_account.gitleaks_secret_accesor.name

--- a/configs/terraform/modules/rotate-service-account/output.tf
+++ b/configs/terraform/modules/rotate-service-account/output.tf
@@ -7,7 +7,13 @@ output "service_account_keys_rotator_service_account_iam" {
 }
 
 output "service_account_keys_rotator_cloud_run_service" {
-  value = google_cloud_run_service.service_account_keys_rotator
+  value = {
+    id       = google_cloud_run_service.service_account_keys_rotator.id
+    name     = google_cloud_run_service.service_account_keys_rotator.name
+    location = google_cloud_run_service.service_account_keys_rotator.location
+    project  = google_cloud_run_service.service_account_keys_rotator.project
+    status   = google_cloud_run_service.service_account_keys_rotator.status
+  }
 }
 
 output "service_account_keys_rotator_subscription" {

--- a/configs/terraform/modules/service-account-keys-cleaner/output.tf
+++ b/configs/terraform/modules/service-account-keys-cleaner/output.tf
@@ -3,7 +3,13 @@ output "service_account_keys_cleaner_service_account" {
 }
 
 output "service_account_keys_cleaner_cloud_run_service" {
-  value = google_cloud_run_service.service_account_keys_cleaner
+  value = {
+    id       = google_cloud_run_service.service_account_keys_cleaner.id
+    name     = google_cloud_run_service.service_account_keys_cleaner.name
+    location = google_cloud_run_service.service_account_keys_cleaner.location
+    project  = google_cloud_run_service.service_account_keys_cleaner.project
+    status   = google_cloud_run_service.service_account_keys_cleaner.status
+  }
 }
 
 output "service_account_keys_cleaner_secheduler" {

--- a/configs/terraform/modules/signify-secret-rotator/output.tf
+++ b/configs/terraform/modules/signify-secret-rotator/output.tf
@@ -3,7 +3,13 @@ output "signify_secret_rotator_service_account" {
 }
 
 output "signify_secret_rotator_cloud_run_service" {
-  value = google_cloud_run_service.signify_secret_rotator
+  value = {
+    id       = google_cloud_run_service.signify_secret_rotator.id
+    name     = google_cloud_run_service.signify_secret_rotator.name
+    location = google_cloud_run_service.signify_secret_rotator.location
+    project  = google_cloud_run_service.signify_secret_rotator.project
+    status   = google_cloud_run_service.signify_secret_rotator.status
+  }
 }
 
 output "signify_secret_rotator_subscription" {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

  ---                                                                                                                                                                                                                                                                                                                                                                                                                                      
  gitleaks.tf                                                                                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                                           
  Change: for_each = data.github_repository.gitleaks_repository → for_each = var.gitleaks_repositories                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                                                           
  When Terraform iterates over a full data source object in for_each, it reads all attributes including deprecated ones (has_downloads, pages). By iterating over the original var.gitleaks_repositories map instead and accessing data.github_repository.gitleaks_repository[each.key].repo_id directly, only the specific needed attribute is touched — avoiding the deprecated ones.                                                    
                                                                                                                                                                                                                                                                                                                                                                                                                                           
  ---                                                                                                                                                                                                                                                                                                                                                                                                                                      
  rotate-service-account/output.tf, service-account-keys-cleaner/output.tf, signify-secret-rotator/output.tf
                                                                                                                                                                                                                                                                                                                                                                                                                                           
  Change: Replaced value = google_cloud_run_service.<name> with an explicit object containing only non-deprecated fields (id, name, location, project, status).
                                                                                                                                                                                                                                                                                                                                                                                                                                           
  Outputting the entire resource causes Terraform to evaluate all its attributes, including the deprecated working_dir and serving_state. Scoping the output to specific stable fields eliminates the warnings without losing useful information. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- `kyma/test-infra/issues/1335`