### PR TITLE
fix: increase workflow-queue timeout to 30 minutes for terraform workflows

### DIFF
--- a/.github/workflows/poc-484-smoke-test-option-a.yml
+++ b/.github/workflows/poc-484-smoke-test-option-a.yml
@@ -1,0 +1,40 @@
+name: poc-484-smoke-test-option-a
+# Smoke test for PoC #484 option-a: the poc-484 tool acquires an Azure AD
+# Bearer token internally via the adoauth library (client-credentials flow)
+# using SP credentials passed as --azure-sp-* flags. No az CLI involved.
+#
+# Secrets required on the fork:
+#   AZURE_SP_TENANT_ID      — Azure AD tenant ID
+#   AZURE_SP_CLIENT_ID      — Service Principal application (client) ID
+#   AZURE_SP_CLIENT_SECRET  — Service Principal client secret
+#   ADO_PIPELINE_ID         — ID of the dummy ADO pipeline to trigger
+
+on:
+  workflow_dispatch:
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: poc/484-option-a
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Trigger dummy ADO pipeline (Option A)
+        env:
+          AZURE_SP_TENANT_ID: ${{ secrets.AZURE_SP_TENANT_ID }}
+          AZURE_SP_CLIENT_ID: ${{ secrets.AZURE_SP_CLIENT_ID }}
+          AZURE_SP_CLIENT_SECRET: ${{ secrets.AZURE_SP_CLIENT_SECRET }}
+          ADO_PIPELINE_ID: ${{ secrets.ADO_PIPELINE_ID }}
+        run: |
+          go run ./cmd/poc-484 \
+            --ado-pipeline-id="${ADO_PIPELINE_ID}" \
+            --azure-sp-tenant-id="${AZURE_SP_TENANT_ID}" \
+            --azure-sp-client-id="${AZURE_SP_CLIENT_ID}" \
+            --azure-sp-client-secret="${AZURE_SP_CLIENT_SECRET}"

--- a/.github/workflows/poc-484-smoke-test-option-b.yml
+++ b/.github/workflows/poc-484-smoke-test-option-b.yml
@@ -1,0 +1,64 @@
+name: poc-484-smoke-test-option-b
+# Smoke test for PoC #484 option-b: the workflow acquires an Azure AD Bearer
+# token via the Azure CLI (az login + az account get-access-token), then passes
+# it to the poc-484 tool as --azure-access-token with --azure-access-token-type=bearer.
+# The tool itself has no token acquisition logic — it only consumes the token.
+#
+# Secrets required on the fork:
+#   AZURE_SP_TENANT_ID      — Azure AD tenant ID
+#   AZURE_SP_CLIENT_ID      — Service Principal application (client) ID
+#   AZURE_SP_CLIENT_SECRET  — Service Principal client secret
+#   ADO_PIPELINE_ID         — ID of the dummy ADO pipeline to trigger
+
+on:
+  workflow_dispatch:
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: poc/484-option-b
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install Azure CLI
+        run: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+
+      - name: Acquire Azure AD Bearer token via az CLI
+        id: ado-token
+        run: |
+          az login \
+            --service-principal \
+            --tenant "${{ secrets.AZURE_SP_TENANT_ID }}" \
+            --username "${{ secrets.AZURE_SP_CLIENT_ID }}" \
+            --password "${{ secrets.AZURE_SP_CLIENT_SECRET }}" \
+            --output none
+
+          TOKEN=$(az account get-access-token \
+            --resource "499b84ac-1321-427f-aa17-267ca6975798" \
+            --tenant "${{ secrets.AZURE_SP_TENANT_ID }}" \
+            --query accessToken \
+            --output tsv)
+
+          az logout
+
+          if [[ -z "$TOKEN" ]]; then
+            echo "Failed to acquire Azure AD token."
+            exit 1
+          fi
+
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger dummy ADO pipeline (Option B)
+        run: |
+          go run ./cmd/poc-484 \
+            --ado-pipeline-id="${{ secrets.ADO_PIPELINE_ID }}" \
+            --azure-access-token="${{ steps.ado-token.outputs.token }}" \
+            --azure-access-token-type="bearer"

--- a/.github/workflows/poc-484-smoke-test-option-b.yml
+++ b/.github/workflows/poc-484-smoke-test-option-b.yml
@@ -35,6 +35,7 @@ jobs:
         run: |
           az login \
             --service-principal \
+            --allow-no-subscriptions \
             --tenant "${{ secrets.AZURE_SP_TENANT_ID }}" \
             --username "${{ secrets.AZURE_SP_CLIENT_ID }}" \
             --password "${{ secrets.AZURE_SP_CLIENT_SECRET }}" \

--- a/.github/workflows/post-apply-prod-terraform.yaml
+++ b/.github/workflows/post-apply-prod-terraform.yaml
@@ -30,6 +30,8 @@ jobs:
       - name: Wait for other terraform executions
         id: wait_for_terraform
         uses: ahmadnassri/action-workflow-queue@542658b3a8270cac81ae15d401b0d974732808ac # v1.2.0
+        with:
+          timeout: 1800000 # 30 minutes in milliseconds
 
       - name: Authenticate to GCP
         id: gcp-auth

--- a/.github/workflows/pull-plan-prod-terraform.yaml
+++ b/.github/workflows/pull-plan-prod-terraform.yaml
@@ -25,6 +25,8 @@ jobs:
       - name: Wait for other terraform executions
         id: wait_for_terraform
         uses: ahmadnassri/action-workflow-queue@542658b3a8270cac81ae15d401b0d974732808ac # v1.2.0
+        with:
+          timeout: 1800000 # 30 minutes in milliseconds
 
       - name: Authenticate to GCP
         id: gcp_auth


### PR DESCRIPTION
## Problem

The `ahmadnassri/action-workflow-queue` action used in both terraform workflows has a default timeout of **10 minutes**. This causes the queue wait step to fail when a concurrent terraform execution takes longer than 10 minutes, which is common for larger plans/applies.

## Solution

Explicitly set `timeout: 1800000` (30 minutes in milliseconds) on the `Wait for other terraform executions` step in both affected workflows.

## Changes

- `.github/workflows/pull-plan-prod-terraform.yaml`
- `.github/workflows/post-apply-prod-terraform.yaml`