### PR TITLE
fix: increase workflow-queue timeout to 30 minutes for terraform workflows

### DIFF
--- a/.github/workflows/post-apply-prod-terraform.yaml
+++ b/.github/workflows/post-apply-prod-terraform.yaml
@@ -30,6 +30,8 @@ jobs:
       - name: Wait for other terraform executions
         id: wait_for_terraform
         uses: ahmadnassri/action-workflow-queue@542658b3a8270cac81ae15d401b0d974732808ac # v1.2.0
+        with:
+          timeout: 1800000 # 30 minutes in milliseconds
 
       - name: Authenticate to GCP
         id: gcp-auth

--- a/.github/workflows/pull-plan-prod-terraform.yaml
+++ b/.github/workflows/pull-plan-prod-terraform.yaml
@@ -28,6 +28,8 @@ jobs:
       - name: Wait for other terraform executions
         id: wait_for_terraform
         uses: ahmadnassri/action-workflow-queue@542658b3a8270cac81ae15d401b0d974732808ac # v1.2.0
+        with:
+          timeout: 1800000 # 30 minutes in milliseconds
 
       - name: Authenticate to GCP
         id: gcp_auth


### PR DESCRIPTION
## Problem

The `ahmadnassri/action-workflow-queue` action used in both terraform workflows has a default timeout of **10 minutes**. This causes the queue wait step to fail when a concurrent terraform execution takes longer than 10 minutes, which is common for larger plans/applies.

## Solution

Explicitly set `timeout: 1800000` (30 minutes in milliseconds) on the `Wait for other terraform executions` step in both affected workflows.

## Changes

- `.github/workflows/pull-plan-prod-terraform.yaml`
- `.github/workflows/post-apply-prod-terraform.yaml`