### PR TITLE
feat: add SP auth inputs to image-builder action

### DIFF
--- a/.github/actions/image-builder/action.yml
+++ b/.github/actions/image-builder/action.yml
@@ -6,7 +6,16 @@ inputs:
     required: true
   ado-token:
     description: The personal access token to authenticate against Azure DevOps API
-    required: true
+    required: false
+  azure-client-id:
+    description: Azure AD Application (client) ID to authenticate against Azure DevOps API
+    required: false
+  azure-client-secret:
+    description: Azure AD Application client secret to authenticate against Azure DevOps API
+    required: false
+  azure-tenant-id:
+    description: Azure AD Tenant ID to authenticate against Azure DevOps API
+    required: false
   image-name:
     description: Name of the build image
     required: true


### PR DESCRIPTION
## What changed
Add optional SP auth inputs to image-builder composite action and mark ado-token as optional to allow Service Principal-only authentication.

## Changes
- `ado-token` changed from `required: true` to `required: false`
- Added optional inputs: `azure-client-id`, `azure-client-secret`, `azure-tenant-id`