### PR TITLE
feat: add Azure SP credentials fetching to image-builder workflow

### DIFF
--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -119,12 +119,15 @@ jobs:
           project_id: ${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}
           workload_identity_provider: ${{ vars.GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER }}
 
-      - name: Get ADO PAT from Secret Manager
+      - name: Get secrets from Secret Manager
         id: "secrets"
         uses: "google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262" # v3
         with:
           secrets: |-
             ado-pat:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.IMAGE_BUILDER_ADO_PAT_GCP_SECRET_NAME }}
+            tenant-id:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.IMAGE_BUILDER_AZURE_SP_TENANT_ID_GCP_SECRET_NAME }}
+            client-id:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.IMAGE_BUILDER_AZURE_SP_CLIENT_ID_GCP_SECRET_NAME }}
+            client-secret:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.IMAGE_BUILDER_AZURE_SP_CLIENT_SECRET_GCP_SECRET_NAME }}
 
       - name: Build image
         id: build
@@ -132,6 +135,9 @@ jobs:
         with:
           oidc-token: ${{ steps.get_oidc.outputs.jwt }}
           ado-token: ${{ steps.secrets.outputs.ado-pat }}
+          azure-client-id: ${{ steps.secrets.outputs.client-id }}
+          azure-client-secret: ${{ steps.secrets.outputs.client-secret }}
+          azure-tenant-id: ${{ steps.secrets.outputs.tenant-id }}
           context: ${{ inputs.context }}
           build-args: ${{ inputs.build-args }}
           tags: ${{ inputs.tags }}


### PR DESCRIPTION
Extend the Get secrets from Secret Manager step to also fetch Azure SP credentials (tenant-id, client-id, client-secret) from GCP Secret Manager alongside the existing ADO PAT. Pass SP credentials to the image-builder action as optional inputs.

