### PR TITLE
fix(image-syncer): add early event guard and remove dead pull_request branch

### DIFF
--- a/.github/workflows/image-syncer.yml
+++ b/.github/workflows/image-syncer.yml
@@ -32,6 +32,12 @@ jobs:
       - name: Checkout
         uses: kyma-project/test-infra/.github/actions/checkout@main
 
+      - name: Verify supported event
+        if: ${{ github.event_name != 'push' && github.event_name != 'pull_request_target' }}
+        run: |
+          echo "::error title=Unsupported event::Unsupported event: ${{ github.event_name }}. Supported events are: push, pull_request_target"
+          exit 1
+
       # Set the dry-run flag based on the event type.
       # Dry-run flag is enforced for workflow runs triggered by pull requests.
       - name: Set dry-run flag
@@ -39,7 +45,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" == 'push' ]; then
             echo "DRY_RUN=${{ inputs.dry-run }}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" == 'pull_request_target' ] || [ "${{ github.event_name }}" == 'pull_request' ]; then
+          elif [ "${{ github.event_name }}" == 'pull_request_target' ]; then
             echo "::notice title=Force dry-run::Forcing dry-run mode for pull requests"
             echo "DRY_RUN=true" >> $GITHUB_OUTPUT
           fi
@@ -55,9 +61,6 @@ jobs:
             echo "IMAGE_SYNCER_SA_EMAIL=${{ vars.IMAGE_SYNCER_WRITER_SERVICE_ACCOUNT_EMAIL }}" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" == 'pull_request_target' ]; then
             echo "IMAGE_SYNCER_SA_EMAIL=${{ vars.IMAGE_SYNCER_READER_SERVICE_ACCOUNT_EMAIL }}" >> $GITHUB_OUTPUT
-          else
-            echo "::error title=Unsupported event::Unsupported event: ${{ github.event_name }}"
-            exit 1
           fi
 
       # Using access-token as it can be used directly as a bearer token.


### PR DESCRIPTION
**Description**

The `pull_request` event branch in `set_dry_run_flag` was dead code introduced in `396cccfe6` alongside `pull_request_target`. It became unreachable when PR #11921 introduced the service account split — that step has always `exit 1` for any event other than `push` or `pull_request_target`, making the dry-run setting irrelevant. Additionally, the `pull_request` event can never obtain an OIDC token for fork PRs, so the auth step would fail regardless.

Changes:
- Add a `Verify supported event` step early in the job that fails fast with a clear error message for any unsupported event
- Remove the dead `pull_request` branch from `set_dry_run_flag`
- Remove the now-redundant `else exit 1` from `get_image_syncer_gcp_service_account` — the early guard makes it unnecessary

**Related issue(s)**

<!-- none -->