### PR TITLE
chore(pull-plan-prod-terraform): remove concurrency group

### DIFF
--- a/.github/workflows/pull-plan-prod-terraform.yaml
+++ b/.github/workflows/pull-plan-prod-terraform.yaml
@@ -1,9 +1,6 @@
 name: Pull Plan Prod Terraform
 run-name: pull-plan-prod-terraform
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-
 on:
   # This workflow is triggered by workflow controller.
   workflow_call:


### PR DESCRIPTION
## Summary

Remove `concurrency` group from `pull-plan-prod-terraform` workflow.