### PR TITLE
fix: enable Secret Manager IAM binding for component-config-updater by default

### DIFF
--- a/.github/workflows/component-config-updater.yml
+++ b/.github/workflows/component-config-updater.yml
@@ -1,0 +1,26 @@
+name: component-config-updater
+
+# Caller workflow for kyma-project/test-infra (github.com).
+# Invokes the local reusable-component-config-updater workflow.
+#
+# Uses the -public suffix in component_name to avoid a name collision in mODG
+# with the github.tools.sap kyma/test-infra instance.
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Every Sunday at 03:17 UTC. Off-peak; offset to avoid the top of the hour.
+    - cron: '17 3 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  update:
+    uses: ./.github/workflows/reusable-component-config-updater.yml
+    with:
+      component_name: kyma-project.io/tooling/test-infra-public

--- a/.github/workflows/reusable-component-config-updater.yml
+++ b/.github/workflows/reusable-component-config-updater.yml
@@ -63,14 +63,14 @@ jobs:
           CONFIG_PATH_INPUT: ${{ inputs.config_path }}
           GCP_KYMA_PROJECT_PROJECT_ID: ${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}
           GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER: ${{ vars.GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER }}
-          GH_COM_KYMA_PROW_BOT_TOKEN_SECRET_NAME: ${{ vars.GH_COM_KYMA_PROW_BOT_TOKEN_SECRET_NAME }}
+          GH_COM_NEIGHBORS_BOT_AUTO_BUMPER_TOKEN_SECRET_NAME: ${{ vars.GH_COM_NEIGHBORS_BOT_AUTO_BUMPER_TOKEN_SECRET_NAME }}
         shell: bash
         run: |
           set -euo pipefail
           missing=0
           for var in GCP_KYMA_PROJECT_PROJECT_ID \
                      GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER \
-                     GH_COM_KYMA_PROW_BOT_TOKEN_SECRET_NAME; do
+                     GH_COM_NEIGHBORS_BOT_AUTO_BUMPER_TOKEN_SECRET_NAME; do
             if [ -z "${!var:-}" ]; then
               echo "::error title=Missing variable::Required variable '$var' is not set on this repository (or not inherited from the org)."
               missing=1
@@ -96,7 +96,7 @@ jobs:
         uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3
         with:
           secrets: |-
-            service-user-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_COM_KYMA_PROW_BOT_TOKEN_SECRET_NAME }}
+            service-user-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_COM_NEIGHBORS_BOT_AUTO_BUMPER_TOKEN_SECRET_NAME }}
 
       - name: Checkout caller repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/reusable-component-config-updater.yml
+++ b/.github/workflows/reusable-component-config-updater.yml
@@ -64,15 +64,13 @@ jobs:
           GCP_KYMA_PROJECT_PROJECT_ID: ${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}
           GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER: ${{ vars.GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER }}
           GH_COM_KYMA_PROW_BOT_TOKEN_SECRET_NAME: ${{ vars.GH_COM_KYMA_PROW_BOT_TOKEN_SECRET_NAME }}
-          GH_COM_KYMA_BOT_AUTO_APPROVER_TOKEN_SECRET_NAME: ${{ vars.GH_COM_KYMA_BOT_AUTO_APPROVER_TOKEN_SECRET_NAME }}
         shell: bash
         run: |
           set -euo pipefail
           missing=0
           for var in GCP_KYMA_PROJECT_PROJECT_ID \
                      GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER \
-                     GH_COM_KYMA_PROW_BOT_TOKEN_SECRET_NAME \
-                     GH_COM_KYMA_BOT_AUTO_APPROVER_TOKEN_SECRET_NAME; do
+                     GH_COM_KYMA_PROW_BOT_TOKEN_SECRET_NAME; do
             if [ -z "${!var:-}" ]; then
               echo "::error title=Missing variable::Required variable '$var' is not set on this repository (or not inherited from the org)."
               missing=1
@@ -99,7 +97,6 @@ jobs:
         with:
           secrets: |-
             service-user-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_COM_KYMA_PROW_BOT_TOKEN_SECRET_NAME }}
-            auto-approver-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_COM_KYMA_BOT_AUTO_APPROVER_TOKEN_SECRET_NAME }}
 
       - name: Checkout caller repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -169,10 +166,8 @@ jobs:
             [`malachowski-labs/oci-image-detector`](https://github.com/marketplace/actions/oci-image-detector)
             and is consumed by `ocm-artifact-builder` for security scanning.
 
-            This PR will be auto-approved by the auto-approver bot and
-            merged by GitHub's native auto-merge once required checks
-            pass. The component-config.yaml file is fully owned by
-            automation — see ADR-001 for the contract.
+            The component-config.yaml file is fully owned by automation — see
+            ADR-001 for the contract.
 
             ```release-note
             NONE
@@ -180,15 +175,6 @@ jobs:
           labels: |
             kind/chore
             area/security
-            auto-approved
-
-      - name: Auto-approve PR
-        if: ${{ (steps.create-pr.outputs.pull-request-operation == 'created' || steps.create-pr.outputs.pull-request-operation == 'updated') && steps.create-pr.outputs.pull-request-number != '' }}
-        uses: hmarr/auto-approve-action@8f929096a962e83ccdfa8afcf855f39f12d4dac7 # v4
-        with:
-          review-message: 'Auto-approved by component-config-updater workflow.'
-          github-token: ${{ steps.secrets.outputs.auto-approver-token }}
-          pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
 
       - name: Enable native auto-merge on PR
         if: ${{ (steps.create-pr.outputs.pull-request-operation == 'created' || steps.create-pr.outputs.pull-request-operation == 'updated') && steps.create-pr.outputs.pull-request-number != '' }}

--- a/.github/workflows/reusable-component-config-updater.yml
+++ b/.github/workflows/reusable-component-config-updater.yml
@@ -63,7 +63,7 @@ jobs:
           CONFIG_PATH_INPUT: ${{ inputs.config_path }}
           GCP_KYMA_PROJECT_PROJECT_ID: ${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}
           GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER: ${{ vars.GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER }}
-          GH_TOOLS_KYMA_PROW_BOT_TOKEN_SECRET_NAME: ${{ vars.GH_TOOLS_KYMA_PROW_BOT_TOKEN_SECRET_NAME }}
+          GH_COM_KYMA_PROW_BOT_TOKEN_SECRET_NAME: ${{ vars.GH_COM_KYMA_PROW_BOT_TOKEN_SECRET_NAME }}
           GH_COM_KYMA_BOT_AUTO_APPROVER_TOKEN_SECRET_NAME: ${{ vars.GH_COM_KYMA_BOT_AUTO_APPROVER_TOKEN_SECRET_NAME }}
         shell: bash
         run: |
@@ -71,7 +71,7 @@ jobs:
           missing=0
           for var in GCP_KYMA_PROJECT_PROJECT_ID \
                      GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER \
-                     GH_TOOLS_KYMA_PROW_BOT_TOKEN_SECRET_NAME \
+                     GH_COM_KYMA_PROW_BOT_TOKEN_SECRET_NAME \
                      GH_COM_KYMA_BOT_AUTO_APPROVER_TOKEN_SECRET_NAME; do
             if [ -z "${!var:-}" ]; then
               echo "::error title=Missing variable::Required variable '$var' is not set on this repository (or not inherited from the org)."
@@ -98,7 +98,7 @@ jobs:
         uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3
         with:
           secrets: |-
-            service-user-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TOOLS_KYMA_PROW_BOT_TOKEN_SECRET_NAME }}
+            service-user-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_COM_KYMA_PROW_BOT_TOKEN_SECRET_NAME }}
             auto-approver-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_COM_KYMA_BOT_AUTO_APPROVER_TOKEN_SECRET_NAME }}
 
       - name: Checkout caller repository

--- a/.github/workflows/reusable-component-config-updater.yml
+++ b/.github/workflows/reusable-component-config-updater.yml
@@ -5,13 +5,6 @@ name: update-component-config
 # Mirrors kyma/test-infra:.github/workflows/reusable-component-config-updater.yml
 # from github.tools.sap. GitHub Actions does not support cross-instance reusable
 # workflow calls, so this copy lives here to serve callers on github.com.
-#
-# Differences from the internal (github.tools.sap) copy:
-#   - runs-on: ubuntu-latest  (no self-hosted solinas available on github.com)
-#   - WIF provider var: GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER
-#   - Bumper token var:   GH_TOOLS_KYMA_PROW_BOT_TOKEN_SECRET_NAME
-#   - Approver token var: GH_COM_KYMA_BOT_AUTO_APPROVER_TOKEN_SECRET_NAME
-#   - Auto-merge step uses GH_TOKEN (standard gh CLI, no GH_HOST override)
 
 on:
   workflow_call:

--- a/.github/workflows/reusable-component-config-updater.yml
+++ b/.github/workflows/reusable-component-config-updater.yml
@@ -1,0 +1,230 @@
+name: update-component-config
+
+# Reusable workflow — github.com edition.
+#
+# Mirrors kyma/test-infra:.github/workflows/reusable-component-config-updater.yml
+# from github.tools.sap. GitHub Actions does not support cross-instance reusable
+# workflow calls, so this copy lives here to serve callers on github.com.
+#
+# Differences from the internal (github.tools.sap) copy:
+#   - runs-on: ubuntu-latest  (no self-hosted solinas available on github.com)
+#   - WIF provider var: GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER
+#   - Bumper token var:   GH_TOOLS_KYMA_PROW_BOT_TOKEN_SECRET_NAME
+#   - Approver token var: GH_COM_KYMA_BOT_AUTO_APPROVER_TOKEN_SECRET_NAME
+#   - Auto-merge step uses GH_TOKEN (standard gh CLI, no GH_HOST override)
+
+on:
+  workflow_call:
+    inputs:
+      component_name:
+        description: |
+          Component name written to component-config.yaml.
+          Must follow the convention "kyma-project.io/tooling/<repo-name>".
+        required: true
+        type: string
+      team:
+        description: |
+          Team owning the component, in "<org>/<team-slug>" format
+          (e.g. "kyma/neighbors"). Written to component-config.yaml.
+        required: false
+        type: string
+        default: 'kyma/neighbors'
+      directory:
+        description: 'Directory to scan for image references (relative to repo root).'
+        required: false
+        type: string
+        default: '.'
+      config_path:
+        description: |
+          Path to component-config.yaml inside the caller repo.
+          Must be a relative path with no '..' segments.
+        required: false
+        type: string
+        default: 'component-config.yaml'
+      exclude:
+        description: |
+          Newline-separated doublestar glob patterns to exclude from detection.
+          The scanner already excludes .git/** and go.sum unconditionally.
+        required: false
+        type: string
+        default: |
+          node_modules/**
+          vendor/**
+          **/*.md
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: component-config-update-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  detect-and-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate inputs and required organization variables
+        env:
+          CONFIG_PATH_INPUT: ${{ inputs.config_path }}
+          GCP_KYMA_PROJECT_PROJECT_ID: ${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}
+          GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER: ${{ vars.GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER }}
+          GH_TOOLS_KYMA_PROW_BOT_TOKEN_SECRET_NAME: ${{ vars.GH_TOOLS_KYMA_PROW_BOT_TOKEN_SECRET_NAME }}
+          GH_COM_KYMA_BOT_AUTO_APPROVER_TOKEN_SECRET_NAME: ${{ vars.GH_COM_KYMA_BOT_AUTO_APPROVER_TOKEN_SECRET_NAME }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          for var in GCP_KYMA_PROJECT_PROJECT_ID \
+                     GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER \
+                     GH_TOOLS_KYMA_PROW_BOT_TOKEN_SECRET_NAME \
+                     GH_COM_KYMA_BOT_AUTO_APPROVER_TOKEN_SECRET_NAME; do
+            if [ -z "${!var:-}" ]; then
+              echo "::error title=Missing variable::Required variable '$var' is not set on this repository (or not inherited from the org)."
+              missing=1
+            fi
+          done
+          case "$CONFIG_PATH_INPUT" in
+            /* | *..* )
+              echo "::error title=Invalid config_path::config_path must be a relative path with no '..' segments (got: '$CONFIG_PATH_INPUT')."
+              missing=1
+              ;;
+          esac
+          exit "$missing"
+
+      - name: Authenticate in GCP
+        id: auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: ${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}
+          workload_identity_provider: ${{ vars.GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER }}
+
+      - name: Get GitHub Tokens from Secret Manager
+        id: secrets
+        uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3
+        with:
+          secrets: |-
+            service-user-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TOOLS_KYMA_PROW_BOT_TOKEN_SECRET_NAME }}
+            auto-approver-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_COM_KYMA_BOT_AUTO_APPROVER_TOKEN_SECRET_NAME }}
+
+      - name: Checkout caller repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Detect images
+        id: detect
+        uses: malachowski-labs/oci-image-detector@ae8e0e2137b58dd20b6e65eeaa42dc2ecedf49b3 # v1.1.1
+        with:
+          directory: ${{ inputs.directory }}
+          exclude: ${{ inputs.exclude }}
+          allow-empty: 'true'
+
+      - name: Regenerate component-config.yaml
+        env:
+          COMPONENT_NAME: ${{ inputs.component_name }}
+          TEAM: ${{ inputs.team }}
+          CONFIG_PATH: ${{ inputs.config_path }}
+          FINDINGS_FILE: ${{ steps.detect.outputs.output-file }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          images=$(jq -r '
+            [.findings // [] | .[].ref.raw]
+            | unique
+            | .[]
+            | "  - \"" + . + "\""
+          ' "$FINDINGS_FILE")
+          {
+            printf 'name: %s\n' "${COMPONENT_NAME}"
+            printf 'team: %s\n' "${TEAM}"
+            if [ -z "${images}" ]; then
+              printf 'images: []\n'
+            else
+              printf 'images:\n'
+              printf '%s\n' "${images}"
+            fi
+          } > "${CONFIG_PATH}"
+          echo "=== Generated ${CONFIG_PATH} ==="
+          cat "${CONFIG_PATH}"
+
+      - name: Create Pull Request
+        id: create-pr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        with:
+          token: ${{ steps.secrets.outputs.service-user-token }}
+          commit-message: |
+            chore: update component-config.yaml
+
+            Automated update by component-config-updater workflow.
+          branch: automation/component-config-update
+          delete-branch: true
+          title: 'chore: update component-config.yaml'
+          body: |
+            ## Component Config Update
+
+            Automated update of `${{ inputs.config_path }}` produced by the
+            `reusable-component-config-updater` workflow.
+
+            **Component**: `${{ inputs.component_name }}`
+            **Team**: `${{ inputs.team }}`
+            **Scanned directory**: `${{ inputs.directory }}`
+            **Findings count**: `${{ steps.detect.outputs.findings-count }}`
+
+            The list of images was generated by
+            [`malachowski-labs/oci-image-detector`](https://github.com/marketplace/actions/oci-image-detector)
+            and is consumed by `ocm-artifact-builder` for security scanning.
+
+            This PR will be auto-approved by the auto-approver bot and
+            merged by GitHub's native auto-merge once required checks
+            pass. The component-config.yaml file is fully owned by
+            automation — see ADR-001 for the contract.
+
+            ```release-note
+            NONE
+            ```
+          labels: |
+            kind/chore
+            area/security
+            auto-approved
+
+      - name: Auto-approve PR
+        if: ${{ (steps.create-pr.outputs.pull-request-operation == 'created' || steps.create-pr.outputs.pull-request-operation == 'updated') && steps.create-pr.outputs.pull-request-number != '' }}
+        uses: hmarr/auto-approve-action@8f929096a962e83ccdfa8afcf855f39f12d4dac7 # v4
+        with:
+          review-message: 'Auto-approved by component-config-updater workflow.'
+          github-token: ${{ steps.secrets.outputs.auto-approver-token }}
+          pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
+
+      - name: Enable native auto-merge on PR
+        if: ${{ (steps.create-pr.outputs.pull-request-operation == 'created' || steps.create-pr.outputs.pull-request-operation == 'updated') && steps.create-pr.outputs.pull-request-number != '' }}
+        env:
+          GH_TOKEN: ${{ steps.secrets.outputs.service-user-token }}
+          PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          if ! gh pr merge -R "$REPO" --auto --squash "$PR_NUMBER"; then
+            echo "::warning title=auto-merge::Failed to enable auto-merge for PR #${PR_NUMBER} in ${REPO}. Verify 'Allow auto-merge' is enabled in repo Settings → General → Pull Requests. The PR is approved and can be merged manually."
+            exit 0
+          fi
+
+      - name: Summary
+        env:
+          COMPONENT_NAME: ${{ inputs.component_name }}
+          CONFIG_PATH: ${{ inputs.config_path }}
+          FINDINGS_COUNT: ${{ steps.detect.outputs.findings-count }}
+          PR_OP: ${{ steps.create-pr.outputs.pull-request-operation }}
+          PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+          PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}
+        shell: bash
+        run: |
+          echo "=== Component Config Update Summary ==="
+          echo "Component:      ${COMPONENT_NAME}"
+          echo "Config path:    ${CONFIG_PATH}"
+          echo "Findings count: ${FINDINGS_COUNT}"
+          echo "PR operation:   ${PR_OP}"
+          echo "PR number:      ${PR_NUMBER}"
+          echo "PR URL:         ${PR_URL}"

--- a/configs/terraform/environments/prod/component-config-updater.tf
+++ b/configs/terraform/environments/prod/component-config-updater.tf
@@ -1,0 +1,69 @@
+# ==============================================================================
+# component-config-updater workflow — Secret Manager access via WIF (github.com)
+# ==============================================================================
+# Grants the kyma-project/test-infra reusable-component-config-updater.yml
+# workflow (running on github.com) read access to two PAT secrets via the
+# external github.com Workload Identity Federation pool:
+#
+#   - kyma-prow bot PAT (opens PRs)            → GH_TOOLS_KYMA_PROW_BOT_TOKEN_SECRET_NAME
+#   - kyma bot auto-approver PAT (approves PRs) → GH_COM_KYMA_BOT_AUTO_APPROVER_TOKEN_SECRET_NAME
+#
+# Two distinct identities are required because GitHub forbids self-approval.
+#
+# The principal is scoped to the reusable_workflow_ref of the workflow living
+# in kyma-project/test-infra@main on github.com, using the existing
+# gh_com_kyma_project WIF pool (pool id: github-com-kyma-project).
+# Mirrors the internal pattern in kyma/tooling-infra:component-config-updater.tf.
+# ==============================================================================
+
+variable "com_component_config_updater_bumper_token_secret_id" {
+  description = "GCP Secret Manager secret ID for the kyma-prow bot PAT used by the github.com reusable-component-config-updater workflow to open PRs. Must match the kyma-project org variable GH_TOOLS_KYMA_PROW_BOT_TOKEN_SECRET_NAME on github.com. Empty disables the IAM binding."
+  type        = string
+  default     = ""
+}
+
+variable "com_component_config_updater_approver_token_secret_id" {
+  description = "GCP Secret Manager secret ID for the kyma bot auto-approver PAT used by the github.com reusable-component-config-updater workflow to auto-approve PRs. Must match the kyma-project org variable GH_COM_KYMA_BOT_AUTO_APPROVER_TOKEN_SECRET_NAME on github.com. Empty disables the IAM binding."
+  type        = string
+  default     = ""
+}
+
+variable "com_component_config_updater_reusable_workflow_ref" {
+  description = "GitHub reference for the reusable workflow on github.com used by component-config-updater callers. Used to scope the principalSet binding."
+  type        = string
+  default     = "kyma-project/test-infra/.github/workflows/reusable-component-config-updater.yml@refs/heads/main"
+}
+
+locals {
+  com_component_config_updater_supported_events = [
+    "push",
+    "schedule",
+    "workflow_dispatch",
+  ]
+
+  # WIF pool full resource name for the external github.com pool.
+  com_github_wif_pool_name = "projects/${data.google_project.current.number}/locations/global/workloadIdentityPools/${var.gh_com_kyma_project_wif_pool_id}"
+
+  com_component_config_updater_principals = {
+    for event in local.com_component_config_updater_supported_events :
+    event => "principalSet://iam.googleapis.com/${local.com_github_wif_pool_name}/attribute.reusable_workflow_run/event_name:${event}:repository_owner_id:${var.github_kyma_project_organization_id}:reusable_workflow_ref:${var.com_component_config_updater_reusable_workflow_ref}"
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "com_component_config_updater_bumper_token_reader" {
+  for_each = var.com_component_config_updater_bumper_token_secret_id != "" ? toset(local.com_component_config_updater_supported_events) : toset([])
+
+  project   = data.google_project.current.project_id
+  secret_id = var.com_component_config_updater_bumper_token_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = local.com_component_config_updater_principals[each.value]
+}
+
+resource "google_secret_manager_secret_iam_member" "com_component_config_updater_approver_token_reader" {
+  for_each = var.com_component_config_updater_approver_token_secret_id != "" ? toset(local.com_component_config_updater_supported_events) : toset([])
+
+  project   = data.google_project.current.project_id
+  secret_id = var.com_component_config_updater_approver_token_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = local.com_component_config_updater_principals[each.value]
+}

--- a/configs/terraform/environments/prod/component-config-updater.tf
+++ b/configs/terraform/environments/prod/component-config-updater.tf
@@ -16,7 +16,7 @@
 variable "com_component_config_updater_bumper_token_secret_id" {
   description = "GCP Secret Manager secret ID for the neighbors auto-bumper PAT used by the github.com reusable-component-config-updater workflow to open PRs. Must match the kyma-project org variable GH_COM_NEIGHBORS_BOT_AUTO_BUMPER_TOKEN_SECRET_NAME on github.com. Empty disables the IAM binding."
   type        = string
-  default     = ""
+  default     = "auto-bumper-github-com-user-token"
 }
 
 variable "com_component_config_updater_reusable_workflow_ref" {

--- a/configs/terraform/environments/prod/component-config-updater.tf
+++ b/configs/terraform/environments/prod/component-config-updater.tf
@@ -2,13 +2,10 @@
 # component-config-updater workflow — Secret Manager access via WIF (github.com)
 # ==============================================================================
 # Grants the kyma-project/test-infra reusable-component-config-updater.yml
-# workflow (running on github.com) read access to two PAT secrets via the
-# external github.com Workload Identity Federation pool:
+# workflow (running on github.com) read access to the bumper PAT secret via
+# the external github.com Workload Identity Federation pool:
 #
-#   - kyma-prow bot PAT (opens PRs)            → GH_TOOLS_KYMA_PROW_BOT_TOKEN_SECRET_NAME
-#   - kyma bot auto-approver PAT (approves PRs) → GH_COM_KYMA_BOT_AUTO_APPROVER_TOKEN_SECRET_NAME
-#
-# Two distinct identities are required because GitHub forbids self-approval.
+#   - neighbors auto-bumper PAT (opens PRs) → GH_COM_NEIGHBORS_BOT_AUTO_BUMPER_TOKEN_SECRET_NAME
 #
 # The principal is scoped to the reusable_workflow_ref of the workflow living
 # in kyma-project/test-infra@main on github.com, using the existing
@@ -17,13 +14,7 @@
 # ==============================================================================
 
 variable "com_component_config_updater_bumper_token_secret_id" {
-  description = "GCP Secret Manager secret ID for the kyma-prow bot PAT used by the github.com reusable-component-config-updater workflow to open PRs. Must match the kyma-project org variable GH_TOOLS_KYMA_PROW_BOT_TOKEN_SECRET_NAME on github.com. Empty disables the IAM binding."
-  type        = string
-  default     = ""
-}
-
-variable "com_component_config_updater_approver_token_secret_id" {
-  description = "GCP Secret Manager secret ID for the kyma bot auto-approver PAT used by the github.com reusable-component-config-updater workflow to auto-approve PRs. Must match the kyma-project org variable GH_COM_KYMA_BOT_AUTO_APPROVER_TOKEN_SECRET_NAME on github.com. Empty disables the IAM binding."
+  description = "GCP Secret Manager secret ID for the neighbors auto-bumper PAT used by the github.com reusable-component-config-updater workflow to open PRs. Must match the kyma-project org variable GH_COM_NEIGHBORS_BOT_AUTO_BUMPER_TOKEN_SECRET_NAME on github.com. Empty disables the IAM binding."
   type        = string
   default     = ""
 }
@@ -55,15 +46,6 @@ resource "google_secret_manager_secret_iam_member" "com_component_config_updater
 
   project   = data.google_project.current.project_id
   secret_id = var.com_component_config_updater_bumper_token_secret_id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = local.com_component_config_updater_principals[each.value]
-}
-
-resource "google_secret_manager_secret_iam_member" "com_component_config_updater_approver_token_reader" {
-  for_each = var.com_component_config_updater_approver_token_secret_id != "" ? toset(local.com_component_config_updater_supported_events) : toset([])
-
-  project   = data.google_project.current.project_id
-  secret_id = var.com_component_config_updater_approver_token_secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = local.com_component_config_updater_principals[each.value]
 }


### PR DESCRIPTION
## What does this PR do?

Sets the default value of `com_component_config_updater_bumper_token_secret_id` to `"auto-bumper-github-com-user-token"` instead of `""`.

## Why?

The variable's empty default silently disabled the `google_secret_manager_secret_iam_member` binding (guarded by `for_each = var.... != "" ? ... : toset([])`), so no IAM binding was ever created. The `reusable-component-config-updater.yml` workflow then failed at "Get GitHub Tokens from Secret Manager" with a 403:

```
Permission 'secretmanager.versions.access' denied on resource
projects/sap-kyma-prow/secrets/auto-bumper-github-com-user-token/versions/latest
```

Fixes: https://github.com/kyma-project/test-infra/actions/runs/27402932515/job/80985790357