### PR TITLE
fix: enable Secret Manager IAM binding for component-config-updater by default

### DIFF
--- a/configs/terraform/environments/prod/component-config-updater.tf
+++ b/configs/terraform/environments/prod/component-config-updater.tf
@@ -16,7 +16,7 @@
 variable "com_component_config_updater_bumper_token_secret_id" {
   description = "GCP Secret Manager secret ID for the neighbors auto-bumper PAT used by the github.com reusable-component-config-updater workflow to open PRs. Must match the kyma-project org variable GH_COM_NEIGHBORS_BOT_AUTO_BUMPER_TOKEN_SECRET_NAME on github.com. Empty disables the IAM binding."
   type        = string
-  default     = ""
+  default     = "auto-bumper-github-com-user-token"
 }
 
 variable "com_component_config_updater_reusable_workflow_ref" {


### PR DESCRIPTION
## What does this PR do?

Sets the default value of `com_component_config_updater_bumper_token_secret_id` to `"auto-bumper-github-com-user-token"` instead of `""`.

## Why?

The variable's empty default silently disabled the `google_secret_manager_secret_iam_member` binding (guarded by `for_each = var.... != "" ? ... : toset([])`), so no IAM binding was ever created. The `reusable-component-config-updater.yml` workflow then failed at "Get GitHub Tokens from Secret Manager" with a 403:

```
Permission 'secretmanager.versions.access' denied on resource
projects/sap-kyma-prow/secrets/auto-bumper-github-com-user-token/versions/latest
```

Fixes: https://github.com/kyma-project/test-infra/actions/runs/27402932515/job/80985790357