### PR TITLE
chore: add exclude patterns for test and terraform files in component-config-updater

### DIFF
--- a/.github/workflows/component-config-updater.yml
+++ b/.github/workflows/component-config-updater.yml
@@ -24,3 +24,11 @@ jobs:
     uses: ./.github/workflows/reusable-component-config-updater.yml
     with:
       component_name: kyma-project.io/tooling/test-infra-public
+      exclude: |
+        node_modules/**
+        vendor/**
+        **/*.md
+        **/*_test.go
+        **/mocks/**
+        **/testdata/**
+        configs/terraform/**


### PR DESCRIPTION
## What does this PR do?

Adds explicit `exclude` patterns to the `component-config-updater` caller workflow to prevent test files, mocks, and Terraform configs from being scanned for OCI image references.

The reusable workflow already excludes `node_modules/**`, `vendor/**`, and `**/*.md` by default — this overrides the default with a fuller list:

- `**/*_test.go` — Go test files
- `**/mocks/**` — generated mock files
- `**/testdata/**` — test fixtures
- `configs/terraform/**` — Terraform configs contain no image references