### PR TITLE
chore: exclude component-config.yaml from image detection

### DIFF
--- a/.github/workflows/component-config-updater.yml
+++ b/.github/workflows/component-config-updater.yml
@@ -32,3 +32,4 @@ jobs:
         **/mocks/**
         **/testdata/**
         configs/terraform/**
+        component-config.yaml


### PR DESCRIPTION
## What

Adds `component-config.yaml` to the `exclude` list in the `component-config-updater` caller workflow.

## Why

The scanner was picking up image references from `component-config.yaml` itself (e.g. `docker.io/library/multiarch:latest` from test fixtures that had previously been written into the file), creating a self-referential loop. The file is fully owned by the automation — its contents should never feed back into the next scan.

The same pattern was added to the reusable workflow defaults in `kyma/test-infra` (internal) via PR #1369.

```release-note
NONE
```