### PR TITLE
chore: remove terraform exclude from component-config-updater

### DIFF
--- a/.github/workflows/component-config-updater.yml
+++ b/.github/workflows/component-config-updater.yml
@@ -31,5 +31,4 @@ jobs:
         **/*_test.go
         **/mocks/**
         **/testdata/**
-        configs/terraform/**
         component-config.yaml


### PR DESCRIPTION
## What

Removes `configs/terraform/**` from the `exclude` list in the `component-config-updater` caller workflow.

## Why

`configs/terraform/**` is the only place where full OCI image refs for production components are present (e.g. `dashboard-token-proxy`, `github-webhook-gateway`, `slackmessagesender`, `rotate-service-account`, `service-account-keys-cleaner`, `signify-secret-rotator`). Excluding it caused all those images to be dropped from `component-config.yaml`, as visible in #14295.

The pattern was added by mistake alongside the legitimate test/docs excludes.

```release-note
NONE
```