### PR TITLE
sec: use internal Kyma image mirror instead of Docker Hub

### DIFF
--- a/cmd/cloud-run/github-webhook-gateway/Dockerfile
+++ b/cmd/cloud-run/github-webhook-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine3.22 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.4-alpine3.22 as builder
 
 WORKDIR /app
 

--- a/cmd/cloud-run/rotate-service-account/Dockerfile
+++ b/cmd/cloud-run/rotate-service-account/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.26.4-alpine3.22 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.4-alpine3.22 as builder
 
 WORKDIR /go/src/github.com/kyma-project/test-infra
 COPY . .
 
 RUN  CGO_ENABLED=0 go build -o /rotateserviceaccount -ldflags="-s -w" ./cmd/cloud-run/rotate-service-account
 
-FROM alpine:3.24.1
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/alpine:3.24.1
 
 COPY --from=builder /rotateserviceaccount /rotateserviceaccount
 RUN apk add --no-cache ca-certificates && \

--- a/cmd/cloud-run/service-account-keys-cleaner/Dockerfile
+++ b/cmd/cloud-run/service-account-keys-cleaner/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.26.4-alpine3.22 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.4-alpine3.22 as builder
 
 WORKDIR /go/src/github.com/kyma-project/test-infra
 COPY . .
 
 RUN  CGO_ENABLED=0 go build -o /serviceaccountkeyscleaner -ldflags="-s -w" ./cmd/cloud-run/service-account-keys-cleaner
 
-FROM alpine:3.24.1
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/alpine:3.24.1
 
 COPY --from=builder /serviceaccountkeyscleaner /serviceaccountkeyscleaner
 RUN apk add --no-cache ca-certificates && \

--- a/cmd/cloud-run/signifysecretrotator/Dockerfile
+++ b/cmd/cloud-run/signifysecretrotator/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build with dependencies inside venv
-FROM python:3.14.6-alpine3.23 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/python:3.14.6-alpine3.23 as builder
 
 ENV PYTHONUNBUFFERED=1
 
@@ -16,7 +16,7 @@ COPY ./cmd/cloud-run/signifysecretrotator/requirements.txt .
 RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
 
 # Stage 2: Production image
-FROM python:3.14.6-alpine3.23
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/python:3.14.6-alpine3.23
 
 WORKDIR /app
 

--- a/cmd/cloud-run/slackmessagesender/Dockerfile
+++ b/cmd/cloud-run/slackmessagesender/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build with dependencies inside venv
-FROM python:3.14.6-alpine3.23 AS builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/python:3.14.6-alpine3.23 AS builder
 
 ENV PYTHONUNBUFFERED=1
 
@@ -16,7 +16,7 @@ COPY ./cmd/cloud-run/slackmessagesender/requirements.txt .
 RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
 
 # Stage 2: Production image
-FROM python:3.14.6-alpine3.23
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/python:3.14.6-alpine3.23
 
 WORKDIR /app
 

--- a/cmd/dashboard-token-proxy/Dockerfile
+++ b/cmd/dashboard-token-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine3.22 AS builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.4-alpine3.22 AS builder
 
 WORKDIR /app
 

--- a/cmd/image-builder/Dockerfile
+++ b/cmd/image-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine3.22 AS builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.4-alpine3.22 AS builder
 RUN apk add --no-cache ca-certificates curl
 
 RUN curl -fsSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.22/docker-credential-gcr_linux_amd64-2.1.22.tar.gz" \

--- a/cmd/oidc-token-verifier/Dockerfile
+++ b/cmd/oidc-token-verifier/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine3.22 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.4-alpine3.22 as builder
 
 # Add certificate authorities certificates.
 # This let oidctokenverifier to use tls connection to the OIDC provider.


### PR DESCRIPTION
Replace all direct Docker Hub base image references with equivalent images from the internal Kyma registry mirror
(europe-docker.pkg.dev/kyma-project/prod/external/library/) to avoid Docker Hub rate limits and improve supply-chain security.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Replace all Docker Hub base image references in 8 Dockerfiles with equivalent images
  from the internal Kyma registry mirror
  (`europe-docker.pkg.dev/kyma-project/prod/external/library/`)
- Affected: github-webhook-gateway, rotate-service-account, service-account-keys-cleaner,
  signifysecretrotator, slackmessagesender, dashboard-token-proxy, image-builder,
  oidc-token-verifier
- No logic changes — only FROM directives updated

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
