### PR TITLE
feat: add external image sync for base images

### DIFF
--- a/.github/workflows/sync-external-images.yml
+++ b/.github/workflows/sync-external-images.yml
@@ -1,0 +1,32 @@
+name: Sync External Images
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "external-images.yaml"
+  pull_request_target:
+    branches:
+      - main
+    paths:
+      - "external-images.yaml"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Dry run mode"
+        required: false
+        type: boolean
+        default: false
+      debug:
+        description: "Debug mode"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  sync-images:
+    uses: ./.github/workflows/image-syncer.yml
+    with:
+      dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
+      debug: ${{ github.event_name == 'workflow_dispatch' && inputs.debug || false }}

--- a/external-images.yaml
+++ b/external-images.yaml
@@ -1,0 +1,5 @@
+images:
+  - source: "alpine:3.24.1"
+  - source: "gcr.io/distroless/static:latest"
+  - source: "golang:1.26.4-alpine3.22"
+  - source: "python:3.14.6-alpine3.23"


### PR DESCRIPTION
Add external-images.yaml listing all external Docker Hub and distroless base images used across the repo, and a workflow that calls image-syncer to mirror them into the internal Kyma registry on every change to the images list.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- triggers image-syncer on push/PR to main when external-images.yaml changes, plus manual dispatch with optional dry-run/debug flags
- lists all 4 external base images found across the repo (alpine:3.24.1, gcr.io/distroless/static:latest, golang:1.26.4-alpine3.22, python:3.14.6-alpine3.23)
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
