### PR TITLE
Feat/sync external base images

### DIFF
--- a/.github/workflows/sync-external-images.yml
+++ b/.github/workflows/sync-external-images.yml
@@ -24,8 +24,21 @@ on:
         type: boolean
         default: false
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    environment:
+      name: prod
+      deployment: false
+    steps:
+      - run: echo "prod gate passed"
+
   sync-images:
+    needs: gate
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/sync-external-images.yml
+++ b/.github/workflows/sync-external-images.yml
@@ -26,6 +26,9 @@ on:
 
 jobs:
   sync-images:
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/image-syncer.yml
     with:
       dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add `external-images.yaml` listing all external base images used across the repo
  (Docker Hub and distroless) to be mirrored into the internal Kyma registry
- Add `sync-external-images.yml` workflow that calls the existing `image-syncer`
  reusable workflow on every change to `external-images.yaml`
- Fix missing `id-token: write` / `contents: read` permissions on the calling job
  (required by the reusable `image-syncer.yml`)


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
