### PR TITLE
fix(signify): remove debug print leaking response body to stdout

### DIFF
--- a/cmd/cloud-run/signifysecretrotator/signify/client.py
+++ b/cmd/cloud-run/signifysecretrotator/signify/client.py
@@ -83,7 +83,6 @@ class SignifyClient:
             )
 
             if access_token_response.status_code != 200:
-                print(access_token_response.json(), OAuthGrantTypes.CLIENT_CREDENTIALS)
                 raise requests.HTTPError(
                     f"Got non-success status code {access_token_response.status_code}",
                     response=access_token_response,


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Remove `print(access_token_response.json(), OAuthGrantTypes.CLIENT_CREDENTIALS)` from `SignifyClient.fetch_access_token` error path.
- The print logged the raw OAuth token-endpoint response to stdout on 4xx/5xx, which CodeQL flagged as `py/clear-text-logging-sensitive-data` (high). The response object is still propagated to callers via `requests.HTTPError(response=...)`, and `signifysecretrotator.py` already logs the resulting exception through its `pylogger`-based logger.
- No public API change. Existing unit tests in `signify/test_client.py` continue to pass (verified locally).

**Related issue(s)**

Resolves CodeQL alert [#1](https://github.com/kyma-project/test-infra/security/code-scanning/1) — `py/clear-text-logging-sensitive-data` (high).