### PR TITLE
chore: remove stale WIF bindings for kyma/test-infra GHES workflows

### DIFF
--- a/configs/terraform/environments/prod/terraform-executor-variables.tf
+++ b/configs/terraform/environments/prod/terraform-executor-variables.tf
@@ -39,26 +39,7 @@ variable "github_terraform_plan_workflow_name" {
 }
 
 # ------------------------------------------------------------------------------
-# Internal GitHub Enterprise WIF Binding Variables
-# ------------------------------------------------------------------------------
-# Variables for configuring WIF IAM bindings that allow internal GitHub
-# workflows to impersonate the terraform planner and executor service accounts.
-# ------------------------------------------------------------------------------
-
-variable "internal_github_terraform_plan_reusable_workflow_ref" {
-  type        = string
-  default     = "kyma/test-infra/.github/workflows/iac-plan.yml@refs/heads/main"
-  description = "Value of the GitHub OIDC job_workflow_ref claim for the terraform plan workflow on internal GitHub. Used to match the reusable_workflow_ref attribute in the github-tools-sap WIF pool."
-}
-
-variable "internal_github_terraform_deploy_identity" {
-  type        = string
-  default     = "kyma/test-infra/.github/workflows/iac-deploy.yml:main"
-  description = "Value of the deploy_identity attribute for the terraform deploy workflow on internal GitHub. The deploy_identity attribute is derived from job_workflow_ref and only populated when the caller ref is refs/heads/main or a v-tag. Format: org/repo/.github/workflows/workflow.yml:main"
-}
-
-# ------------------------------------------------------------------------------
-# Tooling-Infra Internal GitHub Enterprise WIF Binding Variables
+# Internal GitHub Enterprise WIF Binding Variables (tooling-infra)
 # ------------------------------------------------------------------------------
 # Variables for configuring WIF IAM bindings that allow tooling-infra
 # workflows on internal GitHub to impersonate terraform planner and executor

--- a/configs/terraform/environments/prod/terraform-executor.tf
+++ b/configs/terraform/environments/prod/terraform-executor.tf
@@ -29,9 +29,6 @@ resource "google_service_account_iam_binding" "terraform_workload_identity" {
     # github.com (kyma-project) — post-apply-prod-terraform workflow
     "principal://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/subject/repository_id:${data.github_repository.test_infra.repo_id}:repository_owner_id:${var.github_kyma_project_organization_id}:workflow:${var.github_terraform_apply_workflow_name}",
 
-    # Internal GitHub Enterprise (github-tools-sap) — test-infra deploy workflow
-    "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.deploy_identity/${var.internal_github_terraform_deploy_identity}",
-
     # Internal GitHub Enterprise (github-tools-sap) — tooling-infra deploy workflow (prod, v-tag)
     "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.deploy_identity/${var.internal_github_tooling_infra_terraform_deploy_identity_prod}",
   ]
@@ -88,9 +85,6 @@ resource "google_service_account_iam_binding" "terraform_planner_workload_identi
     # github.com (kyma-project) — reusable workflow triggers for validate service accounts
     "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_run/event_name:pull_request_target:repository_owner_id:${var.github_kyma_project_organization_id}:reusable_workflow_ref:kyma-project/test-infra/.github/workflows/pull-validate-service-accounts.yaml@refs/heads/main",
     "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_run/event_name:merge_group:repository_owner_id:${var.github_kyma_project_organization_id}:reusable_workflow_ref:kyma-project/test-infra/.github/workflows/pull-validate-service-accounts.yaml@refs/heads/main",
-
-    # Internal GitHub Enterprise (github-tools-sap) — test-infra plan workflow
-    "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.reusable_workflow_ref/${var.internal_github_terraform_plan_reusable_workflow_ref}",
 
     # Internal GitHub Enterprise (github-tools-sap) — tooling-infra plan workflow
     "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.reusable_workflow_ref/${var.internal_github_tooling_infra_terraform_plan_reusable_workflow_ref}",


### PR DESCRIPTION
## Description

Remove stale IAM WIF (Workload Identity Federation) bindings and variables that reference non-existent workflows in `kyma/test-infra` on GitHub Enterprise (github.tools.sap).

## Changes

### Removed variables (`terraform-executor-variables.tf`)
- `internal_github_terraform_deploy_identity` — pointed to `kyma/test-infra/.github/workflows/iac-deploy.yml:main`
- `internal_github_terraform_plan_reusable_workflow_ref` — pointed to `kyma/test-infra/.github/workflows/iac-plan.yml@refs/heads/main`

### Removed bindings (`terraform-executor.tf`)
- Executor SA binding: `principalSet://.../attribute.deploy_identity/kyma/test-infra/.github/workflows/iac-deploy.yml:main`
- Planner SA binding: `principalSet://.../attribute.reusable_workflow_ref/kyma/test-infra/.github/workflows/iac-plan.yml@refs/heads/main`

## Rationale

The `kyma/test-infra` repository on GHES has **no** `.github/workflows/iac-deploy.yml` or `iac-plan.yml` workflows — they never existed there. These are leftover bindings from when the IaC deployment was being set up. The actual deploy and plan workflows live exclusively in `kyma/tooling-infra`, which already has correct bindings configured and is unaffected by this change.

## Impact

After `terraform apply`, GCP will remove two unused `principalSet` bindings from the `terraform-executor` and `terraform-planner` service accounts. No active workflow relies on these bindings.