### PR TITLE
fix(ci): unblock fork PRs after actions/checkout v7 bump

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -7,6 +7,15 @@ inputs:
     description: The number of commits to fetch. Defaults to 5, which means only the 5 latest commits are fetched. It must be greater than 4 for the sanity check to pass.
     required: false
     default: "5"
+  allow-unsafe-pr-checkout:
+    description: |
+      Forwarded to actions/checkout. Set to "true" ONLY in workflows triggered by
+      pull_request_target (or workflow_run) that intentionally check out fork PR code.
+      Caller MUST gate the workflow behind a protected environment with required reviewers,
+      or otherwise constrain the privileges available to the checked-out code.
+      See: https://gh.io/securely-using-pull_request_target
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -18,6 +27,7 @@ runs:
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
           fetch-depth: ${{ inputs.fetch-depth }}
+          allow-unsafe-pr-checkout: ${{ inputs.allow-unsafe-pr-checkout }}
         if: ${{ github.event_name == 'pull_request_target' || github.event_name == 'pull_request' }}
 
       # Checkout code from the merge group branch

--- a/.github/workflows/image-syncer.yml
+++ b/.github/workflows/image-syncer.yml
@@ -29,8 +29,15 @@ jobs:
           echo "Using image-syncer workflow outside of kyma-project organisation is not supported."
           exit 1
 
+      # Reached via pull_request_target on fork PRs. The workflow has no
+      # environment-level approval gate, but mitigates risk by forcing
+      # --dry-run and using a read-only GCP service account on PRT runs
+      # (see the "Set dry-run flag" and SA-selection steps below).
+      # TODO: add a protected `prod-readonly` environment with reviewers as a stronger gate.
       - name: Checkout
         uses: kyma-project/test-infra/.github/actions/checkout@main
+        with:
+          allow-unsafe-pr-checkout: "true"
 
       - name: Verify supported event
         if: ${{ github.event_name != 'push' && github.event_name != 'pull_request_target' }}

--- a/.github/workflows/pull-go-lint.yaml
+++ b/.github/workflows/pull-go-lint.yaml
@@ -17,8 +17,13 @@ jobs:
       id-token: write # This is required for requesting the JWT token
       
     steps:
+      # Triggered via workflow-controller-pull-requests on pull_request_target.
+      # Fork PR checkout is gated by the `prod` environment's required reviewers
+      # and the composite action's sanity check on the merge commit's parent.
       - name: Checkout PR code
         uses: kyma-project/test-infra/.github/actions/checkout@main
+        with:
+          allow-unsafe-pr-checkout: "true"
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6

--- a/.github/workflows/pull-plan-prod-terraform.yaml
+++ b/.github/workflows/pull-plan-prod-terraform.yaml
@@ -19,8 +19,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Triggered via workflow-controller-pull-requests on pull_request_target.
+      # Fork PR checkout is gated by the `prod` environment's required reviewers
+      # and the composite action's sanity check on the merge commit's parent.
       - name: Checkout PR code
         uses: kyma-project/test-infra/.github/actions/checkout@main
+        with:
+          allow-unsafe-pr-checkout: "true"
 
       - name: Wait for other terraform executions
         id: wait_for_terraform

--- a/.github/workflows/pull-unit-test-go.yaml
+++ b/.github/workflows/pull-unit-test-go.yaml
@@ -16,8 +16,13 @@ jobs:
       id-token: write # This is required for requesting the JWT token
 
     steps:
+      # Triggered via workflow-controller-pull-requests on pull_request_target.
+      # Fork PR checkout is gated by the `prod` environment's required reviewers
+      # and the composite action's sanity check on the merge commit's parent.
       - name: Checkout PR code
         uses: kyma-project/test-infra/.github/actions/checkout@main
+        with:
+          allow-unsafe-pr-checkout: "true"
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.26.4'


### PR DESCRIPTION
## Problem

After the Renovate bump of `actions/checkout` v6 → v7 in #14324 (`f9aeb2ce8`), every workflow that checks out fork PR code under a `pull_request_target` trigger fails at the checkout step with:

```
Refusing to check out fork pull request code from a 'pull_request_target' workflow.
This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch
cache scope, and runner access. Fetching and executing a fork's code in that trusted
context commonly leads to "pwn request" vulnerabilities. To opt in, review the risks
at https://gh.io/securely-using-pull_request_target and set
'allow-unsafe-pr-checkout: true' on the actions/checkout step.
```

Concretely: this blocks any fork PR that touches paths matching the filters wired into `workflow-controller-pull-requests.yml`. Example failure: https://github.com/kyma-project/test-infra/actions/runs/28025566126/job/82952840392 (PR #14338, a one-line terraform cleanup from a maintainer fork).

## Root cause

`actions/checkout@v7` introduced a guardrail (actions/checkout#2454): it refuses to check out `refs/pull/N/merge` when the underlying `github.event_name` is `pull_request_target` or `workflow_run`, unless the caller explicitly opts in with `allow-unsafe-pr-checkout: true`. Our local composite action `.github/actions/checkout/action.yml` did not expose this input, so every caller using `pull_request_target` regressed.

## Fix

Two-commit opt-in design that mirrors upstream's explicit-opt-in shape:

1. **`chore(actions/checkout): add allow-unsafe-pr-checkout opt-in input`** — adds a new composite input, defaulting to `"false"`, forwarded to `actions/checkout@v7`. The v7 security stance is preserved for every caller by default.

2. **`fix(ci): opt fork-PR pull_request_target workflows into v7 checkout`** — sets `allow-unsafe-pr-checkout: "true"` only in the four workflows that genuinely need fork PR code under `pull_request_target`.

## Affected workflows and their gates

| Workflow | Trigger entry point | Gate |
|---|---|---|
| `pull-plan-prod-terraform.yaml` | `workflow-controller-pull-requests.yml` (PRT) | `prod` environment — required reviewers |
| `pull-go-lint.yaml` | `workflow-controller-pull-requests.yml` (PRT) | `prod` environment — required reviewers |
| `pull-unit-test-go.yaml` | `workflow-controller-pull-requests.yml` (PRT) | `prod` environment — required reviewers |
| `image-syncer.yml` | own `workflow_call` reached via PRT on fork PRs | workflow-internal: forces `--dry-run` and switches to a read-only GCP SA on PRT runs |

For the first three, the v7-docs-recommended posture is satisfied: protected environment + required reviewers + the composite's existing sanity check (`HEAD^1` or `HEAD^2` must equal the PR head SHA).

For `image-syncer.yml`, the workflow has no environment-level gate today; the dry-run + reader-SA enforcement predates v7's guardrail. A `TODO` comment is left to harden this with a proper protected environment in a follow-up — happy to file a tracking issue if reviewers prefer.

## Not changed

- **Unprivileged controller workflows** (`tf-lint`, `pull-validate-dockerfiles`, `code-checks-python`, `lint-markdown-links-pr`) — they run under plain `pull_request`, which v7's gate does not affect.
- **`pull-validate-scripts.yaml`** — uses the composite but isn't wired into either controller in any path I could find. Leaving it as-is preserves the secure default; if it is ever wired into a PRT controller, the failure will be loud.
- **Internal mirror `github.tools.sap/test-infra`** — its `.github/actions/checkout/action.yml` clones this repo at `main` and delegates to the public composite, so the fix propagates automatically. No mirror PR required.

## Verification

Before merge:
- `git diff upstream/main` is 5 files, +32 lines, no removals.
- All edits are additive on a fresh `upstream/main` base.

After merge:
- Re-run the failed `pull-plan-prod-terraform` check on #14338. The reusable workflow resolves at `@main` so the fix applies without rebase.
- Expected: checkout succeeds → reaches `prod` environment approval prompt → on approval, plan posts as a tfcmt comment.
- Sweep other open fork PRs that hit `pull-go-lint` / `pull-unit-test-go` — they should also unblock on re-run.

## Rollback

Single revert of the second commit restores the failing state; revert of the first commit returns the composite to its prior shape. As a last-resort fallback, pin `actions/checkout` back to v6 in `.github/actions/checkout/action.yml` and disable the Renovate rule until a different solution is designed.