### PR TITLE
feat: migrate terraform planner to GitHub App authentication

### DIFF
--- a/.github/workflows/pull-plan-prod-terraform.yaml
+++ b/.github/workflows/pull-plan-prod-terraform.yaml
@@ -40,13 +40,22 @@ jobs:
           workload_identity_provider: ${{ vars.GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER }}
           service_account: ${{ vars.GCP_TERRAFORM_PLANNER_SERVICE_ACCOUNT_EMAIL }}
 
-      - name: Retrieve Terraform Planner github PAT
+      - name: Retrieve Terraform Planner GitHub App credentials
         id: secrets
         uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3
         with:
           secrets: |-
-             gh-terraform-planner-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_PLANNER_SECRET_NAME }}
+             terraform-planner-app-id:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_PLANNER_APP_ID_SECRET_NAME }}
+             terraform-planner-app-private-key:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_PLANNER_APP_PRIVATE_KEY_SECRET_NAME }}
              internal-github-terraform-planner-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.INTERNAL_GITHUB_TERRAFORM_PLANNER_SECRET_NAME }}
+
+      - name: Generate GitHub App token for Terraform Planner
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ steps.secrets.outputs.terraform-planner-app-id }}
+          private-key: ${{ steps.secrets.outputs.terraform-planner-app-private-key }}
+          owner: ${{ github.repository_owner }}
 
       - name: Setup Terraform
         id: setup_terraform
@@ -73,7 +82,7 @@ jobs:
       # The IaC variables are lower case. The opentofu will remove TF_VAR prefix from this env var and match the value with variables names in IaC config case sensitive.
       # I do prefer to keep consistent format of identifiers in IaC config rather than env variables in github action workflow. Thats the reason env var name uses mixed caps.
         env:
-          GITHUB_TOKEN: ${{ steps.secrets.outputs.gh-terraform-planner-token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           TF_VAR_internal_github_token: ${{ steps.secrets.outputs.internal-github-terraform-planner-token }}
         id: terraform_plan
         run: tfcmt -owner $GITHUB_REPOSITORY_OWNER -repo ${{ github.event.repository.name }} -pr ${{ github.event.pull_request.number || 0 }} -sha ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }} plan -- tofu -chdir=./configs/terraform/environments/prod plan -input=false -no-color -lock-timeout=400s

--- a/configs/terraform/environments/prod/terraform-executor.tf
+++ b/configs/terraform/environments/prod/terraform-executor.tf
@@ -136,6 +136,36 @@ resource "github_actions_variable" "github_terraform_planner_secret_name" {
   value         = "kyma-bot-gh-com-terraform-planner-token"
 }
 
+# GitHub App credentials for kyma-project-terraform-planner
+resource "github_actions_variable" "terraform_planner_github_app_id_secret_name" {
+  provider      = github.kyma_project
+  repository    = "test-infra"
+  variable_name = "GH_TERRAFORM_PLANNER_APP_ID_SECRET_NAME"
+  value         = google_secret_manager_secret.terraform_planner_github_app_id.secret_id
+}
+
+resource "github_actions_variable" "terraform_planner_github_app_private_key_secret_name" {
+  provider      = github.kyma_project
+  repository    = "test-infra"
+  variable_name = "GH_TERRAFORM_PLANNER_APP_PRIVATE_KEY_SECRET_NAME"
+  value         = google_secret_manager_secret.terraform_planner_github_app_private_key.secret_id
+}
+
+# GitHub App credentials for kyma-project-terraform-executor
+resource "github_actions_variable" "terraform_executor_github_app_id_secret_name" {
+  provider      = github.kyma_project
+  repository    = "test-infra"
+  variable_name = "GH_TERRAFORM_EXECUTOR_APP_ID_SECRET_NAME"
+  value         = google_secret_manager_secret.terraform_executor_github_app_id.secret_id
+}
+
+resource "github_actions_variable" "terraform_executor_github_app_private_key_secret_name" {
+  provider      = github.kyma_project
+  repository    = "test-infra"
+  variable_name = "GH_TERRAFORM_EXECUTOR_APP_PRIVATE_KEY_SECRET_NAME"
+  value         = google_secret_manager_secret.terraform_executor_github_app_private_key.secret_id
+}
+
 # ------------------------------------------------------------------------------
 # Internal GitHub Token Configuration
 # ------------------------------------------------------------------------------
@@ -192,11 +222,6 @@ resource "google_secret_manager_secret" "internal_github_terraform_executor" {
     github-instance = "internal"
     owner           = "neighbors"
   }
-}
-
-import {
-  to = google_secret_manager_secret.internal_github_terraform_planner
-  id = "projects/${var.terraform_executor_gcp_service_account.project_id}/secrets/${var.internal_github_terraform_planner_secret_name}"
 }
 
 # GCP Secret Manager secret for internal GitHub terraform planner token.


### PR DESCRIPTION
## What changed                                                                                                                                                                                                  
  Migrate `pull-plan-prod-terraform` workflow from kyma-bot PAT to `kyma-project-terraform-planner`                                                                                                                
  GitHub App token, removing the dependency on the owner role in `kyma-project` organisation for                                                                                                                   
  read-only Terraform plan operations.                                                                                                                                                                             
                                                                                                                                                                                                                   
  ## Changes                                                                                                                                                                                                       
  - Replace `get-secretmanager-secrets` PAT retrieval step with GitHub App credentials retrieval                                                                                                                   
  - Add `actions/create-github-app-token` step to generate short-lived installation token                                                                                                                          
  - Add GitHub Actions repo variables exposing GCP Secret Manager secret names for planner and executor app credentials (`GH_TERRAFORM_PLANNER_APP_ID_SECRET_NAME`,                                                
  `GH_TERRAFORM_PLANNER_APP_PRIVATE_KEY_SECRET_NAME`, `GH_TERRAFORM_EXECUTOR_APP_ID_SECRET_NAME`, `GH_TERRAFORM_EXECUTOR_APP_PRIVATE_KEY_SECRET_NAME`)       