### PR TITLE
feat: migrate terraform executor to GitHub App authentication

### DIFF
--- a/.github/workflows/post-apply-prod-terraform.yaml
+++ b/.github/workflows/post-apply-prod-terraform.yaml
@@ -40,13 +40,22 @@ jobs:
           workload_identity_provider: ${{ vars.GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER }}
           service_account: ${{ vars.GCP_TERRAFORM_EXECUTOR_SERVICE_ACCOUNT_EMAIL }}
 
-      - name: Retrieve Terraform Executor github PAT
+      - name: Retrieve Terraform Executor GitHub App credentials
         id: secrets
         uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3
         with:
           secrets: |-
-             gh-terraform-executor-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_EXECUTOR_SECRET_NAME }}
+             terraform-executor-app-id:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_EXECUTOR_APP_ID_SECRET_NAME }}
+             terraform-executor-app-private-key:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_EXECUTOR_APP_PRIVATE_KEY_SECRET_NAME }}
              internal-github-terraform-executor-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.INTERNAL_GITHUB_TERRAFORM_EXECUTOR_SECRET_NAME }}
+
+      - name: Generate GitHub App token for Terraform Executor
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ steps.secrets.outputs.terraform-executor-app-id }}
+          private-key: ${{ steps.secrets.outputs.terraform-executor-app-private-key }}
+          owner: ${{ github.repository_owner }}
 
       - name: Setup Terraform
         id: setup_terraform
@@ -64,7 +73,7 @@ jobs:
       # The IaC variables are lower case. The opentofu will remove TF_VAR prefix from this env var and match the value with variables names in IaC config case sensitive.
       # I do prefer to keep consistent format of identifiers in IaC config rather than env variables in github action workflow. Thats the reason env var name uses mixed caps.
         env:
-          GITHUB_TOKEN: ${{ steps.secrets.outputs.gh-terraform-executor-token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           TF_VAR_internal_github_token: ${{ steps.secrets.outputs.internal-github-terraform-executor-token }}
         id: terraform_apply
         run: tfcmt -owner $GITHUB_REPOSITORY_OWNER -repo ${{ github.event.repository.name }} -sha ${{ github.sha }} apply -- tofu -chdir=./configs/terraform/environments/prod apply -input=false -no-color -auto-approve -lock-timeout=400s


### PR DESCRIPTION
## What changed
  Migrate `post-apply-prod-terraform` workflow from kyma-bot PAT to `kyma-project-terraform-executor`
  GitHub App token, removing the dependency on the owner role in `kyma-project` organisation for
  Terraform apply operations.

## Changes
  - Replace `get-secretmanager-secrets` PAT retrieval step with GitHub App credentials retrieval
  - Add `actions/create-github-app-token` step to generate short-lived installation token