### PR TITLE
fix: update ignorePaths to include component-config files

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -18,8 +18,8 @@
     "**/node_modules/**",
     "**/bower_components/**",
     "**/test*/**",
-    "**/cypress/**"
-
+    "**/cypress/**",
+    "component-config.{yaml,yml}"
   ],
 
   "packageRules": [

--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -19,7 +19,7 @@
     "**/bower_components/**",
     "**/test*/**",
     "**/cypress/**",
-    "component-config.{yaml,yml}"
+    "component-config.yaml"
   ],
 
   "packageRules": [


### PR DESCRIPTION
## What changed
Add `component-config.yaml to `ignorePaths` so Renovate skips the root-level component config file.

## Changes
- Add `component-config.yaml` glob to `ignorePaths`