### PR TITLE
feat: migrate tofu drift detection to GitHub App authentication

### DIFF
--- a/.github/workflows/tofu-drift-detection.yml
+++ b/.github/workflows/tofu-drift-detection.yml
@@ -33,13 +33,22 @@ jobs:
           workload_identity_provider: ${{ vars.GH_COM_KYMA_PROJECT_GCP_WORKLOAD_IDENTITY_FEDERATION_PROVIDER }}
           service_account: ${{ vars.GCP_TERRAFORM_PLANNER_SERVICE_ACCOUNT_EMAIL }}
 
-      - name: Retrieve Terraform Planner github PAT
+      - name: Retrieve Terraform Planner GitHub App credentials
         id: secrets
         uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3
         with:
           secrets: |-
-            public-github-terraform-planner-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_PLANNER_SECRET_NAME }}
+            terraform-planner-app-id:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_PLANNER_APP_ID_SECRET_NAME }}
+            terraform-planner-app-private-key:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_PLANNER_APP_PRIVATE_KEY_SECRET_NAME }}
             internal-github-terraform-planner-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.INTERNAL_GITHUB_TERRAFORM_PLANNER_SECRET_NAME }}
+
+      - name: Generate GitHub App token for Terraform Planner
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ steps.secrets.outputs.terraform-planner-app-id }}
+          private-key: ${{ steps.secrets.outputs.terraform-planner-app-private-key }}
+          owner: ${{ github.repository_owner }}
 
       - name: Tofu init
         id: tofu_init
@@ -48,7 +57,7 @@ jobs:
       - name: Tofu plan
         id: tofu_plan
         env:
-          GITHUB_TOKEN: ${{ steps.secrets.outputs.public-github-terraform-planner-token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           TF_VAR_internal_github_token: ${{ steps.secrets.outputs.internal-github-terraform-planner-token }}
         run: |
           exitcode=0

--- a/configs/terraform/environments/prod/terraform-executor.tf
+++ b/configs/terraform/environments/prod/terraform-executor.tf
@@ -111,31 +111,6 @@ resource "github_actions_variable" "gcp_terraform_planner_service_account_email"
   value         = google_service_account.terraform_planner.email
 }
 
-# ------------------------------------------------------------------------------
-# GitHub Actions Variables for github.com Token Secret Names
-# ------------------------------------------------------------------------------
-# These variables expose the GCP Secret Manager secret names to GitHub Actions
-# workflows. Workflows use these variable names to retrieve the actual tokens
-# from GCP Secret Manager during execution.
-# ------------------------------------------------------------------------------
-
-# Name of the secret manager's secret holding kyma bot token with github variables write permissions
-resource "github_actions_variable" "github_terraform_executor_secret_name" {
-  provider      = github.kyma_project
-  repository    = "test-infra"
-  variable_name = "GH_TERRAFORM_EXECUTOR_SECRET_NAME"
-  value         = "kyma-bot-gh-com-terraform-executor-token"
-}
-
-
-# Name of the secret manager's secret holding kyma bot token for plan prod terraform workflow.
-resource "github_actions_variable" "github_terraform_planner_secret_name" {
-  provider      = github.kyma_project
-  repository    = "test-infra"
-  variable_name = "GH_TERRAFORM_PLANNER_SECRET_NAME"
-  value         = "kyma-bot-gh-com-terraform-planner-token"
-}
-
 # GitHub App credentials for kyma-project-terraform-planner
 resource "github_actions_variable" "terraform_planner_github_app_id_secret_name" {
   provider      = github.kyma_project


### PR DESCRIPTION
## What changed
Migrated \`tofu-drift-detection\` workflow from PAT-based authentication to GitHub App tokens for terraform planner, consistent with \`pull-plan-prod-terraform.yaml\`. Removed the now-obsolete \`GH_TERRAFORM_EXECUTOR_SECRET_NAME\` and \`GH_TERRAFORM_PLANNER_SECRET_NAME\` GitHub Actions variables from Terraform config.

## Changes
- Replace PAT retrieval step with GitHub App credentials (app-id + private-key) in \`tofu-drift-detection.yml\`
- Add \`Generate GitHub App token for Terraform Planner\` step using \`actions/create-github-app-token\`
- Use \`steps.app-token.outputs.token\` as \`GITHUB_TOKEN\` in tofu plan step
- Remove \`github_actions_variable.github_terraform_executor_secret_name\` (\`GH_TERRAFORM_EXECUTOR_SECRET_NAME\`) from \`terraform-executor.tf\`
- Remove \`github_actions_variable.github_terraform_planner_secret_name\` (\`GH_TERRAFORM_PLANNER_SECRET_NAME\`) from \`terraform-executor.tf\`