### PR TITLE
chore: replace deprecated app-id with client-id in create-github-app-token

### DIFF
--- a/.github/workflows/post-apply-prod-terraform.yaml
+++ b/.github/workflows/post-apply-prod-terraform.yaml
@@ -53,7 +53,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ steps.secrets.outputs.terraform-executor-app-id }}
+          client-id: ${{ steps.secrets.outputs.terraform-executor-app-id }}
           private-key: ${{ steps.secrets.outputs.terraform-executor-app-private-key }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/pull-plan-prod-terraform.yaml
+++ b/.github/workflows/pull-plan-prod-terraform.yaml
@@ -53,7 +53,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ steps.secrets.outputs.terraform-planner-app-id }}
+          client-id: ${{ steps.secrets.outputs.terraform-planner-app-id }}
           private-key: ${{ steps.secrets.outputs.terraform-planner-app-private-key }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/tofu-drift-detection.yml
+++ b/.github/workflows/tofu-drift-detection.yml
@@ -46,7 +46,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ steps.secrets.outputs.terraform-planner-app-id }}
+          client-id: ${{ steps.secrets.outputs.terraform-planner-app-id }}
           private-key: ${{ steps.secrets.outputs.terraform-planner-app-private-key }}
           owner: ${{ github.repository_owner }}
 


### PR DESCRIPTION
## What changed
Replaced the deprecated `app-id` input with `client-id` in `actions/create-github-app-token` (deprecated in v3)

## Changes
- Replace `app-id` with `client-id` in `pull-plan-prod-terraform.yaml`
- Replace `app-id` with `client-id` in `tofu-drift-detection.yml`
- Replace `app-id` with `client-id` in `post-apply-prod-terraform.yaml`
