### PR TITLE
feat(logger): add debugging context to ErrInvalidSpanContext error

### DIFF
--- a/pkg/logger/console_test.go
+++ b/pkg/logger/console_test.go
@@ -157,14 +157,16 @@ var _ = Describe("ConsoleLogger", func() {
 
 			It("should return ErrInvalidSpanContext for background context", func() {
 				child, err := logger.WithSpanContext(context.Background(), "my-project")
-				Expect(err).To(MatchError(ErrInvalidSpanContext))
+				Expect(err).To(MatchError(ContainSubstring("span context is not valid")))
+				Expect(err).To(MatchError(ContainSubstring("projectID=my-project")))
 				Expect(child).To(BeNil())
 			})
 
 			It("should return ErrInvalidSpanContext for zero span context", func() {
 				ctx := trace.ContextWithSpanContext(context.Background(), trace.SpanContext{})
 				child, err := logger.WithSpanContext(ctx, "my-project")
-				Expect(err).To(MatchError(ErrInvalidSpanContext))
+				Expect(err).To(MatchError(ContainSubstring("span context is not valid")))
+				Expect(err).To(MatchError(ContainSubstring("traceID=00000000000000000000000000000000")))
 				Expect(child).To(BeNil())
 			})
 		})

--- a/pkg/logger/span_context.go
+++ b/pkg/logger/span_context.go
@@ -18,7 +18,13 @@ var ErrInvalidSpanContext = errors.New("span context is not valid")
 func withSpanContext(ctx context.Context, baseLogger logging.LoggerInterface, projectID string) (logging.LoggerInterface, error) {
 	spanContext := trace.SpanFromContext(ctx).SpanContext()
 	if !spanContext.IsValid() {
-		return nil, ErrInvalidSpanContext
+		return nil, fmt.Errorf("%w: traceID=%s, spanID=%s, traceFlags=%d, projectID=%s",
+			ErrInvalidSpanContext,
+			spanContext.TraceID().String(),
+			spanContext.SpanID().String(),
+			spanContext.TraceFlags(),
+			projectID,
+		)
 	}
 
 	return baseLogger.With(

--- a/pkg/logger/span_context_test.go
+++ b/pkg/logger/span_context_test.go
@@ -20,14 +20,17 @@ var _ = Describe("WithSpanContext", func() {
 
 		It("should return ErrInvalidSpanContext for background context", func() {
 			child, err := logger.WithSpanContext(context.Background(), "my-project")
-			Expect(err).To(MatchError(ErrInvalidSpanContext))
+			Expect(err).To(MatchError(ContainSubstring("span context is not valid")))
+			Expect(err).To(MatchError(ContainSubstring("projectID=my-project")))
 			Expect(child).To(BeNil())
 		})
 
 		It("should return ErrInvalidSpanContext for zero span context", func() {
 			ctx := trace.ContextWithSpanContext(context.Background(), trace.SpanContext{})
 			child, err := logger.WithSpanContext(ctx, "my-project")
-			Expect(err).To(MatchError(ErrInvalidSpanContext))
+			Expect(err).To(MatchError(ContainSubstring("span context is not valid")))
+			Expect(err).To(MatchError(ContainSubstring("traceID=00000000000000000000000000000000")))
+			Expect(err).To(MatchError(ContainSubstring("spanID=0000000000000000")))
 			Expect(child).To(BeNil())
 		})
 	})


### PR DESCRIPTION
## Description

Add contextual debugging information to the `ErrInvalidSpanContext` error returned by `withSpanContext()`.

The wrapped error now includes:
- `traceID` — the trace ID value found in the context
- `spanID` — the span ID value found in the context
- `traceFlags` — the trace flags value
- `projectID` — the GCP project ID passed to the function

This makes it significantly easier to diagnose why span context validation failed without needing to add additional logging at the call site.

## Changes

- `pkg/logger/span_context.go`: Wrap `ErrInvalidSpanContext` with `fmt.Errorf("%w: ...")` including all relevant context fields
- `pkg/logger/span_context_test.go`: Update assertions to use `ContainSubstring` matcher for wrapped error
- `pkg/logger/console_test.go`: Update assertions to use `ContainSubstring` matcher for wrapped error

## Type of change

- [x] Bug fix / improvement (non-breaking change that improves observability)