### PR TITLE
fix: move go builder image to 1.26.5-alpine3.23

### DIFF
--- a/cmd/cloud-run/github-webhook-gateway/Dockerfile
+++ b/cmd/cloud-run/github-webhook-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.4-alpine3.22 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.5-alpine3.23 as builder
 
 WORKDIR /app
 

--- a/cmd/cloud-run/rotate-service-account/Dockerfile
+++ b/cmd/cloud-run/rotate-service-account/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.4-alpine3.22 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.5-alpine3.23 as builder
 
 WORKDIR /go/src/github.com/kyma-project/test-infra
 COPY . .

--- a/cmd/cloud-run/service-account-keys-cleaner/Dockerfile
+++ b/cmd/cloud-run/service-account-keys-cleaner/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.4-alpine3.22 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.5-alpine3.23 as builder
 
 WORKDIR /go/src/github.com/kyma-project/test-infra
 COPY . .

--- a/cmd/dashboard-token-proxy/Dockerfile
+++ b/cmd/dashboard-token-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.4-alpine3.22 AS builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.5-alpine3.23 AS builder
 
 WORKDIR /app
 

--- a/cmd/image-builder/Dockerfile
+++ b/cmd/image-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.4-alpine3.22 AS builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.5-alpine3.23 AS builder
 RUN apk add --no-cache ca-certificates curl
 
 RUN curl -fsSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.22/docker-credential-gcr_linux_amd64-2.1.22.tar.gz" \

--- a/cmd/oidc-token-verifier/Dockerfile
+++ b/cmd/oidc-token-verifier/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.4-alpine3.22 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.5-alpine3.23 as builder
 
 # Add certificate authorities certificates.
 # This let oidctokenverifier to use tls connection to the OIDC provider.

--- a/external-images.yaml
+++ b/external-images.yaml
@@ -1,5 +1,5 @@
 images:
   - source: "alpine:3.24.1"
   - source: "gcr.io/distroless/static:latest"
-  - source: "golang:1.26.4-alpine3.22"
+  - source: "golang:1.26.5-alpine3.23"
   - source: "python:3.14.6-alpine3.23"


### PR DESCRIPTION
## What

Move the Go builder base image from `golang:1.26.4-alpine3.22` to `golang:1.26.5-alpine3.23`:
- `external-images.yaml`: update the mirrored `golang` source tag so the sync populates the new image.
- Six service Dockerfiles (`image-builder`, `oidc-token-verifier`, `dashboard-token-proxy`, `service-account-keys-cleaner`, `rotate-service-account`, `github-webhook-gateway`): point `FROM` at the new tag.

## Why

Renovate PR #14381 bumps the `go` directive in `go.mod` to `1.26.5`. The builder base image, however, was pinned to `golang:1.26.5-alpine3.22`, **a tag that does not exist** — Go `1.26.5` publishes its Alpine images on Alpine `3.23`, not `3.22`. With `GOTOOLCHAIN=local`, the in-image toolchain (1.26.4) refuses to build a module requiring `go >= 1.26.5`, so all six image builds fail:

```
go: /app/go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)
```

This is why Renovate offered no base-image bump: there is no `1.26.5-alpine3.22` to move to. The fix moves both the mirror source and the Dockerfiles to the tag that actually exists.

## Notes for reviewers

- The base image is pulled from the internal mirror, which is fed by `external-images.yaml` via the `Sync External Images` workflow. That workflow runs on `pull_request_target` for changes to `external-images.yaml` (gated by the `prod` environment), so the mirror needs to sync `golang:1.26.5-alpine3.23` before the image-build checks can pass. Please approve the environment gate / let the sync run, then re-run the build checks.
- Once merged, Renovate's #14381 will rebase cleanly on top and its builds should go green.

```release-note
NONE
```