### PR TITLE
chore: sync go 1.26.5-alpine3.23 builder image

### DIFF
--- a/external-images.yaml
+++ b/external-images.yaml
@@ -1,6 +1,6 @@
 images:
   - source: "alpine:3.24.1"
   - source: "gcr.io/distroless/static:latest"
-  - source: "golang:1.26.4-alpine3.22"
+  - source: "golang:1.26.5-alpine3.23"
   - source: "python@sha256:02da11a8d221ca167aa07de20b3cd7104c1f01227f4b02b1fa13cf6517280a81"
     tag: "3.14.6-alpine3.23"


### PR DESCRIPTION
## What

Add `golang:1.26.5-alpine3.23` as the mirrored Go builder base image in `external-images.yaml` (replacing `golang:1.26.4-alpine3.22`), so the tag required by the `go 1.26.5` bump (renovate #14381) is available in `europe-docker.pkg.dev/kyma-project/prod/external/`.

## Why

`go.mod` is moving to `go 1.26.5`. The service Dockerfiles build on `golang:<ver>-alpine3.22`, but Go 1.26.5 ships its Alpine images on **Alpine 3.23** — there is no `1.26.5-alpine3.22`. This change mirrors the correct tag so the Dockerfile update (separate PR) can consume it.

Split from the Dockerfile `FROM` bumps so the sync path is isolated and independently reviewable.

## Notes for reviewers

- Image Syncer runs in **dry-run** on PRs and enforces **tag immutability**. There is a pre-existing drift on the unrelated `python:3.14.6-alpine3.23` entry (upstream re-published that tag; the mirror holds the older content), which makes the dry-run sync check fail on the python line. That is **not** caused by this change — the `golang` tag syncs successfully. Resolving the python drift (re-pin by digest with a fresh target tag, per the image-syncer guide) is out of scope here and left to its owners.
- The real (non-dry-run) sync runs on merge to `main`.

Related: #14381

```release-note
NONE
```