### PR TITLE
fix: use go 1.26.5-alpine3.23 builder image in service Dockerfiles

### DIFF
--- a/cmd/cloud-run/github-webhook-gateway/Dockerfile
+++ b/cmd/cloud-run/github-webhook-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.4-alpine3.22 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.5-alpine3.23 as builder
 
 WORKDIR /app
 

--- a/cmd/cloud-run/rotate-service-account/Dockerfile
+++ b/cmd/cloud-run/rotate-service-account/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.4-alpine3.22 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.5-alpine3.23 as builder
 
 WORKDIR /go/src/github.com/kyma-project/test-infra
 COPY . .

--- a/cmd/cloud-run/service-account-keys-cleaner/Dockerfile
+++ b/cmd/cloud-run/service-account-keys-cleaner/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.4-alpine3.22 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.5-alpine3.23 as builder
 
 WORKDIR /go/src/github.com/kyma-project/test-infra
 COPY . .

--- a/cmd/dashboard-token-proxy/Dockerfile
+++ b/cmd/dashboard-token-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.4-alpine3.22 AS builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.5-alpine3.23 AS builder
 
 WORKDIR /app
 

--- a/cmd/image-builder/Dockerfile
+++ b/cmd/image-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.4-alpine3.22 AS builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.5-alpine3.23 AS builder
 RUN apk add --no-cache ca-certificates curl
 
 RUN curl -fsSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.22/docker-credential-gcr_linux_amd64-2.1.22.tar.gz" \

--- a/cmd/oidc-token-verifier/Dockerfile
+++ b/cmd/oidc-token-verifier/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.4-alpine3.22 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.26.5-alpine3.23 as builder
 
 # Add certificate authorities certificates.
 # This let oidctokenverifier to use tls connection to the OIDC provider.


### PR DESCRIPTION
## What

Point the six service builder Dockerfiles at `golang:1.26.5-alpine3.23` (from `golang:1.26.4-alpine3.22`):
`image-builder`, `oidc-token-verifier`, `dashboard-token-proxy`, `service-account-keys-cleaner`, `rotate-service-account`, `github-webhook-gateway`.

## Why

The `go` directive in `go.mod` is moving to `1.26.5` (renovate #14381). With `GOTOOLCHAIN=local`, the builder image's toolchain must be >= the module's required Go, so the base image must move to a `1.26.5` variant. Go 1.26.5 publishes Alpine images on **Alpine 3.23**, hence `1.26.5-alpine3.23`.

Split from the mirror-sync change so this PR does not touch `external-images.yaml` and therefore does not trigger the image-sync workflow.

## Dependency / ordering

This depends on the mirror carrying `golang:1.26.5-alpine3.23`, which is added by the companion sync PR **#14405**. Merge/real-sync that first; the image-build checks here will pass once the tag is present in the mirror.

Related: #14381

```release-note
NONE
```