### PR TITLE
fix: pin python mirror image by digest to resolve sync drift

### DIFF
--- a/external-images.yaml
+++ b/external-images.yaml
@@ -2,4 +2,5 @@ images:
   - source: "alpine:3.24.1"
   - source: "gcr.io/distroless/static:latest"
   - source: "golang:1.26.4-alpine3.22"
-  - source: "python:3.14.6-alpine3.23"
+  - source: "python@sha256:02da11a8d221ca167aa07de20b3cd7104c1f01227f4b02b1fa13cf6517280a81"
+    tag: "3.14.6-alpine3.23"


### PR DESCRIPTION
## What

Resolve the `python:3.14.6-alpine3.23` image-sync drift that blocks the external-image sync workflow. Single change in `external-images.yaml`: pin the python `source` to the digest **already synced in the mirror** (`python@sha256:02da11a8…`) under the same `3.14.6-alpine3.23` tag.

No Dockerfile changes — consumers keep using `python:3.14.6-alpine3.23`.

## Why

Image Syncer **guarantees target-tag immutability** — it never overwrites an existing tag. Upstream re-published `python:3.14.6-alpine3.23` with new content (`b165067c…`), so the source no longer matches the copy already in the mirror (`02da11a8…`), and every sync run fails with:

```
digests are not equal: sha256:b165067c… , sha256:02da11a8… - probably source index has been changed
```

Pinning the source to the digest that is already in the mirror makes source and target identical, so the sync becomes a clean no-op and the immutability check passes. The mirrored image is unchanged, so nothing that consumes it needs updating.

```release-note
NONE
```