### PR TITLE
feat(terraform): scope kyma-oci-image-builder SA to per-secret IAM bindings

### DIFF
--- a/configs/terraform/environments/prod/image-builder.tf
+++ b/configs/terraform/environments/prod/image-builder.tf
@@ -163,3 +163,145 @@ resource "google_secret_manager_secret" "image_builder_azure_sp" {
     component = "oci-image-builder"
   }
 }
+
+# Secrets used by kyma-oci-image-builder SA in the ADO pipeline.
+import {
+  to = google_secret_manager_secret.oci_image_builder_azure_pipeline_sa
+  id = "projects/${var.gcp_project_id}/secrets/azure-pipeline-image-builder-sa"
+}
+
+resource "google_secret_manager_secret" "oci_image_builder_azure_pipeline_sa" {
+  project   = var.gcp_project_id
+  secret_id = "azure-pipeline-image-builder-sa"
+
+  replication {
+    auto {}
+  }
+
+  labels = {
+    type      = "service-account-key"
+    tool      = "image-builder"
+    owner     = "neighbors"
+    component = "oci-image-builder"
+  }
+}
+
+import {
+  to = google_secret_manager_secret.oci_image_builder_sa_key_restricted_markets
+  id = "projects/${var.gcp_project_id}/secrets/image-builder-sa-key-restricted-markets"
+}
+
+resource "google_secret_manager_secret" "oci_image_builder_sa_key_restricted_markets" {
+  project   = var.gcp_project_id
+  secret_id = "image-builder-sa-key-restricted-markets"
+
+  replication {
+    auto {}
+  }
+
+  labels = {
+    type        = "service-account-key"
+    tool        = "image-builder"
+    environment = "restricted-markets"
+    owner       = "neighbors"
+    component   = "oci-image-builder"
+  }
+}
+
+import {
+  to = google_secret_manager_secret.oci_image_builder_signify_prod
+  id = "projects/${var.gcp_project_id}/secrets/kyma-signify-prod"
+}
+
+resource "google_secret_manager_secret" "oci_image_builder_signify_prod" {
+  project   = var.gcp_project_id
+  secret_id = "kyma-signify-prod"
+
+  replication {
+    auto {}
+  }
+
+  labels = {
+    type      = "signify"
+    tool      = "image-builder"
+    owner     = "neighbors"
+    component = "oci-image-builder"
+    usage     = "image-builder"
+  }
+
+  lifecycle {
+    ignore_changes = [rotation, topics]
+  }
+}
+
+import {
+  to = google_secret_manager_secret.oci_image_builder_sap_github_prow_sa_token
+  id = "projects/${var.gcp_project_id}/secrets/kyma-sap-github-prow-sa-token"
+}
+
+resource "google_secret_manager_secret" "oci_image_builder_sap_github_prow_sa_token" {
+  project   = var.gcp_project_id
+  secret_id = "kyma-sap-github-prow-sa-token"
+
+  replication {
+    auto {}
+  }
+
+  labels = {
+    type            = "github-token"
+    tool            = "image-builder"
+    github-instance = "internal"
+    owner           = "neighbors"
+    component       = "oci-image-builder"
+  }
+}
+
+# Per-secret IAM bindings for kyma-oci-image-builder SA.
+# Replaces the overly broad project-level roles/secretmanager.secretAccessor binding.
+import {
+  to = google_secret_manager_secret_iam_member.oci_image_builder_azure_pipeline_sa_secret_accessor
+  id = "projects/${var.gcp_project_id}/secrets/azure-pipeline-image-builder-sa/members/serviceAccount:kyma-oci-image-builder@${var.gcp_project_id}.iam.gserviceaccount.com/roles/secretmanager.secretAccessor"
+}
+
+resource "google_secret_manager_secret_iam_member" "oci_image_builder_azure_pipeline_sa_secret_accessor" {
+  project   = var.gcp_project_id
+  secret_id = google_secret_manager_secret.oci_image_builder_azure_pipeline_sa.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.kyma-oci-image-builder.email}"
+}
+
+import {
+  to = google_secret_manager_secret_iam_member.oci_image_builder_sa_key_restricted_markets_secret_accessor
+  id = "projects/${var.gcp_project_id}/secrets/image-builder-sa-key-restricted-markets/members/serviceAccount:kyma-oci-image-builder@${var.gcp_project_id}.iam.gserviceaccount.com/roles/secretmanager.secretAccessor"
+}
+
+resource "google_secret_manager_secret_iam_member" "oci_image_builder_sa_key_restricted_markets_secret_accessor" {
+  project   = var.gcp_project_id
+  secret_id = google_secret_manager_secret.oci_image_builder_sa_key_restricted_markets.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.kyma-oci-image-builder.email}"
+}
+
+import {
+  to = google_secret_manager_secret_iam_member.oci_image_builder_signify_prod_secret_accessor
+  id = "projects/${var.gcp_project_id}/secrets/kyma-signify-prod/members/serviceAccount:kyma-oci-image-builder@${var.gcp_project_id}.iam.gserviceaccount.com/roles/secretmanager.secretAccessor"
+}
+
+resource "google_secret_manager_secret_iam_member" "oci_image_builder_signify_prod_secret_accessor" {
+  project   = var.gcp_project_id
+  secret_id = google_secret_manager_secret.oci_image_builder_signify_prod.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.kyma-oci-image-builder.email}"
+}
+
+import {
+  to = google_secret_manager_secret_iam_member.oci_image_builder_sap_github_prow_sa_token_secret_accessor
+  id = "projects/${var.gcp_project_id}/secrets/kyma-sap-github-prow-sa-token/members/serviceAccount:kyma-oci-image-builder@${var.gcp_project_id}.iam.gserviceaccount.com/roles/secretmanager.secretAccessor"
+}
+
+resource "google_secret_manager_secret_iam_member" "oci_image_builder_sap_github_prow_sa_token_secret_accessor" {
+  project   = var.gcp_project_id
+  secret_id = google_secret_manager_secret.oci_image_builder_sap_github_prow_sa_token.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.kyma-oci-image-builder.email}"
+}

--- a/configs/terraform/environments/prod/image-builder.tf
+++ b/configs/terraform/environments/prod/image-builder.tf
@@ -235,11 +235,11 @@ resource "google_secret_manager_secret" "oci_image_builder_signify_prod" {
 }
 
 import {
-  to = google_secret_manager_secret.oci_image_builder_sap_github_prow_sa_token
+  to = google_secret_manager_secret.sap_github_prow_sa_token
   id = "projects/${var.gcp_project_id}/secrets/kyma-sap-github-prow-sa-token"
 }
 
-resource "google_secret_manager_secret" "oci_image_builder_sap_github_prow_sa_token" {
+resource "google_secret_manager_secret" "sap_github_prow_sa_token" {
   project   = var.gcp_project_id
   secret_id = "kyma-sap-github-prow-sa-token"
 
@@ -249,10 +249,8 @@ resource "google_secret_manager_secret" "oci_image_builder_sap_github_prow_sa_to
 
   labels = {
     type            = "github-token"
-    tool            = "image-builder"
     github-instance = "internal"
     owner           = "neighbors"
-    component       = "oci-image-builder"
   }
 }
 
@@ -301,7 +299,7 @@ import {
 
 resource "google_secret_manager_secret_iam_member" "oci_image_builder_sap_github_prow_sa_token_secret_accessor" {
   project   = var.gcp_project_id
-  secret_id = google_secret_manager_secret.oci_image_builder_sap_github_prow_sa_token.secret_id
+  secret_id = google_secret_manager_secret.sap_github_prow_sa_token.secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.kyma-oci-image-builder.email}"
 }

--- a/configs/terraform/environments/prod/image-builder.tf
+++ b/configs/terraform/environments/prod/image-builder.tf
@@ -255,7 +255,6 @@ resource "google_secret_manager_secret" "sap_github_prow_sa_token" {
 }
 
 # Per-secret IAM bindings for kyma-oci-image-builder SA.
-# Replaces the overly broad project-level roles/secretmanager.secretAccessor binding.
 resource "google_secret_manager_secret_iam_member" "oci_image_builder_azure_pipeline_sa_secret_accessor" {
   project   = var.gcp_project_id
   secret_id = google_secret_manager_secret.oci_image_builder_azure_pipeline_sa.secret_id

--- a/configs/terraform/environments/prod/image-builder.tf
+++ b/configs/terraform/environments/prod/image-builder.tf
@@ -256,21 +256,11 @@ resource "google_secret_manager_secret" "sap_github_prow_sa_token" {
 
 # Per-secret IAM bindings for kyma-oci-image-builder SA.
 # Replaces the overly broad project-level roles/secretmanager.secretAccessor binding.
-import {
-  to = google_secret_manager_secret_iam_member.oci_image_builder_azure_pipeline_sa_secret_accessor
-  id = "projects/${var.gcp_project_id}/secrets/azure-pipeline-image-builder-sa roles/secretmanager.secretAccessor serviceAccount:kyma-oci-image-builder@${var.gcp_project_id}.iam.gserviceaccount.com"
-}
-
 resource "google_secret_manager_secret_iam_member" "oci_image_builder_azure_pipeline_sa_secret_accessor" {
   project   = var.gcp_project_id
   secret_id = google_secret_manager_secret.oci_image_builder_azure_pipeline_sa.secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.kyma-oci-image-builder.email}"
-}
-
-import {
-  to = google_secret_manager_secret_iam_member.oci_image_builder_sa_key_restricted_markets_secret_accessor
-  id = "projects/${var.gcp_project_id}/secrets/image-builder-sa-key-restricted-markets roles/secretmanager.secretAccessor serviceAccount:kyma-oci-image-builder@${var.gcp_project_id}.iam.gserviceaccount.com"
 }
 
 resource "google_secret_manager_secret_iam_member" "oci_image_builder_sa_key_restricted_markets_secret_accessor" {
@@ -280,21 +270,11 @@ resource "google_secret_manager_secret_iam_member" "oci_image_builder_sa_key_res
   member    = "serviceAccount:${google_service_account.kyma-oci-image-builder.email}"
 }
 
-import {
-  to = google_secret_manager_secret_iam_member.oci_image_builder_signify_prod_secret_accessor
-  id = "projects/${var.gcp_project_id}/secrets/kyma-signify-prod roles/secretmanager.secretAccessor serviceAccount:kyma-oci-image-builder@${var.gcp_project_id}.iam.gserviceaccount.com"
-}
-
 resource "google_secret_manager_secret_iam_member" "oci_image_builder_signify_prod_secret_accessor" {
   project   = var.gcp_project_id
   secret_id = google_secret_manager_secret.oci_image_builder_signify_prod.secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.kyma-oci-image-builder.email}"
-}
-
-import {
-  to = google_secret_manager_secret_iam_member.oci_image_builder_sap_github_prow_sa_token_secret_accessor
-  id = "projects/${var.gcp_project_id}/secrets/kyma-sap-github-prow-sa-token roles/secretmanager.secretAccessor serviceAccount:kyma-oci-image-builder@${var.gcp_project_id}.iam.gserviceaccount.com"
 }
 
 resource "google_secret_manager_secret_iam_member" "oci_image_builder_sap_github_prow_sa_token_secret_accessor" {

--- a/configs/terraform/environments/prod/image-builder.tf
+++ b/configs/terraform/environments/prod/image-builder.tf
@@ -258,7 +258,7 @@ resource "google_secret_manager_secret" "sap_github_prow_sa_token" {
 # Replaces the overly broad project-level roles/secretmanager.secretAccessor binding.
 import {
   to = google_secret_manager_secret_iam_member.oci_image_builder_azure_pipeline_sa_secret_accessor
-  id = "projects/${var.gcp_project_id}/secrets/azure-pipeline-image-builder-sa/members/serviceAccount:kyma-oci-image-builder@${var.gcp_project_id}.iam.gserviceaccount.com/roles/secretmanager.secretAccessor"
+  id = "projects/${var.gcp_project_id}/secrets/azure-pipeline-image-builder-sa roles/secretmanager.secretAccessor serviceAccount:kyma-oci-image-builder@${var.gcp_project_id}.iam.gserviceaccount.com"
 }
 
 resource "google_secret_manager_secret_iam_member" "oci_image_builder_azure_pipeline_sa_secret_accessor" {
@@ -270,7 +270,7 @@ resource "google_secret_manager_secret_iam_member" "oci_image_builder_azure_pipe
 
 import {
   to = google_secret_manager_secret_iam_member.oci_image_builder_sa_key_restricted_markets_secret_accessor
-  id = "projects/${var.gcp_project_id}/secrets/image-builder-sa-key-restricted-markets/members/serviceAccount:kyma-oci-image-builder@${var.gcp_project_id}.iam.gserviceaccount.com/roles/secretmanager.secretAccessor"
+  id = "projects/${var.gcp_project_id}/secrets/image-builder-sa-key-restricted-markets roles/secretmanager.secretAccessor serviceAccount:kyma-oci-image-builder@${var.gcp_project_id}.iam.gserviceaccount.com"
 }
 
 resource "google_secret_manager_secret_iam_member" "oci_image_builder_sa_key_restricted_markets_secret_accessor" {
@@ -282,7 +282,7 @@ resource "google_secret_manager_secret_iam_member" "oci_image_builder_sa_key_res
 
 import {
   to = google_secret_manager_secret_iam_member.oci_image_builder_signify_prod_secret_accessor
-  id = "projects/${var.gcp_project_id}/secrets/kyma-signify-prod/members/serviceAccount:kyma-oci-image-builder@${var.gcp_project_id}.iam.gserviceaccount.com/roles/secretmanager.secretAccessor"
+  id = "projects/${var.gcp_project_id}/secrets/kyma-signify-prod roles/secretmanager.secretAccessor serviceAccount:kyma-oci-image-builder@${var.gcp_project_id}.iam.gserviceaccount.com"
 }
 
 resource "google_secret_manager_secret_iam_member" "oci_image_builder_signify_prod_secret_accessor" {
@@ -294,7 +294,7 @@ resource "google_secret_manager_secret_iam_member" "oci_image_builder_signify_pr
 
 import {
   to = google_secret_manager_secret_iam_member.oci_image_builder_sap_github_prow_sa_token_secret_accessor
-  id = "projects/${var.gcp_project_id}/secrets/kyma-sap-github-prow-sa-token/members/serviceAccount:kyma-oci-image-builder@${var.gcp_project_id}.iam.gserviceaccount.com/roles/secretmanager.secretAccessor"
+  id = "projects/${var.gcp_project_id}/secrets/kyma-sap-github-prow-sa-token roles/secretmanager.secretAccessor serviceAccount:kyma-oci-image-builder@${var.gcp_project_id}.iam.gserviceaccount.com"
 }
 
 resource "google_secret_manager_secret_iam_member" "oci_image_builder_sap_github_prow_sa_token_secret_accessor" {


### PR DESCRIPTION
## What changed

Replace the overly broad project-level `roles/secretmanager.secretAccessor` binding for the `kyma-oci-image-builder` SA with per-secret IAM members scoped to only the 4 secrets actually used by the ADO pipeline. Secrets and their IAM bindings are imported into Terraform IaC.

## Changes

- Add `google_secret_manager_secret` resources for the 4 secrets used by the ADO pipeline (`azure-pipeline-image-builder-sa`, `image-builder-sa-key-restricted-markets`, `kyma-signify-prod`, `kyma-sap-github-prow-sa-token`) with `import` blocks
- Add `google_secret_manager_secret_iam_member` per-secret bindings for `kyma-oci-image-builder` SA replacing the project-level binding
