### PR TITLE
fix(terraform): disable sa-kyma-project and sa-dev-kyma-project SAs

### DIFF
--- a/configs/terraform/environments/prod/service_accounts.tf
+++ b/configs/terraform/environments/prod/service_accounts.tf
@@ -32,6 +32,7 @@ resource "google_service_account" "sa-kyma-project" {
   account_id   = "sa-kyma-project"
   display_name = "sa-kyma-project"
   description  = "SA to manage PROD Artifact Registry in SAP CX Kyma Project"
+  disabled     = true
 
   lifecycle {
     prevent_destroy = true
@@ -58,6 +59,7 @@ resource "google_service_account" "sa-dev-kyma-project" {
   account_id   = "sa-dev-kyma-project"
   display_name = "sa-dev-kyma-project"
   description  = "SA to manage DEV Artifact Registry in SAP CX Kyma Project"
+  disabled     = true
 
   lifecycle {
     prevent_destroy = true


### PR DESCRIPTION
Both SAs don't have any activity in logs since 90 days.
Let disable them and see what will happen. Later on i plan to delete them completely.
Both have project wide permissions to deprecated gcr

> sa-kyma-project and sa-dev-kyma-project — likely unused.
> 
> Audit logs from the last 90 days across both sap-kyma-prow and kyma-project: no activity for either SA.
> 
> Pushes to europe/prod and europe/dev AR repositories in kyma-project are performed by azure-pipeline-image-builder@kyma-project — confirmed active in logs today (11:38 UTC). Both SAs hold roles/artifactregistry.writer bindings on those repos but  have not used them recently.
> 
> Conclusion: legacy SAs, superseded by azure-pipeline-image-builder@kyma-project. Safe to disable.

<img width="1095" height="486" alt="image" src="https://github.com/user-attachments/assets/f8a2477a-423c-4ea8-8ec3-18f9f5409e2d" />

<img width="1071" height="475" alt="image" src="https://github.com/user-attachments/assets/65b155f1-c150-4c37-91f8-eb90d609d6f3" />

