### PR TITLE
chore: reorder renovate docker image rules for correct matching

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -53,6 +53,17 @@
       "groupName": "docker images"
     },
     {
+    "matchManagers": ["regex"],
+    "matchDatasources": ["docker"],
+    "matchCurrentVersion": "!/^v?\\d+\\.\\d+\\.\\d+$/",
+    "versioning": "loose",
+    "groupName": "custom docker images (loose) to {{newVersion}}",
+    "commitMessageTopic": "custom docker images (loose) to {{newVersion}}",
+    "commitMessageExtra": "",
+    "separateMajorMinor": false,
+    "maxMajorIncrement": 0
+    },
+    {
       "matchManagers": ["regex"],
       "matchDatasources": ["docker"],
       "matchCurrentVersion": "v?\\d+\\.\\d+\\.\\d+",
@@ -61,16 +72,6 @@
       "commitMessageTopic": "custom docker images (semver) to {{newVersion}}",
       "commitMessageExtra": "",
       "separateMajorMinor": false
-    },
-    {
-    "matchManagers": ["regex"],
-    "matchDatasources": ["docker"],
-    "versioning": "loose",
-    "groupName": "custom docker images (loose) to {{newVersion}}",
-    "commitMessageTopic": "custom docker images (loose) to {{newVersion}}",
-    "commitMessageExtra": "",
-    "separateMajorMinor": false,
-    "maxMajorIncrement": 0
     }
   ],
 

--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -55,7 +55,7 @@
     {
     "matchManagers": ["regex"],
     "matchDatasources": ["docker"],
-    "matchCurrentVersion": "!/^v?\\d+\\.\\d+\\.\\d+$/",
+    "matchCurrentVersion": "!/v?\\d+\\.\\d+\\.\\d+/",
     "versioning": "loose",
     "groupName": "custom docker images (loose) to {{newVersion}}",
     "commitMessageTopic": "custom docker images (loose) to {{newVersion}}",


### PR DESCRIPTION
Reorders renovate package rules so the loose-versioning rule with `matchCurrentVersion` negative filter is evaluated before the semver rule. This ensures that non-semver Docker image tags are correctly matched by the loose rule and semver tags by the semver rule.

Changes:
- Move the loose-versioning rule before the semver rule
- Add `matchCurrentVersion` negative filter to the loose rule to explicitly exclude semver-formatted tags
- Remove duplicate semver rule and keep one copy at the end