### PR TITLE
fix(terraform): scope signify-rotator SA to per-secret IAM bindings

### DIFF
--- a/configs/terraform/environments/prod/secrets-rotator-variables.tf
+++ b/configs/terraform/environments/prod/secrets-rotator-variables.tf
@@ -77,6 +77,12 @@ variable "signify_secret_rotator_account_id" {
   description = "Service account ID of the signify secret rotator."
 }
 
+variable "signify_secret_id" {
+  type        = string
+  default     = "kyma-signify-prod"
+  description = "Secret Manager secret ID of the Signify secret that the rotator reads and updates."
+}
+
 variable "signify_secret_rotator_image" {
   type        = string
   description = "Image of the signify secret rotator."

--- a/configs/terraform/environments/prod/secrets-rotator-variables.tf
+++ b/configs/terraform/environments/prod/secrets-rotator-variables.tf
@@ -77,12 +77,6 @@ variable "signify_secret_rotator_account_id" {
   description = "Service account ID of the signify secret rotator."
 }
 
-variable "signify_secret_id" {
-  type        = string
-  default     = "kyma-signify-prod"
-  description = "Secret Manager secret ID of the Signify secret that the rotator reads and updates."
-}
-
 variable "signify_secret_rotator_image" {
   type        = string
   description = "Image of the signify secret rotator."

--- a/configs/terraform/environments/prod/secrets-rotator.tf
+++ b/configs/terraform/environments/prod/secrets-rotator.tf
@@ -64,12 +64,12 @@ output "service_account_keys_cleaner" {
 # -------------------------------------------------------------------------------
 
 import {
-  id = "sap-kyma-prow/roles/logging.logWriter/serviceAccount:signify-rotator@sap-kyma-prow.iam.gserviceaccount.com"
+  id = "sap-kyma-prow roles/logging.logWriter serviceAccount:signify-rotator@sap-kyma-prow.iam.gserviceaccount.com"
   to = module.signify_secret_rotator.google_project_iam_member.signify_secret_rotator_log_writer
 }
 
 import {
-  id = "sap-kyma-prow/roles/errorreporting.writer/serviceAccount:signify-rotator@sap-kyma-prow.iam.gserviceaccount.com"
+  id = "sap-kyma-prow roles/errorreporting.writer serviceAccount:signify-rotator@sap-kyma-prow.iam.gserviceaccount.com"
   to = module.signify_secret_rotator.google_project_iam_member.signify_secret_rotator_error_reporting_writer
 }
 

--- a/configs/terraform/environments/prod/secrets-rotator.tf
+++ b/configs/terraform/environments/prod/secrets-rotator.tf
@@ -58,6 +58,21 @@ output "service_account_keys_cleaner" {
   value = module.service_account_keys_cleaner
 }
 
+# -------------------------------------------------------------------------------
+# Import — signify-rotator project-level IAM bindings created before IaC support.
+# Safe to remove after the first successful apply.
+# -------------------------------------------------------------------------------
+
+import {
+  id = "sap-kyma-prow/roles/logging.logWriter/serviceAccount:signify-rotator@sap-kyma-prow.iam.gserviceaccount.com"
+  to = module.signify_secret_rotator.google_project_iam_member.signify_secret_rotator_log_writer
+}
+
+import {
+  id = "sap-kyma-prow/roles/errorreporting.writer/serviceAccount:signify-rotator@sap-kyma-prow.iam.gserviceaccount.com"
+  to = module.signify_secret_rotator.google_project_iam_member.signify_secret_rotator_error_reporting_writer
+}
+
 module "signify_secret_rotator" {
   source = "../../modules/signify-secret-rotator"
 
@@ -71,8 +86,8 @@ module "signify_secret_rotator" {
   cloud_run_service_listen_port                = var.secrets_rotator_cloud_run_listen_port
   secret_manager_notifications_topic           = var.secret_manager_notifications_topic
   secrets_rotator_sa_email                     = google_service_account.secrets-rotator.email
+  signify_secret_id                            = var.signify_secret_id
 }
-
 
 ### dead letter monitoring ###
 

--- a/configs/terraform/environments/prod/secrets-rotator.tf
+++ b/configs/terraform/environments/prod/secrets-rotator.tf
@@ -86,7 +86,7 @@ module "signify_secret_rotator" {
   cloud_run_service_listen_port                = var.secrets_rotator_cloud_run_listen_port
   secret_manager_notifications_topic           = var.secret_manager_notifications_topic
   secrets_rotator_sa_email                     = google_service_account.secrets-rotator.email
-  signify_secret_id                            = var.signify_secret_id
+  signify_secret_id                            = google_secret_manager_secret.oci_image_builder_signify_prod.secret_id
 }
 
 ### dead letter monitoring ###

--- a/configs/terraform/modules/signify-secret-rotator/main.tf
+++ b/configs/terraform/modules/signify-secret-rotator/main.tf
@@ -8,25 +8,41 @@ resource "google_service_account" "signify_secret_rotator" {
 }
 
 // roles/secretmanager.secretAccessor is required to be able to access the secret version payload in secret manager
-resource "google_project_iam_member" "signify_secret_rotator_secret_version_accessor" {
-  project = data.google_project.project.project_id
-  role = "roles/secretmanager.secretAccessor"
-
-  member = "serviceAccount:${google_service_account.signify_secret_rotator.email}"
+resource "google_secret_manager_secret_iam_member" "signify_secret_rotator_secret_accessor" {
+  project   = data.google_project.project.project_id
+  secret_id = var.signify_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.signify_secret_rotator.email}"
 }
 
 // roles/secretmanager.secretVersionAdder is required to be able to add new versions to the secret in secret manager
-resource "google_project_iam_member" "signify_secret_rotator_secret_version_adder" {
-  project = data.google_project.project.project_id
-  role = "roles/secretmanager.secretVersionAdder"
-  member = "serviceAccount:${google_service_account.signify_secret_rotator.email}"
+resource "google_secret_manager_secret_iam_member" "signify_secret_rotator_secret_version_adder" {
+  project   = data.google_project.project.project_id
+  secret_id = var.signify_secret_id
+  role      = "roles/secretmanager.secretVersionAdder"
+  member    = "serviceAccount:${google_service_account.signify_secret_rotator.email}"
 }
 
 // roles/secretmanager.viewer is required to be able to access the secret in secret manager and read its metadata
-resource "google_project_iam_member" "service_account_keys_rotator_secret_version_viewer" {
+resource "google_secret_manager_secret_iam_member" "signify_secret_rotator_secret_viewer" {
+  project   = data.google_project.project.project_id
+  secret_id = var.signify_secret_id
+  role      = "roles/secretmanager.viewer"
+  member    = "serviceAccount:${google_service_account.signify_secret_rotator.email}"
+}
+
+// roles/logging.logWriter is required to write logs to Cloud Logging
+resource "google_project_iam_member" "signify_secret_rotator_log_writer" {
   project = data.google_project.project.project_id
-  role    = "roles/secretmanager.viewer"
-  member = "serviceAccount:${google_service_account.signify_secret_rotator.email}"  
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.signify_secret_rotator.email}"
+}
+
+// roles/errorreporting.writer is required to report errors to Cloud Error Reporting
+resource "google_project_iam_member" "signify_secret_rotator_error_reporting_writer" {
+  project = data.google_project.project.project_id
+  role    = "roles/errorreporting.writer"
+  member  = "serviceAccount:${google_service_account.signify_secret_rotator.email}"
 }
 
 resource "google_cloud_run_service_iam_member" "signify_secret_rotator_invoker" {

--- a/configs/terraform/modules/signify-secret-rotator/variables.tf
+++ b/configs/terraform/modules/signify-secret-rotator/variables.tf
@@ -1,3 +1,8 @@
+variable "signify_secret_id" {
+  type        = string
+  description = "Secret Manager secret ID of the Signify secret that the rotator reads and updates."
+}
+
 variable "region" {
   type        = string
   description = "Google Cloud region to deploy the signify secret rotator to."


### PR DESCRIPTION
## What changed
Replace project-level Secret Manager IAM bindings for `signify-rotator` SA with per-secret bindings scoped to `kyma-signify-prod`. Add `logging.logWriter` and `errorreporting.writer` to IaC with import blocks for existing bindings.

## Changes
- Replace 3x `google_project_iam_member` (secretAccessor, secretVersionAdder, viewer) with `google_secret_manager_secret_iam_member` scoped to `kyma-signify-prod` in `signify-secret-rotator` module
- Add `logging.logWriter` and `errorreporting.writer` as `google_project_iam_member` to IaC (project-level is correct for these)
- Add import blocks for logging/errorreporting bindings that exist in GCP
- Add `signify_secret_id` variable to module and prod environment

The secret was rotated manually so we have 9 days to fix possible errors after merge
![Uploading image.png…]()
