### PR TITLE
fix(terraform): remove prevent_destroy from legacy sa-kyma-project SAs

### DIFF
--- a/configs/terraform/environments/prod/service_accounts.tf
+++ b/configs/terraform/environments/prod/service_accounts.tf
@@ -33,10 +33,6 @@ resource "google_service_account" "sa-kyma-project" {
   display_name = "sa-kyma-project"
   description  = "SA to manage PROD Artifact Registry in SAP CX Kyma Project"
   disabled     = true
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "google_service_account" "sa-secret-update" {
@@ -60,10 +56,6 @@ resource "google_service_account" "sa-dev-kyma-project" {
   display_name = "sa-dev-kyma-project"
   description  = "SA to manage DEV Artifact Registry in SAP CX Kyma Project"
   disabled     = true
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 


### PR DESCRIPTION
## What changed
Remove `prevent_destroy` lifecycle from `sa-kyma-project` and `sa-dev-kyma-project` service accounts to allow Terraform to delete them. Both SAs are unused legacy accounts replaced by `azure-pipeline-image-builder@kyma-project`.

## Changes
- Remove `prevent_destroy = true` from `sa-kyma-project` and `sa-dev-kyma-project` in `service_accounts.tf`
- Both SAs have been disabled since 2026-07-24 with no observed breakage
- Audit logs confirm no activity in last 90 days — all AR pushes go through `azure-pipeline-image-builder@kyma-project`