### PR TITLE
fix(terraform): delete legacy sa-kyma-project and sa-dev-kyma-project SAs

### DIFF
--- a/configs/terraform/environments/prod/service_accounts.tf
+++ b/configs/terraform/environments/prod/service_accounts.tf
@@ -28,13 +28,6 @@ resource "google_service_account" "terraform-executor" {
   }
 }
 
-resource "google_service_account" "sa-kyma-project" {
-  account_id   = "sa-kyma-project"
-  display_name = "sa-kyma-project"
-  description  = "SA to manage PROD Artifact Registry in SAP CX Kyma Project"
-  disabled     = true
-}
-
 resource "google_service_account" "sa-secret-update" {
   account_id   = "sa-secret-update"
   display_name = "sa-secret-update"
@@ -49,13 +42,6 @@ resource "google_service_account" "sa-security-dashboard-oauth" {
   lifecycle {
     prevent_destroy = true
   }
-}
-
-resource "google_service_account" "sa-dev-kyma-project" {
-  account_id   = "sa-dev-kyma-project"
-  display_name = "sa-dev-kyma-project"
-  description  = "SA to manage DEV Artifact Registry in SAP CX Kyma Project"
-  disabled     = true
 }
 
 


### PR DESCRIPTION
## What changed
Remove `sa-kyma-project` and `sa-dev-kyma-project` service accounts from IaC to trigger their deletion in GCP. Both are unused legacy SAs superseded by `azure-pipeline-image-builder@kyma-project`.

## Changes
- Remove `sa-kyma-project` resource from `service_accounts.tf`
- Remove `sa-dev-kyma-project` resource from `service_accounts.tf`

## Evidence
- Audit logs: no activity in last 90 days for either SA
- All AR pushes to `kyma-project/prod` and `kyma-project/dev` confirmed going through `azure-pipeline-image-builder@kyma-project`
- Both SAs disabled since 2026-07-24 with no observed breakage
- `prevent_destroy` removed in #14434 (merged)
<img width="943" height="426" alt="image" src="https://github.com/user-attachments/assets/f7ca55fa-d8c2-4cb5-8552-28b7d3fde829" />
<img width="893" height="430" alt="image" src="https://github.com/user-attachments/assets/ce74cdda-b6f2-466b-bd99-ad66681e91eb" />
