### PR TITLE
fix(iac): allow tooling-infra staging branch to impersonate terraform-executor

### DIFF
--- a/configs/terraform/environments/prod/terraform-executor-variables.tf
+++ b/configs/terraform/environments/prod/terraform-executor-variables.tf
@@ -63,3 +63,9 @@ variable "internal_github_tooling_infra_terraform_deploy_identity_prod" {
   default     = "kyma/tooling-infra/.github/workflows/iac-deploy.yml:vtag"
   description = "Value of the deploy_identity attribute for the terraform deploy workflow in the tooling-infra repo on internal GitHub for prod. The deploy_identity attribute is derived from job_workflow_ref and only populated when the caller ref is a v-tag. Format: org/repo/.github/workflows/workflow.yml:vtag"
 }
+
+variable "internal_github_tooling_infra_terraform_deploy_identity_staging" {
+  type        = string
+  default     = "kyma/tooling-infra/.github/workflows/iac-deploy.yml:staging"
+  description = "Value of the deploy_identity attribute for the terraform deploy workflow in the tooling-infra repo on internal GitHub for staging. The deploy_identity attribute is derived from job_workflow_ref and only populated when the caller ref is refs/heads/staging. Format: org/repo/.github/workflows/workflow.yml:staging"
+}

--- a/configs/terraform/environments/prod/terraform-executor.tf
+++ b/configs/terraform/environments/prod/terraform-executor.tf
@@ -31,6 +31,9 @@ resource "google_service_account_iam_binding" "terraform_workload_identity" {
 
     # Internal GitHub Enterprise (github-tools-sap) — tooling-infra deploy workflow (prod, v-tag)
     "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.deploy_identity/${var.internal_github_tooling_infra_terraform_deploy_identity_prod}",
+
+    # Internal GitHub Enterprise (github-tools-sap) — tooling-infra deploy workflow (staging branch)
+    "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.deploy_identity/${var.internal_github_tooling_infra_terraform_deploy_identity_staging}",
   ]
   role               = "roles/iam.workloadIdentityUser"
   service_account_id = google_service_account.terraform_executor.name


### PR DESCRIPTION
## What does this PR do

The `iac-staging.yml` workflow in `kyma/tooling-infra` now triggers on pushes to both `main` and `staging` branches. When it runs from the `staging` branch, the OIDC token carries `job_workflow_ref: kyma/tooling-infra/.github/workflows/iac-deploy.yml@refs/heads/staging`, which the WIF provider maps to `deploy_identity: kyma/tooling-infra/.github/workflows/iac-deploy.yml:staging`.

Without this change, the `terraform_workload_identity` IAM binding has no member matching that attribute, so the `Authenticate to GCP` step fails with:

```
permission 'iam.serviceAccounts.getAccessToken' denied on resource
```

## Changes

- Add `internal_github_tooling_infra_terraform_deploy_identity_staging` variable (default: `kyma/tooling-infra/.github/workflows/iac-deploy.yml:staging`)
- Add the corresponding `principalSet` member to `google_service_account_iam_binding.terraform_workload_identity`
