### PR TITLE
feat(iac): add GitHub App secrets for internal GitHub terraform auth

### DIFF
--- a/configs/terraform/environments/prod/terraform-executor.tf
+++ b/configs/terraform/environments/prod/terraform-executor.tf
@@ -376,3 +376,137 @@ resource "google_secret_manager_secret_iam_member" "terraform_planner_github_app
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.terraform_planner.email}"
 }
+
+# ==============================================================================
+# GitHub App Authentication — internal GitHub (github.tools.sap) — executor
+# ==============================================================================
+# Replaces the long-lived PAT (iac-bot-gh-tools-sap-terraform-executor-token)
+# for the Terraform executor workflow. The App token is generated at runtime
+# via actions/create-github-app-token with github-api-url pointing to
+# github.tools.sap and passed as TF_VAR_internal_github_token.
+# Secret values must be added manually via GCP Console or CLI after App creation.
+# ==============================================================================
+
+resource "google_secret_manager_secret" "terraform_executor_internal_github_app_id" {
+  project   = var.terraform_executor_gcp_service_account.project_id
+  secret_id = "terraform-executor_internal-github-app-id"
+
+  replication {
+    auto {}
+  }
+
+  labels = {
+    type            = "github-app-id"
+    tool            = "iac"
+    github-instance = "internal"
+    owner           = "neighbors"
+  }
+}
+
+resource "google_secret_manager_secret" "terraform_executor_internal_github_app_private_key" {
+  project   = var.terraform_executor_gcp_service_account.project_id
+  secret_id = "terraform-executor_internal-github-app-private-key"
+
+  replication {
+    auto {}
+  }
+
+  labels = {
+    type            = "github-app-private-key"
+    tool            = "iac"
+    github-instance = "internal"
+    owner           = "neighbors"
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "terraform_executor_internal_github_app_id_reader" {
+  project   = var.terraform_executor_gcp_service_account.project_id
+  secret_id = google_secret_manager_secret.terraform_executor_internal_github_app_id.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.terraform_executor.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "terraform_executor_internal_github_app_private_key_reader" {
+  project   = var.terraform_executor_gcp_service_account.project_id
+  secret_id = google_secret_manager_secret.terraform_executor_internal_github_app_private_key.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.terraform_executor.email}"
+}
+
+resource "github_actions_variable" "terraform_executor_internal_github_app_id_secret_name" {
+  provider      = github.kyma_project
+  repository    = "test-infra"
+  variable_name = "GH_TERRAFORM_EXECUTOR_INTERNAL_APP_ID_SECRET_NAME"
+  value         = google_secret_manager_secret.terraform_executor_internal_github_app_id.secret_id
+}
+
+resource "github_actions_variable" "terraform_executor_internal_github_app_private_key_secret_name" {
+  provider      = github.kyma_project
+  repository    = "test-infra"
+  variable_name = "GH_TERRAFORM_EXECUTOR_INTERNAL_APP_PRIVATE_KEY_SECRET_NAME"
+  value         = google_secret_manager_secret.terraform_executor_internal_github_app_private_key.secret_id
+}
+
+# ==============================================================================
+# GitHub App Authentication — internal GitHub (github.tools.sap) — planner
+# ==============================================================================
+
+resource "google_secret_manager_secret" "terraform_planner_internal_github_app_id" {
+  project   = var.terraform_executor_gcp_service_account.project_id
+  secret_id = "terraform-planner_internal-github-app-id"
+
+  replication {
+    auto {}
+  }
+
+  labels = {
+    type            = "github-app-id"
+    tool            = "iac"
+    github-instance = "internal"
+    owner           = "neighbors"
+  }
+}
+
+resource "google_secret_manager_secret" "terraform_planner_internal_github_app_private_key" {
+  project   = var.terraform_executor_gcp_service_account.project_id
+  secret_id = "terraform-planner_internal-github-app-private-key"
+
+  replication {
+    auto {}
+  }
+
+  labels = {
+    type            = "github-app-private-key"
+    tool            = "iac"
+    github-instance = "internal"
+    owner           = "neighbors"
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "terraform_planner_internal_github_app_id_reader" {
+  project   = var.terraform_executor_gcp_service_account.project_id
+  secret_id = google_secret_manager_secret.terraform_planner_internal_github_app_id.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.terraform_planner.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "terraform_planner_internal_github_app_private_key_reader" {
+  project   = var.terraform_executor_gcp_service_account.project_id
+  secret_id = google_secret_manager_secret.terraform_planner_internal_github_app_private_key.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.terraform_planner.email}"
+}
+
+resource "github_actions_variable" "terraform_planner_internal_github_app_id_secret_name" {
+  provider      = github.kyma_project
+  repository    = "test-infra"
+  variable_name = "GH_TERRAFORM_PLANNER_INTERNAL_APP_ID_SECRET_NAME"
+  value         = google_secret_manager_secret.terraform_planner_internal_github_app_id.secret_id
+}
+
+resource "github_actions_variable" "terraform_planner_internal_github_app_private_key_secret_name" {
+  provider      = github.kyma_project
+  repository    = "test-infra"
+  variable_name = "GH_TERRAFORM_PLANNER_INTERNAL_APP_PRIVATE_KEY_SECRET_NAME"
+  value         = google_secret_manager_secret.terraform_planner_internal_github_app_private_key.secret_id
+}

--- a/configs/terraform/environments/prod/terraform-executor.tf
+++ b/configs/terraform/environments/prod/terraform-executor.tf
@@ -380,11 +380,7 @@ resource "google_secret_manager_secret_iam_member" "terraform_planner_github_app
 # ==============================================================================
 # GitHub App Authentication — internal GitHub (github.tools.sap) — executor
 # ==============================================================================
-# Replaces the long-lived PAT (iac-bot-gh-tools-sap-terraform-executor-token)
-# for the Terraform executor workflow. The App token is generated at runtime
-# via actions/create-github-app-token with github-api-url pointing to
-# github.tools.sap and passed as TF_VAR_internal_github_token.
-# Secret values must be added manually via GCP Console or CLI after App creation.
+# Replaces the long-lived PAT (iac-bot-gh-tools-sap-terraform-executor-token).
 # ==============================================================================
 
 resource "google_secret_manager_secret" "terraform_executor_internal_github_app_id" {
@@ -449,6 +445,9 @@ resource "github_actions_variable" "terraform_executor_internal_github_app_priva
 
 # ==============================================================================
 # GitHub App Authentication — internal GitHub (github.tools.sap) — planner
+# ==============================================================================
+# Replaces the long-lived PAT (iac-bot-gh-tools-sap-terraform-planner-token).
+# Secret values must be added manually after App creation.
 # ==============================================================================
 
 resource "google_secret_manager_secret" "terraform_planner_internal_github_app_id" {


### PR DESCRIPTION
## What changed

Adds GCP Secret Manager containers and IAM bindings for GitHub App credentials (app ID + private key) used by Terraform planner and executor to authenticate against github.tools.sap. This is the IaC prerequisite for replacing long-lived PATs with short-lived GitHub App tokens in CI workflows.

## Changes

- Add 4 secret containers in `sap-kyma-prow`: `terraform-executor_internal-github-app-id`, `terraform-executor_internal-github-app-private-key`, `terraform-planner_internal-github-app-id`, `terraform-planner_internal-github-app-private-key`
- Grant `secretAccessor` IAM to the respective terraform SA for each secret
- Expose secret names as GitHub Actions repository variables (`GH_TERRAFORM_EXECUTOR_INTERNAL_APP_ID_SECRET_NAME` etc.) via `github.kyma_project` provider
