### PR TITLE
feat(ci): replace internal GitHub PAT with GitHub App token in terraform workflows

### DIFF
--- a/.github/workflows/post-apply-prod-terraform.yaml
+++ b/.github/workflows/post-apply-prod-terraform.yaml
@@ -47,15 +47,25 @@ jobs:
           secrets: |-
              terraform-executor-app-id:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_EXECUTOR_APP_ID_SECRET_NAME }}
              terraform-executor-app-private-key:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_EXECUTOR_APP_PRIVATE_KEY_SECRET_NAME }}
-             internal-github-terraform-executor-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.INTERNAL_GITHUB_TERRAFORM_EXECUTOR_SECRET_NAME }}
+             terraform-executor-internal-app-id:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_EXECUTOR_INTERNAL_APP_ID_SECRET_NAME }}
+             terraform-executor-internal-app-private-key:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_EXECUTOR_INTERNAL_APP_PRIVATE_KEY_SECRET_NAME }}
 
-      - name: Generate GitHub App token for Terraform Executor
+      - name: Generate GitHub App token for Terraform Executor (github.com)
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ steps.secrets.outputs.terraform-executor-app-id }}
           private-key: ${{ steps.secrets.outputs.terraform-executor-app-private-key }}
           owner: ${{ github.repository_owner }}
+
+      - name: Generate GitHub App token for Terraform Executor (github.tools.sap)
+        id: app-token-internal
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ steps.secrets.outputs.terraform-executor-internal-app-id }}
+          private-key: ${{ steps.secrets.outputs.terraform-executor-internal-app-private-key }}
+          owner: kyma
+          github-api-url: https://github.tools.sap/api/v3
 
       - name: Setup Terraform
         id: setup_terraform
@@ -74,6 +84,6 @@ jobs:
       # I do prefer to keep consistent format of identifiers in IaC config rather than env variables in github action workflow. Thats the reason env var name uses mixed caps.
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          TF_VAR_internal_github_token: ${{ steps.secrets.outputs.internal-github-terraform-executor-token }}
+          TF_VAR_internal_github_token: ${{ steps.app-token-internal.outputs.token }}
         id: terraform_apply
         run: tfcmt -owner $GITHUB_REPOSITORY_OWNER -repo ${{ github.event.repository.name }} -sha ${{ github.sha }} apply -- tofu -chdir=./configs/terraform/environments/prod apply -input=false -no-color -auto-approve -lock-timeout=400s

--- a/.github/workflows/pull-plan-prod-terraform.yaml
+++ b/.github/workflows/pull-plan-prod-terraform.yaml
@@ -47,15 +47,25 @@ jobs:
           secrets: |-
              terraform-planner-app-id:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_PLANNER_APP_ID_SECRET_NAME }}
              terraform-planner-app-private-key:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_PLANNER_APP_PRIVATE_KEY_SECRET_NAME }}
-             internal-github-terraform-planner-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.INTERNAL_GITHUB_TERRAFORM_PLANNER_SECRET_NAME }}
+             terraform-planner-internal-app-id:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_PLANNER_INTERNAL_APP_ID_SECRET_NAME }}
+             terraform-planner-internal-app-private-key:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_PLANNER_INTERNAL_APP_PRIVATE_KEY_SECRET_NAME }}
 
-      - name: Generate GitHub App token for Terraform Planner
+      - name: Generate GitHub App token for Terraform Planner (github.com)
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ steps.secrets.outputs.terraform-planner-app-id }}
           private-key: ${{ steps.secrets.outputs.terraform-planner-app-private-key }}
           owner: ${{ github.repository_owner }}
+
+      - name: Generate GitHub App token for Terraform Planner (github.tools.sap)
+        id: app-token-internal
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ steps.secrets.outputs.terraform-planner-internal-app-id }}
+          private-key: ${{ steps.secrets.outputs.terraform-planner-internal-app-private-key }}
+          owner: kyma
+          github-api-url: https://github.tools.sap/api/v3
 
       - name: Setup Terraform
         id: setup_terraform
@@ -83,7 +93,7 @@ jobs:
       # I do prefer to keep consistent format of identifiers in IaC config rather than env variables in github action workflow. Thats the reason env var name uses mixed caps.
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          TF_VAR_internal_github_token: ${{ steps.secrets.outputs.internal-github-terraform-planner-token }}
+          TF_VAR_internal_github_token: ${{ steps.app-token-internal.outputs.token }}
         id: terraform_plan
         run: tfcmt -owner $GITHUB_REPOSITORY_OWNER -repo ${{ github.event.repository.name }} -pr ${{ github.event.pull_request.number || 0 }} -sha ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }} plan -- tofu -chdir=./configs/terraform/environments/prod plan -input=false -no-color -lock-timeout=400s
 

--- a/.github/workflows/tofu-drift-detection.yml
+++ b/.github/workflows/tofu-drift-detection.yml
@@ -40,15 +40,25 @@ jobs:
           secrets: |-
             terraform-planner-app-id:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_PLANNER_APP_ID_SECRET_NAME }}
             terraform-planner-app-private-key:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_PLANNER_APP_PRIVATE_KEY_SECRET_NAME }}
-            internal-github-terraform-planner-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.INTERNAL_GITHUB_TERRAFORM_PLANNER_SECRET_NAME }}
+            terraform-planner-internal-app-id:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_PLANNER_INTERNAL_APP_ID_SECRET_NAME }}
+            terraform-planner-internal-app-private-key:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TERRAFORM_PLANNER_INTERNAL_APP_PRIVATE_KEY_SECRET_NAME }}
 
-      - name: Generate GitHub App token for Terraform Planner
+      - name: Generate GitHub App token for Terraform Planner (github.com)
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ steps.secrets.outputs.terraform-planner-app-id }}
           private-key: ${{ steps.secrets.outputs.terraform-planner-app-private-key }}
           owner: ${{ github.repository_owner }}
+
+      - name: Generate GitHub App token for Terraform Planner (github.tools.sap)
+        id: app-token-internal
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ steps.secrets.outputs.terraform-planner-internal-app-id }}
+          private-key: ${{ steps.secrets.outputs.terraform-planner-internal-app-private-key }}
+          owner: kyma
+          github-api-url: https://github.tools.sap/api/v3
 
       - name: Tofu init
         id: tofu_init
@@ -58,7 +68,7 @@ jobs:
         id: tofu_plan
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          TF_VAR_internal_github_token: ${{ steps.secrets.outputs.internal-github-terraform-planner-token }}
+          TF_VAR_internal_github_token: ${{ steps.app-token-internal.outputs.token }}
         run: |
           exitcode=0
           tofu plan -detailed-exitcode -no-color -out plan || exitcode=$?


### PR DESCRIPTION
## What changed

Update the three Terraform CI workflows to generate short-lived tokens for github.tools.sap via `actions/create-github-app-token` instead of reading a long-lived PAT from Secret Manager. The new GitHub App credentials (app ID + private key) are fetched from GCP Secret Manager and referenced via Actions variables set by the IaC in PR #14440.

## Changes

- `post-apply-prod-terraform.yaml` — replace PAT fetch with App credentials fetch + `create-github-app-token` step for github.tools.sap
- `pull-plan-prod-terraform.yaml` — same
- `tofu-drift-detection.yml` — same

> [!WARNING]
> This PR depends on #14440 being merged and applied first. The GitHub Actions variables `GH_TERRAFORM_EXECUTOR_INTERNAL_APP_ID_SECRET_NAME`, `GH_TERRAFORM_EXECUTOR_INTERNAL_APP_PRIVATE_KEY_SECRET_NAME`, `GH_TERRAFORM_PLANNER_INTERNAL_APP_ID_SECRET_NAME` and `GH_TERRAFORM_PLANNER_INTERNAL_APP_PRIVATE_KEY_SECRET_NAME` are set by the IaC in that PR. Without them, these workflows will fail to fetch secrets.
>
> Additionally, the GitHub App on github.tools.sap must be created and its credentials populated in GCP Secret Manager before merging this PR.
