### PR TITLE
feat(iac): add installation ID secrets for internal GitHub App terraform authentication

### DIFF
--- a/configs/terraform/environments/prod/terraform-executor.tf
+++ b/configs/terraform/environments/prod/terraform-executor.tf
@@ -384,3 +384,69 @@ resource "github_actions_variable" "terraform_planner_internal_github_app_privat
   variable_name = "GH_TERRAFORM_PLANNER_INTERNAL_APP_PRIVATE_KEY_SECRET_NAME"
   value         = google_secret_manager_secret.terraform_planner_internal_github_app_private_key.secret_id
 }
+
+# ==============================================================================
+# GitHub App Authentication — internal GitHub (github.tools.sap) — installation IDs
+# ==============================================================================
+# Installation ID is not sensitive but stored as a secret for consistency.
+# ==============================================================================
+
+resource "google_secret_manager_secret" "terraform_executor_internal_github_app_installation_id" {
+  project   = var.terraform_executor_gcp_service_account.project_id
+  secret_id = "terraform-executor_internal-github-app-installation-id"
+
+  replication {
+    auto {}
+  }
+
+  labels = {
+    type            = "github-app-installation-id"
+    tool            = "iac"
+    github-instance = "internal"
+    owner           = "neighbors"
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "terraform_executor_internal_github_app_installation_id_reader" {
+  project   = var.terraform_executor_gcp_service_account.project_id
+  secret_id = google_secret_manager_secret.terraform_executor_internal_github_app_installation_id.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.terraform_executor.email}"
+}
+
+resource "github_actions_variable" "terraform_executor_internal_github_app_installation_id_secret_name" {
+  provider      = github.kyma_project
+  repository    = "test-infra"
+  variable_name = "GH_TERRAFORM_EXECUTOR_INTERNAL_APP_INSTALLATION_ID_SECRET_NAME"
+  value         = google_secret_manager_secret.terraform_executor_internal_github_app_installation_id.secret_id
+}
+
+resource "google_secret_manager_secret" "terraform_planner_internal_github_app_installation_id" {
+  project   = var.terraform_executor_gcp_service_account.project_id
+  secret_id = "terraform-planner_internal-github-app-installation-id"
+
+  replication {
+    auto {}
+  }
+
+  labels = {
+    type            = "github-app-installation-id"
+    tool            = "iac"
+    github-instance = "internal"
+    owner           = "neighbors"
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "terraform_planner_internal_github_app_installation_id_reader" {
+  project   = var.terraform_executor_gcp_service_account.project_id
+  secret_id = google_secret_manager_secret.terraform_planner_internal_github_app_installation_id.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.terraform_planner.email}"
+}
+
+resource "github_actions_variable" "terraform_planner_internal_github_app_installation_id_secret_name" {
+  provider      = github.kyma_project
+  repository    = "test-infra"
+  variable_name = "GH_TERRAFORM_PLANNER_INTERNAL_APP_INSTALLATION_ID_SECRET_NAME"
+  value         = google_secret_manager_secret.terraform_planner_internal_github_app_installation_id.secret_id
+}


### PR DESCRIPTION
# What changed
Adds GCP Secret Manager containers for GitHub App installation IDs for the internal GitHub (github.tools.sap) terraform-planner and terraform-executor Apps. The installation ID is stored as a secret (alongside existing app-id and private-key) so it's managed consistently and accessible via the same IAM path.

## Changes
Add terraform-planner_internal-github-app-installation-id secret container + secretAccessor IAM for planner SA
Add terraform-executor_internal-github-app-installation-id secret container + secretAccessor IAM for executor SA
Expose both secret names as GitHub Actions variables (GH_TERRAFORM_PLANNER_INTERNAL_APP_INSTALLATION_ID_SECRET_NAME, GH_TERRAFORM_EXECUTOR_INTERNAL_APP_INSTALLATION_ID_SECRET_NAME)