### PR TITLE
fix(ci): rely on the lock timeout instead of external action

### DIFF
--- a/.github/workflows/pull-plan-prod-terraform.yaml
+++ b/.github/workflows/pull-plan-prod-terraform.yaml
@@ -27,12 +27,6 @@ jobs:
         with:
           allow-unsafe-pr-checkout: "true"
 
-      - name: Wait for other terraform executions
-        id: wait_for_terraform
-        uses: ahmadnassri/action-workflow-queue@542658b3a8270cac81ae15d401b0d974732808ac # v1.2.0
-        with:
-          timeout: 1800000 # 30 minutes in milliseconds
-
       - name: Authenticate to GCP
         id: gcp_auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3


### PR DESCRIPTION
Currently only pull-plan-terraform uses action to wait for other executions. The action is also waiting for workflwo runs which are in waiting status, waiting for approval. That behavior is causing lock adn failure of the workflwo runs.

The proposed change is to use tofu's native lock timeout instead. Primary it's locking the state for exact time needed to execute the plan or apply. Second benefit is that it won't cause dead-lock as it's idependent of runner on which terraform was started.
