### PR TITLE
feat(iac): add tooling-infra repository_id WIF binding for terraform-planner

### DIFF
--- a/configs/terraform/environments/prod/terraform-executor.tf
+++ b/configs/terraform/environments/prod/terraform-executor.tf
@@ -1,3 +1,8 @@
+data "github_repository" "tooling_infra" {
+  provider = github.internal_github
+  name     = "tooling-infra"
+}
+
 # Create the terraform executor Google Cloud service account.
 # It grants owner rights to the Google Cloud service account. The owner role is required to let
 # the terraform executor manage all the resources in the Google Cloud project.
@@ -94,6 +99,9 @@ resource "google_service_account_iam_binding" "terraform_planner_workload_identi
 
     # Internal GitHub Enterprise (github-tools-sap) — tooling-infra validate workflow
     "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.reusable_workflow_ref/${var.internal_github_tooling_infra_terraform_validate_reusable_workflow_ref}",
+
+    # Internal GitHub Enterprise (github-tools-sap) — any workflow in kyma/tooling-infra
+    "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.repository_id/${data.github_repository.tooling_infra.repo_id}",
   ]
   role               = "roles/iam.workloadIdentityUser"
   service_account_id = google_service_account.terraform_planner.name


### PR DESCRIPTION
## What changed

Adds a `principalSet` WIF binding scoped to `attribute.repository_id` for the `kyma/tooling-infra` repository, granting all its workflows the ability to impersonate the `terraform-planner` service account. The repository ID is resolved dynamically via a `github_repository` data source instead of being hardcoded.

## Changes

- Add `data "github_repository" "tooling_infra"` using the `github.internal_github` provider
- Add `principalSet://…/attribute.repository_id/${data.github_repository.tooling_infra.repo_id}` to `google_service_account_iam_binding.terraform_planner_workload_identity`