### PR TITLE
fix: shorter renovate external images bumps

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -53,15 +53,15 @@
       "groupName": "docker images"
     },
     {
-    "matchManagers": ["regex"],
-    "matchDatasources": ["docker"],
-    "matchCurrentVersion": "!/v?\\d+\\.\\d+\\.\\d+/",
-    "versioning": "loose",
-    "groupName": "custom docker images (loose) to {{newVersion}}",
-    "commitMessageTopic": "custom docker images (loose) to {{newVersion}}",
-    "commitMessageExtra": "",
-    "separateMajorMinor": false,
-    "maxMajorIncrement": 0
+      "matchManagers": ["regex"],
+      "matchDatasources": ["docker"],
+      "matchCurrentVersion": "!/v?\\d+\\.\\d+\\.\\d+/",
+      "versioning": "loose",
+      "groupName": "custom docker images (loose) to {{newVersion}}",
+      "commitMessageTopic": "custom docker images (loose) to {{newVersion}}",
+      "commitMessageExtra": "",
+      "separateMajorMinor": false,
+      "maxMajorIncrement": 0
     },
     {
       "matchManagers": ["regex"],
@@ -72,6 +72,12 @@
       "commitMessageTopic": "custom docker images (semver) to {{newVersion}}",
       "commitMessageExtra": "",
       "separateMajorMinor": false
+    },
+    {
+      "matchDepNames": [
+        "europe-docker.pkg.dev/kyma-project/prod/external/library/**"
+      ],
+      "commitMessageTopic": "docker prod external images"
     }
   ],
 


### PR DESCRIPTION
Currently for some repos the bumps of synced external docker images are causing failures on the conform check due to too long descirption.

This PR shorters it globally to less emaningfull, but shorter version. Exact images list will be kept in the PR description.
