### PR TITLE
fix: shortcut docker image bumps from our registries

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -50,7 +50,7 @@
     },
     {
       "matchDatasources": ["docker"],
-      "groupName": "docker images"
+      "groupName": "docker deps"
     },
     {
       "matchManagers": ["regex"],
@@ -77,7 +77,19 @@
       "matchDepNames": [
         "europe-docker.pkg.dev/kyma-project/prod/external/library/**"
       ],
-      "commitMessageTopic": "docker prod external images"
+      "commitMessageTopic": "external/library image"
+    },
+    {
+      "matchDepNames": [
+        "europe-docker.pkg.dev/kyma-project/prod/**"
+      ],
+      "commitMessageTopic": "prod image"
+    },
+    {
+      "matchDepNames": [
+        "europe-docker.pkg.dev/kyma-project/dev/**"
+      ],
+      "commitMessageTopic": "dev image"
     }
   ],
 


### PR DESCRIPTION
Currently the conform is failing for some of our images due to too long description. Instead of changing value in conform config for each repo, I propose to shortcut commit messages for docker images centrally in renovate config