### PR TITLE
feat: support external-images.yaml by renvoate

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -97,6 +97,18 @@
       "depNameTemplate": "{{depName}}",
       "currentValueTemplate": "{{currentValue}}",
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/external-images\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "source:\\s*\"(?<depName>[^:\"]+):(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "{{depName}}",
+      "currentValueTemplate": "{{currentValue}}",
+      "datasourceTemplate": "docker"
     }
   ]
 }


### PR DESCRIPTION
Currently renovate don't bump our external-images files, so we're stuck on single dependecies verison. Even with inline comment renovate refuses to bump the sourcce image. To fix that, added a globally manager to bump that files