### PR TITLE
fix: add additional semver compatible PR tag

### DIFF
--- a/.github/actions/image-builder/action.yml
+++ b/.github/actions/image-builder/action.yml
@@ -103,6 +103,9 @@ runs:
             result+=" --tag=\"$entry\""
           fi
         done
+        if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "pull_request_target" ]]; then
+          result+=" --tag=\"v{{ .PRNumber }}-PR\""
+        fi
         echo "tags=$result" >> $GITHUB_OUTPUT
       id: prepare-tags
       shell: bash


### PR DESCRIPTION
Current PR-123 tags aren't semver compatible and are blocking tests of PR images. The proposed fix is the simplest and fastest way to add an additional semver compatible tag.
