### PR TITLE
fix: delete all dev artifact registry images older than 30 days

### DIFF
--- a/configs/terraform/environments/prod/artifact-registry-variables.tf
+++ b/configs/terraform/environments/prod/artifact-registry-variables.tf
@@ -73,15 +73,14 @@ variable "dev_docker_repository" {
       }
       },
       {
-        id     = "delete-old-pr-images"
+        id     = "delete-old-images"
         action = "DELETE"
         condition = {
           tag_state = "TAGGED"
           # Google provider does not support the time units,
           # so we need to provide the time in seconds.
           # Time after which the images will be deleted.
-          older_than   = "2592000s" # 2592000s = 720h = 30 days
-          tag_prefixes = ["PR-"]
+          older_than = "2592000s" # 2592000s = 720h = 30 days
         }
     }]
 

--- a/configs/terraform/environments/prod/restricted-registry-variables.tf
+++ b/configs/terraform/environments/prod/restricted-registry-variables.tf
@@ -83,12 +83,11 @@ variable "kyma_restricted_images_dev" {
         }
       },
       {
-        id     = "delete-old-pr-images"
+        id     = "delete-old-images"
         action = "DELETE"
         condition = {
-          tag_state    = "TAGGED"
-          older_than   = "2592000s"
-          tag_prefixes = ["PR-"]
+          tag_state  = "TAGGED"
+          older_than = "2592000s"
         }
       }
     ]


### PR DESCRIPTION
## Summary

- Remove `tag_prefixes = ["PR-"]` restriction from the `delete-old-images` cleanup policy in both dev artifact registries (`dev` and `kyma-restricted-images-dev`)
- All tagged images older than 30 days will now be deleted, not only those with the `PR-` prefix
- Rename policy id from `delete-old-pr-images` to `delete-old-images` to reflect the broader scope

## Related issues

- https://github.tools.sap/kyma/test-infra/issues/1408
- https://github.tools.sap/kyma/oci-image-builder/issues/396

## Test plan

- [ ] Verify Terraform plan shows updated cleanup policies for `dev` and `kyma-restricted-images-dev` registries