### PR TITLE
feat: use 0.0.0-MG.<sha> tag for image-builder merge-group artifacts in dev

### DIFF
--- a/.github/actions/image-builder/action.yml
+++ b/.github/actions/image-builder/action.yml
@@ -107,7 +107,7 @@ runs:
           result+=" --tag=\"v{{ .PRNumber }}-PR\""
         fi
         if [[ "${{ github.event_name }}" == "merge_group" ]]; then
-          result+=" --tag=\"MG-{{ .ShortSHA }}\""
+          result+=" --tag=\"0.0.0-MG.{{ .ShortSHA }}\""
         fi
         echo "tags=$result" >> $GITHUB_OUTPUT
       id: prepare-tags

--- a/.github/actions/image-builder/action.yml
+++ b/.github/actions/image-builder/action.yml
@@ -106,6 +106,9 @@ runs:
         if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "pull_request_target" ]]; then
           result+=" --tag=\"v{{ .PRNumber }}-PR\""
         fi
+        if [[ "${{ github.event_name }}" == "merge_group" ]]; then
+          result+=" --tag=\"MG-{{ .ShortSHA }}\""
+        fi
         echo "tags=$result" >> $GITHUB_OUTPUT
       id: prepare-tags
       shell: bash

--- a/.github/actions/image-builder/action.yml
+++ b/.github/actions/image-builder/action.yml
@@ -106,9 +106,6 @@ runs:
         if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "pull_request_target" ]]; then
           result+=" --tag=\"v{{ .PRNumber }}-PR\""
         fi
-        if [[ "${{ github.event_name }}" == "merge_group" ]]; then
-          result+=" --tag=\"0.0.0-MG.{{ .ShortSHA }}\""
-        fi
         echo "tags=$result" >> $GITHUB_OUTPUT
       id: prepare-tags
       shell: bash

--- a/cmd/image-builder/config.go
+++ b/cmd/image-builder/config.go
@@ -42,6 +42,10 @@ type Config struct {
 	// The value can be a go-template string or literal tag value string.
 	// See tags.Tag struct for more information and available fields
 	DefaultPRTag tags.Tag `yaml:"default-pr-tag" json:"default-pr-tag"`
+	// Default Tag template used for images build on merge group event.
+	// The value can be a go-template string or literal tag value string.
+	// See tags.Tag struct for more information and available fields
+	DefaultMergeGroupTag tags.Tag `yaml:"default-merge-group-tag" json:"default-merge-group-tag"`
 	// LogFormat defines the format docker buildx logs are projected.
 	// Supported formats are 'color', 'text' and 'json'. Default: 'color'
 	LogFormat string `yaml:"log-format" json:"log-format"`

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -742,6 +742,10 @@ func parseTags(logger Logger, o options) ([]tags.Tag, error) {
 		pr = fmt.Sprint(o.gitState.PullRequestNumber)
 		logger.Debugw("Running for pull request event, PR number found", "pr-number", pr)
 	}
+	if o.gitState.JobType == "merge_group" && o.gitState.PullHeadCommitSHA != "" {
+		sha = o.gitState.PullHeadCommitSHA
+		logger.Debugw("running for merge_group event, pull head commit SHA found", "sha", sha)
+	}
 
 	// TODO (dekiel): Tags provided as base64 encoded string should be parsed and added to the tags list when parsing flags.
 	//   This way all tags are available in the tags list from thr very beginning of execution and can be used in any process.
@@ -792,6 +796,10 @@ func parseTags(logger Logger, o options) ([]tags.Tag, error) {
 // The default tag is read from the provided 'options' struct.
 func getDefaultTag(logger Logger, o options) (tags.Tag, error) {
 	logger.Debugw("reading gitstate data")
+	if o.gitState.JobType == "merge_group" {
+		logger.Debugw("merge_group event, returning default merge group tag")
+		return o.DefaultMergeGroupTag, nil
+	}
 	if o.gitState.isPullRequest && o.gitState.PullRequestNumber > 0 {
 		logger.Debugw("pull request number provided, returning default pr tag")
 		return o.DefaultPRTag, nil

--- a/configs/image-builder-client-config.yaml
+++ b/configs/image-builder-client-config.yaml
@@ -1,8 +1,8 @@
 log-format: json
 default-merge-group-tag:
   name: default_tag
-  value: "MG-{{ .ShortSHA }}"
-  validation: "^MG-[0-9a-f]{8}$"
+  value: "0.0.0-MG.{{ .ShortSHA }}"
+  validation: "^0\\.0\\.0-MG\\.[0-9a-f]{8}$"
 ado-config:
   ado-organization-url: https://dev.azure.com/hyperspace-pipelines
   ado-project-name: kyma

--- a/configs/image-builder-client-config.yaml
+++ b/configs/image-builder-client-config.yaml
@@ -1,4 +1,8 @@
 log-format: json
+default-merge-group-tag:
+  name: default_tag
+  value: "MG-{{ .ShortSHA }}"
+  validation: "^MG-[0-9a-f]{8}$"
 ado-config:
   ado-organization-url: https://dev.azure.com/hyperspace-pipelines
   ado-project-name: kyma


### PR DESCRIPTION
## Summary

- Add `DefaultMergeGroupTag` field to `Config` struct (`default-merge-group-tag` in yaml/json)
- In `parseTags`: set SHA from `PullHeadCommitSHA` for `merge_group` events so `{{ .ShortSHA }}` is populated in tag templates
- In `getDefaultTag`: return `DefaultMergeGroupTag` for `merge_group` events (takes priority over PR/commit tag logic)
- In `action.yml`: inject `0.0.0-MG.{{ .ShortSHA }}` tag automatically for `merge_group` events (mirrors how `PR-<n>` is injected for pull requests)
- In `image-builder-client-config.yaml`: configure `default-merge-group-tag` as `0.0.0-MG.{{ .ShortSHA }}` for the ADO path

## Result

| Event | Tag format | OCM-compatible | Registry |
|---|---|---|---|
| `pull_request` | `PR-<number>` | No | dev |
| `merge_group` | `0.0.0-MG.<sha>` | Yes ✓ | dev |
| `push`/`postsubmit` | `v<date>-<sha>` | Yes ✓ | prod |

The `0.0.0-MG.<sha>` format satisfies the OCM semver pattern:
```
^[v]?(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:\.(0|[1-9]\d*))?(?:-(...))?...
```
so merge-group images can be used as OCM component resource versions without errors.

## Related issues

- https://github.tools.sap/kyma/oci-image-builder/issues/396
- https://github.tools.sap/kyma/test-infra/issues/1408

## Test plan

- [x] Verify `go test ./cmd/image-builder/...` passes (done locally)
- [x] Trigger a merge-group build and confirm the image is tagged `0.0.0-MG.<sha>` in the dev artifact registry
- [x] Confirm `vYYYYMMDD-<sha>` tags are no longer produced for merge-group events in dev
- [x] Verify OCM artifact generation succeeds with the new tag format