### PR TITLE
fix: add semver-compatible additional PR tag via image-builder config

### DIFF
--- a/.github/actions/image-builder/action.yml
+++ b/.github/actions/image-builder/action.yml
@@ -103,9 +103,6 @@ runs:
             result+=" --tag=\"$entry\""
           fi
         done
-        if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "pull_request_target" ]]; then
-          result+=" --tag=\"v{{ .PRNumber }}-PR\""
-        fi
         echo "tags=$result" >> $GITHUB_OUTPUT
       id: prepare-tags
       shell: bash

--- a/cmd/image-builder/config.go
+++ b/cmd/image-builder/config.go
@@ -46,6 +46,10 @@ type Config struct {
 	// The value can be a go-template string or literal tag value string.
 	// See tags.Tag struct for more information and available fields
 	DefaultMergeGroupTag tags.Tag `yaml:"default-merge-group-tag" json:"default-merge-group-tag"`
+	// AdditionalPRTag is an extra tag added for pull request builds alongside DefaultPRTag.
+	// The value can be a go-template string or literal tag value string.
+	// See tags.Tag struct for more information and available fields
+	AdditionalPRTag tags.Tag `yaml:"additional-pr-tag" json:"additional-pr-tag"`
 	// LogFormat defines the format docker buildx logs are projected.
 	// Supported formats are 'color', 'text' and 'json'. Default: 'color'
 	LogFormat string `yaml:"log-format" json:"log-format"`

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -741,6 +741,10 @@ func parseTags(logger Logger, o options) ([]tags.Tag, error) {
 	if o.gitState.isPullRequest && o.gitState.PullRequestNumber > 0 {
 		pr = fmt.Sprint(o.gitState.PullRequestNumber)
 		logger.Debugw("Running for pull request event, PR number found", "pr-number", pr)
+		if len(o.AdditionalPRTag.Value) > 0 {
+			o.tags = append(o.tags, o.AdditionalPRTag)
+			logger.Debugw("additional PR tag appended", "tag", o.AdditionalPRTag.Value)
+		}
 	}
 	if o.gitState.JobType == "merge_group" && o.gitState.PullHeadCommitSHA != "" {
 		sha = o.gitState.PullHeadCommitSHA

--- a/configs/image-builder-client-config.yaml
+++ b/configs/image-builder-client-config.yaml
@@ -3,8 +3,8 @@ default-merge-group-tag:
   name: default_tag
   value: "0.0.0-MG.{{ .ShortSHA }}"
   validation: "^0\\.0\\.0-MG\\.[0-9a-f]{8}$"
-default-pr-tag:
-  name: default_tag
+additional-pr-tag:
+  name: semver_pr_tag
   value: "v{{ .PRNumber }}-PR"
   validation: "^v[0-9]+-PR$"
 ado-config:

--- a/configs/image-builder-client-config.yaml
+++ b/configs/image-builder-client-config.yaml
@@ -3,6 +3,10 @@ default-merge-group-tag:
   name: default_tag
   value: "0.0.0-MG.{{ .ShortSHA }}"
   validation: "^0\\.0\\.0-MG\\.[0-9a-f]{8}$"
+default-pr-tag:
+  name: default_tag
+  value: "v{{ .PRNumber }}-PR"
+  validation: "^v[0-9]+-PR$"
 ado-config:
   ado-organization-url: https://dev.azure.com/hyperspace-pipelines
   ado-project-name: kyma


### PR DESCRIPTION
## Summary

- Add `AdditionalPRTag tags.Tag` field to `Config` struct (yaml key: `additional-pr-tag`)
- In `parseTags`: for `pull_request`/`pull_request_target` events, append `AdditionalPRTag` to the tags list so it is generated **in addition to** any existing default PR tag — not instead of it
- Remove `v{{ .PRNumber }}-PR` shell injection from `action.yml` (previously added in #14492)
- Configure `additional-pr-tag: v{{ .PRNumber }}-PR` in `image-builder-client-config.yaml`

## Result

For PR builds, the image gets `v<PR_NUMBER>-PR` (e.g. `v123-PR`) as an extra tag alongside all other configured tags. The `v<n>-PR` format is semver-compatible:

```
v123-PR  →  major=123, pre-release=PR  →  matches OCM semver pattern ✓
```

This unblocks OCM artifact generation for PR images in `pr-deploy`.

## Related issues

- https://github.tools.sap/kyma/test-infra/issues/1408
- Supersedes #14492

## Test plan

- [x] Verify `go test ./cmd/image-builder/...` passes (done locally)
- [x] Trigger a PR build and confirm the image gets the additional `v<n>-PR` tag
- [x] Verify OCM artifact generation succeeds with the `v<n>-PR` tag format