### PR TITLE
fix(iac): migrate internal GitHub WIF pool to github-tools-sap-v2

### DIFF
--- a/configs/terraform/environments/prod/gcp-workfload-identity-federation-variables.tf
+++ b/configs/terraform/environments/prod/gcp-workfload-identity-federation-variables.tf
@@ -37,6 +37,6 @@ variable "gh_com_kyma_project_wif_attribute_condition" {
 # Internal GitHub Enterprise (SAP) Workload Identity Federation
 variable "internal_github_wif_pool_id" {
   type        = string
-  default     = "github-tools-sap"
+  default     = "github-tools-sap-v2"
   description = "Workload Identity Federation pool id used for internal GitHub Enterprise workflows"
 }

--- a/configs/terraform/environments/prod/gcp-workfload-identity-federation.tf
+++ b/configs/terraform/environments/prod/gcp-workfload-identity-federation.tf
@@ -8,8 +8,12 @@ data "google_project" "current" {
 }
 
 locals {
-  # Full resource name of the internal GitHub Enterprise WIF pool.
+  # Full resource name of the internal GitHub Enterprise WIF pool (v2 — managed by foundation module).
   internal_github_wif_pool_name = "projects/${data.google_project.current.number}/locations/global/workloadIdentityPools/${var.internal_github_wif_pool_id}"
+
+  # Legacy pool kept alongside v2 during migration. Remove once GCP_WIF_PROVIDER is
+  # updated to v2 in all environments and the old pool bindings are no longer needed.
+  internal_github_wif_pool_name_legacy = "projects/${data.google_project.current.number}/locations/global/workloadIdentityPools/github-tools-sap"
 }
 
 module "gh_com_kyma_project_workload_identity_federation" {

--- a/configs/terraform/environments/prod/terraform-executor-variables.tf
+++ b/configs/terraform/environments/prod/terraform-executor-variables.tf
@@ -52,12 +52,6 @@ variable "internal_github_tooling_infra_terraform_plan_reusable_workflow_ref" {
   description = "Value of the GitHub OIDC job_workflow_ref claim for the terraform plan workflow in the tooling-infra repo on internal GitHub. Used to match the reusable_workflow_ref attribute in the github-tools-sap WIF pool."
 }
 
-variable "internal_github_tooling_infra_terraform_validate_reusable_workflow_ref" {
-  type        = string
-  default     = "kyma/tooling-infra/.github/workflows/iac-validate.yml@refs/heads/main"
-  description = "Value of the GitHub OIDC job_workflow_ref claim for the terraform validate workflow in the tooling-infra repo on internal GitHub. Used to match the reusable_workflow_ref attribute in the github-tools-sap WIF pool. This workflow is called as a reusable workflow by both iac-plan.yml and iac-staging.yml."
-}
-
 variable "internal_github_tooling_infra_terraform_deploy_identity_prod" {
   type        = string
   default     = "kyma/tooling-infra/.github/workflows/iac-deploy.yml:vtag"

--- a/configs/terraform/environments/prod/terraform-executor.tf
+++ b/configs/terraform/environments/prod/terraform-executor.tf
@@ -39,6 +39,10 @@ resource "google_service_account_iam_binding" "terraform_workload_identity" {
 
     # Internal GitHub Enterprise (github-tools-sap) — tooling-infra deploy workflow (staging branch)
     "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.deploy_identity/${var.internal_github_tooling_infra_terraform_deploy_identity_staging}",
+
+    # Internal GitHub Enterprise (github-tools-sap legacy) — kept during pool migration; remove once GCP_WIF_PROVIDER is updated to v2
+    "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name_legacy}/attribute.deploy_identity/${var.internal_github_tooling_infra_terraform_deploy_identity_prod}",
+    "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name_legacy}/attribute.deploy_identity/${var.internal_github_tooling_infra_terraform_deploy_identity_staging}",
   ]
   role               = "roles/iam.workloadIdentityUser"
   service_account_id = google_service_account.terraform_executor.name
@@ -99,6 +103,10 @@ resource "google_service_account_iam_binding" "terraform_planner_workload_identi
 
     # Internal GitHub Enterprise (github-tools-sap) — any workflow in kyma/tooling-infra
     "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.repository_id/${data.github_repository.tooling_infra.repo_id}",
+
+    # Internal GitHub Enterprise (github-tools-sap legacy) — kept during pool migration; remove once GCP_WIF_PROVIDER is updated to v2
+    "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name_legacy}/attribute.reusable_workflow_ref/${var.internal_github_tooling_infra_terraform_plan_reusable_workflow_ref}",
+    "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name_legacy}/attribute.repository_id/${data.github_repository.tooling_infra.repo_id}",
   ]
   role               = "roles/iam.workloadIdentityUser"
   service_account_id = google_service_account.terraform_planner.name

--- a/configs/terraform/environments/prod/terraform-executor.tf
+++ b/configs/terraform/environments/prod/terraform-executor.tf
@@ -97,9 +97,6 @@ resource "google_service_account_iam_binding" "terraform_planner_workload_identi
     # Internal GitHub Enterprise (github-tools-sap) — tooling-infra plan workflow
     "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.reusable_workflow_ref/${var.internal_github_tooling_infra_terraform_plan_reusable_workflow_ref}",
 
-    # Internal GitHub Enterprise (github-tools-sap) — tooling-infra validate workflow
-    "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.reusable_workflow_ref/${var.internal_github_tooling_infra_terraform_validate_reusable_workflow_ref}",
-
     # Internal GitHub Enterprise (github-tools-sap) — any workflow in kyma/tooling-infra
     "principalSet://iam.googleapis.com/${local.internal_github_wif_pool_name}/attribute.repository_id/${data.github_repository.tooling_infra.repo_id}",
   ]


### PR DESCRIPTION
The internal_github_wif_pool_id variable still pointed to the old github-tools-sap pool, while the foundation module has been provisioning github-tools-sap-v2 in all environments. This bumps the default to v2 so the terraform-planner and terraform-executor WIF bindings reference the correct pool. The dead iac-validate.yml workflow ref is also removed since that workflow no longer exists — its validate job is inlined in iac-plan.yml.

NOTE: this change must not be applied until GCP_WIF_PROVIDER is updated to point to the github-tools-sap-v2 provider in all environments, otherwise CI will break.