### PR TITLE
chore: group golang docker base image with Go dependencies in Renovate

### DIFF
--- a/.github/renovate-sharable-config.json
+++ b/.github/renovate-sharable-config.json
@@ -80,6 +80,10 @@
       "commitMessageTopic": "external/library image"
     },
     {
+      "matchDepNames": ["europe-docker.pkg.dev/kyma-project/prod/external/library/golang"],
+      "groupName": "All Go dependencies"
+    },
+    {
       "matchDepNames": [
         "europe-docker.pkg.dev/kyma-project/prod/**"
       ],


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add a `packageRule` to `renovate-sharable-config.json` that assigns the `europe-docker.pkg.dev/kyma-project/prod/external/library/golang` Docker base image to the `"All Go dependencies"` Renovate group.
- This ensures that when Renovate bumps the Go version in `go.mod`, the corresponding Golang Docker builder image is updated in the same PR, preventing build failures caused by a version mismatch between the two.
- The rule is placed after all other docker catch-all rules so it takes precedence (Renovate applies rules last-match-wins).
- Since all repos in the kyma org extend this sharable config, the fix propagates to all of them automatically.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->