### PR TITLE
fix(image-builder): include AdditionalPRTag in ADO build parameters

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -200,6 +200,15 @@ func buildInADO(o options) error {
 		fmt.Println("Running in dry-run mode. Skipping authentication check.")
 	}
 
+	if o.gitState.isPullRequest && o.gitState.PullRequestNumber > 0 && len(o.AdditionalPRTag.Value) > 0 {
+		pr := fmt.Sprint(o.gitState.PullRequestNumber)
+		resolvedAdditionalTags, err := getTags(o.logger, pr, "", []tags.Tag{o.AdditionalPRTag})
+		if err != nil {
+			return fmt.Errorf("build in ADO failed, failed resolving additional PR tag: %w", err)
+		}
+		o.tags = append(o.tags, resolvedAdditionalTags...)
+	}
+
 	fmt.Println("Preparing ADO template parameters.")
 	// Preparing ADO pipeline parameters.
 	templateParameters, err := prepareADOTemplateParameters(o)

--- a/cmd/image-builder/main_test.go
+++ b/cmd/image-builder/main_test.go
@@ -832,6 +832,35 @@ func Test_parseTags(t *testing.T) {
 				{Name: "base64testtemplate", Value: "test-5"},
 				expectedDefaultPRTag(prGitState.PullRequestNumber)},
 		},
+		{
+			name: "parse PR default tag and additional PR tag from config",
+			options: options{
+				gitState: prGitState,
+				Config: Config{
+					DefaultPRTag:     defaultPRTag,
+					DefaultCommitTag: defaultCommitTag,
+					AdditionalPRTag:  tags.Tag{Name: "semver_pr_tag", Value: "v{{ .PRNumber }}-PR", Validation: "^v[0-9]+-PR$"},
+				},
+				logger: logger,
+			},
+			expectedTags: []tags.Tag{
+				{Name: "semver_pr_tag", Value: "v5-PR", Validation: "^v[0-9]+-PR$"},
+				expectedDefaultPRTag(prGitState.PullRequestNumber),
+			},
+		},
+		{
+			name: "additional PR tag from config is not added for non-PR builds",
+			options: options{
+				gitState: commitGitState,
+				Config: Config{
+					DefaultPRTag:     defaultPRTag,
+					DefaultCommitTag: defaultCommitTag,
+					AdditionalPRTag:  tags.Tag{Name: "semver_pr_tag", Value: "v{{ .PRNumber }}-PR", Validation: "^v[0-9]+-PR$"},
+				},
+				logger: logger,
+			},
+			expectedTags: []tags.Tag{expectedDefaultCommitTag(commitGitState.BaseCommitSHA)},
+		},
 	}
 
 	for _, c := range tc {


### PR DESCRIPTION
## Summary

- `AdditionalPRTag` (e.g. `v{{ .PRNumber }}-PR`) configured in `image-builder-client-config.yaml` was only resolved in `parseTags()`, which is only called by the `--parse-tags-only` path
- `buildInADO` never called `parseTags`, so the resolved additional semver-compatible tag was never included in the `Tags` parameter sent to the ADO pipeline
- As a result, the `v<PR>-PR` Docker image tag was never created for PR builds

Fix by resolving `AdditionalPRTag` in `buildInADO` before preparing ADO template parameters, so the tag is included when building PR images.

Related to: https://github.tools.sap/kyma/test-infra/issues/1408

## Test plan

- [ ] New `Test_parseTags` cases: `parse PR default tag and additional PR tag from config` and `additional PR tag from config is not added for non-PR builds`
- [ ] All existing `cmd/image-builder` tests pass
- [ ] PR build creates both `PR-<number>` and `v<number>-PR` image tags