### PR TITLE
fix(iac): use variable for WIF pool ID in kyma-runtime update-components IAM member

### DIFF
--- a/configs/terraform/environments/prod/kyma-runtime-update-components-config.tf
+++ b/configs/terraform/environments/prod/kyma-runtime-update-components-config.tf
@@ -70,7 +70,7 @@ resource "google_secret_manager_secret_iam_member" "kyma_modules_update_componen
   project   = var.gcp_project_id
   secret_id = google_secret_manager_secret.kyma_modules_runtime_internal_github_token.secret_id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "principal://iam.googleapis.com/projects/351981214969/locations/global/workloadIdentityPools/github-tools-sap/subject/repository_id:${data.github_repository.kyma_modules_internal.repo_id}:repository_owner_id:2457:workflow:Update Component Version on Push"
+  member    = "principal://iam.googleapis.com/projects/351981214969/locations/global/workloadIdentityPools/${var.internal_github_wif_pool_id}/subject/repository_id:${data.github_repository.kyma_modules_internal.repo_id}:repository_owner_id:2457:workflow:Update Component Version on Push"
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
# What changed
Replaced the hardcoded Workload Identity Federation pool ID (`github-tools-sap-v2`)
in the `google_secret_manager_secret_iam_member` resource with the existing
`var.internal_github_wif_pool_id` variable. This removes duplication and ensures
the pool ID is managed from a single source of truth.

## Changes
- `kyma-runtime-update-components-config.tf`: replace hardcoded `github-tools-sap-v2`
  in the IAM member `member` string with `${var.internal_github_wif_pool_id}`