### PR TITLE
remove gcr.io/distroless/static from external image sync

### DIFF
--- a/external-images.yaml
+++ b/external-images.yaml
@@ -1,6 +1,5 @@
 images:
   - source: "alpine:3.24.1"
-  - source: "gcr.io/distroless/static:latest"
   - source: "golang:1.27.0-alpine3.23"
   - source: "python@sha256:02da11a8d221ca167aa07de20b3cd7104c1f01227f4b02b1fa13cf6517280a81"
     tag: "3.14.6-alpine3.23"


### PR DESCRIPTION
## Summary

- Removes `gcr.io/distroless/static:latest` from `external-images.yaml`
- The mutable `:latest` tag causes intermittent `sync-images` CI failures when upstream pushes a new digest between image-syncer's two fetch operations (error: _digests are not equal — probably source index has been changed_)
- The entry provides no value: `cmd/image-builder/Dockerfile` pulls the image directly from `gcr.io/distroless/static:latest`, not from the mirrored `europe-docker.pkg.dev/kyma-project/prod/external/` path

## Test plan

- [x] Verify `sync-images` CI check passes on this PR
- [x] Confirm `image-builder` image build still succeeds (Dockerfile unchanged)