### PR TITLE
chore(iac): add GitHub App credentials and WIF access for reusable workflow

### DIFF
--- a/configs/terraform/environments/prod/go-ci-workflows.tf
+++ b/configs/terraform/environments/prod/go-ci-workflows.tf
@@ -54,14 +54,99 @@ resource "google_secret_manager_secret_iam_member" "pull_unit_test_go_workflow_i
 # Expose the GCP secret name as a repository-level variable so the reusable
 # workflows can resolve the secret at runtime.
 
-import {
-  to = github_actions_variable.gh_tools_kyma_prow_bot_token_secret_name
-  id = "test-infra:${var.gh_tools_kyma_prow_bot_token_secret_name}"
-}
-
 resource "github_actions_variable" "gh_tools_kyma_prow_bot_token_secret_name" {
   provider      = github.kyma_project
   repository    = data.github_repository.test_infra.name
   variable_name = var.gh_tools_kyma_prow_bot_token_secret_name
   value         = google_secret_manager_secret.kyma_modules_runtime_internal_github_token.secret_id
+}
+
+# ==============================================================================
+# neighbors-gh-automations — GitHub App credentials + WIF access
+# ==============================================================================
+
+variable "neighbors_gh_automations_internal_app_id_secret_id" {
+  type        = string
+  default     = "neighbors-gh-automations_internal-github-app-id"
+  description = "GCP Secret Manager secret ID for the neighbors-gh-automations GitHub App ID on the internal GitHub (github.tools.sap)"
+}
+
+variable "neighbors_gh_automations_internal_private_key_secret_id" {
+  type        = string
+  default     = "neighbors-gh-automations_internal-github-app-private-key"
+  description = "GCP Secret Manager secret ID for the neighbors-gh-automations GitHub App private key on the internal GitHub (github.tools.sap)"
+}
+
+# ------------------------------------------------------------------------------
+# GCP Secret Manager — secret containers
+# ------------------------------------------------------------------------------
+
+resource "google_secret_manager_secret" "neighbors_gh_automations_internal_app_id" {
+  project   = var.gcp_project_id
+  secret_id = var.neighbors_gh_automations_internal_app_id_secret_id
+
+  replication {
+    auto {}
+  }
+
+  labels = {
+    owner           = "neighbors"
+    type            = "app-id"
+    tool            = "neighbors-gh-automations"
+    entity          = "github-app"
+    github-instance = "internal"
+  }
+}
+
+resource "google_secret_manager_secret" "neighbors_gh_automations_internal_private_key" {
+  project   = var.gcp_project_id
+  secret_id = var.neighbors_gh_automations_internal_private_key_secret_id
+
+  replication {
+    auto {}
+  }
+
+  labels = {
+    owner           = "neighbors"
+    type            = "private-key"
+    tool            = "neighbors-gh-automations"
+    entity          = "github-app"
+    github-instance = "internal"
+  }
+}
+
+# ------------------------------------------------------------------------------
+# IAM — grant pull-go-lint reusable workflow secretAccessor via WIF
+# ------------------------------------------------------------------------------
+
+resource "google_secret_manager_secret_iam_member" "pull_go_lint_neighbors_internal_app_id_reader" {
+  project   = var.gcp_project_id
+  secret_id = google_secret_manager_secret.neighbors_gh_automations_internal_app_id.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_ref/${var.pull_go_lint_reusable_workflow_ref}"
+}
+
+resource "google_secret_manager_secret_iam_member" "pull_go_lint_neighbors_internal_private_key_reader" {
+  project   = var.gcp_project_id
+  secret_id = google_secret_manager_secret.neighbors_gh_automations_internal_private_key.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_ref/${var.pull_go_lint_reusable_workflow_ref}"
+}
+
+# ------------------------------------------------------------------------------
+# IAM — grant pull-unit-test-go reusable workflow secretAccessor via WIF
+# ------------------------------------------------------------------------------
+
+resource "google_secret_manager_secret_iam_member" "pull_unit_test_go_neighbors_internal_app_id_reader" {
+  project   = var.gcp_project_id
+  secret_id = google_secret_manager_secret.neighbors_gh_automations_internal_app_id.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_ref/${var.pull_unit_test_go_reusable_workflow_ref}"
+}
+
+resource "google_secret_manager_secret_iam_member" "pull_unit_test_go_neighbors_internal_private_key_reader" {
+  project   = var.gcp_project_id
+  secret_id = google_secret_manager_secret.neighbors_gh_automations_internal_private_key.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_ref/${var.pull_unit_test_go_reusable_workflow_ref}"
 }

--- a/configs/terraform/environments/prod/go-ci-workflows.tf
+++ b/configs/terraform/environments/prod/go-ci-workflows.tf
@@ -62,40 +62,40 @@ resource "github_actions_variable" "gh_tools_kyma_prow_bot_token_secret_name" {
 }
 
 # ==============================================================================
-# neighbors-gh-automations — GitHub App credentials + WIF access
+# test-infra-private-repo-access — GitHub App credentials + WIF access
 # ==============================================================================
 
-variable "neighbors_gh_automations_internal_app_id_secret_id" {
+variable "test_infra_private_repo_access_internal_app_id_secret_id" {
   type        = string
-  default     = "neighbors-gh-automations_internal-github-app-id"
-  description = "GCP Secret Manager secret ID for the neighbors-gh-automations GitHub App ID on the internal GitHub (github.tools.sap)"
+  default     = "test-infra-private-repo-access_internal-github-app-id"
+  description = "GCP Secret Manager secret ID for the test-infra-private-repo-access GitHub App ID on the internal GitHub (github.tools.sap)"
 }
 
-variable "neighbors_gh_automations_internal_private_key_secret_id" {
+variable "test_infra_private_repo_access_internal_private_key_secret_id" {
   type        = string
-  default     = "neighbors-gh-automations_internal-github-app-private-key"
-  description = "GCP Secret Manager secret ID for the neighbors-gh-automations GitHub App private key on the internal GitHub (github.tools.sap)"
+  default     = "test-infra-private-repo-access_internal-github-app-private-key"
+  description = "GCP Secret Manager secret ID for the test-infra-private-repo-access GitHub App private key on the internal GitHub (github.tools.sap)"
 }
 
-variable "gh_neighbors_automations_internal_app_id_secret_var_name" {
+variable "gh_test_infra_private_repo_access_internal_app_id_secret_var_name" {
   type        = string
-  default     = "GH_NEIGHBORS_AUTOMATIONS_INTERNAL_APP_ID_SECRET_NAME"
-  description = "GitHub Actions repository variable name that holds the GCP secret name for the neighbors-gh-automations App ID"
+  default     = "GH_TEST_INFRA_PRIVATE_REPO_ACCESS_INTERNAL_APP_ID_SECRET_NAME"
+  description = "GitHub Actions repository variable name that holds the GCP secret name for the test-infra-private-repo-access App ID"
 }
 
-variable "gh_neighbors_automations_internal_private_key_secret_var_name" {
+variable "gh_test_infra_private_repo_access_internal_private_key_secret_var_name" {
   type        = string
-  default     = "GH_NEIGHBORS_AUTOMATIONS_INTERNAL_PRIVATE_KEY_SECRET_NAME"
-  description = "GitHub Actions repository variable name that holds the GCP secret name for the neighbors-gh-automations App private key"
+  default     = "GH_TEST_INFRA_PRIVATE_REPO_ACCESS_INTERNAL_PRIVATE_KEY_SECRET_NAME"
+  description = "GitHub Actions repository variable name that holds the GCP secret name for the test-infra-private-repo-access App private key"
 }
 
 # ------------------------------------------------------------------------------
 # GCP Secret Manager — secret containers
 # ------------------------------------------------------------------------------
 
-resource "google_secret_manager_secret" "neighbors_gh_automations_internal_app_id" {
+resource "google_secret_manager_secret" "test_infra_private_repo_access_internal_app_id" {
   project   = var.gcp_project_id
-  secret_id = var.neighbors_gh_automations_internal_app_id_secret_id
+  secret_id = var.test_infra_private_repo_access_internal_app_id_secret_id
 
   replication {
     auto {}
@@ -104,15 +104,15 @@ resource "google_secret_manager_secret" "neighbors_gh_automations_internal_app_i
   labels = {
     owner           = "neighbors"
     type            = "app-id"
-    tool            = "neighbors-gh-automations"
+    tool            = "test-infra-private-repo-access"
     entity          = "github-app"
     github-instance = "internal"
   }
 }
 
-resource "google_secret_manager_secret" "neighbors_gh_automations_internal_private_key" {
+resource "google_secret_manager_secret" "test_infra_private_repo_access_internal_private_key" {
   project   = var.gcp_project_id
-  secret_id = var.neighbors_gh_automations_internal_private_key_secret_id
+  secret_id = var.test_infra_private_repo_access_internal_private_key_secret_id
 
   replication {
     auto {}
@@ -121,7 +121,7 @@ resource "google_secret_manager_secret" "neighbors_gh_automations_internal_priva
   labels = {
     owner           = "neighbors"
     type            = "private-key"
-    tool            = "neighbors-gh-automations"
+    tool            = "test-infra-private-repo-access"
     entity          = "github-app"
     github-instance = "internal"
   }
@@ -131,16 +131,16 @@ resource "google_secret_manager_secret" "neighbors_gh_automations_internal_priva
 # IAM — grant pull-go-lint reusable workflow secretAccessor via WIF
 # ------------------------------------------------------------------------------
 
-resource "google_secret_manager_secret_iam_member" "pull_go_lint_neighbors_internal_app_id_reader" {
+resource "google_secret_manager_secret_iam_member" "pull_go_lint_test_infra_private_repo_access_internal_app_id_reader" {
   project   = var.gcp_project_id
-  secret_id = google_secret_manager_secret.neighbors_gh_automations_internal_app_id.secret_id
+  secret_id = google_secret_manager_secret.test_infra_private_repo_access_internal_app_id.secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_ref/${var.pull_go_lint_reusable_workflow_ref}"
 }
 
-resource "google_secret_manager_secret_iam_member" "pull_go_lint_neighbors_internal_private_key_reader" {
+resource "google_secret_manager_secret_iam_member" "pull_go_lint_test_infra_private_repo_access_internal_private_key_reader" {
   project   = var.gcp_project_id
-  secret_id = google_secret_manager_secret.neighbors_gh_automations_internal_private_key.secret_id
+  secret_id = google_secret_manager_secret.test_infra_private_repo_access_internal_private_key.secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_ref/${var.pull_go_lint_reusable_workflow_ref}"
 }
@@ -149,16 +149,16 @@ resource "google_secret_manager_secret_iam_member" "pull_go_lint_neighbors_inter
 # IAM — grant pull-unit-test-go reusable workflow secretAccessor via WIF
 # ------------------------------------------------------------------------------
 
-resource "google_secret_manager_secret_iam_member" "pull_unit_test_go_neighbors_internal_app_id_reader" {
+resource "google_secret_manager_secret_iam_member" "pull_unit_test_go_test_infra_private_repo_access_internal_app_id_reader" {
   project   = var.gcp_project_id
-  secret_id = google_secret_manager_secret.neighbors_gh_automations_internal_app_id.secret_id
+  secret_id = google_secret_manager_secret.test_infra_private_repo_access_internal_app_id.secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_ref/${var.pull_unit_test_go_reusable_workflow_ref}"
 }
 
-resource "google_secret_manager_secret_iam_member" "pull_unit_test_go_neighbors_internal_private_key_reader" {
+resource "google_secret_manager_secret_iam_member" "pull_unit_test_go_test_infra_private_repo_access_internal_private_key_reader" {
   project   = var.gcp_project_id
-  secret_id = google_secret_manager_secret.neighbors_gh_automations_internal_private_key.secret_id
+  secret_id = google_secret_manager_secret.test_infra_private_repo_access_internal_private_key.secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_ref/${var.pull_unit_test_go_reusable_workflow_ref}"
 }
@@ -167,16 +167,16 @@ resource "google_secret_manager_secret_iam_member" "pull_unit_test_go_neighbors_
 # GitHub Actions Repository Variables — expose secret names to reusable workflows
 # ------------------------------------------------------------------------------
 
-resource "github_actions_variable" "neighbors_gh_automations_internal_app_id_secret_name" {
+resource "github_actions_variable" "test_infra_private_repo_access_internal_app_id_secret_name" {
   provider      = github.kyma_project
   repository    = data.github_repository.test_infra.name
-  variable_name = var.gh_neighbors_automations_internal_app_id_secret_var_name
-  value         = google_secret_manager_secret.neighbors_gh_automations_internal_app_id.secret_id
+  variable_name = var.gh_test_infra_private_repo_access_internal_app_id_secret_var_name
+  value         = google_secret_manager_secret.test_infra_private_repo_access_internal_app_id.secret_id
 }
 
-resource "github_actions_variable" "neighbors_gh_automations_internal_private_key_secret_name" {
+resource "github_actions_variable" "test_infra_private_repo_access_internal_private_key_secret_name" {
   provider      = github.kyma_project
   repository    = data.github_repository.test_infra.name
-  variable_name = var.gh_neighbors_automations_internal_private_key_secret_var_name
-  value         = google_secret_manager_secret.neighbors_gh_automations_internal_private_key.secret_id
+  variable_name = var.gh_test_infra_private_repo_access_internal_private_key_secret_var_name
+  value         = google_secret_manager_secret.test_infra_private_repo_access_internal_private_key.secret_id
 }

--- a/configs/terraform/environments/prod/go-ci-workflows.tf
+++ b/configs/terraform/environments/prod/go-ci-workflows.tf
@@ -77,6 +77,18 @@ variable "neighbors_gh_automations_internal_private_key_secret_id" {
   description = "GCP Secret Manager secret ID for the neighbors-gh-automations GitHub App private key on the internal GitHub (github.tools.sap)"
 }
 
+variable "gh_neighbors_automations_internal_app_id_secret_var_name" {
+  type        = string
+  default     = "GH_NEIGHBORS_AUTOMATIONS_INTERNAL_APP_ID_SECRET_NAME"
+  description = "GitHub Actions repository variable name that holds the GCP secret name for the neighbors-gh-automations App ID"
+}
+
+variable "gh_neighbors_automations_internal_private_key_secret_var_name" {
+  type        = string
+  default     = "GH_NEIGHBORS_AUTOMATIONS_INTERNAL_PRIVATE_KEY_SECRET_NAME"
+  description = "GitHub Actions repository variable name that holds the GCP secret name for the neighbors-gh-automations App private key"
+}
+
 # ------------------------------------------------------------------------------
 # GCP Secret Manager — secret containers
 # ------------------------------------------------------------------------------
@@ -149,4 +161,22 @@ resource "google_secret_manager_secret_iam_member" "pull_unit_test_go_neighbors_
   secret_id = google_secret_manager_secret.neighbors_gh_automations_internal_private_key.secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "principalSet://iam.googleapis.com/${module.gh_com_kyma_project_workload_identity_federation.pool_name}/attribute.reusable_workflow_ref/${var.pull_unit_test_go_reusable_workflow_ref}"
+}
+
+# ------------------------------------------------------------------------------
+# GitHub Actions Repository Variables — expose secret names to reusable workflows
+# ------------------------------------------------------------------------------
+
+resource "github_actions_variable" "neighbors_gh_automations_internal_app_id_secret_name" {
+  provider      = github.kyma_project
+  repository    = data.github_repository.test_infra.name
+  variable_name = var.gh_neighbors_automations_internal_app_id_secret_var_name
+  value         = google_secret_manager_secret.neighbors_gh_automations_internal_app_id.secret_id
+}
+
+resource "github_actions_variable" "neighbors_gh_automations_internal_private_key_secret_name" {
+  provider      = github.kyma_project
+  repository    = data.github_repository.test_infra.name
+  variable_name = var.gh_neighbors_automations_internal_private_key_secret_var_name
+  value         = google_secret_manager_secret.neighbors_gh_automations_internal_private_key.secret_id
 }


### PR DESCRIPTION
## What changed

Adds GCP Secret Manager containers and WIF IAM bindings for the `neighbors-gh-automations` GitHub App (internal github.tools.sap instance). The `pull-go-lint` and `pull-unit-test-go` reusable workflows from the public `test-infra` repository are granted `secretAccessor` on both secrets via the existing `gh_com_kyma_project` WIF pool.

## Changes

- Added `google_secret_manager_secret` resources for `neighbors-gh-automations` App ID and private key with `github-instance = "internal"` label
- Added `google_secret_manager_secret_iam_member` bindings for `pull-go-lint` and `pull-unit-test-go` reusable workflows (2 workflows × 2 secrets = 4 bindings)
- Added variables `neighbors_gh_automations_internal_app_id_secret_id` and `neighbors_gh_automations_internal_private_key_secret_id` with sensible defaults
