### PR TITLE
feat(iac): add KEEP policy for IB-TESTS images in restricted registry

### DIFF
--- a/configs/terraform/environments/prod/restricted-registry-variables.tf
+++ b/configs/terraform/environments/prod/restricted-registry-variables.tf
@@ -32,14 +32,6 @@ variable "kyma_restricted_images_prod" {
     cleanup_policy_dry_run     = false
     cleanup_policies = [
       {
-        id     = "keep-tests-images"
-        action = "KEEP"
-        condition = {
-          tag_state    = "TAGGED"
-          tag_prefixes = ["IB-TESTS"]
-        }
-      },
-      {
         id     = "delete-untagged"
         action = "DELETE"
         condition = {

--- a/configs/terraform/environments/prod/restricted-registry-variables.tf
+++ b/configs/terraform/environments/prod/restricted-registry-variables.tf
@@ -32,6 +32,14 @@ variable "kyma_restricted_images_prod" {
     cleanup_policy_dry_run     = false
     cleanup_policies = [
       {
+        id     = "keep-tests-images"
+        action = "KEEP"
+        condition = {
+          tag_state    = "TAGGED"
+          tag_prefixes = ["IB-TESTS"]
+        }
+      },
+      {
         id     = "delete-untagged"
         action = "DELETE"
         condition = {
@@ -75,6 +83,14 @@ variable "kyma_restricted_images_dev" {
     type                       = "development"
     cleanup_policy_dry_run     = false
     cleanup_policies = [
+      {
+        id     = "keep-tests-images"
+        action = "KEEP"
+        condition = {
+          tag_state    = "TAGGED"
+          tag_prefixes = ["IB-TESTS"]
+        }
+      },
       {
         id     = "delete-untagged"
         action = "DELETE"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add a `keep-tests-images` KEEP cleanup policy for images tagged with the `IB-TESTS` prefix to both `kyma_restricted_images_prod` and `kyma_restricted_images_dev` Artifact Registry repositories.
- The KEEP policy is placed before all DELETE policies so it takes precedence, ensuring test images are never deleted by the `delete-untagged` or `delete-old-images` (30-day TTL on dev) policies.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->