### PR TITLE
chore(workflows): use GitHub App token for private module access

### DIFF
--- a/.github/workflows/post-apply-prod-terraform.yaml
+++ b/.github/workflows/post-apply-prod-terraform.yaml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Generate GitHub App token for Terraform Executor (github.com)
         id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.terraform-executor-app-id }}
           private-key: ${{ steps.secrets.outputs.terraform-executor-app-private-key }}
@@ -60,7 +60,7 @@ jobs:
 
       - name: Generate GitHub App token for Terraform Executor (github.tools.sap)
         id: app-token-internal
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.terraform-executor-internal-app-id }}
           private-key: ${{ steps.secrets.outputs.terraform-executor-internal-app-private-key }}

--- a/.github/workflows/pull-go-lint.yaml
+++ b/.github/workflows/pull-go-lint.yaml
@@ -42,13 +42,23 @@ jobs:
         uses: 'google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262' # v3
         with:
           secrets: |-
-            internal-github-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TOOLS_KYMA_PROW_BOT_TOKEN_SECRET_NAME }}
+            test-infra-private-repo-access-app-id:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TEST_INFRA_PRIVATE_REPO_ACCESS_INTERNAL_APP_ID_SECRET_NAME }}
+            test-infra-private-repo-access-private-key:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TEST_INFRA_PRIVATE_REPO_ACCESS_INTERNAL_PRIVATE_KEY_SECRET_NAME }}
+
+      - name: Generate GitHub App token for test-infra-private-repo-access (github.tools.sap)
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ steps.secrets.outputs.test-infra-private-repo-access-app-id }}
+          private-key: ${{ steps.secrets.outputs.test-infra-private-repo-access-private-key }}
+          owner: kyma
+          github-api-url: https://github.tools.sap/api/v3
 
       - name: Setup authentication for private Go modules
         run: |
           echo "machine github.tools.sap" >> ~/.netrc
           echo "login $GITHUB_ACTOR" >> ~/.netrc
-          echo "password ${{ steps.secrets.outputs.internal-github-token }}" >> ~/.netrc
+          echo "password ${{ steps.app-token.outputs.token }}" >> ~/.netrc
           chmod 600 ~/.netrc
 
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0

--- a/.github/workflows/pull-plan-prod-terraform.yaml
+++ b/.github/workflows/pull-plan-prod-terraform.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Generate GitHub App token for Terraform Planner (github.com)
         id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.terraform-planner-app-id }}
           private-key: ${{ steps.secrets.outputs.terraform-planner-app-private-key }}
@@ -54,7 +54,7 @@ jobs:
 
       - name: Generate GitHub App token for Terraform Planner (github.tools.sap)
         id: app-token-internal
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.terraform-planner-internal-app-id }}
           private-key: ${{ steps.secrets.outputs.terraform-planner-internal-app-private-key }}

--- a/.github/workflows/pull-unit-test-go.yaml
+++ b/.github/workflows/pull-unit-test-go.yaml
@@ -39,13 +39,23 @@ jobs:
         uses: 'google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262' # v3
         with:
           secrets: |-
-            internal-github-token:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TOOLS_KYMA_PROW_BOT_TOKEN_SECRET_NAME }}
+            test-infra-private-repo-access-app-id:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TEST_INFRA_PRIVATE_REPO_ACCESS_INTERNAL_APP_ID_SECRET_NAME }}
+            test-infra-private-repo-access-private-key:${{ vars.GCP_KYMA_PROJECT_PROJECT_ID }}/${{ vars.GH_TEST_INFRA_PRIVATE_REPO_ACCESS_INTERNAL_PRIVATE_KEY_SECRET_NAME }}
+
+      - name: Generate GitHub App token for test-infra-private-repo-access (github.tools.sap)
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ steps.secrets.outputs.test-infra-private-repo-access-app-id }}
+          private-key: ${{ steps.secrets.outputs.test-infra-private-repo-access-private-key }}
+          owner: kyma
+          github-api-url: https://github.tools.sap/api/v3
 
       - name: Setup authentication for private Go modules
         run: |
           echo "machine github.tools.sap" >> ~/.netrc
           echo "login $GITHUB_ACTOR" >> ~/.netrc
-          echo "password ${{ steps.secrets.outputs.internal-github-token }}" >> ~/.netrc
+          echo "password ${{ steps.app-token.outputs.token }}" >> ~/.netrc
           chmod 600 ~/.netrc
 
       # https://github.com/golang/go/issues/75031

--- a/.github/workflows/tofu-drift-detection.yml
+++ b/.github/workflows/tofu-drift-detection.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Generate GitHub App token for Terraform Planner (github.com)
         id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.terraform-planner-app-id }}
           private-key: ${{ steps.secrets.outputs.terraform-planner-app-private-key }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Generate GitHub App token for Terraform Planner (github.tools.sap)
         id: app-token-internal
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ steps.secrets.outputs.terraform-planner-internal-app-id }}
           private-key: ${{ steps.secrets.outputs.terraform-planner-internal-app-private-key }}


### PR DESCRIPTION
## What changed

Replace PAT-based authentication in `pull-go-lint` and `pull-unit-test-go` reusable workflows with a GitHub App token (`test-infra-private-repo-access`) generated via WIF. Credentials are fetched from GCP Secret Manager using variables provisioned by the IaC in #14552.

Also fix incorrect version comments on `create-github-app-token`: the pinned SHA `bcd2ba49` corresponds to `v3.2.0`, not `v3`.

## Changes

- Replace `internal-github-token` PAT with GitHub App token in `pull-go-lint` and `pull-unit-test-go` workflows
- Add `Generate GitHub App token for test-infra-private-repo-access` step using `actions/create-github-app-token` with `github-api-url: https://github.tools.sap/api/v3`
- Fix version comments on `create-github-app-token` action: `# v3` → `# v3.2.0` across all affected workflows